### PR TITLE
fix(mise): pin rust to 1.95.0; correct renovate mise packageNames

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -2,7 +2,7 @@
 # Mise is the source of truth for Rust and project tools in developer shells and CI.
 
 [tools]
-rust = { version = "1.96.0", components = "rustfmt,clippy,llvm-tools-preview" }
+rust = { version = "1.95.0", components = "rustfmt,clippy,llvm-tools-preview" }
 lefthook = "2.1.9"
 oxfmt = "0.53.0"
 zizmor = "1.25.2"

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -5,7 +5,12 @@
     {
       description: "Disable Auto Merge",
       matchManagers: ["mise"],
-      matchPackageNames: ["rust", "cargo-llvm-cov", "cargo-deny", "kopia"],
+      matchPackageNames: [
+        "rust-lang/rust",
+        "kopia/kopia",
+        "EmbarkStudios/cargo-deny",
+        "taiki-e/cargo-llvm-cov",
+      ],
       automerge: false,
     },
   ],


### PR DESCRIPTION
Two linked fixes around the new mise setup.

## Renovate: the mise automerge-disable rule was matching nothing
`matchPackageNames` matches Renovate's resolved **`packageName`**, not the short mise key. Confirmed from the live Renovate run (`26924246288`):

| mise key | `packageName` Renovate matches |
|---|---|
| `rust` | `rust-lang/rust` |
| `kopia` | `kopia/kopia` |
| `aqua:EmbarkStudios/cargo-deny` | `EmbarkStudios/cargo-deny` |
| `aqua:taiki-e/cargo-llvm-cov` | `taiki-e/cargo-llvm-cov` |

So `matchPackageNames: ["rust","cargo-llvm-cov","cargo-deny","kopia"]` matched **zero** of them — all four kept auto-merging via the org preset's *"Auto-merge Mise Tools"* rule. That's how rust auto-bumped `1.95.0 → 1.96.0` (`a564bba`). Switched to the real packageNames so the `automerge: false` override applies.

## Pin rust back to 1.95.0
Reverts the slipped-through bump, and re-aligns `.mise/config.toml` (was `1.96.0`) with `.mise/mise.lock` (still `1.95.0`). The version flows from mise into the Docker build-args and the release workflow (`mise config get tools.rust.version`), so this one edit covers every build path.

## Verification
- `mise config get tools.rust.version` → `1.95.0`; lock agrees; `mise-lock` pre-commit hook left the tree clean.
- Renovate package names taken verbatim from the run log, not inferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
