### PR TITLE
ci: regenerate chart docs in renovate postUpgrade tasks

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,4 +1,16 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
+  // Regenerate the chart's committed docs after an upgrade so a value bump
+  // doesn't leave README.md / values.schema.json stale and fail helm-docs-check.
+  // Runs the helm-docs + helm-schema binaries shipped in the Renovate container
+  // (mirrors `mise run helm-docs`).
+  postUpgradeTasks: {
+    commands: [
+      "helm-docs --chart-search-root=deploy/helm --log-level=warn",
+      "helm-schema --chart-search-root deploy/helm/kopiur --skip-auto-generation required,additionalProperties --append-newline",
+    ],
+    fileFilters: ["deploy/helm/kopiur/README.md", "deploy/helm/kopiur/values.schema.json"],
+    executionMode: "branch",
+  },
 }


### PR DESCRIPTION
Adds a Renovate `postUpgradeTask` that regenerates the chart's committed `README.md` + `values.schema.json` after an upgrade, so a Renovate bump to a charted value can't leave them stale and fail the `helm-docs-check` (Helm Lint) gate.

Runs `helm-docs` + `helm-schema` directly — the binaries ship in the Renovate container ([home-operations/.github#14](https://github.com/home-operations/.github/pull/14)) and the commands are allowlisted ([home-operations/.github#15](https://github.com/home-operations/.github/pull/15)) — and commits the result via `fileFilters`. Mirrors `mise run helm-docs` (chart-search-root `deploy/helm`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
