### PR TITLE
test(chart): add a helm-unittest suite and drop kubeconform

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,8 +20,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
-  HELM_UNITTEST_VERSION: "v1.0.3"
 
 jobs:
   rust-lint:
@@ -74,11 +72,6 @@ jobs:
 
       - name: Run helm lint
         run: mise run helm-lint
-
-      - name: Run helm unit tests
-        run: |
-          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
-          mise run helm-test
 
       - name: Check chart docs are current
         run: mise run helm-docs-check

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -20,6 +20,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+  HELM_UNITTEST_VERSION: "v1.0.3"
 
 jobs:
   rust-lint:
@@ -72,6 +74,11 @@ jobs:
 
       - name: Run helm lint
         run: mise run helm-lint
+
+      - name: Run helm unit tests
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
+          mise run helm-test
 
       - name: Check chart docs are current
         run: mise run helm-docs-check

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ env:
   HELM_UNITTEST_VERSION: "v1.0.3"
 
 jobs:
-  test:
+  rust-test:
     name: Rust Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -56,7 +56,7 @@ jobs:
       - name: Check generated manifests
         run: mise run gen-check
 
-  integration:
+  integration-test:
     name: Integration Tests
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -21,10 +21,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
+  HELM_UNITTEST_VERSION: "v1.0.3"
 
 jobs:
   test:
-    name: Run on Ubuntu
+    name: Rust Tests
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -91,3 +93,25 @@ jobs:
 
       - name: Run integration tests
         run: cargo test --workspace --features integration --locked -- --include-ignored
+
+  helm-test:
+    name: Helm Unit Tests
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          experimental: true
+          install_args: --locked
+
+      - name: Run helm unit tests
+        run: |
+          helm plugin install https://github.com/helm-unittest/helm-unittest --version "${HELM_UNITTEST_VERSION}" --verify=false
+          mise run helm-test

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -26,7 +26,6 @@ kubectl = "1.36.1"
 shellcheck = "0.11.0"
 kind = "0.32.0"
 kopia = "0.23.0"
-kubeconform = "0.8.0"
 "aqua:EmbarkStudios/cargo-deny" = "0.19.8"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.7"
 # Docs site toolchain. The docs are an MkDocs Material site (see `mise run docs`);
@@ -136,14 +135,17 @@ description = "Build all three component images locally"
 depends = ["image-controller", "image-webhook", "image-mover"]
 
 [tasks.helm-lint]
-description = "Lint the chart and validate rendered manifests (both scopes) + CRDs against the k8s schema"
+description = "Lint the chart and check it renders in both install scopes"
 run = """
 helm lint deploy/helm/kopiur
 for scope in namespaced cluster; do
-  helm template kopiur deploy/helm/kopiur --set installScope="$scope" | kubeconform -strict -summary -ignore-missing-schemas
+  helm template kopiur deploy/helm/kopiur --set installScope="$scope" >/dev/null
 done
-kubeconform -strict -summary -ignore-missing-schemas deploy/crds/all-crds.yaml
 """
+
+[tasks.helm-test]
+description = "Run helm unit tests"
+run = "helm unittest deploy/helm/kopiur"
 
 [tasks.helm-docs]
 description = "Generate the chart README + values.schema.json from Chart.yaml + values.yaml"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -263,38 +263,6 @@ url = "https://github.com/kopia/kopia/releases/download/v0.23.0/kopia-0.23.0-mac
 checksum = "sha256:85045291338f026e07af0775c1ec86debd0df10ae02253db8cff8646d28084c0"
 url = "https://github.com/kopia/kopia/releases/download/v0.23.0/kopia-0.23.0-windows-x64.zip"
 
-[[tools.kubeconform]]
-version = "0.8.0"
-backend = "aqua:yannh/kubeconform"
-
-[tools.kubeconform."platforms.linux-arm64"]
-checksum = "sha256:1f53fc8e81258197a35e8603054162a5af1de8c5af13746c71ab680d9534ed87"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-arm64.tar.gz"
-
-[tools.kubeconform."platforms.linux-arm64-musl"]
-checksum = "sha256:1f53fc8e81258197a35e8603054162a5af1de8c5af13746c71ab680d9534ed87"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-arm64.tar.gz"
-
-[tools.kubeconform."platforms.linux-x64"]
-checksum = "sha256:9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz"
-
-[tools.kubeconform."platforms.linux-x64-musl"]
-checksum = "sha256:9bc2bffbf71f261128533edaf912153948b7ff238f9a531ae6d34466ec287883"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-linux-amd64.tar.gz"
-
-[tools.kubeconform."platforms.macos-arm64"]
-checksum = "sha256:f84f4dfbebf4a6b0b230385fa065a39ea35e02608c2b50d025dcf64775a69d67"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-darwin-arm64.tar.gz"
-
-[tools.kubeconform."platforms.macos-x64"]
-checksum = "sha256:71dbc87ac9f24099a62b93570e65aa06312ba6ac8aea63b7f86e9d999edf5a92"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-darwin-amd64.tar.gz"
-
-[tools.kubeconform."platforms.windows-x64"]
-checksum = "sha256:e3f56102bcf4f50b034a567e2482a1c5330799983ddd655952310211aef73d93"
-url = "https://github.com/yannh/kubeconform/releases/download/v0.8.0/kubeconform-windows-amd64.zip"
-
 [[tools.kubectl]]
 version = "1.36.1"
 backend = "aqua:kubernetes/kubernetes/kubectl"

--- a/deploy/helm/kopiur/tests/crds_test.yaml
+++ b/deploy/helm/kopiur/tests/crds_test.yaml
@@ -1,0 +1,16 @@
+suite: crds
+templates:
+  - crds.yaml
+tests:
+  - it: renders the CRDs as templates by default
+    asserts:
+      - isKind:
+          of: CustomResourceDefinition
+        documentIndex: 0
+
+  - it: omits the CRDs when installCRDs is false
+    set:
+      installCRDs: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/kopiur/tests/deployment_test.yaml
+++ b/deploy/helm/kopiur/tests/deployment_test.yaml
@@ -1,0 +1,73 @@
+suite: deployment
+templates:
+  - deployment.yaml
+tests:
+  - it: is the controller Deployment
+    asserts:
+      - isKind:
+          of: Deployment
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-kopiur-controller
+
+  - it: renders the controller image from the chart appVersion
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: ^ghcr\.io/home-operations/kopiur-controller:.+
+
+  - it: pins the controller image by digest when set, overriding the tag
+    set:
+      image.controller.digest: sha256:abc123
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: ghcr.io/home-operations/kopiur-controller@sha256:abc123
+
+  - it: stamps the digest-pinned mover image into the controller env
+    set:
+      image.mover.digest: sha256:def456
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KOPIUR_MOVER_IMAGE
+            value: ghcr.io/home-operations/kopiur-mover@sha256:def456
+
+  - it: sets replicas from controller.replicaCount
+    set:
+      controller.replicaCount: 3
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+
+  - it: runs non-root with a read-only root filesystem
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+
+  - it: defaults to namespaced scope (mover RoleKind = Role)
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KOPIUR_MOVER_ROLE_KIND
+            value: Role
+
+  - it: passes cluster-scope args when installScope is cluster
+    set:
+      installScope: cluster
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --cluster-scope
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KOPIUR_MOVER_ROLE_KIND
+            value: ClusterRole

--- a/deploy/helm/kopiur/tests/metrics-service_test.yaml
+++ b/deploy/helm/kopiur/tests/metrics-service_test.yaml
@@ -1,0 +1,18 @@
+suite: metrics-service
+templates:
+  - metrics-service.yaml
+tests:
+  - it: renders the controller metrics Service by default
+    asserts:
+      - isKind:
+          of: Service
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-kopiur-controller-metrics
+
+  - it: omits the Service when metrics.enabled is false
+    set:
+      metrics.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/kopiur/tests/rbac_test.yaml
+++ b/deploy/helm/kopiur/tests/rbac_test.yaml
@@ -1,0 +1,32 @@
+suite: rbac
+templates:
+  - role.yaml
+  - clusterrole.yaml
+tests:
+  - it: namespaced scope renders a Role and no ClusterRole
+    set:
+      installScope: namespaced
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: role.yaml
+      - isKind:
+          of: Role
+        template: role.yaml
+      - hasDocuments:
+          count: 0
+        template: clusterrole.yaml
+
+  - it: cluster scope renders a ClusterRole and no Role
+    set:
+      installScope: cluster
+    asserts:
+      - hasDocuments:
+          count: 1
+        template: clusterrole.yaml
+      - isKind:
+          of: ClusterRole
+        template: clusterrole.yaml
+      - hasDocuments:
+          count: 0
+        template: role.yaml

--- a/deploy/helm/kopiur/tests/serviceaccount_test.yaml
+++ b/deploy/helm/kopiur/tests/serviceaccount_test.yaml
@@ -1,0 +1,15 @@
+suite: serviceaccount
+templates:
+  - serviceaccount.yaml
+tests:
+  - it: creates a ServiceAccount by default
+    asserts:
+      - isKind:
+          of: ServiceAccount
+
+  - it: omits the ServiceAccount when serviceAccount.create is false
+    set:
+      serviceAccount.create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/helm/kopiur/tests/webhook_test.yaml
+++ b/deploy/helm/kopiur/tests/webhook_test.yaml
@@ -1,0 +1,17 @@
+suite: webhook
+templates:
+  - webhook-deployment.yaml
+tests:
+  - it: renders the webhook Deployment by default
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+
+  - it: omits the webhook Deployment when webhook.enabled is false
+    set:
+      webhook.enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0


### PR DESCRIPTION
Brings kopiur's chart testing in line with the other charts: **helm-unittest in, kubeconform out**.

## Added — helm-unittest suites (`deploy/helm/kopiur/tests/`, 6 suites / 18 tests)

- **deployment** — controller image renders from appVersion; digest pin overrides the tag; the digest-pinned mover image is stamped into `KOPIUR_MOVER_IMAGE`; replicas; non-root + read-only rootfs; namespaced vs `--cluster-scope` args and `KOPIUR_MOVER_ROLE_KIND`.
- **rbac** — `installScope` switches a `Role` (namespaced) vs a `ClusterRole` (cluster), each excluding the other.
- **webhook / crds / metrics-service / serviceaccount** — the `webhook.enabled` / `installCRDs` / `metrics.enabled` / `serviceAccount.create` toggles.

Run in the **Helm Lint** job via `mise run helm-test`, with the plugin version in a Renovate-annotated `HELM_UNITTEST_VERSION` env (the manager lands via renovate-config#10).

## Dropped — kubeconform

`helm-lint` now just lints the chart and checks both install scopes render (`helm template … >/dev/null`); kubeconform is removed from the task and the mise toolchain. Rendered-template correctness is covered by the unit suites, and real-cluster validity by the kind e2e.

## Verified

- `helm unittest` 6/6 suites, 18/18 tests; `helm lint` clean; both scopes render.

> Note: kopiur `main` is currently red on Coverage / E2E / Integration (unrelated to this change — those jobs fail on `main` too). The relevant **Helm Lint** check passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
