### PR TITLE
ci: sign the published Helm chart with Cosign

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -156,6 +156,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write # keyless Cosign signing of the published chart
       packages: write
     env:
       VERSION: ${{ github.event.release.tag_name }}
@@ -199,7 +200,6 @@ jobs:
 
       - name: Package Helm chart
         run: |
-          VERSION="${VERSION#v}"
           helm package deploy/helm/kopiur \
             --version "${VERSION}" \
             --app-version "${VERSION}"
@@ -213,5 +213,8 @@ jobs:
 
       - name: Publish Helm chart to GHCR
         run: |-
-          VERSION="${VERSION#v}"
           helm push "kopiur-${VERSION}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/charts"
+
+      - name: Sign the published chart with Cosign
+        run: |-
+          cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/kopiur:${VERSION}"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -20,6 +20,7 @@ lefthook = "2.1.9"
 oxfmt = "0.53.0"
 zizmor = "1.25.2"
 helm = "4.2.0"
+cosign = "3.0.6"
 kubectl = "1.36.1"
 # The shared pre-commit hooks (home-operations/.github lefthook config) run
 # `shellcheck` on staged *.sh files; pin it so the hook resolves a binary.

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -135,6 +135,45 @@ url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.8.7/cargo-
 checksum = "sha256:56bce7aef6bf906af0fe025d2459f8be483d65ed4c105760671f9c92449c966d"
 url = "https://github.com/taiki-e/cargo-llvm-cov/releases/download/v0.8.7/cargo-llvm-cov-x86_64-pc-windows-msvc.tar.gz"
 
+[[tools.cosign]]
+version = "3.0.6"
+backend = "aqua:sigstore/cosign"
+
+[tools.cosign."platforms.linux-arm64"]
+checksum = "sha256:bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-arm64-musl"]
+checksum = "sha256:bedac92e8c3729864e13d4a17048007cfafa79d5deca993a43a90ffe018ef2b8"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64"]
+checksum = "sha256:c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.linux-x64-musl"]
+checksum = "sha256:c956e5dfcac53d52bcf058360d579472f0c1d2d9b69f55209e256fe7783f4c74"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-linux-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-arm64"]
+checksum = "sha256:5fadd012ae6381a6a29ff86a7d39aa873878852f1073fc90b15995961ecfb084"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-arm64"
+provenance = "cosign"
+
+[tools.cosign."platforms.macos-x64"]
+checksum = "sha256:4c3e7af8372d3ca3296e62fa56f23fcbb5721cc6ac1827900d398f110d7cd280"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-darwin-amd64"
+provenance = "cosign"
+
+[tools.cosign."platforms.windows-x64"]
+checksum = "sha256:9b85a88ebff2d9dd30ff4984a6f61f2cedc232dd87d81fa7f2ff3c0ed96c241c"
+url = "https://github.com/sigstore/cosign/releases/download/v3.0.6/cosign-windows-amd64.exe"
+provenance = "cosign"
+
 [[tools.helm]]
 version = "4.2.0"
 backend = "aqua:helm/helm"


### PR DESCRIPTION
Cosign-sign the chart OCI artifact after it's pushed to GHCR, matching how [`charts-mirror`](https://github.com/home-operations/charts-mirror) already signs its published charts.

### What
- Add `cosign` (3.0.6, same pin as charts-mirror) as a mise tool — pinned + locked like the rest of the toolchain.
- Grant the `helm` job `id-token: write` so cosign can keyless-sign via OIDC/Fulcio.
- After `helm push`, run `cosign sign --yes ghcr.io/<owner>/charts/kopiur:${VERSION}`.
- Drop the redundant `${VERSION#v}` strips from the package/push steps — release-please pins `include-v-in-tag: false`, so tags never carry a `v` (e.g. `0.1.14`) and the strip was a no-op. Tag handling now matches kromgo/tuppr/konflate.

### Why
The container image is already signed (`sign: true` via `docker/github-builder`), but the **chart** OCI artifact was unsigned. This closes that gap so consumers can `cosign verify` the chart the same way they can the image.

### Verify (after the next release)
```sh
cosign verify ghcr.io/home-operations/charts/kopiur:<version> \
  --certificate-identity-regexp '^https://github.com/home-operations/kopiur/' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com
```

zizmor clean; `mise lock` generated the cosign entry for all 7 platforms.

> kopiur builds three images (controller/webhook/mover) but publishes a single chart — this signs that chart.
