### PR TITLE
ci: path-filter triggers, add concurrency

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,9 +15,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   schedule:
     # 07:00 UTC nightly.
     - cron: "0 7 * * *"

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -8,6 +8,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release-please:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,9 +6,15 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   release:
     types:
       - published
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'release' }}
 
 jobs:
   versions:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "**.md"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Applies the language-agnostic parts of home-operations/kromgo#239 to kopiur (Rust). The golangci-lint-cache part has no analog to add — kopiur already runs `Swatinem/rust-cache` on every CI workflow.

### What
- **paths-ignore `"**.md"`** on `coverage`, `e2e`, `lint`, `tests` (push + PR) and the **push** trigger of `release.yaml`. Docs-only changes no longer run the Rust suites, the kind-based e2e, or — post-merge — the **three-image** rolling rebuild.
- **Concurrency** on `release.yaml` (`cancel-in-progress: ${{ github.event_name != 'release' }}` — cancel superseded `main` builds, never interrupt a published release) and `release-please.yaml` (`cancel-in-progress: false`).

### Bigger win than the single-image Go apps
`release.yaml` builds **three** images (controller/webhook/mover), so concurrency prevents duplicate *triple*-builds on rapid `main` merges, and the release path-filter skips a triple-rebuild on docs-only pushes.

### Deliberately untouched
- **`docs.yaml`** — it builds the MkDocs + rustdoc site *from* markdown, so it must run on `**.md` changes; `paths-ignore` there would be backwards. Its `concurrency: { group: pages }` is intentional Pages-deploy serialization.
- No `golangci-lint` cache (Rust) — `Swatinem/rust-cache` already covers build caching on all CI workflows.

zizmor clean on all six changed workflows. Safe because kopiur has no required status checks.
