### PR TITLE
ci: emit OCI image labels and annotations via the builder

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,6 +77,8 @@ jobs:
       platforms: linux/amd64,linux/arm64
       push: true
       sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
       sign: true
     secrets:
       registry-auths: |
@@ -112,6 +114,8 @@ jobs:
       platforms: linux/amd64,linux/arm64
       push: true
       sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
       sign: true
     secrets:
       registry-auths: |
@@ -146,6 +150,8 @@ jobs:
       platforms: linux/amd64,linux/arm64
       push: true
       sbom: true
+      set-meta-annotations: true
+      set-meta-labels: true
       sign: true
     secrets:
       registry-auths: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,7 +52,6 @@ RUN set -eux; \
 
 # Distroless runtime: glibc + CA certs, non-root (uid 65532), no shell.
 FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
-LABEL org.opencontainers.image.source="https://github.com/home-operations/kopiur"
 COPY --from=builder /usr/local/bin/app /usr/local/bin/app
 COPY --from=kopia /usr/local/bin/kopia /usr/local/bin/kopia
 USER 65532:65532

--- a/docker/Dockerfile.mover
+++ b/docker/Dockerfile.mover
@@ -60,7 +60,6 @@ RUN set -eux; \
     install -m 0755 /tmp/rclone /usr/local/bin/rclone
 
 FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
-LABEL org.opencontainers.image.source="https://github.com/home-operations/kopiur"
 COPY --from=builder /usr/local/bin/kopiur-mover /usr/local/bin/kopiur-mover
 COPY --from=kopia /usr/local/bin/kopia /usr/local/bin/kopia
 COPY --from=rclone /usr/local/bin/rclone /usr/local/bin/rclone


### PR DESCRIPTION
Moves OCI image metadata to the builder so Renovate can resolve `org.opencontainers.image.source` and surface this image's changelog/release notes on dependency PRs.

`docker/github-builder` already runs `docker/metadata-action` (we pass `meta-images`/`meta-tags`) — it just wasn't applying the generated metadata. This flips on the two builder toggles:

- `set-meta-labels: true` — appends metadata-action's OCI **labels**, including `org.opencontainers.image.source` (the repo URL Renovate reads), plus `revision`, `created`, `title`, `version`, …
- `set-meta-annotations: true` — appends the matching OCI manifest **annotations** (best practice for multi-arch images).

…and **removes the now-redundant `LABEL org.opencontainers.image.*`** from the Dockerfile — the builder provides the same values (derived from git context), so there's no longer a hardcoded copy to drift.

Takes effect on the next release build. No app/runtime change.
