### PR TITLE
build: drop redundant USER directive (distroless nonroot defaults to 65532)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,5 +54,4 @@ RUN set -eux; \
 FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 COPY --from=builder /usr/local/bin/app /usr/local/bin/app
 COPY --from=kopia /usr/local/bin/kopia /usr/local/bin/kopia
-USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/app"]

--- a/docker/Dockerfile.mover
+++ b/docker/Dockerfile.mover
@@ -63,5 +63,4 @@ FROM gcr.io/distroless/cc-debian13:nonroot AS runtime
 COPY --from=builder /usr/local/bin/kopiur-mover /usr/local/bin/kopiur-mover
 COPY --from=kopia /usr/local/bin/kopia /usr/local/bin/kopia
 COPY --from=rclone /usr/local/bin/rclone /usr/local/bin/rclone
-USER 65532:65532
 ENTRYPOINT ["/usr/local/bin/kopiur-mover"]


### PR DESCRIPTION
kopiur keeps its existing base images (`gcr.io/distroless/cc-debian13:nonroot` — glibc, unchanged). This only **drops the redundant `USER 65532:65532`** from both Dockerfiles: the `:nonroot` distroless tag already runs as uid/gid 65532 by default, so the explicit directive is a no-op. No base, chart, or runtime change.
