### PR TITLE
fix(restore): complete the populator rebind when the mover stamps Completed early

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -131,10 +131,13 @@ jobs:
             backends: true
           # ADR-0004/0005 reshape scenarios (Filesystem only). Split in two so the
           # cron-driven verify/replication waits don't push one shard past the job
-          # timeout.
+          # timeout. `csi: true` installs the CSI snapshot stack (csi-hostpath-sc) so
+          # the populator-restore handshake (repository_lifecycle) and copyMethod
+          # Snapshot/Clone (copy_methods) tests run for real instead of self-skipping.
           - shard: reshape-core
-            bins: "mover_config data_integrity repository_lifecycle tenancy"
+            bins: "mover_config data_integrity repository_lifecycle tenancy copy_methods"
             backends: false
+            csi: true
           # Hooks (ADR §4.8) + GFS time-bucketed retention + policy knobs. The
           # httpRequest hook reuses the WebDAV fixture as its receiver, so this
           # shard preloads the backend images.
@@ -191,6 +194,15 @@ jobs:
       - name: Seed node fixtures
         run: mise run //crates/e2e:node-seed
 
+      # CSI snapshot stack (vendored, hermetic): csi-hostpath-sc + a default
+      # VolumeSnapshotClass. Required by the populator-restore handshake and the
+      # copyMethod Snapshot/Clone tests; those tests SKIP without it, so a shard that
+      # runs them must opt in via `csi: true`. Installed before the chart, matching
+      # scripts/with-kind.sh's ordering.
+      - name: Install CSI snapshot stack
+        if: matrix.csi
+        run: mise run //crates/e2e:snapshot-stack
+
       - name: Install chart
         run: mise run //crates/e2e:helm
 
@@ -198,6 +210,11 @@ jobs:
         env:
           KOPIUR_E2E_BINS: ${{ matrix.bins }}
           KOPIUR_E2E_SKIP_BUILD: "1"
+          # On a `csi: true` shard the stack is installed above, so a missing
+          # csi-hostpath-sc is a setup failure — make the CSI-dependent tests
+          # HARD-FAIL instead of silently skipping (which once let a populator
+          # regression ship green; see #121).
+          KOPIUR_E2E_REQUIRE_CSI: ${{ matrix.csi && '1' || '' }}
         run: mise run //crates/e2e:run
 
       # Dump cluster state for this shard before teardown so a failure is

--- a/crates/controller/src/restore.rs
+++ b/crates/controller/src/restore.rs
@@ -100,6 +100,19 @@ pub fn populator_state(target: &RestoreTarget) -> PopulatorState {
     }
 }
 
+/// Whether `phase` lets the reconcile-entry guard short-circuit. `Failed` always does.
+/// `Completed` does for a DIRECT restore (the mover wrote the target PVC itself), but
+/// NOT for a populator: there the mover stamps `Completed` on finishing the PRIME PVC
+/// while the prime→consumer rebind is still pending, so it must fall through to
+/// [`drive_populator_restore`]. Pure.
+fn phase_is_terminal_at_guard(phase: RestorePhase, state: PopulatorState) -> bool {
+    match phase {
+        RestorePhase::Failed => true,
+        RestorePhase::Completed => state == PopulatorState::DirectTarget,
+        RestorePhase::Pending | RestorePhase::Resolving | RestorePhase::Restoring => false,
+    }
+}
+
 /// Map a `Restore` phase to its kstatus [`io::ReadyOutcome`] (ADR-0005 §2), so
 /// `kubectl wait --for=condition=Ready` and Flux/Argo health checks work on a
 /// `Restore` exactly like every other kopiur CRD. Pure + exhaustive: a new phase
@@ -246,13 +259,16 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     let name = restore.name_any();
     let api: Api<Restore> = Api::namespaced(ctx.client.clone(), &namespace);
 
+    let state = populator_state(&restore.spec.target);
+
     // Already terminal: a Restore is one-shot. Once Completed/Failed there is
     // nothing left to do until the spec changes, so don't re-resolve, re-pin a
     // fresh timestamp, or re-write the phase — each of which would churn status and
     // self-trigger another reconcile (the same hot-loop class as the repo bug).
-    // Mirrors the Snapshot reconciler's terminal discipline.
+    // Mirrors the Snapshot reconciler's terminal discipline. (A `Completed` populator
+    // is NOT terminal here — see `phase_is_terminal_at_guard`.)
     match restore.status.as_ref().and_then(|s| s.phase) {
-        Some(phase @ (RestorePhase::Completed | RestorePhase::Failed)) => {
+        Some(phase) if phase_is_terminal_at_guard(phase, state) => {
             // The kstatus conditions come from the controller's transition patch
             // in `drive_direct_restore` — which the MOVER's own terminal `phase`
             // stamp races past in the common case (its in-cluster PATCH carries
@@ -288,7 +304,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
             }
             return Ok(Action::requeue(std::time::Duration::from_secs(600)));
         }
-        None | Some(RestorePhase::Pending | RestorePhase::Resolving | RestorePhase::Restoring) => {}
+        _ => {}
     }
 
     // §3: pin the resolved source kind to status so the SOURCE printer column shows
@@ -309,7 +325,6 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
         .await?;
     }
 
-    let state = populator_state(&restore.spec.target);
     let on_missing = effective_on_missing(
         restore
             .spec
@@ -549,9 +564,12 @@ async fn drive_populator_restore(
     let populate_job = format!("{name}-populate");
 
     let phase = restore.status.as_ref().and_then(|s| s.phase);
-    // Terminal — and `finalize_populator` strips the rebind annotation, so the
-    // `our_rebound_pv` probe below would no longer recognize our PV. Short-circuit.
-    if phase == Some(RestorePhase::Completed) {
+    // Terminal only once the consumer is bound: the mover stamps `Completed` on finishing
+    // the prime PVC, but the rebind may still be pending. Once bound, `finalize_populator`
+    // has stripped the rebind annotation so the `our_rebound_pv` probe below would no
+    // longer recognize our PV — short-circuit to avoid recreating the prime. While
+    // `Completed` but not yet bound, fall through to issue/await the rebind.
+    if phase == Some(RestorePhase::Completed) && pvc_is_bound(&consumer) {
         return Ok(Action::requeue(std::time::Duration::from_secs(600)));
     }
 
@@ -2026,6 +2044,26 @@ mod tests {
             })),
             PopulatorState::DirectTarget
         );
+    }
+
+    #[test]
+    fn populator_completed_is_not_terminal_at_guard() {
+        use PopulatorState::{AwaitingClaim, DirectTarget};
+        use RestorePhase::{Completed, Failed, Pending, Resolving, Restoring};
+
+        // A populator `Completed` (mover done with the prime PVC, rebind still pending)
+        // must NOT be terminal at the guard, or the rebind never runs.
+        assert!(!phase_is_terminal_at_guard(Completed, AwaitingClaim));
+        // A direct restore writes the target itself, so `Completed` IS terminal.
+        assert!(phase_is_terminal_at_guard(Completed, DirectTarget));
+        // `Failed` is terminal regardless of dispatch model.
+        assert!(phase_is_terminal_at_guard(Failed, AwaitingClaim));
+        assert!(phase_is_terminal_at_guard(Failed, DirectTarget));
+        // In-flight phases are never terminal.
+        for p in [Pending, Resolving, Restoring] {
+            assert!(!phase_is_terminal_at_guard(p, AwaitingClaim));
+            assert!(!phase_is_terminal_at_guard(p, DirectTarget));
+        }
     }
 
     // --- kstatus Ready conditions (ADR-0005 §2) -----------------------------

--- a/crates/e2e/manifests/csi-snapshot/32-hostpath-storageclass-wffc.yaml
+++ b/crates/e2e/manifests/csi-snapshot/32-hostpath-storageclass-wffc.yaml
@@ -1,0 +1,13 @@
+# A WaitForFirstConsumer variant of csi-hostpath-sc, over the SAME hostpath provisioner.
+# Late binding defers provisioning until a pod schedules the claim (the scheduler then
+# stamps `volume.kubernetes.io/selected-node`), which exercises the populator handshake's
+# selected-node path (prime-PVC node pinning) — see the WFFC populator e2e in
+# crates/e2e/tests/repository_lifecycle.rs.
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: csi-hostpath-sc-wffc
+provisioner: hostpath.csi.k8s.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -183,7 +183,7 @@ kubectl annotate volumesnapshotclass csi-hostpath-snapclass \\
 echo "==> waiting for snapshot-controller + csi-hostpathplugin"
 kubectl -n kube-system rollout status deploy/snapshot-controller --timeout=150s
 kubectl -n default     rollout status statefulset/csi-hostpathplugin --timeout=180s
-echo "==> CSI snapshot stack ready (storageclass csi-hostpath-sc, snapclass csi-hostpath-snapclass)"
+echo "==> CSI snapshot stack ready (storageclasses csi-hostpath-sc + csi-hostpath-sc-wffc, snapclass csi-hostpath-snapclass)"
 """
 
 [tasks.helm]

--- a/crates/e2e/tests/repository_lifecycle.rs
+++ b/crates/e2e/tests/repository_lifecycle.rs
@@ -24,7 +24,13 @@ use kopiur_e2e::{
 
 /// CSI hostpath StorageClass installed by the `snapshot-stack` harness step — a
 /// populator-aware provisioner (its external-provisioner defers to `dataSourceRef`).
+/// `Immediate` binding (provisions the prime PVC as soon as it's created).
 const CSI_STORAGE_CLASS: &str = "csi-hostpath-sc";
+/// The `WaitForFirstConsumer` variant over the same hostpath provisioner (also installed
+/// by `snapshot-stack`). Exercises the populator handshake's late-binding path: the claim
+/// only gets a `selected-node` once a pod schedules it, which the controller pins the
+/// prime PVC to. See [`restore_populator_wffc_binds_pvc_and_restores_data`].
+const CSI_STORAGE_CLASS_WFFC: &str = "csi-hostpath-sc-wffc";
 
 /// `Restore.spec.target.populator: {}` (ADR-0005 §9): the explicit passive-populator
 /// target form is accepted and threads through to a restore mover Job. (The empty
@@ -77,49 +83,53 @@ async fn restore_populator_target_form_is_accepted() {
     let _ = restores.delete(name, &DeleteParams::default()).await;
 }
 
-/// ADR-0005 §9 end-to-end: a PVC whose `dataSourceRef` claims a populator `Restore`
-/// is filled via the prime-PVC/rebind handshake and binds carrying the snapshot's
-/// data (the seed source's `a.txt`).
-#[tokio::test]
-#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
-async fn restore_populator_binds_pvc_and_restores_data() {
-    let Some(world) = World::connect().await else {
-        return;
-    };
-    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
-    let client = world.client().clone();
-
-    // The populator handshake needs a populator-aware CSI provisioner: its
-    // external-provisioner defers when the claim has a populator `dataSourceRef`, so the
-    // claim only ever binds to the PV our handshake hands it. The harness installs one as
-    // `csi-hostpath-sc` (snapshot-stack step); the default local-path does NOT defer and
-    // would bind the claim to an empty volume. Skip where CSI isn't present (a shard that
-    // doesn't install the snapshot stack), like the CSI copy-method tests.
+/// Whether `storage_class` is present (proceed with the test). If it's absent we either
+/// HARD-FAIL or skip: a `csi: true` CI shard installs the snapshot stack and sets
+/// `KOPIUR_E2E_REQUIRE_CSI=1`, so there an absent class is a real setup failure and must
+/// NOT silently pass — a silent skip once let a populator regression ship green (#121).
+/// Without that env (local dev with no snapshot stack) we skip gracefully.
+async fn csi_class_present_or_skip(client: &kube::Client, storage_class: &str) -> bool {
     let scs: Api<StorageClass> = Api::all(client.clone());
     if scs
-        .get_opt(CSI_STORAGE_CLASS)
+        .get_opt(storage_class)
         .await
         .expect("list storageclasses")
-        .is_none()
+        .is_some()
     {
-        eprintln!(
-            "skipping {CSI_STORAGE_CLASS} populator test: storageclass absent \
-             (run `mise run //crates/e2e:snapshot-stack`)"
-        );
-        return;
+        return true;
     }
+    let require = std::env::var("KOPIUR_E2E_REQUIRE_CSI").is_ok_and(|v| v == "1");
+    assert!(
+        !require,
+        "storageclass {storage_class} absent but KOPIUR_E2E_REQUIRE_CSI=1 — this shard must \
+         install the CSI snapshot stack (mise run //crates/e2e:snapshot-stack) before the \
+         populator/copyMethod tests; refusing to silently skip (cf. #121)"
+    );
+    eprintln!(
+        "skipping populator test: storageclass {storage_class} absent \
+         (run `mise run //crates/e2e:snapshot-stack`)"
+    );
+    false
+}
 
-    ensure_seed(
-        &client,
-        "e2e-pop2-repo",
-        "e2e-pop2-policy",
-        "e2e-pop2-seed",
-        "populator2",
-    )
-    .await;
-
+/// Shared body for the populator data-integrity tests (ADR-0005 §9): given an
+/// already-seeded `repo`/`seed`, create a populator `Restore`, a claiming PVC whose
+/// `dataSourceRef` points at it on `storage_class`, and a reader pod that asserts the
+/// seed source's `a.txt`. The pod schedules the claim (also producing the `selected-node`
+/// a `WaitForFirstConsumer` class needs) and can only run once the claim BINDS, so its
+/// success proves BOTH the prime→consumer rebind and the restored bytes. Then assert the
+/// `Restore` settles `Completed` — the regression guard for the #121 wedge, where the
+/// mover stamped `Completed` before the rebind, leaving the claim `Pending` forever.
+/// `prefix` namespaces the per-test object names so the binding-mode variants don't clash.
+async fn assert_populator_binds_and_restores(
+    client: &kube::Client,
+    storage_class: &str,
+    repo: &str,
+    seed: &str,
+    prefix: &str,
+) {
     let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let restore_name = "e2e-pop2-restore";
+    let restore_name = format!("{prefix}-restore");
     restores
         .create(
             &PostParams::default(),
@@ -128,8 +138,8 @@ async fn restore_populator_binds_pvc_and_restores_data() {
                 "kind": "Restore",
                 "metadata": { "name": restore_name, "namespace": E2E_NAMESPACE },
                 "spec": {
-                    "repository": { "kind": "Repository", "name": "e2e-pop2-repo" },
-                    "source": { "snapshotRef": { "name": "e2e-pop2-seed" } },
+                    "repository": { "kind": "Repository", "name": repo },
+                    "source": { "snapshotRef": { "name": seed } },
                     "target": { "populator": {} }
                 }
             })),
@@ -137,10 +147,10 @@ async fn restore_populator_binds_pvc_and_restores_data() {
         .await
         .expect("create populator Restore");
 
-    // The claiming PVC: its dataSourceRef points at the Restore, so a provisioner
-    // defers to the populator handshake instead of binding it directly.
+    // The claiming PVC: its dataSourceRef points at the Restore, so a populator-aware
+    // provisioner defers to the handshake instead of binding it to an empty volume.
     let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let claim = "e2e-pop2-data";
+    let claim = format!("{prefix}-data");
     pvcs.create(
         &PostParams::default(),
         &cr(serde_json::json!({
@@ -149,7 +159,7 @@ async fn restore_populator_binds_pvc_and_restores_data() {
             "metadata": { "name": claim, "namespace": E2E_NAMESPACE },
             "spec": {
                 "accessModes": ["ReadWriteOnce"],
-                "storageClassName": CSI_STORAGE_CLASS,
+                "storageClassName": storage_class,
                 "resources": { "requests": { "storage": "1Gi" } },
                 "dataSourceRef": {
                     "apiGroup": "kopiur.home-operations.com",
@@ -162,40 +172,116 @@ async fn restore_populator_binds_pvc_and_restores_data() {
     .await
     .expect("create claiming PVC");
 
-    // One pod does double duty: scheduling it unblocks WaitForFirstConsumer (so the
-    // prime PVC provisions on the chosen node), and it asserts the restored bytes —
-    // `a.txt` is "hello kopiur e2e" in the seed source. It can only run once the claim
-    // binds, so its success proves both the bind and the data.
+    // One pod does double duty: scheduling it produces the `selected-node` a
+    // WaitForFirstConsumer claim needs (the controller pins the prime PVC to it), and it
+    // asserts the restored bytes — `a.txt` is "hello kopiur e2e" in the seed source. It
+    // can only run once the claim binds, so its success proves both the bind and the data.
     let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let reader = "e2e-pop2-reader";
+    let reader = format!("{prefix}-reader");
     pods.create(
         &PostParams::default(),
         &builders::one_shot_pod(
             E2E_NAMESPACE,
-            reader,
+            &reader,
             &[
                 "sh",
                 "-c",
                 "test \"$(cat /mnt/a.txt)\" = 'hello kopiur e2e'",
             ],
-            &[(claim, "/mnt")],
+            &[(claim.as_str(), "/mnt")],
         ),
     )
     .await
     .expect("create reader pod");
 
-    wait::pod_succeeded(&client, E2E_NAMESPACE, reader)
+    wait::pod_succeeded(client, E2E_NAMESPACE, &reader)
         .await
         .expect("the claiming PVC binds and a.txt is restored into it");
-    wait_phase(&restores, restore_name, "Completed")
+    wait_phase(&restores, &restore_name, "Completed")
         .await
         .expect("the populator Restore reaches Completed once the claim is bound");
 
-    let _ = pods.delete(reader, &DeleteParams::default()).await;
-    let _ = pvcs.delete(claim, &DeleteParams::default()).await;
+    let _ = pods.delete(&reader, &DeleteParams::default()).await;
+    let _ = pvcs.delete(&claim, &DeleteParams::default()).await;
     let _ = restores
-        .delete(restore_name, &DeleteParams::default())
+        .delete(&restore_name, &DeleteParams::default())
         .await;
+}
+
+/// ADR-0005 §9 end-to-end (Immediate binding): a PVC whose `dataSourceRef` claims a
+/// populator `Restore` is filled via the prime-PVC/rebind handshake and binds carrying
+/// the snapshot's data (the seed source's `a.txt`).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn restore_populator_binds_pvc_and_restores_data() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    // Needs a populator-aware CSI provisioner whose external-provisioner defers to a
+    // populator `dataSourceRef` (the default local-path would bind the claim to an empty
+    // volume). The harness installs `csi-hostpath-sc` via the snapshot-stack step.
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS).await {
+        return;
+    }
+
+    ensure_seed(
+        &client,
+        "e2e-pop2-repo",
+        "e2e-pop2-policy",
+        "e2e-pop2-seed",
+        "populator2",
+    )
+    .await;
+
+    assert_populator_binds_and_restores(
+        &client,
+        CSI_STORAGE_CLASS,
+        "e2e-pop2-repo",
+        "e2e-pop2-seed",
+        "e2e-pop2",
+    )
+    .await;
+}
+
+/// ADR-0005 §9 end-to-end (WaitForFirstConsumer binding): the late-binding path of the
+/// populator handshake. The claim only gets a `selected-node` once the reader pod
+/// schedules it; the controller then pins the prime PVC to that node (the
+/// `consumer_storage_class_is_wffc` / `AwaitingPodSchedule` path in restore.rs) before
+/// restoring + rebinding. Reuses the `populator2` seed (restores are read-only and the
+/// tests run sequentially), with its own object names + the WFFC StorageClass.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn restore_populator_wffc_binds_pvc_and_restores_data() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS_WFFC).await {
+        return;
+    }
+
+    ensure_seed(
+        &client,
+        "e2e-pop2-repo",
+        "e2e-pop2-policy",
+        "e2e-pop2-seed",
+        "populator2",
+    )
+    .await;
+
+    assert_populator_binds_and_restores(
+        &client,
+        CSI_STORAGE_CLASS_WFFC,
+        "e2e-pop2-repo",
+        "e2e-pop2-seed",
+        "e2e-pop3",
+    )
+    .await;
 }
 
 /// `mode: ReadOnly` (ADR-0005 §11): a ReadOnly repository serves restores but the


### PR DESCRIPTION
## Problem

A `target.populator` restore (#117) wedges: data is restored into the prime PVC, but the prime→consumer rebind never runs, so the claiming PVC stays `Pending` forever and the workload never starts.

The restore **mover** stamps `phase: Completed` on the `Restore` as soon as it finishes writing data. That is correct for a **direct** restore (the mover writes the target PVC itself), but in the **populator** path the mover writes the **prime** PVC and the prime→consumer rebind must still happen afterward. Two short-circuits then treat that premature `Completed` as terminal:

1. `reconcile_inner`'s terminal guard returns early for any `Completed`/`Failed` — before populator routing — so `drive_populator_restore` is never reached.
2. `drive_populator_restore` itself short-circuits on `Completed`.

Result: `Restore` is `Completed` with `target.pvcPrime: awaiting-claim`, a `prime-<uid>` PVC/PV still bound with no rebind annotation, and the consumer PVC `Pending`.

Observed in the wild (a `qui` restore): mover Job `Complete`, snapshot written into the prime PV, consumer PVC `Pending` for hours.

## Fix

A populator restore is terminal only once the **consumer PVC is bound** — not when the mover stamps `Completed`.

- New pure helper `phase_is_terminal_at_guard(phase, state)`: `Failed` is always terminal; `Completed` is terminal only for a **direct** restore. A `Completed` populator falls through the reconcile-entry guard into `drive_populator_restore`.
- `drive_populator_restore` short-circuits on `Completed` only when `pvc_is_bound(&consumer)` (truly finalized — the rebind annotation has been stripped, so `our_rebound_pv` would no longer match). While `Completed` but not yet bound, it falls through to issue/await the rebind.

Once the rebind is issued and the consumer binds, `finalize_populator` runs as before and the `Restore` settles `Completed`.

## Tests

- Added `populator_completed_is_not_terminal_at_guard`.
- `cargo test -p kopiur-controller`: 284 passed; clippy + fmt clean (rust 1.95).

## Note

Unit-tested but not yet validated against a live `kind` populator restore — worth an e2e pass (cf. the form-only e2e shard noted in #113) before release.