### PR TITLE
fix(docker): tolerate a v-prefixed KOPIA_VERSION so image builds don't 404

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -39,6 +39,10 @@ ARG KOPIA_VERSION
 ARG TARGETARCH
 RUN set -eux; \
     test -n "${KOPIA_VERSION}" || { echo "KOPIA_VERSION build arg is required" >&2; exit 1; }; \
+    # Normalize the pin: mise/renovate may carry a leading "v" (e.g. "v0.23.1"), \
+    # but the release tag is "v<ver>" and the asset is "kopia-<ver>-...". Strip any \
+    # leading "v" so both "0.23.1" and "v0.23.1" resolve to the same real URL. \
+    KVER="${KOPIA_VERSION#v}"; \
     apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \
     case "${TARGETARCH}" in \
       amd64) KARCH=x64 ;; \
@@ -46,9 +50,9 @@ RUN set -eux; \
       *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/kopia.tar.gz \
-      "https://github.com/kopia/kopia/releases/download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-${KARCH}.tar.gz"; \
+      "https://github.com/kopia/kopia/releases/download/v${KVER}/kopia-${KVER}-linux-${KARCH}.tar.gz"; \
     tar -xzf /tmp/kopia.tar.gz -C /tmp; \
-    install -m 0755 "/tmp/kopia-${KOPIA_VERSION}-linux-${KARCH}/kopia" /usr/local/bin/kopia
+    install -m 0755 "/tmp/kopia-${KVER}-linux-${KARCH}/kopia" /usr/local/bin/kopia
 
 # Distroless runtime: glibc + CA certs, non-root (uid 65532), no shell.
 FROM gcr.io/distroless/cc-debian13:nonroot AS runtime

--- a/docker/Dockerfile.mover
+++ b/docker/Dockerfile.mover
@@ -30,6 +30,10 @@ ARG KOPIA_VERSION
 ARG TARGETARCH
 RUN set -eux; \
     test -n "${KOPIA_VERSION}" || { echo "KOPIA_VERSION build arg is required" >&2; exit 1; }; \
+    # Normalize the pin: mise/renovate may carry a leading "v" (e.g. "v0.23.1"), \
+    # but the release tag is "v<ver>" and the asset is "kopia-<ver>-...". Strip any \
+    # leading "v" so both "0.23.1" and "v0.23.1" resolve to the same real URL. \
+    KVER="${KOPIA_VERSION#v}"; \
     apt-get update && apt-get install -y --no-install-recommends curl ca-certificates; \
     case "${TARGETARCH}" in \
       amd64) KARCH=x64 ;; \
@@ -37,9 +41,9 @@ RUN set -eux; \
       *) echo "unsupported arch ${TARGETARCH}" >&2; exit 1 ;; \
     esac; \
     curl -fsSL -o /tmp/kopia.tar.gz \
-      "https://github.com/kopia/kopia/releases/download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-${KARCH}.tar.gz"; \
+      "https://github.com/kopia/kopia/releases/download/v${KVER}/kopia-${KVER}-linux-${KARCH}.tar.gz"; \
     tar -xzf /tmp/kopia.tar.gz -C /tmp; \
-    install -m 0755 "/tmp/kopia-${KOPIA_VERSION}-linux-${KARCH}/kopia" /usr/local/bin/kopia
+    install -m 0755 "/tmp/kopia-${KVER}-linux-${KARCH}/kopia" /usr/local/bin/kopia
 
 # Pull the official rclone release binary at a pinned version (the rclone backend
 # shells out to it). Distributed as a .zip, so this stage needs unzip.


### PR DESCRIPTION
## What broke

`main` is red. PR #120 bumped the mise kopia pin from `0.23.0` → **`v0.23.1`** (renovate's `github-releases` datasource carries the tag's leading `v`). Both Dockerfiles build the kopia download URL as:

```
.../download/v${KOPIA_VERSION}/kopia-${KOPIA_VERSION}-linux-${KARCH}.tar.gz
```

so a `v`-prefixed pin produced `vv0.23.1/kopia-v0.23.1-linux-x64.tar.gz` → **HTTP 404**. That failed:

- **E2E** — the `build` matrix (controller/webhook/mover) failed; the `test` shards `needs: build`, so they showed "skipping".
- **Release** — the multi-arch buildx legs 404'd (one leg's failure canceled the sibling arch → "context canceled").
- Locally, `mise run image-*` broke identically — they pass the same `mise config get tools.kopia` value. So this was **not** a CI-only discrepancy; the hermetic local gate (`mise run ci`) just never builds images, so it slipped through.

## Fix

Normalize the pin in both Dockerfiles by stripping a leading `v` and deriving the tag/asset/dir from the bare version:

```dockerfile
KVER="${KOPIA_VERSION#v}"
.../download/v${KVER}/kopia-${KVER}-linux-${KARCH}.tar.gz
```

Both `0.23.1` and `v0.23.1` now resolve to the real `v0.23.1/kopia-0.23.1-linux-x64.tar.gz`, so future renovate bumps can't rebreak this regardless of prefix.

## Verification

Built the `kopia` stage of **both** Dockerfiles with `--build-arg KOPIA_VERSION=v0.23.1` **and** `=0.23.1`; the curl/extract/install succeeded in all four combinations against the real release URL.

## Note (not changed here)

PR #120 merged despite all three **Build * image** checks failing red. Those image-build checks don't appear to be required for merge, and a failed E2E `build` only *skips* the `test` shards rather than failing the workflow conclusion — so a broken build can merge green-ish. Worth making the image-build jobs required status checks; that's a branch-protection setting, out of scope for this PR.