### PR TITLE
feat: move the controller monitoring port (metrics + health) to 8081

### DIFF
--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -48,8 +48,8 @@ pub const OPERATOR_NAMESPACE_ENV: &str = "KOPIUR_NAMESPACE";
 pub const KOPIA_CACHE_DIR_ENV: &str = "KOPIUR_KOPIA_CACHE_DIR";
 
 /// Address the controller's HTTP server (`/metrics`, `/healthz`, `/readyz`)
-/// binds to. Matches the chart's `controller.probePort` (8080).
-pub const HTTP_ADDR: &str = "0.0.0.0:8080";
+/// binds to. Matches the chart's `controller.probePort` (8081).
+pub const HTTP_ADDR: &str = "0.0.0.0:8081";
 
 /// Number of tokio worker threads the controller runtime runs. The controller is
 /// I/O-bound — watch streams, debounced reconciles, short idempotent kopia calls —

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -104,10 +104,10 @@ pub fn poll_interval() -> Duration {
 
 /// Scrape the controller's `/metrics` through the API server's Service-proxy
 /// subresource (no port-forward / `ws` feature needed). The chart names the
-/// controller metrics Service `kopiur-controller-metrics` on port 8080.
+/// controller metrics Service `kopiur-controller-metrics` on port 8081.
 pub async fn scrape_controller_metrics(client: &Client) -> anyhow::Result<String> {
     let path = format!(
-        "/api/v1/namespaces/{E2E_NAMESPACE}/services/kopiur-controller-metrics:8080/proxy/metrics"
+        "/api/v1/namespaces/{E2E_NAMESPACE}/services/kopiur-controller-metrics:8081/proxy/metrics"
     );
     let req = http::Request::get(path).body(Vec::new())?;
     Ok(client.request_text(req).await?)

--- a/deploy/helm/kopiur/README.md
+++ b/deploy/helm/kopiur/README.md
@@ -71,7 +71,7 @@ Disable the webhook entirely with `webhook.enabled=false` (validation then falls
 | controller.podAnnotations | object | `{}` |  |
 | controller.podLabels | object | `{}` | Extra pod labels / annotations. |
 | controller.priorityClassName | string | `""` | Pod-level priority class. |
-| controller.probePort | int | `8080` | Liveness/readiness HTTP probe port on the controller (serves /healthz, /readyz, /metrics). |
+| controller.probePort | int | `8081` | Liveness/readiness HTTP probe port on the controller (serves /healthz, /readyz, /metrics). |
 | controller.replicaCount | int | `1` | Number of controller replicas. >1 enables HA via leader election; only the elected leader reconciles, so deterministic jitter (ADR §4.1) keeps schedules identical across replicas and across failover. |
 | controller.resources | object | `{"limits":{"memory":"1Gi"},"requests":{"cpu":"50m","memory":"128Mi"}}` | Resource requests/limits for the controller pod. No CPU limit (CPU throttling on an operator only adds reconcile latency; the request reserves a fair share). The memory limit must cover the *burst* on startup/restart, not just steady state (~120Mi): on (re)start the controller reconciles every existing resource at once, spawning concurrent in-process `kopia` subprocesses (whose RSS counts against this container's cgroup) to list/connect a repository that may hold many snapshots. With the OpenTelemetry/OTLP stack linked in, 256Mi was too tight — the burst OOMKilled the controller, which then crash-looped (OOM -> restart -> re-reconcile burst -> OOM). 1Gi gives ample headroom. See crates/e2e/tests/lifecycle.rs. |
 | controller.streamingLists | bool | `false` | Opt-in: use the Kubernetes WatchList streaming-list API for the controller's cluster-wide watches, lowering peak memory during the initial resync by streaming pages instead of buffering them. Requires apiserver support (WatchList: beta in 1.32, GA in 1.34); leave off on older clusters. |
@@ -108,7 +108,7 @@ Disable the webhook entirely with `webhook.enabled=false` (validation then falls
 | logging.format | string | `"text"` | Console format: "text" (human-readable, default) or "json" (one structured object per line for Loki/ELK/Datadog). Unknown values degrade to text. |
 | logging.level | string | `""` | Log level / filter directive (RUST_LOG style: error|warn|info|debug|trace; per-target works too, e.g. "info,kopia=debug" to see kopia's own progress in mover logs). When empty, falls back to the deprecated `controller.logLevel`. |
 | metrics.enabled | bool | `true` | Expose a Service for the controller's /metrics endpoint. |
-| metrics.port | int | `8080` | Service port for /metrics. |
+| metrics.port | int | `8081` | Service port for /metrics. |
 | metrics.prometheusRule.backupStaleAfterSeconds | int | `172800` | Age (seconds) after which a SnapshotPolicy's last success is "stale". |
 | metrics.prometheusRule.enabled | bool | `false` | Create a Prometheus-Operator PrometheusRule with kopiur alerts. |
 | metrics.prometheusRule.labels | object | `{}` | Extra labels (e.g. to match your Prometheus ruleSelector). |

--- a/deploy/helm/kopiur/values.schema.json
+++ b/deploy/helm/kopiur/values.schema.json
@@ -84,7 +84,7 @@
           "type": "string"
         },
         "probePort": {
-          "default": 8080,
+          "default": 8081,
           "description": "Liveness/readiness HTTP probe port on the controller (serves /healthz, /readyz, /metrics).",
           "title": "probePort",
           "type": "integer"
@@ -407,7 +407,7 @@
           "type": "boolean"
         },
         "port": {
-          "default": 8080,
+          "default": 8081,
           "description": "Service port for /metrics.",
           "title": "port",
           "type": "integer"

--- a/deploy/helm/kopiur/values.yaml
+++ b/deploy/helm/kopiur/values.yaml
@@ -179,7 +179,7 @@ controller:
   podLabels: {}
   podAnnotations: {}
   # -- Liveness/readiness HTTP probe port on the controller (serves /healthz, /readyz, /metrics).
-  probePort: 8080
+  probePort: 8081
 
 # =============================================================================
 # Admission webhook
@@ -263,7 +263,7 @@ metrics:
   # -- Expose a Service for the controller's /metrics endpoint.
   enabled: true
   # -- Service port for /metrics.
-  port: 8080
+  port: 8081
   serviceMonitor:
     # -- Create a Prometheus-Operator ServiceMonitor. Requires the CRD to exist.
     enabled: false

--- a/docs/dev/observability.md
+++ b/docs/dev/observability.md
@@ -41,7 +41,7 @@ helm upgrade --install kopiur deploy/helm/kopiur -n kopiur-system \
 
 | Component  | Endpoint                                                | Notes                                   |
 | ---------- | ------------------------------------------------------- | --------------------------------------- |
-| Controller | `GET /metrics`, `/healthz`, `/readyz` on `:8080` (axum) | probes hit the real health routes       |
+| Controller | `GET /metrics`, `/healthz`, `/readyz` on `:8081` (axum) | probes hit the real health routes       |
 | Webhook    | `GET /metrics` on its TLS port (8443)                   | plus `/healthz`, `/readyz`              |
 | Mover      | none (short-lived Job)                                  | OTLP **push** only; flushed before exit |
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -129,7 +129,7 @@ Eight runnable walkthroughs live in `deploy/examples/`:
 
 ## Observability
 
-- The controller serves `/metrics`, `/healthz`, and `/readyz` on its probe port (`:8080`); the webhook serves `/metrics` on its TLS port. All metrics are under the `kopiur_` namespace.
+- The controller serves `/metrics`, `/healthz`, and `/readyz` on its probe port (`:8081`); the webhook serves `/metrics` on its TLS port. All metrics are under the `kopiur_` namespace.
 - `metrics.enabled=true` (default) creates a metrics `Service`.
 - `metrics.serviceMonitor.enabled=true` creates a Prometheus-Operator `ServiceMonitor` (requires the Prometheus-Operator CRDs); `metrics.prometheusRule.enabled=true` ships the kopiur alert rules.
 - `grafanaDashboard.enabled=true` ships the Grafana dashboard as a sidecar-discoverable `ConfigMap` (source: `deploy/dashboards/kopiur.json`). Set `grafanaDashboard.grafanaOperator.enabled=true` to instead render a [grafana-operator](https://grafana.github.io/grafana-operator/) `GrafanaDashboard` CR from the same JSON (use `grafanaDashboard.grafanaOperator.matchLabels` to select the Grafana instance).


### PR DESCRIPTION
## What

Moves the controller's combined monitoring port — which serves `/metrics`, `/healthz`, and `/readyz` together — from **8080** to **8081**. This changes the released default controller probe/metrics port.

The separate admission **webhook** server (axum + TLS on 8443) is **untouched**.

## Why

8080 is a heavily-conventional port; moving the controller's probe/metrics listener to 8081 avoids collisions with other workloads and with the various unrelated 8080 references in this repo (kopia server CRD defaults, example notifier hook URLs).

## Changes (old → new)

| File | Change |
| --- | --- |
| `crates/controller/src/config.rs` | `HTTP_ADDR` bind `0.0.0.0:8080` → `0.0.0.0:8081` (+ doc comment "Matches the chart's `controller.probePort`") |
| `deploy/helm/kopiur/values.yaml` | `controller.probePort` `8080` → `8081`; `metrics.port` `8080` → `8081` |
| `deploy/helm/kopiur/README.md` | regenerated (helm-docs): both port rows now `8081` |
| `deploy/helm/kopiur/values.schema.json` | regenerated (helm-schema): both `default` `8080` → `8081` |
| `crates/e2e/src/lib.rs` | controller-metrics Service proxy scrape `kopiur-controller-metrics:8080` → `:8081` (+ doc comment) |
| `docs/install.md` | probe-port reference `:8080` → `:8081` |
| `docs/dev/observability.md` | controller endpoints reference `:8080` → `:8081` |

## Deliberately NOT changed (unrelated 8080)

- `crates/mover/src/serve.rs`, `crates/kopia/src/client.rs`, `crates/api/src/server.rs` — kopia **server** CRD `listenPort` / address test fixtures
- `crates/api/src/validate.rs`, `deploy/examples/20-backup-with-hooks.yaml` — example notifier webhook URLs (`http://notifier.tools.svc:8080/fire`)

## Verification

- `mise run ci` (fmt-check + clippy `-D warnings` + build + test + drift) — green
- `cargo check -p kopiur-e2e --features e2e --tests` — compiles
- `mise run helm-lint` — passes
- `mise run helm-test` — 40/40 unit tests pass
- chart README + `values.schema.json` regenerated via helm-docs (pre-commit lefthook re-ran it identically)
