### PR TITLE
feat(secctx): also accept the legacy inheritSecurityContextFrom shape

### DIFF
--- a/crates/api/src/common.rs
+++ b/crates/api/src/common.rs
@@ -1081,8 +1081,16 @@ pub struct PodSelector {
 /// contexts (webhook/[`crate::validate::validate_mover`]-enforced). The resolved context
 /// enters [`resolve_mover`] as the *recipe layer*, so the hardened base still applies.
 ///
+/// **Backward compatibility:** the pre-enum **legacy** wire shape — a bare `PodSelector` at
+/// the top level (`{ podSelector: …, container?: … }`, the old `Option<PodSelector>` field) —
+/// is still accepted on input and normalized to [`Self::WorkloadSelector`], so manifests
+/// written before the enum rename keep applying. Output is always canonical
+/// (`workloadSelector`/`pvcConsumer`). The hand-written `Deserialize`/`JsonSchema` below carry
+/// this: the generated CRD's structural schema must ALSO permit the legacy shape, because the
+/// apiserver validates it before the controller deserializes.
+///
 /// Not `Eq`: `WorkloadSelector` embeds [`PodSelector`] → `LabelSelector` (`PartialEq` only).
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[derive(Serialize, Clone, Debug, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum InheritSecurityContextFrom {
     /// Match the workload pod(s) by an explicit label selector and inherit the chosen
@@ -1096,6 +1104,82 @@ pub enum InheritSecurityContextFrom {
     /// pod may not exist yet, exactly like a populator), so restore must use
     /// `workloadSelector`.
     PvcConsumer(PvcConsumerInherit),
+}
+
+impl<'de> Deserialize<'de> for InheritSecurityContextFrom {
+    /// Accept the canonical externally-tagged shapes (`{ workloadSelector: … }`,
+    /// `{ pvcConsumer: … }`) AND the **legacy** bare-`PodSelector` shape
+    /// (`{ podSelector: …, container?: … }`), normalizing the latter to `WorkloadSelector`.
+    /// Goes through `serde_json::Value` (the cluster's path — kube uses serde_json) so the
+    /// three shapes are distinguished unambiguously by their top-level key.
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        use serde::de::Error as _;
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let obj = value
+            .as_object()
+            .ok_or_else(|| D::Error::custom("inheritSecurityContextFrom must be an object"))?;
+        if let Some(ws) = obj.get("workloadSelector") {
+            return serde_json::from_value(ws.clone())
+                .map(Self::WorkloadSelector)
+                .map_err(D::Error::custom);
+        }
+        if let Some(pc) = obj.get("pvcConsumer") {
+            return serde_json::from_value(pc.clone())
+                .map(Self::PvcConsumer)
+                .map_err(D::Error::custom);
+        }
+        // Legacy: a bare PodSelector at the top level → WorkloadSelector.
+        if obj.contains_key("podSelector") {
+            return serde_json::from_value::<PodSelector>(value.clone())
+                .map(Self::WorkloadSelector)
+                .map_err(D::Error::custom);
+        }
+        Err(D::Error::custom(
+            "inheritSecurityContextFrom must set exactly one of: workloadSelector, pvcConsumer, \
+             or (legacy) podSelector",
+        ))
+    }
+}
+
+impl JsonSchema for InheritSecurityContextFrom {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "InheritSecurityContextFrom".into()
+    }
+
+    /// A `oneOf` of THREE branches — the two canonical variants plus the legacy bare
+    /// `PodSelector` — so the generated CRD's structural schema accepts legacy manifests
+    /// (the apiserver validates against this before the controller's [`Deserialize`] runs).
+    /// Mirrors the externally-tagged shape kube's structural-schema rewriter expects
+    /// (per-branch `properties` + `required`); a new variant must be reflected here.
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let pod_selector = generator.subschema_for::<PodSelector>();
+        let pvc_consumer = generator.subschema_for::<PvcConsumerInherit>();
+        let label_selector = generator.subschema_for::<LabelSelector>();
+        schemars::json_schema!({
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["workloadSelector"],
+                    "properties": { "workloadSelector": pod_selector },
+                },
+                {
+                    "type": "object",
+                    "required": ["pvcConsumer"],
+                    "properties": { "pvcConsumer": pvc_consumer },
+                },
+                {
+                    // Legacy bare PodSelector (the pre-enum shape).
+                    "type": "object",
+                    "required": ["podSelector"],
+                    "properties": {
+                        "podSelector": label_selector,
+                        "container": { "type": "string", "nullable": true },
+                    },
+                },
+            ],
+        })
+    }
 }
 
 /// Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
@@ -1983,6 +2067,70 @@ mod tests {
             Some(InheritSecurityContextFrom::PvcConsumer(PvcConsumerInherit { container }))
                 if container.as_deref() == Some("app"),
         ));
+    }
+
+    #[test]
+    fn inherit_security_context_from_accepts_the_legacy_pod_selector_shape() {
+        // Backward compat: the pre-enum bare-PodSelector shape (`{ podSelector, container }`)
+        // must still deserialize, normalized to WorkloadSelector, so old manifests keep working.
+        let legacy: MoverSpec = crate::testutil::from_yaml(
+            r#"
+            inheritSecurityContextFrom:
+              podSelector:
+                matchLabels:
+                  app: pg
+              container: postgres
+            "#,
+        );
+        match legacy.inherit_security_context_from {
+            Some(InheritSecurityContextFrom::WorkloadSelector(s)) => {
+                assert_eq!(s.container.as_deref(), Some("postgres"));
+                assert_eq!(
+                    s.pod_selector
+                        .match_labels
+                        .as_ref()
+                        .and_then(|m| m.get("app")),
+                    Some(&"pg".to_string())
+                );
+            }
+            other => panic!("legacy podSelector must normalize to WorkloadSelector, got {other:?}"),
+        }
+
+        // Legacy without a container is also fine.
+        let legacy_no_container: MoverSpec = crate::testutil::from_yaml(
+            r#"
+            inheritSecurityContextFrom:
+              podSelector:
+                matchLabels:
+                  app: pg
+            "#,
+        );
+        assert!(matches!(
+            legacy_no_container.inherit_security_context_from,
+            Some(InheritSecurityContextFrom::WorkloadSelector(_))
+        ));
+    }
+
+    #[test]
+    fn inherit_security_context_from_always_serializes_canonical() {
+        // Whatever shape came in, output is always the canonical externally-tagged form —
+        // a legacy-deserialized value re-serializes as `workloadSelector`, never `podSelector`.
+        let legacy: MoverSpec = crate::testutil::from_yaml(
+            r#"
+            inheritSecurityContextFrom:
+              podSelector: { matchLabels: { app: pg } }
+            "#,
+        );
+        let json = serde_json::to_value(&legacy).unwrap();
+        let inherit = &json["inheritSecurityContextFrom"];
+        assert!(
+            inherit.get("workloadSelector").is_some(),
+            "must serialize canonically as workloadSelector: {inherit}"
+        );
+        assert!(
+            inherit.get("podSelector").is_none(),
+            "must NOT emit the legacy top-level podSelector key: {inherit}"
+        );
     }
 
     // --- §12 mover Job TTL precedence (recipe over default over built-in) ---

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -705,15 +705,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -724,9 +755,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -558,15 +558,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -577,9 +608,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -702,15 +702,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -721,9 +752,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -3431,15 +3462,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -3450,9 +3512,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -15913,15 +15975,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -15932,9 +16025,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -17599,15 +17692,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -17618,9 +17742,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -18529,15 +18653,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -18548,9 +18703,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -19717,15 +19872,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -19736,9 +19922,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -793,15 +793,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -812,9 +843,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/maintenances.yaml
+++ b/deploy/crds/maintenances.yaml
@@ -131,15 +131,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -150,9 +181,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -702,15 +702,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -721,9 +752,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -555,15 +555,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -574,9 +605,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -139,15 +139,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -158,9 +189,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -10541,15 +10541,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -10560,9 +10591,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -793,15 +793,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -812,9 +843,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/maintenances.yaml
+++ b/deploy/helm/kopiur/files/crds/maintenances.yaml
@@ -131,15 +131,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -150,9 +181,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -702,15 +702,46 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - podSelector
                         properties:
+                          container:
+                            nullable: true
+                            type: string
+                          podSelector:
+                            description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                  required:
+                                  - key
+                                  - operator
+                                  type: object
+                                type: array
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
                           pvcConsumer:
                             description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                              Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                              so future knobs slot in without an API break (ADR §4.11).
                             properties:
                               container:
                                 description: |-
@@ -721,9 +752,9 @@ spec:
                             type: object
                           workloadSelector:
                             description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                              Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                              Not `Eq`: `LabelSelector` only implements `PartialEq`.
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
@@ -555,15 +555,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -574,9 +605,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/restores.yaml
+++ b/deploy/helm/kopiur/files/crds/restores.yaml
@@ -139,15 +139,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -158,9 +189,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -10541,15 +10541,46 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - podSelector
                     properties:
+                      container:
+                        nullable: true
+                        type: string
+                      podSelector:
+                        description: A label selector is a label query over a set of resources. The result of matchLabels and matchExpressions are ANDed. An empty label selector matches all objects. A null label selector matches no objects.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - key
+                              - operator
+                              type: object
+                            type: array
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
                       pvcConsumer:
                         description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                          Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
+                          so future knobs slot in without an API break (ADR §4.11).
                         properties:
                           container:
                             description: |-
@@ -10560,9 +10591,9 @@ spec:
                         type: object
                       workloadSelector:
                         description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                          Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
+
+                          Not `Eq`: `LabelSelector` only implements `PartialEq`.
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.

--- a/docs/security-context.md
+++ b/docs/security-context.md
@@ -164,6 +164,12 @@ $ kubectl get pod app-7c9d8f5b6-h2k4p -n app --show-labels
 
 How it resolves: the controller lists pods matching the selector, prefers a **Running** one, picks the named container (or the pod's first), and copies **that container's `securityContext` and the pod's pod-level `securityContext`** onto the mover. If no pod matches, the selector is empty, the named container is absent, or the pod sets *neither* a container nor a pod-level `securityContext`, the Backup/Restore is held with an actionable `MissingDependency`-style condition telling you exactly what to fix. The matched workload must be **running** so its identity can be read.
 
+/// note | Legacy shape is still accepted
+
+Before the enum, `inheritSecurityContextFrom` was a bare selector — `{ podSelector: …, container?: … }` — with no `workloadSelector`/`pvcConsumer` key. That **legacy shape still applies**: Kopiur accepts it and treats it exactly like `workloadSelector`. You don't have to migrate existing manifests, though new ones should prefer the explicit form. (Objects are always *stored* in the canonical `workloadSelector` shape.)
+
+///
+
 Two constraints to remember:
 
 - **Mutually exclusive with both `securityContext` and `podSecurityContext`.** Because inherit copies both levels, combining it with either explicit context is rejected by the admission webhook.


### PR DESCRIPTION
## What

#134 renamed `mover.inheritSecurityContextFrom` from a bare `PodSelector` to an externally-tagged enum (`workloadSelector` / `pvcConsumer`), which **broke pre-existing manifests**. This restores backward compatibility: the legacy shape `inheritSecurityContextFrom: { podSelector: …, container? }` is accepted again and normalized to `workloadSelector`.

## How

The apiserver validates the CRD's **structural schema before** the controller deserializes, so a custom `Deserialize` alone is insufficient — the generated schema must also permit the legacy shape. So `InheritSecurityContextFrom` now hand-implements:

- **`Deserialize`** — accepts `{ workloadSelector }` | `{ pvcConsumer }` | (legacy) `{ podSelector, container? }`, mapping legacy → `WorkloadSelector` (via the `serde_json::Value` cluster path; the three are distinguished unambiguously by top-level key).
- **`JsonSchema`** — a 3-branch `oneOf` (the legacy bare `podSelector` is the third branch). The generated CRD is structurally valid: kube's rewriter hoists all four properties to the top level and reduces `oneOf` to `required`-only, exactly matching the proven 2-branch pattern.
- **`Serialize`** stays canonical — objects are always *stored* as `workloadSelector`/`pvcConsumer`, never the legacy shape.

## Tests

- legacy `{ podSelector, container }` round-trips to `WorkloadSelector` (with and without `container`);
- a legacy-deserialized value re-serializes canonically (emits `workloadSelector`, never `podSelector`);
- CRD regenerated + insta goldens updated; `gen-check` clean.

The structural schema is validated locally (`T::crd()` + the generated CRD shape) and definitively by CI's integration tier (it applies the CRD to a real apiserver).

Follow-up: a comprehensive docs PR (field-reference, troubleshooting, restores) is coming separately.