### PR TITLE
feat(identity): validate identity shape + guard re-identification on edit

### DIFF
--- a/crates/api/src/consts.rs
+++ b/crates/api/src/consts.rs
@@ -63,6 +63,20 @@ pub const RUN_REQUESTED_ANNOTATION: &str = "kopiur.home-operations.com/run-reque
 /// (see `kopiur_api::maintenance::ManualRunMode`).
 pub const RUN_MODE_ANNOTATION: &str = "kopiur.home-operations.com/run-mode";
 
+/// Acknowledges an intentional change to a `SnapshotPolicy`'s resolved kopia
+/// identity (`username@hostname`, or a source's path) on UPDATE. Without it, the
+/// webhook **rejects** an edit that would re-identify a policy with existing
+/// snapshot history, because new snapshots land under a new kopia source and the
+/// old history is orphaned (GFS retention treats them as separate sources and never
+/// prunes the old set). Any **non-empty** value acknowledges the re-identification
+/// for that admission (presence-only, mirroring [`SKIP_SNAPSHOT_CLEANUP_ANNOTATION`];
+/// a specific value isn't required because an edit can change more than one identity
+/// component at once, and the operator-resolved string is not something the author
+/// can pre-compute). Lives here because the operator and any GitOps/user automation
+/// must agree on it byte-for-byte.
+pub const ALLOW_IDENTITY_CHANGE_ANNOTATION: &str =
+    "kopiur.home-operations.com/allow-identity-change";
+
 /// The API version string for kopiur CRDs (used in mover `TargetRef`s and
 /// `kubectl -o name`-style output).
 pub const API_VERSION: &str = "kopiur.home-operations.com/v1alpha1";
@@ -159,6 +173,7 @@ mod tests {
             SESSION_REPO_LABEL,
             RUN_REQUESTED_ANNOTATION,
             RUN_MODE_ANNOTATION,
+            ALLOW_IDENTITY_CHANGE_ANNOTATION,
         ] {
             assert!(s.starts_with(crate::GROUP), "{s} must be group-prefixed");
         }

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -249,6 +249,64 @@ pub enum ValidationError {
         conflict: String,
     },
 
+    /// A kopia identity component (`username` or `hostname`) — whether an explicit
+    /// `spec.identity` override or the value an `identityDefaults` CEL expression
+    /// resolved to — contains a character that breaks kopia's
+    /// `username@hostname:path` contract. kopia parses a source on the **first** `@`
+    /// and **first** `:` with no escaping, so an embedded `@`, `:`, ASCII whitespace,
+    /// or control character silently misparses the identity into a *different* one
+    /// (or makes the snapshot un-findable on `snapshot list --source`). Rejected at
+    /// admission/resolution so it never reaches a mover Job. Shape-only — every other
+    /// character (dots, dashes, slashes, unicode letters) is allowed.
+    #[error(
+        "{field} {value:?} is not a valid kopia identity component: {reason} \
+         (kopia parses username@hostname:path on the first @ and first :, with no escaping)"
+    )]
+    IdentityComponentInvalid {
+        /// The offending field (e.g. `"spec.identity.username"` or `"resolved hostname"`).
+        field: String,
+        /// The rejected value.
+        value: String,
+        /// What's wrong (e.g. `"must not contain ':'"`).
+        reason: String,
+    },
+
+    /// A kopia identity `sourcePath` is malformed — empty, or it contains a newline
+    /// or an ASCII control character. The path is everything after the first `:` in
+    /// `username@hostname:path`; it may legitimately contain spaces and further `:`,
+    /// but not control characters, and must be non-empty when set.
+    #[error("{field} {value:?} is not a valid kopia source path: {reason}")]
+    IdentitySourcePathInvalid {
+        /// The offending field (e.g. `"spec.sources[0].sourcePathOverride"`).
+        field: String,
+        /// The rejected value.
+        value: String,
+        /// What's wrong and how to fix it.
+        reason: String,
+    },
+
+    /// An UPDATE to a `SnapshotPolicy` would change its resolved kopia identity
+    /// (`username@hostname`, or a source's path) while the policy already has snapshot
+    /// history. New snapshots would land under the new kopia source, orphaning the old
+    /// history — GFS retention treats them as separate sources and never prunes the
+    /// old set (a storage leak), and the new identity restarts retention from zero.
+    /// Rejected unless the change is acknowledged with the
+    /// `kopiur.home-operations.com/allow-identity-change` annotation
+    /// ([`crate::consts::ALLOW_IDENTITY_CHANGE_ANNOTATION`]).
+    #[error(
+        "this edit changes the policy's resolved kopia identity from {old:?} to {new:?}, but the \
+         policy already has snapshot history; new snapshots would orphan the old history (kopia \
+         treats them as a separate source and GFS retention never prunes the old set). To \
+         intentionally re-identify, set annotation \
+         kopiur.home-operations.com/allow-identity-change (any non-empty value)"
+    )]
+    IdentityWouldFork {
+        /// The previously-pinned identity (or source path).
+        old: String,
+        /// The new identity (or source path) this edit would resolve to.
+        new: String,
+    },
+
     /// A verification `successExpr` (ADR-0005 §4/§15) failed to **compile** (a
     /// syntax error, or it exceeds the length budget). Surfaced at admission.
     #[error("successExpr {expr:?} failed to compile: {reason} (check the CEL syntax)")]

--- a/crates/api/src/identity.rs
+++ b/crates/api/src/identity.rs
@@ -236,6 +236,18 @@ pub fn resolve_identity(inputs: &IdentityInputs<'_>) -> ValidationResult<Resolve
             .or_else(|| inputs.default_source_path.map(String::from)),
     };
 
+    // Shape-check the fully-resolved identity, regardless of where each component came
+    // from (explicit override, CEL expression result, or the name/namespace/PVC
+    // default). kopia parses `username@hostname:path` on the first `@`/`:` with no
+    // escaping, so a component carrying a delimiter/whitespace/control char would
+    // silently misparse or become un-findable. Rejecting here means the controller
+    // never PINS a bad identity into status, and the webhook surfaces it at admission.
+    crate::validate::validate_identity_component("resolved username", &username)?;
+    crate::validate::validate_identity_component("resolved hostname", &hostname)?;
+    if let Some(p) = &source_path {
+        crate::validate::validate_source_path("resolved sourcePath", p)?;
+    }
+
     Ok(ResolvedIdentity {
         username,
         hostname,
@@ -437,6 +449,33 @@ mod tests {
             ..with
         };
         assert_eq!(identity_string(&without), "postgres-data@billing");
+    }
+
+    #[test]
+    fn resolve_rejects_override_with_kopia_delimiter() {
+        // An explicit override carrying kopia's '@' delimiter would misparse — rejected
+        // at resolution so the controller never pins it.
+        let ovr = Identity {
+            username: Some("bad@user".to_string()),
+            hostname: None,
+        };
+        let err = resolve_identity(&inputs("c", "n", Some(&ovr), None, Some("p"))).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::IdentityComponentInvalid { .. }
+        ));
+    }
+
+    #[test]
+    fn resolve_rejects_cel_result_with_delimiter() {
+        // A CEL expression that resolves to a string with ':' is caught at resolution
+        // (the static override validator can't see CEL results).
+        let d = defaults(None, Some("'a:b'"));
+        let err = resolve_identity(&inputs("c", "n", None, Some(&d), Some("p"))).unwrap_err();
+        assert!(matches!(
+            err,
+            ValidationError::IdentityComponentInvalid { .. }
+        ));
     }
 
     #[test]

--- a/crates/api/src/validate.rs
+++ b/crates/api/src/validate.rs
@@ -670,6 +670,165 @@ pub fn detect_identity_collision(
         .map(|e| e.name.clone())
 }
 
+// --- Identity shape validation (kopia username@hostname:path contract) -------
+
+/// Generous byte cap for a single identity component. kopia imposes none; this only
+/// bounds adversarial input (a hostname mirrors DNS's 253 here).
+const IDENTITY_MAX_LEN: usize = 253;
+
+/// The shape problem (if any) with a kopia identity `username`/`hostname` component.
+/// kopia (`snapshot.ParseSourceInfo`) splits a source on the **first** `@` and
+/// **first** `:` with no escaping, so an embedded delimiter silently reparses the
+/// identity into a *different* one; whitespace and ASCII control characters survive
+/// verbatim but make the identity un-typeable/un-findable on a later
+/// `snapshot list --source`. This is the minimal shape rule — NOT a character class;
+/// dots, dashes, slashes and unicode letters all pass.
+fn identity_char_problem(value: &str) -> Option<String> {
+    if value.is_empty() {
+        return Some("must not be empty".to_string());
+    }
+    if value.len() > IDENTITY_MAX_LEN {
+        return Some(format!(
+            "is {} bytes; the maximum is {IDENTITY_MAX_LEN}",
+            value.len()
+        ));
+    }
+    if value.contains('@') {
+        return Some("must not contain '@' (kopia's username/hostname delimiter)".to_string());
+    }
+    if value.contains(':') {
+        return Some("must not contain ':' (kopia's hostname/path delimiter)".to_string());
+    }
+    if let Some(c) = value.chars().find(|c| c.is_ascii_whitespace()) {
+        return Some(format!("must not contain whitespace (found {c:?})"));
+    }
+    if let Some(c) = value.chars().find(|c| c.is_ascii_control()) {
+        return Some(format!("must not contain control characters (found {c:?})"));
+    }
+    None
+}
+
+/// Validate a resolved kopia identity component (`username`/`hostname`). Shape-only
+/// (see [`identity_char_problem`]); `field` names the surface for the message. Called
+/// both from the static admission validator (on explicit overrides) and from
+/// [`crate::resolve_identity`] (on the fully-resolved value, covering CEL results and
+/// defaults), so a bad identity can never be pinned.
+pub fn validate_identity_component(field: &str, value: &str) -> ValidationResult {
+    match identity_char_problem(value) {
+        None => Ok(()),
+        Some(reason) => Err(ValidationError::IdentityComponentInvalid {
+            field: field.to_string(),
+            value: value.to_string(),
+            reason,
+        }),
+    }
+}
+
+/// Validate a kopia identity `sourcePath` (the part after the first `:`). Lenient:
+/// spaces and `:` are allowed (only the first `:` is kopia's delimiter, and the rest
+/// is the path verbatim), but the path must be non-empty and free of newlines / ASCII
+/// control characters.
+pub fn validate_source_path(field: &str, value: &str) -> ValidationResult {
+    let reason = if value.is_empty() {
+        Some("must not be empty when set".to_string())
+    } else {
+        value
+            .chars()
+            .find(|c| c.is_ascii_control())
+            .map(|c| format!("must not contain control characters (found {c:?})"))
+    };
+    match reason {
+        None => Ok(()),
+        Some(reason) => Err(ValidationError::IdentitySourcePathInvalid {
+            field: field.to_string(),
+            value: value.to_string(),
+            reason,
+        }),
+    }
+}
+
+// --- Fork-on-edit guard (re-identifying a policy with history orphans snapshots) ---
+
+/// Pure decision for the fork-on-edit guard on a `username@hostname` change. Returns
+/// `Some(IdentityWouldFork)` iff the policy has snapshot history, the change was not
+/// acknowledged, and the resolved identity actually differs. The webhook does the IO
+/// (read the old object's pinned identity + history, resolve the new identity) and
+/// calls this.
+///
+/// ```
+/// use kopiur_api::validate::detect_identity_fork;
+///
+/// // History + a real change + no ack → fork.
+/// assert!(detect_identity_fork("pg@billing", "pg@payments", true, false).is_some());
+/// // No history yet (e.g. typo fixed before the first backup) → allowed.
+/// assert!(detect_identity_fork("pg@billing", "pg@payments", false, false).is_none());
+/// // Acknowledged → allowed.
+/// assert!(detect_identity_fork("pg@billing", "pg@payments", true, true).is_none());
+/// // No actual change → allowed.
+/// assert!(detect_identity_fork("pg@billing", "pg@billing", true, false).is_none());
+/// ```
+pub fn detect_identity_fork(
+    old_identity: &str,
+    new_identity: &str,
+    has_history: bool,
+    acknowledged: bool,
+) -> Option<ValidationError> {
+    (has_history && !acknowledged && old_identity != new_identity).then(|| {
+        ValidationError::IdentityWouldFork {
+            old: old_identity.to_string(),
+            new: new_identity.to_string(),
+        }
+    })
+}
+
+/// The `(pvcName, effectivePath)` kopia would record for a PVC-addressed source: an
+/// explicit `sourcePathOverride`, else the `/pvc/<name>` default (mirrors
+/// [`crate::resolve_identity`]). `None` for non-PVC sources (selector/NFS), which the
+/// path-fork guard does not reason about — their data identity is the selection/export
+/// itself, not an editable per-source path.
+fn pvc_source_effective_path(source: &Source) -> Option<(String, String)> {
+    let name = source.pvc.as_ref()?.name.clone();
+    let path = source
+        .source_path_override
+        .clone()
+        .unwrap_or_else(|| format!("/pvc/{name}"));
+    Some((name, path))
+}
+
+/// Pure decision for the fork-on-edit guard on a per-source path change. A PVC's kopia
+/// source path is part of its identity, so changing `sourcePathOverride` on a PVC that
+/// already has history orphans that PVC's snapshots exactly as a username/hostname
+/// change would. Sources are matched across the edit by PVC name (paths are never
+/// CEL-driven, so an old-vs-new spec diff is complete); selector/NFS sources are out of
+/// scope. Returns the first offending change.
+pub fn detect_source_path_fork(
+    old: &SnapshotPolicySpec,
+    new: &SnapshotPolicySpec,
+    has_history: bool,
+    acknowledged: bool,
+) -> Option<ValidationError> {
+    if !has_history || acknowledged {
+        return None;
+    }
+    let old_paths: BTreeMap<String, String> = old
+        .sources
+        .iter()
+        .filter_map(pvc_source_effective_path)
+        .collect();
+    for source in &new.sources {
+        if let Some((name, new_path)) = pvc_source_effective_path(source)
+            && let Some(old_path) = old_paths.get(&name)
+            && *old_path != new_path
+        {
+            return Some(ValidationError::IdentityWouldFork {
+                old: old_path.clone(),
+                new: new_path,
+            });
+        }
+    }
+    None
+}
+
 /// A cron expression parses with the same parser the controller uses at runtime, so
 /// bad expressions are rejected at apply time, not at first reconcile (ADR §4.1).
 ///
@@ -722,6 +881,31 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
     }
     for source in &spec.sources {
         if let Err(e) = validate_source(source) {
+            errs.push(e);
+        }
+    }
+    // Identity shape (kopia's username@hostname:path contract). The explicit
+    // overrides are validated here — client-free, so this runs on every admission
+    // even when the webhook has no kube client. CEL-resolved values and the
+    // name/namespace defaults are validated where they are resolved
+    // (`resolve_identity`), and again defensively at reconcile time.
+    if let Some(id) = &spec.identity {
+        if let Some(u) = &id.username
+            && let Err(e) = validate_identity_component("spec.identity.username", u)
+        {
+            errs.push(e);
+        }
+        if let Some(h) = &id.hostname
+            && let Err(e) = validate_identity_component("spec.identity.hostname", h)
+        {
+            errs.push(e);
+        }
+    }
+    for (i, source) in spec.sources.iter().enumerate() {
+        if let Some(p) = &source.source_path_override
+            && let Err(e) =
+                validate_source_path(&format!("spec.sources[{i}].sourcePathOverride"), p)
+        {
             errs.push(e);
         }
     }
@@ -3818,5 +4002,113 @@ server:
             )),
             "absent retention is the safe no-prune case and must not be flagged: {errs:?}"
         );
+    }
+
+    // --- identity shape validation ---
+
+    #[test]
+    fn identity_component_accepts_normal_values() {
+        for v in [
+            "postgres-data",
+            "billing",
+            "billing-postgres-data",
+            "team.prod",
+            "my_app",
+            "a",
+            "café", // unicode letters pass — shape-only, not a character class
+        ] {
+            assert!(
+                validate_identity_component("f", v).is_ok(),
+                "{v:?} should be accepted"
+            );
+        }
+    }
+
+    #[test]
+    fn identity_component_rejects_kopia_delimiters_and_blanks() {
+        // The exact misparse/un-findability cases kopia's first-@/first-: parser hits.
+        for (v, why) in [
+            ("", "empty"),
+            ("a@b", "@ delimiter"),
+            ("ho:st", ": delimiter"),
+            ("has space", "whitespace"),
+            ("tab\there", "tab"),
+            ("line\nbreak", "newline"),
+            ("nul\0byte", "control char"),
+        ] {
+            let err = validate_identity_component("spec.identity.username", v).unwrap_err();
+            assert!(
+                matches!(err, ValidationError::IdentityComponentInvalid { .. }),
+                "{v:?} ({why}) should be rejected, got {err:?}"
+            );
+        }
+        // Over the length cap.
+        let long = "a".repeat(IDENTITY_MAX_LEN + 1);
+        assert!(validate_identity_component("f", &long).is_err());
+    }
+
+    #[test]
+    fn source_path_is_lenient_but_rejects_empty_and_control() {
+        // Spaces and ':' are fine in a path (only the first ':' is kopia's delimiter).
+        assert!(validate_source_path("f", "/pvc/data").is_ok());
+        assert!(validate_source_path("f", "/mnt/My Files").is_ok());
+        assert!(validate_source_path("f", "/data:extra").is_ok());
+        // Empty-when-set and control chars are not.
+        assert!(validate_source_path("f", "").is_err());
+        assert!(validate_source_path("f", "/data\nx").is_err());
+    }
+
+    #[test]
+    fn backup_config_rejects_bad_identity_override_and_path() {
+        let mut spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: data } } ]\n",
+        );
+        spec.identity = Some(Identity {
+            username: Some("bad@user".into()),
+            hostname: Some("ok-host".into()),
+        });
+        spec.sources[0].source_path_override = Some("/data\nx".into());
+        let errs = validate_backup_config(&spec);
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::IdentityComponentInvalid { field, .. } if field == "spec.identity.username")),
+            "{errs:?}"
+        );
+        assert!(
+            errs.iter()
+                .any(|e| matches!(e, ValidationError::IdentitySourcePathInvalid { field, .. } if field == "spec.sources[0].sourcePathOverride")),
+            "{errs:?}"
+        );
+    }
+
+    // --- fork-on-edit detectors ---
+
+    #[test]
+    fn identity_fork_only_when_history_change_and_unacked() {
+        assert!(detect_identity_fork("pg@a", "pg@b", true, false).is_some());
+        assert!(detect_identity_fork("pg@a", "pg@b", false, false).is_none()); // no history
+        assert!(detect_identity_fork("pg@a", "pg@b", true, true).is_none()); // acked
+        assert!(detect_identity_fork("pg@a", "pg@a", true, false).is_none()); // no change
+    }
+
+    #[test]
+    fn source_path_fork_matches_by_pvc_name() {
+        let mk = |path_override: Option<&str>| -> SnapshotPolicySpec {
+            let mut s: SnapshotPolicySpec = crate::testutil::from_yaml(
+                "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: data } } ]\n",
+            );
+            s.sources[0].source_path_override = path_override.map(String::from);
+            s
+        };
+        // Default /pvc/data → explicit /data on the SAME pvc, with history, no ack → fork.
+        let old = mk(None);
+        let new = mk(Some("/data"));
+        assert!(detect_source_path_fork(&old, &new, true, false).is_some());
+        // Acked → allowed.
+        assert!(detect_source_path_fork(&old, &new, true, true).is_none());
+        // No history → allowed.
+        assert!(detect_source_path_fork(&old, &new, false, false).is_none());
+        // Same effective path (both default) → allowed.
+        assert!(detect_source_path_fork(&mk(None), &mk(None), true, false).is_none());
     }
 }

--- a/crates/cli/src/cmd/migrate/kopia.rs
+++ b/crates/cli/src/cmd/migrate/kopia.rs
@@ -1573,6 +1573,35 @@ mod tests {
         assert_eq!(u, "app");
     }
 
+    #[test]
+    fn fork_sanitized_identity_always_passes_kopiur_validator() {
+        // Locks the invariant the gap-hunt flagged: the bug-for-bug builder.go
+        // sanitizer can never emit a username/hostname that kopiur's shape validator
+        // rejects, so a migrated SnapshotPolicy is never bounced at admission. (Only
+        // explicit fork overrides bypass sanitization — those a user must keep clean,
+        // exactly as the fork itself required.)
+        use kopiur_api::validate::validate_identity_component;
+        for (name, ns) in [
+            ("vs-app", "media"),
+            ("app.v2", "ns.prod"),
+            ("my_app", "my_ns"),
+            ("-_app_-", ""),
+            ("...", "..."),
+            (&"a".repeat(80), &"n".repeat(80)),
+            ("", ""),
+        ] {
+            let (u, h) = fork_identity(name, ns, None, None);
+            assert!(
+                validate_identity_component("username", &u).is_ok(),
+                "fork username {u:?} (from {name:?}) must pass the validator"
+            );
+            assert!(
+                validate_identity_component("hostname", &h).is_ok(),
+                "fork hostname {h:?} (from {ns:?}/{name:?}) must pass the validator"
+            );
+        }
+    }
+
     // --- backend parsing per scheme ---
 
     #[test]

--- a/crates/controller/src/cache.rs
+++ b/crates/controller/src/cache.rs
@@ -107,6 +107,30 @@ pub async fn resolve_cache_volume(
     }
 }
 
+/// Resolve the **verification** mover's kopia cache volume from an effective cache
+/// config. Verify inherits `moverDefaults.cache` like every other mover, but — being
+/// a separate, infrequent lifecycle from backups — it must **never attach the
+/// `SnapshotPolicy`'s persistent (warm) cache PVC**: that PVC is `ReadWriteOnce` and
+/// owned by the backup path, so sharing it would risk a Multi-Attach race and entangle
+/// lifecycles. So `mode` is ignored here and the result is always per-run ephemeral:
+/// - a `capacity` (under either `Ephemeral` *or* `Persistent` mode) → a fresh sized
+///   generic ephemeral volume ([`CacheVolume::Ephemeral`], honoring `storageClassName`);
+/// - no `capacity` → an `emptyDir`.
+///
+/// Pure (no IO): unlike [`resolve_cache_volume`] there is never an owned PVC to
+/// provision, so this needs no client. The cache **budgets** are applied separately via
+/// [`cache_tuning`] in the verify work-spec, so volume + budgets share one
+/// [`effective_cache`] source.
+pub fn verify_cache_volume(effective: Option<&CacheDefaults>) -> CacheVolume {
+    match effective.and_then(|c| c.capacity.clone()) {
+        Some(capacity) => CacheVolume::Ephemeral {
+            capacity,
+            storage_class: effective.and_then(|c| c.storage_class_name.clone()),
+        },
+        None => CacheVolume::EmptyDir,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -216,5 +240,51 @@ mod tests {
     fn effective_scratch_is_none_when_nothing_set() {
         let repo = repo_with_scratch(None);
         assert_eq!(effective_scratch(&repo, &deep(None, None)), None);
+    }
+
+    #[test]
+    fn verify_cache_volume_is_emptydir_without_capacity() {
+        // No effective cache, or budgets-only (no capacity) → emptyDir.
+        assert_eq!(verify_cache_volume(None), CacheVolume::EmptyDir);
+        assert_eq!(
+            verify_cache_volume(Some(&CacheDefaults {
+                metadata_cache_size_mb: Some(512),
+                ..Default::default()
+            })),
+            CacheVolume::EmptyDir
+        );
+    }
+
+    #[test]
+    fn verify_cache_volume_is_sized_ephemeral_with_capacity() {
+        assert_eq!(
+            verify_cache_volume(Some(&CacheDefaults {
+                capacity: Some("8Gi".into()),
+                storage_class_name: Some("fast-ssd".into()),
+                ..Default::default()
+            })),
+            CacheVolume::Ephemeral {
+                capacity: "8Gi".into(),
+                storage_class: Some("fast-ssd".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn verify_cache_volume_coerces_persistent_to_ephemeral() {
+        // Verify must NEVER attach the backup's warm persistent PVC (RWO multi-attach):
+        // a Persistent cache is coerced to a fresh per-run sized ephemeral volume.
+        assert_eq!(
+            verify_cache_volume(Some(&CacheDefaults {
+                capacity: Some("16Gi".into()),
+                storage_class_name: Some("block".into()),
+                mode: Some(CacheVolumeMode::Persistent),
+                ..Default::default()
+            })),
+            CacheVolume::Ephemeral {
+                capacity: "16Gi".into(),
+                storage_class: Some("block".into()),
+            }
+        );
     }
 }

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -303,7 +303,9 @@ async fn spawn_verify_job(
     let creds_secrets = creds.names;
 
     // The verify mover inherits the repository's moverDefaults (security context,
-    // placement, TTL) merged under the recipe's mover (ADR-0004 §1/§2).
+    // placement, resources, TTL, cache) merged under the recipe's mover (ADR-0004
+    // §1/§2). The cache *volume* is resolved separately below (verify never attaches
+    // the backup's persistent cache PVC); the cache *budgets* ride the work-spec.
     let resolved_mover = kopiur_api::common::resolve_mover(
         repo.mover_defaults.as_ref(),
         config
@@ -357,7 +359,17 @@ async fn spawn_verify_job(
         service_account: mover_identity.service_account.as_deref(),
         passthrough_env: ctx.mover_env_passthrough.clone(),
         annotations,
-        cache_volume: Default::default(),
+        // Inherit moverDefaults.cache (overlaid by the recipe's mover.cache) for the
+        // kopia cache volume — but always per-run ephemeral, never the backup's warm
+        // persistent PVC (see `verify_cache_volume`). Same `effective_cache` source as
+        // the cache budgets in `build_verify_work_spec`.
+        cache_volume: crate::cache::verify_cache_volume(
+            crate::cache::effective_cache(
+                repo,
+                config.spec.mover.as_ref().and_then(|m| m.cache.as_ref()),
+            )
+            .as_ref(),
+        ),
         // Deep verify restores into DEEP_SCRATCH_PATH; mount a writable volume there
         // (sized PVC if `capacity` is set, else emptyDir). Quick verify needs none.
         scratch_volume: match tier {

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -306,16 +306,40 @@ pub fn job_pod_sc(job: &Job) -> Option<k8s_openapi::api::core::v1::PodSecurityCo
         .and_then(|p| p.security_context.clone())
 }
 
-/// The deep-verify scratch `Volume` (named `scratch`) from a Job's pod template, or
-/// `None` if the Job mounts no scratch volume. Used to assert how the scratch
-/// restore-test volume was provisioned (emptyDir vs sized ephemeral PVC + class).
-pub fn job_scratch_volume(job: &Job) -> Option<k8s_openapi::api::core::v1::Volume> {
+/// The named `Volume` from a Job's pod template, or `None` if absent. Used to assert
+/// how a mover volume was provisioned (emptyDir vs sized ephemeral PVC + class).
+pub fn job_named_volume(job: &Job, name: &str) -> Option<k8s_openapi::api::core::v1::Volume> {
     job.spec
         .as_ref()
         .and_then(|s| s.template.spec.as_ref())
         .and_then(|p| p.volumes.as_ref())
-        .and_then(|vols| vols.iter().find(|v| v.name == "scratch"))
+        .and_then(|vols| vols.iter().find(|v| v.name == name))
         .cloned()
+}
+
+/// The deep-verify scratch `Volume` (named `scratch`) — see [`job_named_volume`].
+pub fn job_scratch_volume(job: &Job) -> Option<k8s_openapi::api::core::v1::Volume> {
+    job_named_volume(job, "scratch")
+}
+
+/// The kopia cache `Volume` (named `kopia-cache`) — see [`job_named_volume`].
+pub fn job_cache_volume(job: &Job) -> Option<k8s_openapi::api::core::v1::Volume> {
+    job_named_volume(job, "kopia-cache")
+}
+
+/// The `(storageClassName, capacity)` of a `Volume`'s ephemeral `volumeClaimTemplate`,
+/// or `None` if the volume is not a sized ephemeral PVC (e.g. an `emptyDir`).
+pub fn ephemeral_class_and_capacity(
+    vol: &k8s_openapi::api::core::v1::Volume,
+) -> Option<(Option<String>, Option<String>)> {
+    let spec = &vol.ephemeral.as_ref()?.volume_claim_template.as_ref()?.spec;
+    let capacity = spec
+        .resources
+        .as_ref()
+        .and_then(|r| r.requests.as_ref())
+        .and_then(|m| m.get("storage"))
+        .map(|q| q.0.clone());
+    Some((spec.storage_class_name.clone(), capacity))
 }
 
 /// Assert a rendered mover container securityContext STILL carries the hardened

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -149,15 +149,17 @@ async fn verification_deep_scratch_restore_stamps_last_verified() {
     );
 }
 
-/// Repo-level `moverDefaults.scratch` is inherited by a policy's `verification.deep`
-/// scratch PVC — set the scratch size/class ONCE on the `Repository`, leave
-/// `verification.deep` bare, and the spawned deep-verify Job's scratch volume must be
-/// a sized ephemeral PVC carrying the inherited `storageClassName` + `capacity`.
+/// The deep-verify mover inherits the repository's `moverDefaults` — set both the
+/// scratch (`moverDefaults.scratch`) and the kopia cache (`moverDefaults.cache`)
+/// size/class ONCE on the `Repository`, leave `verification.deep` bare, and the
+/// spawned deep-verify Job's `scratch` AND `kopia-cache` volumes must both be sized
+/// ephemeral PVCs carrying the inherited `storageClassName` + `capacity`.
 ///
 /// Regression guard for the inheritance wiring (`moverDefaults.scratch ⊂
-/// verification.deep`). Asserted at the **Job spec** level (no PVC provisioning
-/// required), so a synthetic StorageClass is fine and the test stays fast — we only
-/// enable `deep` (no `quick`) so the single verify Job is the deep one.
+/// verification.deep`, and `moverDefaults.cache` → verify cache volume). Asserted at
+/// the **Job spec** level (no PVC provisioning required), so synthetic StorageClasses
+/// are fine and the test stays fast — we only enable `deep` (no `quick`) so the single
+/// verify Job is the deep one.
 #[tokio::test]
 #[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
 async fn deep_verify_scratch_inherits_repo_mover_defaults() {
@@ -175,14 +177,23 @@ async fn deep_verify_scratch_inherits_repo_mover_defaults() {
     )
     .await;
 
-    // Scratch defaults set ONCE on the Repository (the user's "configure it centrally"
-    // ask). A synthetic class is fine — we assert the Job spec, not a bound PVC.
+    // Scratch + cache defaults set ONCE on the Repository (the user's "configure it
+    // centrally" ask). Synthetic classes are fine — we assert the Job spec, not bound
+    // PVCs. cache.mode: Persistent must be COERCED to a per-run ephemeral volume for
+    // verify (it must never attach the backup's warm RWO PVC).
     let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let repo_patch = serde_json::json!({
-        "spec": { "moverDefaults": { "scratch": {
-            "capacity": "1Gi",
-            "storageClassName": "e2e-scratch-class"
-        } } }
+        "spec": { "moverDefaults": {
+            "scratch": {
+                "capacity": "1Gi",
+                "storageClassName": "e2e-scratch-class"
+            },
+            "cache": {
+                "capacity": "2Gi",
+                "storageClassName": "e2e-cache-class",
+                "mode": "Persistent"
+            }
+        } }
     });
     repos
         .patch(
@@ -191,7 +202,7 @@ async fn deep_verify_scratch_inherits_repo_mover_defaults() {
             &Patch::Merge(&repo_patch),
         )
         .await
-        .expect("patch moverDefaults.scratch onto the Repository");
+        .expect("patch moverDefaults.scratch + moverDefaults.cache onto the Repository");
 
     // Enable ONLY deep verify, with a bare schedule — scratch size/class come entirely
     // from the inherited repo default.
@@ -224,31 +235,36 @@ async fn deep_verify_scratch_inherits_repo_mover_defaults() {
     .await
     .expect("a deep-verify Job should be spawned");
 
-    // The inherited capacity makes scratch a SIZED ephemeral PVC (not an emptyDir),
-    // and the storageClass/capacity are the repo defaults.
+    // The inherited capacities make BOTH the scratch and the kopia cache sized
+    // ephemeral PVCs (not emptyDirs), carrying the repo-default class + capacity.
     let scratch = job_scratch_volume(&job).expect("deep-verify Job must mount a 'scratch' volume");
-    let tmpl = scratch
-        .ephemeral
-        .as_ref()
-        .and_then(|e| e.volume_claim_template.as_ref())
-        .expect(
-            "inherited scratch capacity must make scratch a sized ephemeral PVC, not an emptyDir",
-        );
+    let (scratch_class, scratch_cap) = ephemeral_class_and_capacity(&scratch).expect(
+        "inherited scratch capacity must make scratch a sized ephemeral PVC, not an emptyDir",
+    );
     assert_eq!(
-        tmpl.spec.storage_class_name.as_deref(),
+        scratch_class.as_deref(),
         Some("e2e-scratch-class"),
         "scratch PVC must inherit moverDefaults.scratch.storageClassName"
     );
-    let storage = tmpl
-        .spec
-        .resources
-        .as_ref()
-        .and_then(|r| r.requests.as_ref())
-        .and_then(|m| m.get("storage"))
-        .map(|q| q.0.clone());
     assert_eq!(
-        storage.as_deref(),
+        scratch_cap.as_deref(),
         Some("1Gi"),
         "scratch PVC must inherit moverDefaults.scratch.capacity"
+    );
+
+    let cache = job_cache_volume(&job).expect("deep-verify Job must mount a 'kopia-cache' volume");
+    let (cache_class, cache_cap) = ephemeral_class_and_capacity(&cache).expect(
+        "inherited cache capacity must make the verify cache a sized EPHEMERAL PVC \
+         (a Persistent moverDefaults.cache is coerced to ephemeral for verify), not an emptyDir",
+    );
+    assert_eq!(
+        cache_class.as_deref(),
+        Some("e2e-cache-class"),
+        "verify cache PVC must inherit moverDefaults.cache.storageClassName"
+    );
+    assert_eq!(
+        cache_cap.as_deref(),
+        Some("2Gi"),
+        "verify cache PVC must inherit moverDefaults.cache.capacity"
     );
 }

--- a/crates/e2e/tests/webhook.rs
+++ b/crates/e2e/tests/webhook.rs
@@ -18,7 +18,7 @@
 
 #![cfg(all(unix, feature = "e2e"))]
 
-use kube::api::{DeleteParams, PostParams};
+use kube::api::{DeleteParams, Patch, PatchParams, PostParams};
 use kube::{Api, Client};
 
 use k8s_openapi::api::admissionregistration::v1::{
@@ -26,6 +26,7 @@ use k8s_openapi::api::admissionregistration::v1::{
 };
 use k8s_openapi::api::core::v1::Secret;
 
+use kopiur_api::consts::ALLOW_IDENTITY_CHANGE_ANNOTATION;
 use kopiur_api::{Repository, SnapshotPolicy};
 use kopiur_e2e::{E2E_NAMESPACE, World, default_timeout, poll_interval, wait_until};
 
@@ -174,6 +175,130 @@ async fn self_managed_webhook_tls_bootstraps_and_gates_admission() {
         "mover mutual-exclusivity rejection should come from the webhook, got: {msg}"
     );
     let _ = configs.delete(bad_mover, &DeleteParams::default()).await;
+}
+
+/// A SnapshotPolicy whose explicit `spec.identity.username` carries kopia's `@`
+/// delimiter — structurally a valid string, but the shared `validate_identity_component`
+/// rejects it (it would misparse `username@hostname`). Exercises the identity shape
+/// validator through admission.
+fn bad_identity_backup_config(name: &str) -> SnapshotPolicy {
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotPolicy",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": "any" },
+            "identity": { "username": "bad@user" },
+            "sources": [ { "pvc": { "name": "data" } } ],
+            "retention": { "keepLatest": 5 }
+        }
+    }))
+    .expect("SnapshotPolicy JSON deserializes")
+}
+
+/// A spec-valid SnapshotPolicy with an explicit pinned identity, suspended so the
+/// reconciler doesn't churn it while we drive admission directly.
+fn identity_backup_config(name: &str, username: &str, hostname: &str) -> SnapshotPolicy {
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotPolicy",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": "any" },
+            "identity": { "username": username, "hostname": hostname },
+            "sources": [ { "pvc": { "name": "data" } } ],
+            "retention": { "keepLatest": 5 },
+            "suspend": true
+        }
+    }))
+    .expect("SnapshotPolicy JSON deserializes")
+}
+
+/// The identity shape validator and the fork-on-edit guard run through the real
+/// admission webhook against a live API server. The fork case is the one thing unit
+/// tests can't prove: that the API server delivers `oldObject.status` (the pinned
+/// identity + history) to the webhook on UPDATE.
+#[tokio::test]
+#[ignore = "requires a kind cluster with the operator installed (mise //crates/e2e:test)"]
+async fn identity_shape_and_fork_guard_are_enforced_at_admission() {
+    let Some(world) = World::connect().await else {
+        return; // no cluster: graceful no-op
+    };
+    let client = world.client().clone();
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // 1. An identity component carrying kopia's '@' delimiter is rejected.
+    let bad = "webhook-bad-identity";
+    let _ = policies.delete(bad, &DeleteParams::default()).await;
+    let err = policies
+        .create(&PostParams::default(), &bad_identity_backup_config(bad))
+        .await
+        .expect_err("an identity username with '@' must be DENIED by the webhook");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("denied the request") || msg.to_lowercase().contains("admission"),
+        "identity shape rejection should come from the webhook, got: {msg}"
+    );
+    let _ = policies.delete(bad, &DeleteParams::default()).await;
+
+    // 2. Fork-on-edit guard. Create a pinned-identity policy, simulate history by
+    //    patching status (resolved identity + lastSuccessfulSnapshot), then attempt to
+    //    change the identity.
+    let name = "webhook-identity-fork";
+    let _ = policies.delete(name, &DeleteParams::default()).await;
+    policies
+        .create(
+            &PostParams::default(),
+            &identity_backup_config(name, "pg", "billing"),
+        )
+        .await
+        .expect("a valid pinned-identity policy is admitted");
+
+    let status = serde_json::json!({
+        "status": {
+            "resolved": { "identity": { "username": "pg", "hostname": "billing" } },
+            "lastSuccessfulSnapshot": "2026-01-01T00:00:00Z"
+        }
+    });
+    policies
+        .patch_status(name, &PatchParams::default(), &Patch::Merge(&status))
+        .await
+        .expect("status patch (simulated history) applies");
+
+    // Guard against a false pass: the simulated history must actually be present before
+    // we test the UPDATE (the reconciler is suspended, but assert it didn't clear it).
+    let got = policies.get_status(name).await.expect("get status");
+    assert!(
+        got.status
+            .as_ref()
+            .and_then(|s| s.last_successful_snapshot.as_ref())
+            .is_some(),
+        "simulated history must be pinned before the UPDATE test"
+    );
+
+    // Changing the resolved identity (hostname) on a policy with history → DENIED.
+    let change = serde_json::json!({ "spec": { "identity": { "hostname": "payments" } } });
+    let err = policies
+        .patch(name, &PatchParams::default(), &Patch::Merge(&change))
+        .await
+        .expect_err("re-identifying a policy with history must be DENIED");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("denied the request") || msg.to_lowercase().contains("admission"),
+        "fork rejection should come from the webhook, got: {msg}"
+    );
+
+    // The same change WITH the acknowledgment annotation → ADMITTED.
+    let acked = serde_json::json!({
+        "metadata": { "annotations": { ALLOW_IDENTITY_CHANGE_ANNOTATION: "intentional" } },
+        "spec": { "identity": { "hostname": "payments" } }
+    });
+    policies
+        .patch(name, &PatchParams::default(), &Patch::Merge(&acked))
+        .await
+        .expect("an acknowledged re-identification must be ADMITTED");
+
+    let _ = policies.delete(name, &DeleteParams::default()).await;
 }
 
 /// True when every webhook in the ValidatingWebhookConfiguration carries a

--- a/crates/webhook/src/handlers.rs
+++ b/crates/webhook/src/handlers.rs
@@ -126,6 +126,23 @@ fn decode_old_spec<T: serde::de::DeserializeOwned>(
     decode_spec(&old.data).ok()
 }
 
+/// Decode the OLD object's typed `status` `T` from an UPDATE admission request. The
+/// status subresource is part of the stored object the API server sends as
+/// `oldObject`, so it is present once the controller has written it. A missing
+/// `status` decodes from `{}` (every status field is optional), yielding the default —
+/// used by the fork-on-edit guard to read the previously-pinned identity + history.
+fn decode_old_status<T: serde::de::DeserializeOwned>(
+    req: &AdmissionRequest<DynamicObject>,
+) -> Option<T> {
+    let old = req.old_object.as_ref()?;
+    let status = old
+        .data
+        .get("status")
+        .cloned()
+        .unwrap_or(Value::Object(Default::default()));
+    serde_json::from_value(status).ok()
+}
+
 /// Apply a JSON patch to a response; a serialization failure is the typed
 /// [`AdmissionError::InternalPatch`] (fail closed at the dispatch choke point).
 fn with_patch(resp: AdmissionResponse, ops: Vec<PatchOperation>) -> AdmissionResult {
@@ -231,6 +248,34 @@ async fn handle_snapshot_policy(
                     conflict: collision.conflict,
                 },
             ]));
+        }
+    }
+
+    // Fork-on-edit guard: on UPDATE, reject a change that would re-identify a policy
+    // with existing snapshot history (orphaning the old kopia source) unless it is
+    // acknowledged with the allow-identity-change annotation. Reads the old object's
+    // pinned identity + history; degrades to allow when it can't decide confidently.
+    if req.operation == Operation::Update
+        && let (Some(old_spec), Some(old_status)) = (
+            decode_old_spec::<SnapshotPolicySpec>(req),
+            decode_old_status::<api::snapshot_policy::SnapshotPolicyStatus>(req),
+        )
+    {
+        let name = obj.metadata.name.as_deref().unwrap_or(req.name.as_str());
+        let ns = req.namespace.as_deref().unwrap_or_default();
+        if let Some(err) = crate::identity_fork::check_identity_fork(
+            client,
+            name,
+            ns,
+            &spec,
+            obj.metadata.labels.as_ref(),
+            obj.metadata.annotations.as_ref(),
+            &old_spec,
+            &old_status,
+        )
+        .await
+        {
+            return Err(AdmissionError::Invalid(vec![err]));
         }
     }
 
@@ -676,6 +721,145 @@ mod tests {
             resp.warnings.is_none(),
             "no spurious warnings: {:?}",
             resp.warnings
+        );
+    }
+
+    // --- identity hardening ----------------------------------------------------
+
+    #[tokio::test]
+    async fn create_with_bad_identity_override_is_rejected() {
+        // A '@' in an explicit username override would misparse — rejected at admission
+        // (client-free path, no cluster needed).
+        let spec = json!({
+            "repository": { "kind": "Repository", "name": "r" },
+            "identity": { "username": "bad@user" },
+            "sources": [ { "pvc": { "name": "data" } } ],
+        });
+        let req = admission_request("SnapshotPolicy", spec);
+        let resp = dispatch(&req, None).await;
+        assert!(!resp.allowed, "bad identity override must be rejected");
+        assert!(
+            resp.result
+                .message
+                .contains("not a valid kopia identity component"),
+            "{:?}",
+            resp.result.message
+        );
+    }
+
+    /// Build an UPDATE `AdmissionRequest` for a `SnapshotPolicy`, with the new object
+    /// (spec + annotations) and the `oldObject` (spec + status) as the API server sends
+    /// them. Used by the fork-on-edit guard tests.
+    fn update_policy_request(
+        new_spec: Value,
+        new_annotations: Value,
+        old_spec: Value,
+        old_status: Value,
+    ) -> AdmissionRequest<DynamicObject> {
+        let review = json!({
+            "apiVersion": "admission.k8s.io/v1",
+            "kind": "AdmissionReview",
+            "request": {
+                "uid": "test-uid",
+                "kind": { "group": "kopiur.home-operations.com", "version": "v1alpha1", "kind": "SnapshotPolicy" },
+                "resource": { "group": "kopiur.home-operations.com", "version": "v1alpha1", "resource": "snapshotpolicies" },
+                "name": "pg",
+                "namespace": "billing",
+                "operation": "UPDATE",
+                "userInfo": { "username": "tester" },
+                "object": {
+                    "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                    "kind": "SnapshotPolicy",
+                    "metadata": { "name": "pg", "namespace": "billing", "annotations": new_annotations },
+                    "spec": new_spec,
+                },
+                "oldObject": {
+                    "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                    "kind": "SnapshotPolicy",
+                    "metadata": { "name": "pg", "namespace": "billing" },
+                    "spec": old_spec,
+                    "status": old_status,
+                }
+            }
+        });
+        let review: kube::core::admission::AdmissionReview<DynamicObject> =
+            serde_json::from_value(review).unwrap();
+        review.try_into().unwrap()
+    }
+
+    fn source(path_override: Option<&str>) -> Value {
+        match path_override {
+            Some(p) => json!({ "pvc": { "name": "data" }, "sourcePathOverride": p }),
+            None => json!({ "pvc": { "name": "data" } }),
+        }
+    }
+
+    fn policy_spec(path_override: Option<&str>) -> Value {
+        json!({
+            "repository": { "kind": "Repository", "name": "r" },
+            "sources": [ source(path_override) ],
+        })
+    }
+
+    fn status_with_history(has_history: bool) -> Value {
+        let mut s = json!({
+            "resolved": { "identity": { "username": "pg", "hostname": "billing" } }
+        });
+        if has_history {
+            s["lastSuccessfulSnapshot"] = json!("2026-06-19T00:00:00Z");
+        }
+        s
+    }
+
+    #[tokio::test]
+    async fn source_path_fork_on_policy_with_history_is_rejected() {
+        // The PVC's effective path changes (/pvc/data → /data) on a policy that has
+        // produced snapshots. This path is pure (no CEL), so the guard fires with no
+        // client.
+        let req = update_policy_request(
+            policy_spec(Some("/data")),
+            json!({}),
+            policy_spec(None),
+            status_with_history(true),
+        );
+        let resp = dispatch(&req, None).await;
+        assert!(!resp.allowed, "path re-identification must be rejected");
+        assert!(
+            resp.result.message.contains("orphan the old history"),
+            "{:?}",
+            resp.result.message
+        );
+    }
+
+    #[tokio::test]
+    async fn source_path_fork_is_allowed_with_ack_annotation() {
+        let req = update_policy_request(
+            policy_spec(Some("/data")),
+            json!({ "kopiur.home-operations.com/allow-identity-change": "yes" }),
+            policy_spec(None),
+            status_with_history(true),
+        );
+        let resp = dispatch(&req, None).await;
+        assert!(
+            resp.allowed,
+            "acknowledged re-identification must be allowed"
+        );
+    }
+
+    #[tokio::test]
+    async fn source_path_change_is_allowed_without_history() {
+        // No successful snapshot yet → nothing to orphan → allowed (typo-fix case).
+        let req = update_policy_request(
+            policy_spec(Some("/data")),
+            json!({}),
+            policy_spec(None),
+            status_with_history(false),
+        );
+        let resp = dispatch(&req, None).await;
+        assert!(
+            resp.allowed,
+            "no-history edit must be allowed: {:?}",
+            resp.result.message
         );
     }
 }

--- a/crates/webhook/src/identity_collision.rs
+++ b/crates/webhook/src/identity_collision.rs
@@ -55,14 +55,14 @@ pub fn repo_key(repo: &RepositoryRef, owner_namespace: &str) -> String {
 /// `None` for a namespaced `Repository`. Returns `None` if an expression fails to
 /// resolve (the per-field validators already reject those; here we just skip the
 /// collision check for an unresolvable identity rather than panic).
-pub fn policy_identity_string(
+pub fn resolve_policy_identity(
     name: &str,
     namespace: &str,
     spec: &SnapshotPolicySpec,
     labels: Option<&BTreeMap<String, String>>,
     annotations: Option<&BTreeMap<String, String>>,
     defaults: Option<&IdentityDefaults>,
-) -> Option<String> {
+) -> Option<api::common::ResolvedIdentity> {
     let first = spec.sources.first();
     let pvc_name = first.and_then(|s| s.pvc.as_ref().map(|p| p.name.clone()));
     let nfs_source_path = first.and_then(|s| s.nfs.as_ref().map(|n| n.path.clone()));
@@ -78,14 +78,36 @@ pub fn policy_identity_string(
         default_source_path: nfs_source_path.as_deref(),
         source_path_override: source_path_override.as_deref(),
     };
-    api::resolve_identity(&inputs)
-        .ok()
+    api::resolve_identity(&inputs).ok()
+}
+
+/// As [`resolve_policy_identity`], formatted as kopia's `username@hostname[:path]`
+/// string for collision comparison.
+pub fn policy_identity_string(
+    name: &str,
+    namespace: &str,
+    spec: &SnapshotPolicySpec,
+    labels: Option<&BTreeMap<String, String>>,
+    annotations: Option<&BTreeMap<String, String>>,
+    defaults: Option<&IdentityDefaults>,
+) -> Option<String> {
+    resolve_policy_identity(name, namespace, spec, labels, annotations, defaults)
         .map(|r| api::identity_string(&r))
 }
 
 /// Look up the `identityDefaults` of the `ClusterRepository` a policy references, if
 /// any (`None` for a namespaced `Repository` or when the lookup fails). Cached by
 /// repo name so listing N policies that share a ClusterRepository does one get.
+/// Fetch the `identityDefaults` of the `ClusterRepository` a single policy
+/// references (no cache — for callers resolving one policy, e.g. the fork guard).
+pub(crate) async fn cluster_repo_defaults_for(
+    client: &Client,
+    repo: &RepositoryRef,
+) -> Option<IdentityDefaults> {
+    let mut cache = BTreeMap::new();
+    cluster_repo_defaults(client, repo, &mut cache).await
+}
+
 async fn cluster_repo_defaults(
     client: &Client,
     repo: &RepositoryRef,

--- a/crates/webhook/src/identity_fork.rs
+++ b/crates/webhook/src/identity_fork.rs
@@ -1,0 +1,100 @@
+//! Fork-on-edit guard at admission.
+//!
+//! Kopia records every snapshot under `username@hostname:sourcePath`. If a
+//! `SnapshotPolicy` is *edited* so its resolved identity changes — renamed, a
+//! namespace/label change feeding an `identityDefaults` CEL expression, a hand-edited
+//! `spec.identity`, or a per-source `sourcePathOverride` change — new snapshots land
+//! under the **new** kopia source while the old history orphans: GFS retention treats
+//! them as separate sources and never prunes the old set (a storage leak), and the new
+//! identity restarts retention from zero. That is silent data-loss, so the webhook
+//! **rejects** such an edit unless the operator acknowledges it with the
+//! [`ALLOW_IDENTITY_CHANGE_ANNOTATION`].
+//!
+//! ## Pure core + thin IO (mirrors [`crate::identity_collision`])
+//!
+//! - The decision is the pure, unit-tested [`api::validate::detect_identity_fork`] (on
+//!   the `username@hostname`) and [`api::validate::detect_source_path_fork`] (on each
+//!   PVC source's path — paths are never CEL-driven, so an old-vs-new spec diff is
+//!   complete).
+//! - [`check_identity_fork`] is the thin IO caller: it reads the old object's pinned
+//!   identity + history from `oldObject.status`, resolves the *new* identity (fetching
+//!   the referenced `ClusterRepository`'s `identityDefaults` for CEL), and calls the
+//!   pure decisions.
+//! - It only fires on UPDATE, only when the policy has real history
+//!   (`status.lastSuccessfulSnapshot`), and **degrades to allow** when it cannot make
+//!   a confident decision (no client, or no pinned identity yet) — the same
+//!   fail-open posture as the collision guard.
+
+use std::collections::BTreeMap;
+
+use kopiur_api as api;
+
+use api::consts::ALLOW_IDENTITY_CHANGE_ANNOTATION;
+use api::error::ValidationError;
+use api::snapshot_policy::{SnapshotPolicySpec, SnapshotPolicyStatus};
+use kube::Client;
+
+/// Whether the incoming object acknowledges an intentional re-identification via the
+/// [`ALLOW_IDENTITY_CHANGE_ANNOTATION`] (any non-empty value; presence-only).
+fn acknowledged(annotations: Option<&BTreeMap<String, String>>) -> bool {
+    annotations
+        .and_then(|a| a.get(ALLOW_IDENTITY_CHANGE_ANNOTATION))
+        .is_some_and(|v| !v.trim().is_empty())
+}
+
+/// Check whether an UPDATE to a `SnapshotPolicy` would fork its kopia identity while it
+/// already has snapshot history. Returns the [`ValidationError::IdentityWouldFork`] to
+/// reject with, or `None` to allow.
+///
+/// `old_spec`/`old_status` come from the admission request's `oldObject`. The guard:
+/// - allows when the change is acknowledged, or the policy has no successful snapshot
+///   yet (`status.lastSuccessfulSnapshot` unset → no history to orphan);
+/// - checks per-source path forks purely (no client);
+/// - checks the `username@hostname` fork by resolving the new identity, which needs the
+///   `ClusterRepository` `identityDefaults` for CEL — if there is no client, or the old
+///   identity was never pinned, it degrades to allow.
+#[allow(clippy::too_many_arguments)]
+pub async fn check_identity_fork(
+    client: Option<&Client>,
+    name: &str,
+    namespace: &str,
+    new_spec: &SnapshotPolicySpec,
+    new_labels: Option<&BTreeMap<String, String>>,
+    new_annotations: Option<&BTreeMap<String, String>>,
+    old_spec: &SnapshotPolicySpec,
+    old_status: &SnapshotPolicyStatus,
+) -> Option<ValidationError> {
+    let acked = acknowledged(new_annotations);
+    let has_history = old_status.last_successful_snapshot.is_some();
+    if !has_history || acked {
+        return None;
+    }
+
+    // Per-source path fork: pure spec diff, no client required.
+    if let Some(e) = api::validate::detect_source_path_fork(old_spec, new_spec, has_history, acked)
+    {
+        return Some(e);
+    }
+
+    // username@hostname fork: compare the previously-pinned identity against the
+    // freshly-resolved one. The old identity must have been pinned (else there is no
+    // baseline — degrade to allow), and resolving the new identity needs the
+    // ClusterRepository identityDefaults (CEL), so without a client we degrade to allow.
+    let old_id = old_status.resolved.as_ref()?.identity.as_ref()?;
+    let old_uh = format!("{}@{}", old_id.username, old_id.hostname);
+
+    let client = client?;
+    let defaults =
+        crate::identity_collision::cluster_repo_defaults_for(client, &new_spec.repository).await;
+    let new_id = crate::identity_collision::resolve_policy_identity(
+        name,
+        namespace,
+        new_spec,
+        new_labels,
+        new_annotations,
+        defaults.as_ref(),
+    )?;
+    let new_uh = format!("{}@{}", new_id.username, new_id.hostname);
+
+    api::validate::detect_identity_fork(&old_uh, &new_uh, has_history, acked)
+}

--- a/crates/webhook/src/lib.rs
+++ b/crates/webhook/src/lib.rs
@@ -5,6 +5,7 @@ pub mod config;
 pub mod error;
 pub mod handlers;
 pub mod identity_collision;
+pub mod identity_fork;
 pub mod metrics;
 pub mod routes;
 pub mod secctx;

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -181,6 +181,20 @@ identity:
 
 (For a shared `ClusterRepository`, the repo can supply identity _CEL expressions_ so tenants get distinct identities automatically — see [Repositories → identityDefaults](repositories.md#identitydefaults--per-tenant-identity-cel). An explicit `identity` here always wins.)
 
+!!! warning "Identity strings must round-trip through kopia"
+    `username` and `hostname` form the `username@hostname:path` string kopia parses on the **first** `@` and **first** `:` — with no escaping. The webhook therefore rejects a `username`/`hostname` that is empty or contains `@`, `:`, whitespace, or a control character (a `sourcePathOverride` may contain spaces and `:`, but not control characters and not be empty). This is shape-only — dots, dashes, slashes, and unicode letters are all fine. Normal Kubernetes names and namespaces always pass; the rule only catches values that could never have worked.
+
+!!! warning "Changing a policy's identity after it has snapshots orphans the old history"
+    A snapshot's identity is its address in the repository. If you edit `identity` (or a source's `sourcePathOverride`) on a `SnapshotPolicy` that has **already produced snapshots**, new snapshots land under the new address and the old ones are orphaned: GFS retention treats them as a separate source and never prunes them, and the new identity restarts retention from zero. To stop silent data loss the webhook **rejects** such an edit. If the re-identification is intentional, acknowledge it with the annotation:
+
+    ```yaml
+    metadata:
+      annotations:
+        kopiur.home-operations.com/allow-identity-change: "intentional"  # any non-empty value
+    ```
+
+    Fixing the identity *before* the first successful snapshot is unrestricted (there is no history to orphan).
+
 ### compression, files & extraArgs — kopia tuning and ignores
 
 These map onto kopia's per-source policy and sit as **top-level** siblings of `retention` on the `SnapshotPolicy` spec:

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -108,7 +108,7 @@ Short name `kopiasp`, plural `snapshotpolicies`. Print columns: `REPOSITORY`,
 | Field | Type | Default | Notes |
 | --- | --- | --- | --- |
 | `repository` | [RepositoryRef](#repositoryref) | **required** | The `Repository`/`ClusterRepository` to write to. |
-| `identity` | {`username`?,`hostname`?} | — | Override the resolved `username@hostname`. |
+| `identity` | {`username`?,`hostname`?} | — | Override the resolved `username@hostname`. Each component is shape-checked (no `@`/`:`/whitespace/control chars, ≤253 bytes); changing it after the policy has snapshots is rejected unless `kopiur.home-operations.com/allow-identity-change` is set. See [Backups → identity](backups.md#identity--what-kopia-records-usernamehostnamepath). |
 | `sources` | [][Source](#source) | — | What to back up (≥1, webhook-enforced). |
 | `copyMethod` | enum(`Snapshot`\|`Clone`\|**`Direct`**) | `Direct` | How the source is captured: `Direct` (live PVC, co-located — default, works anywhere), `Snapshot` (CSI VolumeSnapshot → staged PVC, opt-in), `Clone` (CSI clone → staged PVC, opt-in). See [Copy methods](copy-methods.md). |
 | `volumeSnapshotClassName` | string | — | `VolumeSnapshotClass` for `Snapshot`/`Clone`; unset auto-selects the source driver's default class. NFS sources reject it (nothing to snapshot). |

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -226,6 +226,12 @@ Set the UID/GID **once** on `moverDefaults.securityContext.runAsUser/runAsGroup`
 
 `moverDefaults.scratch` is the repo-level default for the **deep-verification** scratch volume (the throwaway restore target a `verification.deep` restore-test writes into, then discards). It's the scratch sibling of `cache`: a `SnapshotPolicy`'s `verification.deep.{capacity,storageClassName}` overlays it field-wise, so you set the scratch size/class **once** here instead of repeating it on every policy. Unlike the cache, scratch has **no `mode`** — it's always ephemeral and discarded after each run. `storageClassName` only applies when a `capacity` is set (an `emptyDir` has no StorageClass); a class with no effective capacity is a no-op and the operator flags it via the `ScratchStorageClassIgnored` condition on the `SnapshotPolicy`. See [verification](backups.md#verification--prove-the-snapshots-are-restorable).
 
+/// note | Verification movers inherit `moverDefaults` too
+
+The `quick`/`deep` verification movers a `SnapshotPolicy` spawns inherit the **whole** `moverDefaults` — security context, resources, scheduling, TTL, throttle, **and** the kopia `cache` (size/class + budgets) — exactly like backup and restore movers. The one exception: a `cache.mode: Persistent` is **coerced to a fresh per-run ephemeral cache** for verification, because a verify run must never attach the backup's warm `ReadWriteOnce` cache PVC (a Multi-Attach race). Set `moverDefaults.cache` once and your verifications are sized/placed without any per-policy config.
+
+///
+
 ### `sourceColocation`: avoid the RWO Multi-Attach error
 
 A `ReadWriteOnce` (RWO) PVC can only be **attached to one node at a time**, though it can be mounted by several pods **on that same node**. When your app pod already holds an RWO PVC on node A and Kopiur's mover lands on node B, the kubelet on B can't attach the volume and the mover pod is stuck with a `Multi-Attach error` (it never starts).

--- a/docs/scenarios/adopt-existing-repo.md
+++ b/docs/scenarios/adopt-existing-repo.md
@@ -76,6 +76,9 @@ identity:
 If you _don't_ match it, backups still succeed — but they start a brand-new
 lineage and re-upload a full copy instead of an incremental one.
 
+!!! tip "Adopting a perfectra1n/volsync **kopia** repo? Use `migrate volsync`, don't hand-write this"
+    Kopiur's *default* identity (`<policyName>@<namespace>:/pvc/<pvc>`) does **not** match what the volsync fork records (`<sanitized-name>@<sanitized-namespace>:/data`) — even the source path differs. Hand-adopting a fork repo without pinning the exact identity silently forks the history. [`kubectl kopiur migrate volsync`](../cli/migrate-volsync.md) computes the fork's identity for you (a bug-for-bug port of its sanitizer) and pins it, so history continues seamlessly. Reach for the manual identity match here only for a non-volsync writer.
+
 ## Verify adoption
 
 ```console

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -130,6 +130,14 @@ permission denied or silently skip unreadable files.
 
 It fires only when the recipe **explicitly pins** a `runAsUser` that shares no UID or group with the workload mounting `source.pvc`. It's **best-effort** — the webhook can't see file modes (the data may be world-readable) or `moverDefaults`, so it stays silent when the UID is image-determined. The authoritative checks come later: the `SecurityContextCompatible` condition at reconcile and kopia's own output at runtime (below). A `Restore` gets the analogous warning about its *target* PVC's future consumer. The fix is always the same — match the mover to the workload via `inheritSecurityContextFrom.pvcConsumer: {}` or a matching `runAsUser`/`fsGroup`.
 
+## `SnapshotPolicy` rejected at admission: identity
+
+| Symptom (at `kubectl apply`) | Cause | Fix |
+| --- | --- | --- |
+| `… is not a valid kopia identity component … (kopia parses username@hostname:path on the first @ and first :)` | A `spec.identity.username`/`hostname` (or an `identityDefaults` CEL expression's result) is empty or contains `@`, `:`, whitespace, or a control character. | Use a value that round-trips through kopia's `username@hostname:path` form — no `@`/`:`/whitespace. Dots, dashes, slashes, and unicode letters are fine. |
+| `… is not a valid kopia source path …` | A `sourcePathOverride` is empty or contains a newline / control character. | Set a non-empty path without control characters (spaces and `:` are allowed). |
+| `this edit changes the policy's resolved kopia identity from … to …, but the policy already has snapshot history` | You edited `identity` (or a source's `sourcePathOverride`) on a `SnapshotPolicy` that has already produced snapshots — the change would orphan the old kopia history. | If unintentional, revert the identity. If you really mean to re-identify, set `kopiur.home-operations.com/allow-identity-change` (any non-empty value) on the policy. See [Backups → identity](backups.md#identity--what-kopia-records-usernamehostnamepath). |
+
 ## Backup runs but `Failed`
 
 The mover Job ran and exhausted its retries (`failurePolicy.backoffLimit`). The error tail is on the `Snapshot`:


### PR DESCRIPTION
## Why

I was nervous about exposing user-specifiable kopia identity. After tracing the code: the capability is **load-bearing** (volsync adoption via `migrate volsync`, shared repos, renames, multi-source dedup all depend on it), so the right move is to **contain the footguns**, not remove the feature. Two real gaps were open:

1. **No content validation.** `spec.identity.{username,hostname}` overrides and CEL-expr results were never shape-checked. kopia parses `username@hostname:path` on the **first** `@`/`:` with no escaping (`snapshot/source.go::ParseSourceInfo`), so an embedded `@`/`:`/whitespace/control char silently misparses the identity or makes the snapshot un-findable — and only fails inside a mover *Job*, not at admission.
2. **Editing a policy's identity silently forks history.** The existing collision check catches two *different* policies clashing, but nothing caught a *single* policy being re-identified. New snapshots land under a new kopia source; the old ones orphan (GFS retention treats them as a separate source and never prunes them).

## What

**Shape validation (footgun #1).** Reject a `username`/`hostname` that is empty or contains `@`, `:`, whitespace, or a control char (≤253 bytes); reject a `sourcePath` that is empty-when-set or has a control char (spaces and `:` allowed). Shape-only — dots/dashes/slashes/unicode all pass; the rule only catches values that could never round-trip through kopia. Enforced in two layers:
- client-free in `validate_backup_config` (explicit overrides → fast admission reject even with no kube client);
- inside `resolve_identity` (CEL results + name/namespace defaults; the controller maps the error to `ErrorClass::Structural`, a 5-min backoff — no hot-loop).

**Fork-on-edit guard (footgun #2).** On UPDATE, reject a change that re-identifies a `SnapshotPolicy` with existing snapshot history (`status.lastSuccessfulSnapshot` set):
- `username@hostname` via resolved-diff vs the pinned `status.resolved.identity`;
- per-source paths via a pure spec diff (paths are never CEL-driven).

Hard-reject (GitOps discards admission *warnings*) with an escape hatch: `kopiur.home-operations.com/allow-identity-change` (any non-empty value). Degrades to *allow* when it can't decide confidently (no client, no pinned identity, no history).

**Inheritance parity.** A new test asserts the bug-for-bug volsync `builder.go` sanitizer can never emit an identity the new validator rejects, so `migrate volsync` adoption is never bounced at admission.

## Design notes (deviations from the original plan, found mid-build)
- **Ack annotation is presence-only**, not value-must-equal-new: one edit can fork two components at once, and the operator-resolved string isn't user-pre-computable. Matches the `skip-snapshot-cleanup` precedent.
- **Per-source path fork** is a pure PVC-name-matched spec diff (no client), separate from the CEL-dependent `username@hostname` diff.

## Tests
- **Unit:** validators (accept/reject incl. the misparse cases), `detect_identity_fork`/`detect_source_path_fork` truth tables, resolution-level rejection, and the fork↔kopiur **parity test**.
- **Webhook handler:** bad-override CREATE reject, path-fork reject, ack-allows, no-history-allows.
- **e2e (`crates/e2e/tests/webhook.rs`):** identity-shape + fork-guard scenarios — incl. the one thing units can't prove: that the API server delivers `oldObject.status` to the webhook on UPDATE.

## Docs (same PR)
`backups.md` (two admonitions), `field-reference.md`, `troubleshooting.md` (new rejection table), `adopt-existing-repo.md` (the hand-adoption-without-`migrate` trap — native default ≠ fork identity).

## Verification
`mise run test` / `clippy` / `fmt-check` / `gen-check` (no CRD drift) / `docs` (strict) all green. e2e compiles under `--features e2e` and is clippy-clean (runs in CI's kind cluster).