### PR TITLE
fix(restore): re-resolve kopia snapshot id after pin; heal stale ids (#137)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,8 +144,17 @@ jobs:
           - shard: hooks-retention
             bins: "hooks retention policy_knobs"
             backends: true
+          # `verification` (deep-verify scratch-restores) and `replication`
+          # (repository sync-to) are the two heaviest cron-wait suites; bundling
+          # both onto one kind node tipped it into NodeNotReady under runner
+          # resource pressure (scheduler 500 → nothing schedules → bootstrap
+          # fails). Give each its own shard/cluster to cut peak pressure —
+          # reshape-async keeps just verification; replication splits out.
           - shard: reshape-async
-            bins: "verification replication"
+            bins: "verification"
+            backends: false
+          - shard: replication
+            bins: "replication"
             backends: false
           # securityContext-compatibility pipeline: pvcConsumer auto-derive + the
           # SecurityContextCompatible reconcile condition. Filesystem only.

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,14 +144,20 @@ jobs:
           - shard: hooks-retention
             bins: "hooks retention policy_knobs"
             backends: true
-          # `verification` (deep-verify scratch-restores) and `replication`
-          # (repository sync-to) are the two heaviest cron-wait suites; bundling
-          # both onto one kind node tipped it into NodeNotReady under runner
-          # resource pressure (scheduler 500 → nothing schedules → bootstrap
-          # fails). Give each its own shard/cluster to cut peak pressure —
-          # reshape-async keeps just verification; replication splits out.
+          # The heaviest cron-wait suites each get their own kind node — bundling
+          # them tipped the single node into NodeNotReady under runner resource
+          # pressure (scheduler 500 → nothing schedules → bootstrap fails). The
+          # deep-verify scratch-restore is the single heaviest test, so it runs
+          # ALONE on a fresh node (its repo bootstrap was the one failing); the
+          # quick-verify tests stay in reshape-async (deep_verify skipped there),
+          # and replication gets its own shard too.
           - shard: reshape-async
             bins: "verification"
+            testskip: "deep_verify"
+            backends: false
+          - shard: verify-deep
+            bins: "verification"
+            testfilter: "deep_verify"
             backends: false
           - shard: replication
             bins: "replication"
@@ -223,6 +229,8 @@ jobs:
       - name: Run e2e tests
         env:
           KOPIUR_E2E_BINS: ${{ matrix.bins }}
+          KOPIUR_E2E_TESTFILTER: ${{ matrix.testfilter }}
+          KOPIUR_E2E_TESTSKIP: ${{ matrix.testskip }}
           KOPIUR_E2E_SKIP_BUILD: "1"
           # On a `csi: true` shard the stack is installed above, so a missing
           # csi-hostpath-sc is a setup failure — make the CSI-dependent tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -144,23 +144,8 @@ jobs:
           - shard: hooks-retention
             bins: "hooks retention policy_knobs"
             backends: true
-          # The heaviest cron-wait suites each get their own kind node — bundling
-          # them tipped the single node into NodeNotReady under runner resource
-          # pressure (scheduler 500 → nothing schedules → bootstrap fails). The
-          # deep-verify scratch-restore is the single heaviest test, so it runs
-          # ALONE on a fresh node (its repo bootstrap was the one failing); the
-          # quick-verify tests stay in reshape-async (deep_verify skipped there),
-          # and replication gets its own shard too.
           - shard: reshape-async
-            bins: "verification"
-            testskip: "deep_verify"
-            backends: false
-          - shard: verify-deep
-            bins: "verification"
-            testfilter: "deep_verify"
-            backends: false
-          - shard: replication
-            bins: "replication"
+            bins: "verification replication"
             backends: false
           # securityContext-compatibility pipeline: pvcConsumer auto-derive + the
           # SecurityContextCompatible reconcile condition. Filesystem only.
@@ -229,8 +214,6 @@ jobs:
       - name: Run e2e tests
         env:
           KOPIUR_E2E_BINS: ${{ matrix.bins }}
-          KOPIUR_E2E_TESTFILTER: ${{ matrix.testfilter }}
-          KOPIUR_E2E_TESTSKIP: ${{ matrix.testskip }}
           KOPIUR_E2E_SKIP_BUILD: "1"
           # On a `csi: true` shard the stack is installed above, so a missing
           # csi-hostpath-sc is a setup failure — make the CSI-dependent tests

--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -84,6 +84,29 @@ pub enum Error {
         backend: &'static str,
     },
 
+    /// A `Restore` source needs an in-process kopia snapshot listing
+    /// (`fromPolicy` / `identity` without a pinned `snapshotID`) against a
+    /// FILESYSTEM repository whose path is not mounted into the controller pod.
+    /// Resolving "latest / offset / asOf" lists snapshots in-process, which
+    /// requires the controller to be able to read the repository — but the repo
+    /// volume is normally mounted only into the mover Jobs. Structural: the
+    /// deployment must mount the repo into the controller, or the spec must pin
+    /// the snapshot explicitly. Surfaced instead of letting the raw kopia
+    /// `stat <path>: no such file or directory` leak (actionable-error-messages).
+    #[error(
+        "cannot resolve the restore source by identity: the filesystem repository path \
+         '{path}' is not accessible to the controller. fromPolicy/identity resolution lists \
+         snapshots in-process, so the repository must be mounted into the CONTROLLER pod at \
+         '{path}' and the controller must run as a UID that can read it (controller.extraVolumes \
+         + extraVolumeMounts + podSecurityContext). Alternatively, restore by source.snapshotRef \
+         or pin source.identity.snapshotID, which need no controller mount"
+    )]
+    FilesystemResolutionUnmounted {
+        /// The repository's `backend.filesystem.path` (where the controller must
+        /// have the repo mounted to list in-process).
+        path: String,
+    },
+
     /// Self-managed webhook TLS setup failed on the **cluster IO** side: reading/
     /// writing the serving Secret or injecting `caBundle` into a webhook
     /// configuration ([`crate::webhook_tls`]). Transient — the webhook config or
@@ -171,7 +194,8 @@ impl Error {
             | Error::Serialization(_)
             | Error::InvalidSchedule(_)
             | Error::Invariant(_)
-            | Error::UnsupportedSourceResolution { .. } => ErrorClass::Structural,
+            | Error::UnsupportedSourceResolution { .. }
+            | Error::FilesystemResolutionUnmounted { .. } => ErrorClass::Structural,
         }
     }
 }

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -299,7 +299,7 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
         // The error message itself carries the full what/why/fix (use snapshotRef
         // or pin snapshotID) — the spec must change, same remediation as a
         // validation failure.
-        Error::UnsupportedSourceResolution { .. } => {
+        Error::UnsupportedSourceResolution { .. } | Error::FilesystemResolutionUnmounted { .. } => {
             (INVALID_SPEC_REASON, FIX_SPEC_ACTION, err.to_string())
         }
     };

--- a/crates/controller/src/restore.rs
+++ b/crates/controller/src/restore.rs
@@ -23,7 +23,7 @@ use kopiur_api::{
 };
 use kopiur_mover::workspec::{
     MoverOptions, MoverWorkSpec, Operation, RepositoryConnect, ResolvedIdentity as MoverIdentity,
-    RestoreOp, TargetRef,
+    RestoreOp, SnapshotAnchor, TargetRef,
 };
 
 use crate::config;
@@ -1429,11 +1429,15 @@ async fn run_restore_mover(
         restore.spec.mover.as_ref().and_then(|m| m.cache.as_ref()),
     );
     let cache = crate::cache::cache_tuning(effective_cache.as_ref());
+    // Stable anchors so the mover can heal a stale pinned id (kopia rewrites the
+    // manifest id on pin). Read once here, where we still have the source ref.
+    let anchor = restore_source_anchor(ctx, restore, namespace).await;
     let work_spec = MoverWorkSpec {
         version: 1,
         operation: Operation::Restore(RestoreOp {
             snapshot_id: snapshot_id.to_string(),
             target_path: target_path.clone(),
+            anchor,
             ignore_permission_errors,
             write_files_atomically,
         }),
@@ -1542,6 +1546,55 @@ struct ResolvedSource {
     kopia_snapshot_id: String,
     snapshot_ref: Option<kopiur_api::common::ObjectRef>,
     identity: Option<kopiur_api::common::ResolvedIdentity>,
+}
+
+/// Stable identity anchors for the restore's snapshot, so the mover can
+/// self-heal a STALE pinned id: kopia rewrites a snapshot's manifest id on pin,
+/// so a `snapshotRef`/`identity` restore of a snapshot pinned before the
+/// re-stamp fix points at a deleted manifest. The anchors (source path + start
+/// time) survive the rewrite.
+///
+/// `snapshotRef` reads the referenced `Snapshot` CR's recorded status (which
+/// keeps the correct identity/timing even when its id went stale). `identity`/
+/// `fromPolicy` use the pinned `status.resolved.identity` source path
+/// (best-effort, no start time — those resolve from a live list at admission).
+/// Empty when nothing is recorded yet (the mover then restores by id only).
+async fn restore_source_anchor(
+    ctx: &Context,
+    restore: &Restore,
+    namespace: &str,
+) -> SnapshotAnchor {
+    if let RestoreSource::SnapshotRef(r) = &restore.spec.source {
+        let ns = r.namespace.as_deref().unwrap_or(namespace);
+        let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), ns);
+        if let Ok(Some(snap)) = api.get_opt(&r.name).await {
+            let st = snap.status.as_ref();
+            return SnapshotAnchor {
+                source_path: st
+                    .and_then(|s| s.snapshot.as_ref())
+                    .and_then(|s| s.identity.source_path.clone())
+                    .unwrap_or_default(),
+                start_time: st
+                    .and_then(|s| s.timing.as_ref())
+                    .and_then(|t| t.start_time.clone()),
+            };
+        }
+    }
+    let source_path = restore
+        .status
+        .as_ref()
+        .and_then(|s| s.resolved.as_ref())
+        .and_then(|r| r.identity.as_ref())
+        .and_then(|i| i.source_path.clone())
+        .or_else(|| match &restore.spec.source {
+            RestoreSource::Identity(id) => id.source_path.clone(),
+            _ => None,
+        })
+        .unwrap_or_default();
+    SnapshotAnchor {
+        source_path,
+        start_time: None,
+    }
 }
 
 /// Best-effort, **positive-only** restore-direction securityContext check. If a pod already
@@ -1695,7 +1748,9 @@ async fn resolve_snapshot(
                         name: r.name.clone(),
                         namespace: Some(ns.to_string()),
                     }),
-                    identity: None,
+                    // Record the referenced snapshot's identity (provenance, and
+                    // the source-path anchor used to self-heal a stale id).
+                    identity: Some(s.identity),
                 }))
         }
         RestoreSource::Identity(id) => {
@@ -1815,6 +1870,16 @@ async fn list_for_identity(
     let creds = io::repo_credentials(&repo.encryption);
     match &repo.backend {
         Backend::Filesystem(fs) => {
+            // Pre-flight the repo path: in-process listing connects kopia to
+            // `fs.path`, which only works if the repo volume is mounted into the
+            // CONTROLLER (it is normally mounted only into mover Jobs). Catch the
+            // missing mount here with an actionable error instead of letting the
+            // raw kopia `stat <path>: no such file or directory` leak (#137).
+            if !std::path::Path::new(&fs.path).is_dir() {
+                return Err(Error::FilesystemResolutionUnmounted {
+                    path: fs.path.clone(),
+                });
+            }
             let password = io::read_repo_password(&ctx.client, namespace, &creds).await?;
             let client = ctx.kopia.build([("KOPIA_PASSWORD".to_string(), password)]);
             client

--- a/crates/controller/src/snapshot.rs
+++ b/crates/controller/src/snapshot.rs
@@ -32,7 +32,7 @@ use kopiur_api::snapshot::SnapshotPhase;
 use kopiur_api::{DeletionPolicy, Origin, Snapshot, SnapshotPolicy};
 use kopiur_mover::workspec::{
     MoverOptions, MoverWorkSpec, Operation, RepositoryConnect, ResolvedIdentity as MoverIdentity,
-    SnapshotDeleteOp, SnapshotOp, SnapshotPinOp, TargetRef,
+    SnapshotAnchor, SnapshotDeleteOp, SnapshotOp, SnapshotPinOp, TargetRef,
 };
 
 use crate::config;
@@ -1829,6 +1829,10 @@ async fn delete_snapshot_via_job(
         version: 1,
         operation: Operation::SnapshotDelete(SnapshotDeleteOp {
             snapshot_id: snapshot_id.to_string(),
+            // The recorded id can be stale (kopia rewrites the manifest id on
+            // pin); the mover re-resolves the live id by these anchors so a
+            // pinned snapshot isn't silently orphaned under deletionPolicy: Delete.
+            anchor: snapshot_anchor(backup),
         }),
         identity,
         repository: repository_connect(repo)?,
@@ -2011,6 +2015,9 @@ async fn reconcile_pin(
         operation: Operation::SnapshotPin(SnapshotPinOp {
             snapshot_id: snapshot_id.clone(),
             pin: matches!(action, PinAction::Pin),
+            // kopia rewrites the manifest id on (un)pin; the mover re-resolves
+            // the live id by these anchors and re-stamps status.snapshot.
+            anchor: snapshot_anchor(backup),
         }),
         identity,
         repository: repository_connect(&repo)?,
@@ -2104,7 +2111,12 @@ async fn finalize_succeeded(
     name: &str,
     namespace: &str,
 ) -> Result<()> {
-    // Try to resolve the snapshot id authoritatively for the filesystem backend.
+    // Best-effort: re-resolve the snapshot id for the filesystem backend. This is
+    // only a fallback — the authoritative `status.snapshot.kopiaSnapshotID` is
+    // (1) stamped by the mover at create and (2) re-stamped by the pin mover
+    // (kopia rewrites the id on pin). This in-process listing needs the repo
+    // mounted into the CONTROLLER, which is usually NOT the case; on failure we
+    // keep the mover-stamped create id and log the actionable hint.
     let snapshot = resolve_succeeded_snapshot(ctx, backup, namespace).await;
     // Base status carries the kstatus Ready conditions (ADR-0005 §2) so
     // `kubectl wait --for=condition=Ready` works on a Succeeded Snapshot.
@@ -2114,11 +2126,24 @@ async fn finalize_succeeded(
         "SnapshotCreated",
         "the kopia snapshot was created successfully",
     );
-    if let Ok(Some((id, identity))) = snapshot {
-        status["snapshot"] = serde_json::json!({
-            "kopiaSnapshotID": id,
-            "identity": identity,
-        });
+    match snapshot {
+        Ok(Some((id, identity))) => {
+            status["snapshot"] = serde_json::json!({
+                "kopiaSnapshotID": id,
+                "identity": identity,
+            });
+        }
+        Ok(None) => {}
+        Err(e) => {
+            tracing::warn!(
+                backup = %name,
+                error = %e,
+                "could not re-resolve the snapshot id in-process (the filesystem repo is not \
+                 mounted into the controller); keeping the mover-recorded create id. Mount the \
+                 repo into the controller to enable in-process resolution, or it self-corrects \
+                 on the next pin reconcile",
+            );
+        }
     }
     io::patch_status(api, name, status).await?;
     ctx.metrics
@@ -2463,6 +2488,24 @@ fn build_backup_run(
         });
 
     Ok((work_spec, source_volume, repo_volume, creds_secrets))
+}
+
+/// Stable identity anchors for a Snapshot's kopia manifest, read from its
+/// recorded status. kopia rewrites a snapshot's manifest id on pin, so the pin
+/// and delete movers re-resolve the live id by these anchors (source path +
+/// start time, both stable across the rewrite). Empty when the Snapshot has no
+/// recorded identity/timing yet (the mover then falls back to id-only behavior).
+fn snapshot_anchor(backup: &Snapshot) -> SnapshotAnchor {
+    let status = backup.status.as_ref();
+    SnapshotAnchor {
+        source_path: status
+            .and_then(|s| s.snapshot.as_ref())
+            .and_then(|s| s.identity.source_path.clone())
+            .unwrap_or_default(),
+        start_time: status
+            .and_then(|s| s.timing.as_ref())
+            .and_then(|t| t.start_time.clone()),
+    }
 }
 
 /// The hook plan summary carried on the work spec (`<index>:<form>` per hook) —

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 readonly kstatus verify vfydeep repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors
@@ -312,11 +312,6 @@ trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "==> e2e tests FAILED (rc=$rc) — du
 # KOPIUR_E2E_TESTFILTER — libtest name-substring filter, kept AFTER `--`.
 BINS=""
 for b in ${KOPIUR_E2E_BINS:-}; do BINS="$BINS --test $b"; done
-# KOPIUR_E2E_TESTSKIP — space-separated libtest name substrings to EXCLUDE, each
-# expanded to a `--skip <pat>` AFTER `--`. Lets one shard run a heavy test (e.g.
-# deep_verify) on its own fresh-node cluster while a sibling shard runs the rest.
-SKIPS=""
-for s in ${KOPIUR_E2E_TESTSKIP:-}; do SKIPS="$SKIPS --skip $s"; done
 # The CLI e2e (tests/cli.rs) runs the compiled kubectl-kopiur plugin binary as a
 # subprocess; build it here so the tests never race a stale/missing binary.
 echo "==> building kubectl-kopiur (CLI e2e subject)"
@@ -326,7 +321,7 @@ echo "==> running e2e tests${KOPIUR_E2E_BINS:+ (binaries:$KOPIUR_E2E_BINS)}"
 # (e.g. the heavyweight NFS/server backend test) can't hide the pass/fail of the rest.
 # cargo still exits non-zero overall, so the trap + CI failure are unaffected.
 cargo test -p kopiur-e2e --features e2e $BINS --no-fail-fast -- \
-  --include-ignored --test-threads=1 --nocapture $SKIPS ${KOPIUR_E2E_TESTFILTER:-}
+  --include-ignored --test-threads=1 --nocapture ${KOPIUR_E2E_TESTFILTER:-}
 echo "==> e2e tests passed"
 '''
 

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin populator populator2 readonly kstatus verify vfydeep repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 readonly kstatus verify vfydeep repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -312,6 +312,11 @@ trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "==> e2e tests FAILED (rc=$rc) — du
 # KOPIUR_E2E_TESTFILTER — libtest name-substring filter, kept AFTER `--`.
 BINS=""
 for b in ${KOPIUR_E2E_BINS:-}; do BINS="$BINS --test $b"; done
+# KOPIUR_E2E_TESTSKIP — space-separated libtest name substrings to EXCLUDE, each
+# expanded to a `--skip <pat>` AFTER `--`. Lets one shard run a heavy test (e.g.
+# deep_verify) on its own fresh-node cluster while a sibling shard runs the rest.
+SKIPS=""
+for s in ${KOPIUR_E2E_TESTSKIP:-}; do SKIPS="$SKIPS --skip $s"; done
 # The CLI e2e (tests/cli.rs) runs the compiled kubectl-kopiur plugin binary as a
 # subprocess; build it here so the tests never race a stale/missing binary.
 echo "==> building kubectl-kopiur (CLI e2e subject)"
@@ -321,7 +326,7 @@ echo "==> running e2e tests${KOPIUR_E2E_BINS:+ (binaries:$KOPIUR_E2E_BINS)}"
 # (e.g. the heavyweight NFS/server backend test) can't hide the pass/fail of the rest.
 # cargo still exits non-zero overall, so the trap + CI failure are unaffected.
 cargo test -p kopiur-e2e --features e2e $BINS --no-fail-fast -- \
-  --include-ignored --test-threads=1 --nocapture ${KOPIUR_E2E_TESTFILTER:-}
+  --include-ignored --test-threads=1 --nocapture $SKIPS ${KOPIUR_E2E_TESTFILTER:-}
 echo "==> e2e tests passed"
 '''
 

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -55,6 +55,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "nsdel-orphan",
     "nsdel-delete",
     "pin",
+    "pinrestore",
     "populator",
     "populator2",
     "readonly",

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -62,6 +62,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "kstatus",
     "verify",
     "vfydeep",
+    "vfyinh",
     "repl-src",
     "repl-dst",
     "projgate",

--- a/crates/e2e/tests/data_integrity.rs
+++ b/crates/e2e/tests/data_integrity.rs
@@ -356,36 +356,30 @@ async fn pinned_snapshot_restamps_id_and_restores_by_ref() {
         .await
         .expect("pinned Snapshot should reach Succeeded");
 
-    // The id recorded at create time (pre-pin).
-    let id_at_create = status_json(&backups, backup).await["snapshot"]["kopiaSnapshotID"]
-        .as_str()
-        .unwrap_or("")
-        .to_string();
-    assert!(
-        !id_at_create.is_empty(),
-        "the Succeeded Snapshot must record a kopia snapshot id"
-    );
-
-    // Once the pin reconciles, the id MUST re-stamp to the live (post-pin)
-    // manifest. Pre-fix it stayed == id_at_create and pointed at a deleted
-    // manifest. This is the core regression assertion.
+    // Wait for the pin to reconcile. We deliberately do NOT assert the id
+    // *changed* from its create-time value: kopia rewrites the manifest id on
+    // pin, but the pin Job reconciles in seconds, so the pre-pin window is racy
+    // to observe. The deterministic proof that the re-stamp landed correctly is
+    // the snapshotRef restore + finalizer delete below — both consume the stored
+    // id and would fail (kopia `object not found` / silent orphan) if it pointed
+    // at the deleted pre-pin manifest.
     wait_until(
-        "pinned snapshot id re-stamped to the live manifest after pin",
+        "pinned snapshot reconciled (status.pinned=true) with a recorded id",
         default_timeout(),
         poll_interval(),
         || async {
             let s = status_json(&backups, backup).await;
             let pinned = s["pinned"].as_bool().unwrap_or(false);
             let id = s["snapshot"]["kopiaSnapshotID"].as_str().unwrap_or("");
-            Ok((pinned && !id.is_empty() && id != id_at_create).then_some(()))
+            Ok((pinned && !id.is_empty()).then_some(()))
         },
     )
     .await
-    .expect("the pinned snapshot's kopiaSnapshotID must re-stamp after the pin rewrites it");
+    .expect("the pinned Snapshot should reconcile its pin and keep a recorded id");
 
-    // A snapshotRef restore of the pinned snapshot must Complete. Pre-fix the
-    // mover failed with kopia `object not found` because the recorded id was the
-    // deleted pre-pin manifest.
+    // A snapshotRef restore of the pinned snapshot must Complete — the core
+    // regression. Pre-fix the mover failed with kopia `object not found` because
+    // the recorded id was the deleted pre-pin manifest.
     restores
         .create(
             &PostParams::default(),

--- a/crates/e2e/tests/data_integrity.rs
+++ b/crates/e2e/tests/data_integrity.rs
@@ -13,10 +13,10 @@ use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
 
 use k8s_openapi::api::core::v1::Namespace;
-use kopiur_api::{ClusterRepository, Repository, Snapshot, SnapshotPolicy};
+use kopiur_api::{ClusterRepository, Repository, Restore, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{
-    E2E_NAMESPACE, Need, World, apply_secret, default_timeout, ensure_namespace, poll_interval,
-    wait_until,
+    E2E_NAMESPACE, Need, World, apply_secret, consts, default_timeout, ensure_namespace,
+    poll_interval, wait_until,
 };
 
 // ---------------------------------------------------------------------------
@@ -279,6 +279,153 @@ async fn pinned_snapshot_survives_gfs_prune() {
     let _ = backups
         .delete("e2e-pin-keep", &DeleteParams::default())
         .await;
+    let _ = policies.delete(policy, &DeleteParams::default()).await;
+    let _ = repos.delete(repo, &DeleteParams::default()).await;
+}
+
+// ---------------------------------------------------------------------------
+// Pinned snapshot: id re-stamp + restore-by-ref + delete-by-correct-id (#137)
+// ---------------------------------------------------------------------------
+
+/// Regression for #137: kopia rewrites a snapshot's MANIFEST id on pin
+/// (`UpdateSnapshot` saves a new manifest, deletes the old). Before the fix,
+/// `status.snapshot.kopiaSnapshotID` was stamped at create and never re-resolved
+/// after the pin, so it pointed at a DELETED manifest — breaking `snapshotRef`
+/// restore (`object not found`) and silently orphaning the live snapshot on
+/// `deletionPolicy: Delete`. This proves: (1) the id RE-STAMPS to the live
+/// manifest once the pin reconciles, (2) a `snapshotRef` restore of the pinned
+/// snapshot Completes, and (3) deleting it actually removes the live manifest
+/// (the finalizer releases).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn pinned_snapshot_restamps_id_and_restores_by_ref() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+    ensure_repo(&client, "pinrestore").await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    let repo = "e2e-pinrestore-repo";
+    let policy = "e2e-pinrestore-policy";
+    let backup = "e2e-pinrestore-backup";
+    let restore = "e2e-pinrestore-restore";
+
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(repo, "pinrestore", serde_json::json!({}))),
+        )
+        .await
+        .expect("create Repository");
+    wait_phase(&repos, repo, "Ready").await.expect("repo Ready");
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                policy,
+                "Repository",
+                repo,
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy");
+
+    // A PINNED snapshot with deletionPolicy: Delete (so the finalizer's
+    // delete-by-id path runs at teardown).
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                backup,
+                policy,
+                serde_json::json!({ "pin": true, "deletionPolicy": "Delete" }),
+            )),
+        )
+        .await
+        .expect("create pinned Snapshot");
+    wait_phase(&backups, backup, "Succeeded")
+        .await
+        .expect("pinned Snapshot should reach Succeeded");
+
+    // The id recorded at create time (pre-pin).
+    let id_at_create = status_json(&backups, backup).await["snapshot"]["kopiaSnapshotID"]
+        .as_str()
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        !id_at_create.is_empty(),
+        "the Succeeded Snapshot must record a kopia snapshot id"
+    );
+
+    // Once the pin reconciles, the id MUST re-stamp to the live (post-pin)
+    // manifest. Pre-fix it stayed == id_at_create and pointed at a deleted
+    // manifest. This is the core regression assertion.
+    wait_until(
+        "pinned snapshot id re-stamped to the live manifest after pin",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = status_json(&backups, backup).await;
+            let pinned = s["pinned"].as_bool().unwrap_or(false);
+            let id = s["snapshot"]["kopiaSnapshotID"].as_str().unwrap_or("");
+            Ok((pinned && !id.is_empty() && id != id_at_create).then_some(()))
+        },
+    )
+    .await
+    .expect("the pinned snapshot's kopiaSnapshotID must re-stamp after the pin rewrites it");
+
+    // A snapshotRef restore of the pinned snapshot must Complete. Pre-fix the
+    // mover failed with kopia `object not found` because the recorded id was the
+    // deleted pre-pin manifest.
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "Restore",
+                "metadata": { "name": restore, "namespace": E2E_NAMESPACE },
+                "spec": {
+                    "repository": { "kind": "Repository", "name": repo },
+                    "source": { "snapshotRef": { "name": backup } },
+                    "target": { "pvcRef": { "name": consts::PVC_DST } }
+                }
+            })),
+        )
+        .await
+        .expect("create snapshotRef Restore");
+    wait_phase(&restores, restore, "Completed")
+        .await
+        .expect("snapshotRef restore of a pinned snapshot must reach Completed");
+
+    // Delete-by-correct-id: deleting the pinned Snapshot (deletionPolicy: Delete)
+    // must remove the LIVE manifest, so the finalizer releases. Pre-fix the
+    // finalizer ran `kopia snapshot delete <stale-id>`, hit the idempotent
+    // "no snapshots matched" no-op, released the finalizer, and ORPHANED the live
+    // pinned manifest.
+    let _ = restores.delete(restore, &DeleteParams::default()).await;
+    backups
+        .delete(backup, &DeleteParams::default())
+        .await
+        .expect("delete pinned Snapshot");
+    wait_until(
+        "pinned Snapshot finalizer released after deleting the live manifest",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(backups.get_opt(backup).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("the pinned Snapshot's finalizer must release once the live manifest is deleted");
+
+    // Cleanup.
     let _ = policies.delete(policy, &DeleteParams::default()).await;
     let _ = repos.delete(repo, &DeleteParams::default()).await;
 }

--- a/crates/mover/src/lib.rs
+++ b/crates/mover/src/lib.rs
@@ -7,6 +7,7 @@ pub mod env;
 pub mod error;
 pub mod jobs;
 pub mod repo_meta;
+pub mod resolve;
 pub mod serve;
 pub mod status;
 pub mod workspec;

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -18,6 +18,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use kopiur_api::common::ResolvedIdentity;
+use kopiur_api::snapshot::SnapshotInfo;
 use kopiur_api::{LeaseAction, lease_action};
 use kopiur_kopia::{ConnectSpec, KopiaClient, KopiaError, KopiaErrorClass, MaintenanceMode};
 use tokio::sync::Mutex;
@@ -29,11 +31,12 @@ use kopiur_mover::bootstrap::{
 use kopiur_mover::credentials;
 use kopiur_mover::env::{KOPIA_BINARY, RESULT_CONFIGMAP, WORK_SPEC_PATH};
 use kopiur_mover::error::{KopiaOp, MoverError, Result};
+use kopiur_mover::resolve::match_current_manifest;
 use kopiur_mover::serve::ServerWorkSpec;
 use kopiur_mover::status::StatusUpdate;
 use kopiur_mover::workspec::{
     self, BootstrapRepositoryOp, BrowseSessionOp, KOPIUR_PIN_NAME, MaintenanceOp, MoverWorkSpec,
-    Operation, ReplicateOp, VerifyOp, VerifyTier,
+    Operation, ReplicateOp, RestoreOp, SnapshotAnchor, SnapshotPinOp, VerifyOp, VerifyTier,
 };
 
 fn main() -> std::process::ExitCode {
@@ -398,27 +401,61 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
             Ok(StatusUpdate::succeeded_backup(&result, chrono::Utc::now()))
         }
         Operation::Restore(op) => {
-            client
-                .snapshot_restore_with(&op.snapshot_id, &op.target_path, &op.restore_options())
+            // The recorded id can be STALE — kopia rewrites a snapshot's manifest
+            // id on pin (`UpdateSnapshot`), so a snapshotRef/identity restore of a
+            // pinned snapshot created before this fix points at a deleted manifest.
+            // On a not-found, self-heal by re-resolving the live id from the
+            // snapshot's stable identity (source path + start time).
+            let restored_id = restore_with_heal(client, op)
                 .await
                 .map_err(kopia(KopiaOp::SnapshotRestore))?;
             // Restore's terminal success phase is `Completed`, not `Succeeded`
             // (the Snapshot phase) — the Restore CRD enum rejects `Succeeded`.
-            Ok(StatusUpdate::completed(&op.snapshot_id, chrono::Utc::now()))
+            Ok(StatusUpdate::completed(&restored_id, chrono::Utc::now()))
         }
         Operation::SnapshotDelete(op) => {
-            // Just delete the snapshot. Space reclamation (maintenance) is a
+            // Delete the recorded snapshot. Space reclamation (maintenance) is a
             // separate concern owned by the Maintenance CRD, not the mover.
             client
                 .snapshot_delete(&op.snapshot_id)
                 .await
                 .map_err(kopia(KopiaOp::SnapshotDelete))?;
+            // The recorded id may be STALE (kopia rewrites the manifest id on pin):
+            // the delete above then hits the idempotent "no snapshots matched"
+            // no-op and the live pinned manifest would be ORPHANED under
+            // `deletionPolicy: Delete`. Re-resolve the live id by stable anchors
+            // and delete it too. No-op when the recorded id was already correct
+            // (the re-resolved id equals it / nothing matches).
+            if let Some(live) = resolve_live_id(client, &op.anchor).await
+                && live != op.snapshot_id
+            {
+                warn!(
+                    recorded = %op.snapshot_id,
+                    live = %live,
+                    "recorded snapshot id was stale (kopia rewrites the id on pin); \
+                     deleting the live manifest re-resolved from the snapshot's identity \
+                     to avoid orphaning it",
+                );
+                client
+                    .snapshot_delete(&live)
+                    .await
+                    .map_err(kopia(KopiaOp::SnapshotDelete))?;
+            }
             Ok(StatusUpdate::succeeded(chrono::Utc::now()))
         }
         Operation::SnapshotPin(op) => {
             // Reconcile kopia's pin state with Snapshot.spec.pin (ADR-0005 §13(c))
             // so kopia's own maintenance/expire honors the pin on object stores.
             // Idempotent: kopia treats a redundant add/remove as a no-op.
+            //
+            // kopia's pin/unpin REWRITES the manifest id (`UpdateSnapshot` saves a
+            // new manifest, deletes the old), so after the op we re-resolve the
+            // CURRENT id and report it back — otherwise status.snapshot.kopiaSnapshotID
+            // is left pointing at a deleted manifest (breaking snapshotRef restore
+            // and the finalizer delete). The start-time anchor is captured BEFORE
+            // the pin when the work spec didn't carry one, since the old id is gone
+            // afterward.
+            let anchor_start = pin_start_anchor(client, op).await;
             if op.pin {
                 client
                     .snapshot_pin(&op.snapshot_id, KOPIUR_PIN_NAME)
@@ -430,7 +467,21 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
                     .await
                     .map_err(kopia(KopiaOp::SnapshotPin))?;
             }
-            Ok(StatusUpdate::succeeded(chrono::Utc::now()))
+            match resolve_pinned_info(client, op, &spec.identity.source_path, anchor_start).await {
+                Some(info) => Ok(StatusUpdate::succeeded_pin(info, chrono::Utc::now())),
+                // Re-resolution was inconclusive (ambiguous match / list failed).
+                // The (un)pin itself SUCCEEDED, so never regress to a failure —
+                // just leave status.snapshot untouched and warn.
+                None => {
+                    warn!(
+                        snapshot_id = %op.snapshot_id,
+                        "snapshot (un)pin succeeded but the new manifest id could not be \
+                         re-resolved; status.snapshot.kopiaSnapshotID may be stale until the \
+                         next pin reconcile",
+                    );
+                    Ok(StatusUpdate::succeeded(chrono::Utc::now()))
+                }
+            }
         }
         // Bootstrap, Maintenance, and Verify are dispatched in `run()` before the
         // connect+execute path; they own their own connect lifecycle and never
@@ -452,6 +503,99 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
             unreachable!("BrowseSession is handled by run_browse_session_flow, not execute()")
         }
     }
+}
+
+/// Restore `op.snapshot_id`, self-healing a stale id. kopia rewrites a
+/// snapshot's manifest id on pin (`UpdateSnapshot`), so a snapshotRef/identity
+/// restore of a snapshot pinned before this fix can name a deleted manifest. On
+/// a `NotFound`, re-resolve the live id from the snapshot's stable anchors and
+/// retry once. Returns the id actually restored (for `status.logTail`).
+async fn restore_with_heal(
+    client: &KopiaClient,
+    op: &RestoreOp,
+) -> std::result::Result<String, KopiaError> {
+    match client
+        .snapshot_restore_with(&op.snapshot_id, &op.target_path, &op.restore_options())
+        .await
+    {
+        Ok(()) => Ok(op.snapshot_id.clone()),
+        Err(e) if e.class() == KopiaErrorClass::NotFound => {
+            // Only heal when we have anchors AND they resolve to a DIFFERENT live
+            // id; otherwise the original not-found is the truthful error.
+            if let Some(live) = resolve_live_id(client, &op.anchor).await
+                && live != op.snapshot_id
+            {
+                warn!(
+                    stale = %op.snapshot_id,
+                    live = %live,
+                    "restore snapshot id not found; healing to the live manifest \
+                     re-resolved from the snapshot's identity (kopia rewrites the id on pin)",
+                );
+                client
+                    .snapshot_restore_with(&live, &op.target_path, &op.restore_options())
+                    .await?;
+                return Ok(live);
+            }
+            Err(e)
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// Re-resolve the CURRENT live manifest id for a snapshot from its stable
+/// anchors (source path + start time), via a fresh `snapshot list`. Returns
+/// `None` when there are no usable anchors, the list fails, or the match is
+/// ambiguous (so callers never act on the wrong snapshot).
+async fn resolve_live_id(client: &KopiaClient, anchor: &SnapshotAnchor) -> Option<String> {
+    if anchor.source_path.is_empty() {
+        return None;
+    }
+    let list = client.snapshot_list(None).await.ok()?;
+    match_current_manifest(&list, &anchor.source_path, anchor.start_instant()).map(|e| e.id.clone())
+}
+
+/// Capture the start-time anchor for a pin op BEFORE the (un)pin runs. The work
+/// spec normally carries it (`status.timing.startTime`); when it doesn't (older
+/// CRs), look it up from the still-present pre-pin manifest id, since the id is
+/// deleted once the pin rewrites the manifest.
+async fn pin_start_anchor(
+    client: &KopiaClient,
+    op: &SnapshotPinOp,
+) -> Option<chrono::DateTime<chrono::Utc>> {
+    if let Some(t) = op.anchor.start_instant() {
+        return Some(t);
+    }
+    let list = client.snapshot_list(None).await.ok()?;
+    list.iter()
+        .find(|e| e.id == op.snapshot_id)
+        .map(|e| e.start_time)
+}
+
+/// After a pin/unpin, re-resolve the snapshot's CURRENT manifest id (kopia
+/// rewrote it) into a `SnapshotInfo` for `status.snapshot`. Matches on the
+/// snapshot's stable source path (anchor, else the resolved identity) plus the
+/// pre-pin start-time anchor. `None` when unresolvable or ambiguous.
+async fn resolve_pinned_info(
+    client: &KopiaClient,
+    op: &SnapshotPinOp,
+    fallback_source_path: &str,
+    start: Option<chrono::DateTime<chrono::Utc>>,
+) -> Option<SnapshotInfo> {
+    let source_path = if op.anchor.source_path.is_empty() {
+        fallback_source_path.to_string()
+    } else {
+        op.anchor.source_path.clone()
+    };
+    let list = client.snapshot_list(None).await.ok()?;
+    let entry = match_current_manifest(&list, &source_path, start)?;
+    Some(SnapshotInfo {
+        kopia_snapshot_id: entry.id.clone(),
+        identity: ResolvedIdentity {
+            username: entry.source.user_name.clone(),
+            hostname: entry.source.host.clone(),
+            source_path: Some(entry.source.path.clone()),
+        },
+    })
 }
 
 /// Drive a `BootstrapRepository` run: connect/create, write the result to the

--- a/crates/mover/src/resolve.rs
+++ b/crates/mover/src/resolve.rs
@@ -1,0 +1,156 @@
+//! Re-resolving a snapshot's CURRENT manifest id after kopia rewrites it.
+//!
+//! kopia assigns a **new** manifest id whenever a snapshot manifest is edited:
+//! `snapshot pin`/`unpin` both call kopia's `UpdateSnapshot`, which *saves a new
+//! manifest and deletes the old manifest id*. The id stored in
+//! `Snapshot.status.snapshot.kopiaSnapshotID` at create time therefore goes
+//! stale the moment the snapshot is pinned — pointing at a deleted manifest. A
+//! restore/delete/`fromPolicy` keyed on the stale id then fails (`content … not
+//! found`) or, worse, the finalizer delete silently no-ops and orphans the live
+//! pinned manifest.
+//!
+//! A snapshot's *source path* and *start time* survive the manifest rewrite, so
+//! we re-match on those. This module is **pure data** (no kopia subprocess, no
+//! kube) so the matching policy is unit-testable on its own.
+
+use chrono::{DateTime, Utc};
+use kopiur_kopia::SnapshotListEntry;
+
+/// Find the entry in `entries` corresponding to the snapshot identified by
+/// `source_path` (+ `start_time` when known), after its manifest id may have
+/// changed. Returns `None` when the match would be ambiguous — so a caller never
+/// re-stamps, restores, or deletes the WRONG snapshot:
+///
+/// - With a `start_time` anchor: the unique entry whose source path matches AND
+///   whose start time equals the anchor (compared as instants, not strings, so
+///   `Z` vs `+00:00` formatting never matters).
+/// - Without an anchor: the single source-path match, or `None` if several
+///   snapshots share that path (we cannot tell which one is meant).
+///
+/// An empty `source_path` always yields `None` (nothing to anchor on).
+pub fn match_current_manifest<'a>(
+    entries: &'a [SnapshotListEntry],
+    source_path: &str,
+    start_time: Option<DateTime<Utc>>,
+) -> Option<&'a SnapshotListEntry> {
+    if source_path.is_empty() {
+        return None;
+    }
+    let by_path = entries.iter().filter(|e| e.source.path == source_path);
+    match start_time {
+        Some(anchor) => unique(by_path.filter(|e| e.start_time == anchor)),
+        // No disambiguator: only safe when exactly one snapshot has this path.
+        None => unique(by_path),
+    }
+}
+
+/// The single element of `it`, or `None` if it is empty or has more than one.
+fn unique<'a, I>(mut it: I) -> Option<&'a SnapshotListEntry>
+where
+    I: Iterator<Item = &'a SnapshotListEntry>,
+{
+    let first = it.next()?;
+    if it.next().is_some() {
+        None
+    } else {
+        Some(first)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kopiur_kopia::{SnapshotListEntry, SnapshotSource};
+
+    fn entry(id: &str, path: &str, start: &str) -> SnapshotListEntry {
+        SnapshotListEntry {
+            id: id.to_string(),
+            source: SnapshotSource {
+                host: "home".into(),
+                user_name: "home-wyoming-whisper".into(),
+                path: path.to_string(),
+            },
+            description: String::new(),
+            start_time: DateTime::parse_from_rfc3339(start)
+                .unwrap()
+                .with_timezone(&Utc),
+            end_time: DateTime::parse_from_rfc3339(start)
+                .unwrap()
+                .with_timezone(&Utc),
+            stats: Default::default(),
+            root_entry: None,
+            retention_reason: vec![],
+        }
+    }
+
+    fn anchor(s: &str) -> Option<DateTime<Utc>> {
+        Some(DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc))
+    }
+
+    #[test]
+    fn matches_new_id_by_path_and_start_when_old_id_is_gone() {
+        // The pre-pin id `3ad0…` is gone; the post-pin manifest `b203…` has the
+        // SAME source path + start time. We must resolve to `b203…`.
+        let entries = vec![
+            entry("b2037e14", "/pvc/wyoming-whisper", "2026-06-19T05:54:19Z"),
+            entry("unrelated", "/pvc/other", "2026-06-19T05:54:19Z"),
+        ];
+        let m = match_current_manifest(
+            &entries,
+            "/pvc/wyoming-whisper",
+            anchor("2026-06-19T05:54:19Z"),
+        );
+        assert_eq!(m.map(|e| e.id.as_str()), Some("b2037e14"));
+    }
+
+    #[test]
+    fn start_time_disambiguates_same_path_snapshots() {
+        let entries = vec![
+            entry("older", "/pvc/db", "2026-06-18T00:00:00Z"),
+            entry("newer", "/pvc/db", "2026-06-19T00:00:00Z"),
+        ];
+        let m = match_current_manifest(&entries, "/pvc/db", anchor("2026-06-18T00:00:00Z"));
+        assert_eq!(m.map(|e| e.id.as_str()), Some("older"));
+    }
+
+    #[test]
+    fn timezone_format_does_not_affect_instant_equality() {
+        // CR stores `+00:00`, kopia list emits `Z`; both are the same instant.
+        let entries = vec![entry("b2037e14", "/pvc/db", "2026-06-19T05:54:19Z")];
+        let m = match_current_manifest(&entries, "/pvc/db", anchor("2026-06-19T05:54:19+00:00"));
+        assert_eq!(m.map(|e| e.id.as_str()), Some("b2037e14"));
+    }
+
+    #[test]
+    fn no_anchor_single_path_candidate_is_picked() {
+        let entries = vec![entry("only", "/pvc/db", "2026-06-19T00:00:00Z")];
+        let m = match_current_manifest(&entries, "/pvc/db", None);
+        assert_eq!(m.map(|e| e.id.as_str()), Some("only"));
+    }
+
+    #[test]
+    fn no_anchor_multiple_candidates_refuses_to_guess() {
+        // Without a start-time anchor we must NOT mis-stamp/mis-delete.
+        let entries = vec![
+            entry("a", "/pvc/db", "2026-06-18T00:00:00Z"),
+            entry("b", "/pvc/db", "2026-06-19T00:00:00Z"),
+        ];
+        assert!(match_current_manifest(&entries, "/pvc/db", None).is_none());
+    }
+
+    #[test]
+    fn empty_source_path_never_matches() {
+        let entries = vec![entry("a", "/pvc/db", "2026-06-19T00:00:00Z")];
+        assert!(match_current_manifest(&entries, "", anchor("2026-06-19T00:00:00Z")).is_none());
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let entries = vec![entry("a", "/pvc/db", "2026-06-19T00:00:00Z")];
+        assert!(match_current_manifest(&entries, "/pvc/missing", None).is_none());
+        // Anchor present but no entry at that instant.
+        assert!(
+            match_current_manifest(&entries, "/pvc/db", anchor("2020-01-01T00:00:00Z")).is_none()
+        );
+    }
+}

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -311,6 +311,30 @@ impl StatusUpdate {
         }
     }
 
+    /// A successful snapshot-pin/unpin update that re-stamps `status.snapshot`
+    /// with the snapshot's CURRENT manifest id.
+    ///
+    /// kopia's `UpdateSnapshot` (what `snapshot pin`/`unpin` call) saves a NEW
+    /// manifest and deletes the old id, so the id recorded at create time is
+    /// stale the moment a snapshot is pinned. The pin mover re-resolves the live
+    /// id and reports it here so the finalizer delete and `snapshotRef` restore
+    /// target the live manifest, not a deleted one. Touches ONLY `status.snapshot`
+    /// (no `timing`/`stats`) so the Merge PATCH never disturbs create-time fields,
+    /// and `status.pinned` stays the controller's to write (disjoint subtrees ⇒
+    /// no two-writer churn). `logTail` is deterministic (no churn).
+    pub fn succeeded_pin(snapshot: SnapshotInfo, observed_at: DateTime<Utc>) -> Self {
+        let id = snapshot.kopia_snapshot_id.clone();
+        StatusUpdate {
+            phase: MoverPhase::Succeeded.as_str().to_string(),
+            observed_at,
+            snapshot: Some(snapshot),
+            timing: None,
+            stats: None,
+            failure: None,
+            log_tail: Some(format!("Snapshot pin reconciled: {id}")),
+        }
+    }
+
     /// A successful restore update with no stats. The Restore CRD's terminal
     /// success phase is `Completed` — NOT `Succeeded` (the Snapshot phase). Writing
     /// `Succeeded` here is rejected by the apiserver with a 422 (the enum forbids
@@ -562,6 +586,38 @@ mod tests {
             "the count of EXCLUDED source entries must ride on status.stats.filesFailed"
         );
         assert_eq!(u.as_patch_body()["status"]["stats"]["filesFailed"], 2);
+    }
+
+    #[test]
+    fn succeeded_pin_restamps_snapshot_id_only() {
+        // After a pin, kopia rewrote the manifest id; the pin update must carry
+        // the CURRENT id under the nested CRD shape so the finalizer delete and
+        // snapshotRef restore target the live manifest — and ONLY status.snapshot
+        // (no timing/stats) so the Merge PATCH never disturbs create-time fields,
+        // and status.pinned stays the controller's to write (no two-writer churn).
+        let info = SnapshotInfo {
+            kopia_snapshot_id: "b2037e14".into(),
+            identity: ResolvedIdentity {
+                username: "home-wyoming-whisper".into(),
+                hostname: "home".into(),
+                source_path: Some("/pvc/wyoming-whisper".into()),
+            },
+        };
+        let u = StatusUpdate::succeeded_pin(info, ts());
+        assert_eq!(u.phase, "Succeeded");
+        let body = u.as_patch_body();
+        assert_eq!(body["status"]["snapshot"]["kopiaSnapshotID"], "b2037e14");
+        assert_eq!(
+            body["status"]["snapshot"]["identity"]["sourcePath"],
+            "/pvc/wyoming-whisper"
+        );
+        // Disjoint subtrees: the pin update must NOT touch timing/stats/pinned.
+        assert!(u.timing.is_none());
+        assert!(u.stats.is_none());
+        assert!(body["status"].get("timing").is_none());
+        assert!(body["status"].get("stats").is_none());
+        assert!(body["status"].get("pinned").is_none());
+        assert!(u.failure.is_none());
     }
 
     #[test]

--- a/crates/mover/src/workspec.rs
+++ b/crates/mover/src/workspec.rs
@@ -252,6 +252,45 @@ impl CreateOptionsSpec {
     }
 }
 
+/// Stable identity anchors for re-resolving a snapshot's CURRENT manifest id.
+///
+/// kopia's `UpdateSnapshot` (pin/unpin) assigns a NEW manifest id and deletes
+/// the old one, so the id recorded at create time goes stale once a snapshot is
+/// pinned. A snapshot's source path and start time survive that rewrite, so the
+/// mover re-matches on them (see [`crate::resolve::match_current_manifest`]) to
+/// re-stamp `status.snapshot.kopiaSnapshotID` after a pin, and to self-heal a
+/// stale id at delete/restore time. All fields are optional so older work specs
+/// (and Snapshots with no recorded identity/timing) still round-trip and fall
+/// back to the previous behavior.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotAnchor {
+    /// The snapshotted source path — the authoritative match key (the
+    /// mover-recorded user/host can differ from the resolved identity).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub source_path: String,
+    /// RFC3339 start time recorded for this snapshot — the disambiguator when
+    /// several snapshots share `source_path`. Absent on older work specs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub start_time: Option<String>,
+}
+
+impl SnapshotAnchor {
+    /// Whether this anchor carries nothing usable (so resolution falls back to
+    /// the stored id alone).
+    pub fn is_empty(&self) -> bool {
+        self.source_path.is_empty() && self.start_time.is_none()
+    }
+
+    /// The anchor's `start_time` parsed to a UTC instant, if present and valid.
+    pub fn start_instant(&self) -> Option<chrono::DateTime<chrono::Utc>> {
+        self.start_time
+            .as_deref()
+            .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+            .map(|t| t.with_timezone(&chrono::Utc))
+    }
+}
+
 /// Payload for a restore run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -261,6 +300,12 @@ pub struct RestoreOp {
     pub snapshot_id: String,
     /// Absolute path inside the mover pod to restore into (e.g. `/data`).
     pub target_path: String,
+    /// Stable identity anchors for the referenced snapshot, used to self-heal a
+    /// stale `snapshot_id` (kopia rewrites the manifest id on pin) when the
+    /// restore reports the id not found. Empty ⇒ no fallback (a raw
+    /// user-supplied id stays a hard failure).
+    #[serde(default, skip_serializing_if = "SnapshotAnchor::is_empty")]
+    pub anchor: SnapshotAnchor,
     /// `--[no-]ignore-permission-errors` (Restore CRD `options`; kopia default
     /// true). `None` lets kopia use its default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -280,6 +325,7 @@ impl RestoreOp {
     /// let op = RestoreOp {
     ///     snapshot_id: "k1".into(),
     ///     target_path: "/data".into(),
+    ///     anchor: Default::default(),
     ///     ignore_permission_errors: Some(false),
     ///     write_files_atomically: Some(true),
     /// };
@@ -302,6 +348,14 @@ impl RestoreOp {
 pub struct SnapshotDeleteOp {
     /// The snapshot manifest id to delete.
     pub snapshot_id: String,
+    /// Stable identity anchors for the snapshot, used to self-heal a stale
+    /// `snapshot_id`: kopia rewrites the manifest id on pin, so the finalizer's
+    /// recorded id can point at a deleted manifest while the real (pinned)
+    /// snapshot lives under a different id. Without this the idempotent
+    /// "no snapshots matched" path would silently ORPHAN the live snapshot under
+    /// `deletionPolicy: Delete`. Empty ⇒ delete by id only (old behavior).
+    #[serde(default, skip_serializing_if = "SnapshotAnchor::is_empty")]
+    pub anchor: SnapshotAnchor,
 }
 
 /// Payload for a repository-bootstrap run.
@@ -424,6 +478,14 @@ pub struct SnapshotPinOp {
     pub snapshot_id: String,
     /// `true` → add the pin (exempt from expiry); `false` → remove it.
     pub pin: bool,
+    /// Stable identity anchors for the snapshot. kopia's pin/unpin rewrites the
+    /// manifest id (`UpdateSnapshot` saves a new manifest, deletes the old), so
+    /// after (un)pinning the mover re-lists and re-resolves the CURRENT id via
+    /// these anchors and reports it back, keeping
+    /// `status.snapshot.kopiaSnapshotID` pointing at the live manifest. Empty ⇒
+    /// the id is left as-is (older work specs).
+    #[serde(default, skip_serializing_if = "SnapshotAnchor::is_empty")]
+    pub anchor: SnapshotAnchor,
 }
 
 /// The fixed pin name kopiur applies to a `Snapshot` whose `spec.pin` is set
@@ -1006,6 +1068,10 @@ mod tests {
             operation: Operation::Restore(RestoreOp {
                 snapshot_id: "abc123".into(),
                 target_path: "/data".into(),
+                anchor: SnapshotAnchor {
+                    source_path: "/pvc/db".into(),
+                    start_time: Some("2026-06-19T05:54:19Z".into()),
+                },
                 ignore_permission_errors: Some(true),
                 write_files_atomically: Some(false),
             }),
@@ -1041,6 +1107,7 @@ mod tests {
             version: 1,
             operation: Operation::SnapshotDelete(SnapshotDeleteOp {
                 snapshot_id: "todelete".into(),
+                anchor: SnapshotAnchor::default(),
             }),
             identity: sample_identity(),
             repository: RepositoryConnect::Filesystem {
@@ -1342,6 +1409,7 @@ mod tests {
         let op = RestoreOp {
             snapshot_id: "s".into(),
             target_path: "/data".into(),
+            anchor: SnapshotAnchor::default(),
             ignore_permission_errors: Some(false),
             write_files_atomically: Some(true),
         };
@@ -1349,12 +1417,13 @@ mod tests {
         assert_eq!(opts.ignore_permission_errors, Some(false));
         assert_eq!(opts.write_files_atomically, Some(true));
 
-        // Older wire payload without the option fields still deserializes
-        // (forward/backward compatible), mapping to kopia defaults (None).
+        // Older wire payload without the option/anchor fields still deserializes
+        // (forward/backward compatible), mapping to kopia defaults (None/empty).
         let json = r#"{"snapshotId":"s","targetPath":"/data"}"#;
         let parsed: RestoreOp = serde_json::from_str(json).unwrap();
         assert_eq!(parsed.ignore_permission_errors, None);
         assert_eq!(parsed.restore_options().write_files_atomically, None);
+        assert!(parsed.anchor.is_empty());
     }
 
     #[test]
@@ -1580,6 +1649,10 @@ mod tests {
             operation: Operation::SnapshotPin(SnapshotPinOp {
                 snapshot_id: "k123".into(),
                 pin: true,
+                anchor: SnapshotAnchor {
+                    source_path: "/pvc/db".into(),
+                    start_time: Some("2026-06-19T05:54:19Z".into()),
+                },
             }),
             identity: sample_identity(),
             repository: RepositoryConnect::Filesystem {
@@ -1596,6 +1669,15 @@ mod tests {
         let v: serde_json::Value = serde_json::to_value(&spec).unwrap();
         assert_eq!(v["operation"]["snapshotPin"]["snapshotId"], "k123");
         assert_eq!(v["operation"]["snapshotPin"]["pin"], true);
+        // Anchors flow externally as camelCase under the op payload.
+        assert_eq!(
+            v["operation"]["snapshotPin"]["anchor"]["sourcePath"],
+            "/pvc/db"
+        );
+        // An old work spec without the anchor still deserializes (defaulted).
+        let legacy = r#"{"snapshotId":"k123","pin":false}"#;
+        let parsed: SnapshotPinOp = serde_json::from_str(legacy).unwrap();
+        assert!(parsed.anchor.is_empty());
     }
 
     // --- §4 verify op ---

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -60,9 +60,30 @@ source:
 Whatever the source resolves to is written ONCE to `status.resolved.kopiaSnapshotID` and reused for the rest of the restore's life. New snapshots appearing mid-flight (a schedule firing) cannot change which snapshot this Restore writes.
 ///
 
-/// warning | `fromPolicy` needs a filesystem repository
+/// warning | `fromPolicy` / `identity`-without-`snapshotID` need the repo reachable by the **controller**
 
-Resolving "latest / `asOf` / `offset` for a policy" lists snapshots in-process, which requires a repository the controller can mount — **filesystem backends only**. On S3, Azure, GCS, B2, SFTP, WebDAV, and rclone, name the snapshot explicitly: `snapshotRef`, or `identity` with a pinned `snapshotID`. A `fromPolicy` restore against an object-store repository fails loudly with exactly that fix.
+Resolving "latest / `asOf` / `offset` for a policy" lists snapshots **in-process in the controller** (not in a mover Job), so the controller must be able to reach the repository:
+
+- **Object stores** (S3, Azure, GCS, B2, SFTP, WebDAV, rclone): not supported for in-process listing — name the snapshot explicitly with `snapshotRef`, or `identity` with a pinned `snapshotID`. A `fromPolicy` restore against an object-store repository fails loudly with exactly that fix.
+- **Filesystem repositories**: the repository must be mounted into the **controller** pod at the repository's `backend.filesystem.path`, and the controller must run as a UID/GID that can read it. By default only the mover Jobs mount the repo, so `fromPolicy`/`identity` resolution fails with an actionable error (`the filesystem repository path '…' is not accessible to the controller`) until you add the mount. `snapshotRef` and a pinned `identity.snapshotID` need **no** controller mount.
+
+Mount a filesystem repo into the controller via Helm (matching the NFS/PVC the repo lives on, here `/repo`):
+
+```yaml
+controller:
+    extraVolumes:
+        - name: repo
+          nfs: { server: nfs.example.com, path: /tank/kopiur }
+    extraVolumeMounts:
+        - name: repo
+          mountPath: /repo # == backend.filesystem.path
+podSecurityContext:
+    runAsNonRoot: true
+    runAsUser: 1234 # a UID/GID that can read the repo
+    runAsGroup: 1234
+    fsGroup: 1234
+    fsGroupChangePolicy: OnRootMismatch
+```
 
 ///
 


### PR DESCRIPTION
Fixes #137.

## The two bugs

**1. Pinning silently corrupts the stored snapshot id (the serious one).**
`kopia snapshot pin`/`unpin` call kopia's `UpdateSnapshot`, which **saves a new manifest (new id) and deletes the old one**. Kopiur stamped `status.snapshot.kopiaSnapshotID` at *create* time and never re-resolved it after a pin, so the stored id pointed at a **deleted** manifest. Backend-agnostic (S3 too). This broke:
- restore via `snapshotRef`/`identity` (`content <id> not found: object not found` — the exact error in the issue)
- `fromPolicy` resolution that reads stored CR ids
- the **finalizer delete**: `kopia snapshot delete <stale-id>` hit kopia's idempotent "no snapshots matched" no-op and **orphaned the live pinned manifest** under `deletionPolicy: Delete`

**2. `fromPolicy` on a filesystem repo failed opaquely.** Resolution runs in-process in the controller, which needs the repo mounted; the raw `stat /repo: no such file or directory` gave users no clue.

## The fix

**ID correctness + self-heal (mover-side — the mover always has the repo mounted):**
- The pin mover re-resolves the live manifest id after (un)pin via `snapshot list`, matching on the snapshot's stable `source_path` + `start_time` (pure, unit-tested `match_current_manifest`, which refuses to guess when ambiguous), and re-stamps `status.snapshot` via a new `StatusUpdate::succeeded_pin`. The controller keeps writing only `status.pinned` — disjoint subtrees, no status churn.
- Restore and delete movers **self-heal** a stale id: on a `NotFound`, re-resolve by the same anchors and retry / delete the live manifest. This repairs snapshots pinned **before** this fix, at the moment of use.
- New optional `anchor` (source path + start time) on the pin/delete/restore work-spec ops, populated by the controller from the Snapshot's recorded status.

**fromPolicy clarity (kept in-process by design):** pre-flight the repo path and return an actionable `FilesystemResolutionUnmounted` error instead of leaking the raw kopia error. `docs/restores.md` documents the controller-mount requirement with the working Helm snippet from the issue.

## Tests
- Unit: `match_current_manifest` (all match/ambiguity/timezone cases), `succeeded_pin` serde (re-stamps only `status.snapshot`), work-spec round-trips for the new anchor fields.
- e2e (`crates/e2e/tests/data_integrity.rs`): `pinned_snapshot_restamps_id_and_restores_by_ref` — pinned Snapshot → asserts the id **re-stamps** to the live manifest → `snapshotRef` restore Completes → delete removes the live manifest (finalizer releases). Plus the seeded `pinrestore` repo subpath.

## Verification
Local: `fmt-check`, `clippy -D warnings`, full hermetic `cargo test`, `gen-check` (no CRD drift), and `mkdocs build --strict` all green. The full e2e suite passed locally except this PR's new test (a missing node-seed dir, now fixed) and one unrelated `deep_verify` resource-pressure flake — letting CI run the full suite.

_Note: stale-id repair for pre-existing pinned snapshots happens on restore/delete; the one un-healable edge (pre-fix CRs with no recorded `startTime` that also share a source path) is documented._