### PR TITLE
feat(migrate): offline/GitOps mode for `migrate volsync`

### DIFF
--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -317,6 +317,33 @@ pub struct MigrateVolsyncArgs {
     /// placeholder remains).
     #[arg(long)]
     pub apply: bool,
+
+    // --- offline / GitOps mode ---
+    /// Read VolSync objects from these YAML files (or directories, or `-` for
+    /// stdin) instead of the cluster. Repeatable; any value engages offline
+    /// mode (no kubeconfig required). Mirrors `kubectl -f`.
+    #[arg(short = 'f', long = "filename", value_name = "PATH")]
+    pub filename: Vec<PathBuf>,
+
+    /// Resolve repository Secrets from these plaintext Secret YAML files (or
+    /// directories, or `-`) in offline mode. Repeatable. Only meaningful with
+    /// --resolve-secrets and offline input (-f).
+    #[arg(long, value_name = "PATH", requires = "resolve_secrets")]
+    pub secrets: Vec<PathBuf>,
+
+    /// In offline mode, still fetch referenced Secrets from the LIVE cluster
+    /// (needs a kubeconfig). Alternative to --secrets.
+    #[arg(long, requires = "resolve_secrets", conflicts_with = "secrets")]
+    pub from_cluster_secrets: bool,
+
+    /// Write one YAML file per ReplicationSource (plus _shared.yaml for derived
+    /// Repositories/Secrets) into this directory instead of stdout.
+    #[arg(long, value_name = "DIR")]
+    pub out_dir: Option<PathBuf>,
+
+    /// Permit overwriting existing files in --out-dir.
+    #[arg(long)]
+    pub force: bool,
 }
 
 /// Flags for `status`.

--- a/crates/cli/src/cmd/migrate/io.rs
+++ b/crates/cli/src/cmd/migrate/io.rs
@@ -1,0 +1,457 @@
+//! Offline / GitOps I/O for `migrate volsync`: read VolSync objects and
+//! repository Secrets from YAML files (or stdin) instead of the cluster, and
+//! write the translated manifests to a directory (one file per source).
+//!
+//! All YAML parsing goes `yaml → serde_json::Value → typed` (never `serde_yaml`
+//! straight into a typed value) — serde_yaml 0.9 mis-encodes externally-tagged
+//! enums, which both the VolSync specs and the emitted kopiur types rely on.
+//! See `crates/api/src/lib.rs::testutil::from_yaml` for the same rule.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use k8s_openapi::ByteString;
+use k8s_openapi::api::core::v1::Secret;
+use kube::api::Api;
+use serde::Deserialize;
+
+use crate::consts::STDIN_TOKEN;
+use crate::error::{CliError, classify_kube};
+
+/// Which VolSync kind a parsed object is. Exhaustive so the orchestration
+/// `match`es it and a new kind can't be silently dropped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VolsyncKind {
+    /// `ReplicationSource`.
+    Source,
+    /// `ReplicationDestination`.
+    Destination,
+}
+
+/// A VolSync object reduced to what the translator needs, sourced identically
+/// whether it came from the cluster or a file — so the reconcile loop never
+/// branches on input origin.
+#[derive(Debug, Clone)]
+pub struct RawVolsync {
+    /// Source or Destination.
+    pub kind: VolsyncKind,
+    /// The object's namespace (metadata, or the fallback for file input).
+    pub namespace: String,
+    /// The object's name.
+    pub name: String,
+    /// The raw `spec` object, decoded into a typed spec by the caller.
+    pub spec: serde_json::Value,
+}
+
+/// How a repository Secret is resolved under `--resolve-secrets`. Exhaustive.
+pub enum SecretSource {
+    /// Live cluster (`get_opt`) — cluster-input runs and the offline
+    /// `--from-cluster-secrets` hybrid.
+    Cluster {
+        /// The connected client to GET Secrets with.
+        client: kube::Client,
+    },
+    /// Plaintext Secret YAML supplied on disk, keyed `(namespace, name)`.
+    Files(BTreeMap<(String, String), Secret>),
+    /// `--repository`: Secrets are never read (policies point at an existing
+    /// kopiur Repository).
+    None,
+}
+
+impl SecretSource {
+    /// Resolve the Secret named `name` in `namespace`, or `None` if absent.
+    pub async fn get(&self, namespace: &str, name: &str) -> Result<Option<Secret>, CliError> {
+        match self {
+            SecretSource::Cluster { client } => {
+                let api: Api<Secret> = Api::namespaced(client.clone(), namespace);
+                api.get_opt(name).await.map_err(|e| {
+                    classify_kube("get", "Secret", "secrets", Some(namespace), Some(name), e)
+                })
+            }
+            SecretSource::Files(map) => {
+                Ok(map.get(&(namespace.to_string(), name.to_string())).cloned())
+            }
+            // Never reached: constructed only when `--repository` is set, and
+            // then resolution is skipped entirely. Typed-error rather than
+            // panic, to honor degrade-not-crash.
+            SecretSource::None => Err(CliError::MigrationInput {
+                what: "internal: secret resolution attempted with --repository set".into(),
+                fix: "this is a kubectl-kopiur bug — please report it".into(),
+            }),
+        }
+    }
+}
+
+/// Read every YAML document from the given inputs. Each input is a file, a
+/// directory (every `*.yaml`/`*.yml` within, sorted by name), or `-` for stdin.
+/// Returns `(human-label, document)` pairs; empty documents are skipped.
+fn collect_documents(paths: &[PathBuf]) -> Result<Vec<(String, serde_json::Value)>, CliError> {
+    let mut out = Vec::new();
+    for path in paths {
+        let blobs: Vec<(String, String)> = if path.as_os_str() == STDIN_TOKEN {
+            let mut buf = String::new();
+            std::io::stdin()
+                .read_to_string(&mut buf)
+                .map_err(|source| CliError::LocalIo {
+                    what: "reading manifests from stdin".into(),
+                    source,
+                })?;
+            vec![("<stdin>".to_string(), buf)]
+        } else if path.is_dir() {
+            let mut entries: Vec<PathBuf> = std::fs::read_dir(path)
+                .map_err(|source| CliError::LocalIo {
+                    what: format!("reading directory {}", path.display()),
+                    source,
+                })?
+                .filter_map(Result::ok)
+                .map(|e| e.path())
+                .filter(|p| {
+                    matches!(
+                        p.extension().and_then(|e| e.to_str()),
+                        Some("yaml") | Some("yml")
+                    )
+                })
+                .collect();
+            entries.sort();
+            entries
+                .into_iter()
+                .map(|p| read_file(&p).map(|c| (p.display().to_string(), c)))
+                .collect::<Result<_, _>>()?
+        } else {
+            vec![(path.display().to_string(), read_file(path)?)]
+        };
+
+        for (label, content) in blobs {
+            for (i, doc) in serde_yaml::Deserializer::from_str(&content).enumerate() {
+                let value =
+                    serde_json::Value::deserialize(doc).map_err(|e| CliError::MigrationInput {
+                        what: format!("{label} document {i} is not valid YAML/JSON: {e}"),
+                        fix: "fix or remove the offending document".into(),
+                    })?;
+                if value.is_null() {
+                    continue;
+                }
+                // Unwrap a `kind: List` wrapper (what `kubectl get -o yaml`
+                // emits) into its items.
+                if is_list(&value)
+                    && let Some(items) = value.get("items").and_then(|v| v.as_array())
+                {
+                    for (j, item) in items.iter().enumerate() {
+                        out.push((format!("{label} document {i} item {j}"), item.clone()));
+                    }
+                    continue;
+                }
+                out.push((format!("{label} document {i}"), value));
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Is this document a Kubernetes List wrapper (`kubectl get -o yaml`)? Matches
+/// the generic `kind: List` and any `*List` (e.g. `ReplicationSourceList`).
+fn is_list(value: &serde_json::Value) -> bool {
+    value.get("items").is_some_and(|v| v.is_array())
+        && value
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .is_some_and(|k| k == "List" || k.ends_with("List"))
+}
+
+fn read_file(path: &Path) -> Result<String, CliError> {
+    std::fs::read_to_string(path).map_err(|source| CliError::LocalIo {
+        what: format!("reading {}", path.display()),
+        source,
+    })
+}
+
+/// Parse VolSync ReplicationSource/Destination objects from `paths`. Non-VolSync
+/// documents (e.g. a whole app manifest) are skipped; `metadata.namespace` wins,
+/// falling back to `fallback_ns`.
+pub fn parse_volsync(paths: &[PathBuf], fallback_ns: &str) -> Result<Vec<RawVolsync>, CliError> {
+    let mut out = Vec::new();
+    for (label, value) in collect_documents(paths)? {
+        if value.get("apiVersion").and_then(|v| v.as_str()) != Some("volsync.backube/v1alpha1") {
+            continue;
+        }
+        let kind = match value.get("kind").and_then(|v| v.as_str()) {
+            Some("ReplicationSource") => VolsyncKind::Source,
+            Some("ReplicationDestination") => VolsyncKind::Destination,
+            _ => continue,
+        };
+        let namespace = value
+            .pointer("/metadata/namespace")
+            .and_then(|v| v.as_str())
+            .unwrap_or(fallback_ns)
+            .to_string();
+        let name = value
+            .pointer("/metadata/name")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| CliError::MigrationInput {
+                what: format!("{label} is a VolSync object with no metadata.name"),
+                fix: "every object needs a name".into(),
+            })?
+            .to_string();
+        let spec = value
+            .get("spec")
+            .cloned()
+            .unwrap_or(serde_json::Value::Null);
+        out.push(RawVolsync {
+            kind,
+            namespace,
+            name,
+            spec,
+        });
+    }
+    Ok(out)
+}
+
+/// Parse plaintext Secret YAML from `paths` into a `(namespace, name) → Secret`
+/// map. `stringData` is folded into `data` so the emit-* code (which reads
+/// `secret.data`) is untouched.
+pub fn parse_secrets(
+    paths: &[PathBuf],
+    fallback_ns: &str,
+) -> Result<BTreeMap<(String, String), Secret>, CliError> {
+    let mut map = BTreeMap::new();
+    for (label, value) in collect_documents(paths)? {
+        if value.get("kind").and_then(|v| v.as_str()) != Some("Secret") {
+            continue;
+        }
+        let mut secret: Secret =
+            serde_json::from_value(value).map_err(|e| CliError::MigrationInput {
+                what: format!("{label} is not a valid Secret: {e}"),
+                fix: "check the Secret's shape".into(),
+            })?;
+        // Fold stringData into data so downstream `secret.data` reads see it.
+        if let Some(string_data) = secret.string_data.take() {
+            let data = secret.data.get_or_insert_with(BTreeMap::new);
+            for (k, v) in string_data {
+                data.entry(k).or_insert_with(|| ByteString(v.into_bytes()));
+            }
+        }
+        let namespace = secret
+            .metadata
+            .namespace
+            .clone()
+            .unwrap_or_else(|| fallback_ns.to_string());
+        let name = secret
+            .metadata
+            .name
+            .clone()
+            .ok_or_else(|| CliError::MigrationInput {
+                what: format!("{label} is a Secret with no metadata.name"),
+                fix: "every Secret needs a name".into(),
+            })?;
+        map.insert((namespace, name), secret);
+    }
+    Ok(map)
+}
+
+/// Write `(filename, content)` pairs into `dir` (created if needed). Each file
+/// is written to a sibling `.part` and renamed on success so a failure never
+/// leaves a half-written manifest. Without `force`, refuses to overwrite any
+/// existing target (protects hand-authored GitOps files).
+pub async fn write_files(
+    dir: &Path,
+    files: &[(String, String)],
+    force: bool,
+) -> Result<(), CliError> {
+    tokio::fs::create_dir_all(dir)
+        .await
+        .map_err(|source| CliError::LocalIo {
+            what: format!("creating directory {}", dir.display()),
+            source,
+        })?;
+    if !force {
+        let mut existing = Vec::new();
+        for (name, _) in files {
+            if tokio::fs::try_exists(dir.join(name)).await.unwrap_or(false) {
+                existing.push(name.clone());
+            }
+        }
+        if !existing.is_empty() {
+            return Err(CliError::MigrationInput {
+                what: format!(
+                    "--out-dir {} already contains: {}",
+                    dir.display(),
+                    existing.join(", ")
+                ),
+                fix: "pass --force to overwrite, or choose an empty directory".into(),
+            });
+        }
+    }
+    for (name, content) in files {
+        let target = dir.join(name);
+        let part = dir.join(format!("{name}.part"));
+        tokio::fs::write(&part, content)
+            .await
+            .map_err(|source| CliError::LocalIo {
+                what: format!("writing {}", part.display()),
+                source,
+            })?;
+        tokio::fs::rename(&part, &target)
+            .await
+            .map_err(|source| CliError::LocalIo {
+                what: format!("renaming {} to {}", part.display(), target.display()),
+                source,
+            })?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn write_temp(name: &str, content: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("kopiur-io-test-{name}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("manifest.yaml");
+        std::fs::write(&path, content).unwrap();
+        path
+    }
+
+    #[test]
+    fn parse_volsync_keeps_only_volsync_and_preserves_namespace() {
+        let path = write_temp(
+            "mixed",
+            "\
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: ignore-me, namespace: media }
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app, namespace: media }
+spec:
+  kopia:
+    repository: vs-kopia
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationDestination
+metadata: { name: app-dst, namespace: db }
+spec:
+  restic:
+    repository: vs-restic
+",
+        );
+        let parsed = parse_volsync(&[path], "fallback").unwrap();
+        assert_eq!(parsed.len(), 2, "{parsed:?}");
+        assert_eq!(parsed[0].kind, VolsyncKind::Source);
+        assert_eq!(parsed[0].namespace, "media");
+        assert_eq!(parsed[0].name, "app");
+        // The spec block round-trips through the Value path.
+        assert_eq!(parsed[0].spec["kopia"]["repository"], "vs-kopia");
+        assert_eq!(parsed[1].kind, VolsyncKind::Destination);
+        assert_eq!(parsed[1].namespace, "db");
+    }
+
+    #[test]
+    fn parse_volsync_unwraps_a_kubectl_get_list() {
+        // `kubectl get replicationsource -o yaml` wraps items in a List.
+        let path = write_temp(
+            "list",
+            "\
+apiVersion: v1
+kind: List
+items:
+  - apiVersion: volsync.backube/v1alpha1
+    kind: ReplicationSource
+    metadata: { name: a, namespace: media }
+    spec: { kopia: { repository: r1 } }
+  - apiVersion: volsync.backube/v1alpha1
+    kind: ReplicationSource
+    metadata: { name: b, namespace: media }
+    spec: { kopia: { repository: r2 } }
+",
+        );
+        let parsed = parse_volsync(&[path], "fallback").unwrap();
+        assert_eq!(parsed.len(), 2, "{parsed:?}");
+        assert_eq!(parsed[0].name, "a");
+        assert_eq!(parsed[1].name, "b");
+    }
+
+    #[test]
+    fn parse_volsync_falls_back_to_namespace_when_missing() {
+        let path = write_temp(
+            "nons",
+            "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app }
+spec: { restic: { repository: r } }
+",
+        );
+        let parsed = parse_volsync(&[path], "the-fallback").unwrap();
+        assert_eq!(parsed[0].namespace, "the-fallback");
+    }
+
+    #[test]
+    fn parse_volsync_reports_malformed_document() {
+        let path = write_temp("bad", "this: : : not yaml\n  - [");
+        let err = parse_volsync(&[path], "ns").unwrap_err();
+        assert!(err.to_string().contains("not valid YAML/JSON"), "{err}");
+    }
+
+    #[test]
+    fn parse_secrets_folds_stringdata_into_data() {
+        let path = write_temp(
+            "stringdata",
+            "\
+apiVersion: v1
+kind: Secret
+metadata: { name: vs-kopia, namespace: media }
+stringData:
+  KOPIA_REPOSITORY: s3://bucket/app
+  KOPIA_PASSWORD: hunter2
+",
+        );
+        let map = parse_secrets(&[path], "fallback").unwrap();
+        let secret = map
+            .get(&("media".to_string(), "vs-kopia".to_string()))
+            .expect("secret keyed by ns/name");
+        let data = secret.data.as_ref().expect("stringData folded into data");
+        assert_eq!(
+            String::from_utf8(data["KOPIA_REPOSITORY"].0.clone()).unwrap(),
+            "s3://bucket/app"
+        );
+        assert_eq!(
+            String::from_utf8(data["KOPIA_PASSWORD"].0.clone()).unwrap(),
+            "hunter2"
+        );
+        assert!(secret.string_data.is_none());
+    }
+
+    #[tokio::test]
+    async fn write_files_refuses_overwrite_without_force() {
+        let dir = std::env::temp_dir().join("kopiur-io-test-overwrite");
+        let _ = std::fs::remove_dir_all(&dir);
+        let files = vec![("app.yaml".to_string(), "first".to_string())];
+        write_files(&dir, &files, false).await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("app.yaml")).unwrap(),
+            "first"
+        );
+
+        // Second write without --force must refuse and leave the file intact.
+        let files2 = vec![("app.yaml".to_string(), "second".to_string())];
+        let err = write_files(&dir, &files2, false).await.unwrap_err();
+        assert!(err.to_string().contains("already contains"), "{err}");
+        assert_eq!(
+            std::fs::read_to_string(dir.join("app.yaml")).unwrap(),
+            "first"
+        );
+
+        // With --force it overwrites, and leaves no .part behind.
+        write_files(&dir, &files2, true).await.unwrap();
+        assert_eq!(
+            std::fs::read_to_string(dir.join("app.yaml")).unwrap(),
+            "second"
+        );
+        assert!(!dir.join("app.yaml.part").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/cli/src/cmd/migrate/mod.rs
+++ b/crates/cli/src/cmd/migrate/mod.rs
@@ -13,6 +13,7 @@
 //!   Secret's `KOPIA_PASSWORD` referenced (never copied), all snapshots
 //!   preserved, and the fork's snapshot identity pinned so history continues.
 
+pub mod io;
 pub mod kopia;
 pub mod translate;
 pub mod volsync_types;
@@ -24,9 +25,10 @@ use kube::api::{Api, DynamicObject, GroupVersionKind, ListParams, Patch, PatchPa
 use kube::discovery::ApiResource;
 
 use crate::CmdOutput;
-use crate::cli::MigrateVolsyncArgs;
-use crate::context::KubeCtx;
+use crate::cli::{GlobalArgs, MigrateVolsyncArgs};
+use crate::context::{self, KubeCtx};
 use crate::error::{CliError, classify_kube};
+use io::{RawVolsync, SecretSource, VolsyncKind};
 use translate::{FieldNote, PASSWORD_PLACEHOLDER, Translation};
 use volsync_types::{
     DestMoverBlock, MoverBlock, ReplicationDestinationSpec, ReplicationSourceSpec,
@@ -41,6 +43,48 @@ enum MoverKind {
     Restic,
     /// Fork kopia mover.
     Kopia,
+}
+
+/// Dedup key for an emitted Repository: `(mover, namespace, Secret name)`. The
+/// namespace matters offline, where one run can span several namespaces and the
+/// same Secret name in two namespaces is two different repositories.
+type RepoKey = (MoverKind, String, String);
+
+/// Translated objects attributed to one ReplicationSource (so `--out-dir` can
+/// write one file per source). `restic`/`kopia` record which mover paragraphs
+/// the file's banner needs.
+struct Group {
+    name: String,
+    objects: Vec<serde_json::Value>,
+    restic: bool,
+    kopia: bool,
+}
+
+/// Append `objects` to the group named `name` (creating it if new), recording
+/// the mover so the per-file banner is accurate.
+fn group_push(
+    groups: &mut Vec<Group>,
+    name: &str,
+    mover: MoverKind,
+    objects: impl IntoIterator<Item = serde_json::Value>,
+) {
+    let group = match groups.iter_mut().find(|g| g.name == name) {
+        Some(g) => g,
+        None => {
+            groups.push(Group {
+                name: name.to_string(),
+                objects: Vec::new(),
+                restic: false,
+                kopia: false,
+            });
+            groups.last_mut().expect("just pushed")
+        }
+    };
+    match mover {
+        MoverKind::Restic => group.restic = true,
+        MoverKind::Kopia => group.kopia = true,
+    }
+    group.objects.extend(objects);
 }
 
 /// Banner header shared by every run.
@@ -337,15 +381,16 @@ fn emit_kopia_repository_objects(
 /// derived Repositories would share the `<secret>-kopiur` name, and the second
 /// server-side apply would silently overwrite the first.
 fn check_cross_mover_collision(
-    emitted_repos: &BTreeMap<(MoverKind, String), serde_json::Value>,
+    emitted_repos: &BTreeMap<RepoKey, serde_json::Value>,
     mover_kind: MoverKind,
+    namespace: &str,
     secret_name: &str,
 ) -> Result<(), CliError> {
     let other_mover = match mover_kind {
         MoverKind::Restic => MoverKind::Kopia,
         MoverKind::Kopia => MoverKind::Restic,
     };
-    if emitted_repos.contains_key(&(other_mover, secret_name.to_string())) {
+    if emitted_repos.contains_key(&(other_mover, namespace.to_string(), secret_name.to_string())) {
         return Err(CliError::MigrationInput {
             what: format!(
                 "Secret {secret_name:?} is referenced by BOTH a restic and a kopia VolSync \
@@ -404,74 +449,216 @@ fn render_yaml(objects: &[serde_json::Value], banner: &str) -> Result<String, Cl
     Ok(out)
 }
 
-/// Run `migrate volsync`.
-pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, CliError> {
-    if matches!(ctx.scope, crate::context::Scope::All) {
+/// List one VolSync kind from the cluster as namespace-tagged [`RawVolsync`].
+async fn list_raw(ctx: &KubeCtx, kind: VolsyncKind) -> Result<Vec<RawVolsync>, CliError> {
+    let (kind_str, plural) = match kind {
+        VolsyncKind::Source => ("ReplicationSource", "replicationsources"),
+        VolsyncKind::Destination => ("ReplicationDestination", "replicationdestinations"),
+    };
+    let listed = volsync_api(ctx, kind_str)
+        .list(&ListParams::default())
+        .await
+        .map_err(|e| match &e {
+            kube::Error::Api(ae) if ae.code == 404 && kind == VolsyncKind::Source => {
+                CliError::MigrationInput {
+                    what: "the cluster has no volsync.backube/v1alpha1 ReplicationSource resource"
+                        .into(),
+                    fix:
+                        "is VolSync installed on this cluster? Nothing to migrate without its CRDs"
+                            .into(),
+                }
+            }
+            _ => classify_kube("list", kind_str, plural, Some(&ctx.namespace), None, e),
+        })?;
+    Ok(listed
+        .items
+        .into_iter()
+        .map(|o| RawVolsync {
+            kind,
+            namespace: ctx.namespace.clone(),
+            name: o.metadata.name.clone().unwrap_or_default(),
+            spec: o
+                .data
+                .get("spec")
+                .cloned()
+                .unwrap_or(serde_json::Value::Null),
+        })
+        .collect())
+}
+
+/// Validate flag combinations clap can't express declaratively. Runs before any
+/// I/O so a misuse fails fast with an actionable message.
+fn validate_args(global: &GlobalArgs, args: &MigrateVolsyncArgs) -> Result<(), CliError> {
+    if global.all_namespaces {
         return Err(CliError::AllNamespacesNotApplicable {
             command: "migrate volsync",
         });
     }
-    let ns = ctx.namespace.clone();
+    let offline = !args.filename.is_empty();
+    let secrets_files = !args.secrets.is_empty();
+    // R1: can't apply what you read from disk.
+    if offline && args.apply {
+        return Err(CliError::MigrationInput {
+            what: "--apply cannot be combined with offline input (-f/--filename)".into(),
+            fix: "drop --apply and `kubectl apply -f` the emitted manifests yourself, or run \
+                  against the cluster"
+                .into(),
+        });
+    }
+    // R2: --out-dir writes files for review; it does not apply.
+    if args.out_dir.is_some() && args.apply {
+        return Err(CliError::MigrationInput {
+            what: "--apply cannot be combined with --out-dir".into(),
+            fix: "--out-dir writes manifests to disk for review; drop one of the two".into(),
+        });
+    }
+    // R3: offline --resolve-secrets needs a Secret source.
+    if offline && args.resolve_secrets && !secrets_files && !args.from_cluster_secrets {
+        return Err(CliError::MigrationInput {
+            what: "offline --resolve-secrets has no Secret source".into(),
+            fix: "pass --secrets <file/dir> for plaintext Secrets, --from-cluster-secrets to \
+                  fetch them live, or --repository to skip secret resolution"
+                .into(),
+        });
+    }
+    // R4: secret-source flags are meaningless without offline input.
+    if !offline && (secrets_files || args.from_cluster_secrets) {
+        return Err(CliError::MigrationInput {
+            what: "--secrets/--from-cluster-secrets only apply to offline input".into(),
+            fix: "add -f/--filename to read VolSync objects from disk, or drop these flags \
+                  (a cluster --resolve-secrets run already reads Secrets live)"
+                .into(),
+        });
+    }
+    // R6: stdin can only be read once.
+    let uses_stdin = |v: &[std::path::PathBuf]| {
+        v.iter()
+            .any(|p| p.as_os_str() == crate::consts::STDIN_TOKEN)
+    };
+    if uses_stdin(&args.filename) && uses_stdin(&args.secrets) {
+        return Err(CliError::MigrationInput {
+            what: "stdin (-) was given for both -f and --secrets".into(),
+            fix: "stdin can only be read once; put one of the two in a file".into(),
+        });
+    }
+    Ok(())
+}
 
-    // --- list the VolSync sources ---
-    let sources_api = volsync_api(ctx, "ReplicationSource");
-    let listed = sources_api
-        .list(&ListParams::default())
-        .await
-        .map_err(|e| match &e {
-            kube::Error::Api(ae) if ae.code == 404 => CliError::MigrationInput {
-                what: "the cluster has no volsync.backube/v1alpha1 ReplicationSource resource"
-                    .into(),
-                fix: "is VolSync installed on this cluster? Nothing to migrate without its CRDs"
-                    .into(),
-            },
-            _ => classify_kube(
-                "list",
-                "ReplicationSource",
-                "replicationsources",
-                Some(&ns),
-                None,
-                e,
-            ),
-        })?;
-    let mut sources: Vec<DynamicObject> = listed.items;
+/// Run `migrate volsync`.
+pub async fn run(global: &GlobalArgs, args: &MigrateVolsyncArgs) -> Result<CmdOutput, CliError> {
+    validate_args(global, args)?;
+    let offline = !args.filename.is_empty();
+
+    // Connect only when a cluster is genuinely needed: cluster input, or the
+    // offline hybrid that reads Secrets live. (Offline --apply is rejected, so
+    // it never forces a connection.)
+    let needs_client = !offline || (args.resolve_secrets && args.from_cluster_secrets);
+    let ctx = if needs_client {
+        Some(context::connect(global).await?)
+    } else {
+        None
+    };
+
+    // Namespace for objects that don't carry their own (file input) and for
+    // cluster scoping.
+    let fallback_ns = match (&ctx, offline) {
+        (Some(c), false) => c.namespace.clone(),
+        _ => global
+            .namespace
+            .clone()
+            .unwrap_or_else(|| "default".to_string()),
+    };
+
+    // --- gather VolSync objects (cluster or files), in a deterministic order ---
+    let mut all: Vec<RawVolsync> = if offline {
+        io::parse_volsync(&args.filename, &fallback_ns)?
+    } else {
+        let ctx = ctx.as_ref().expect("client present for cluster input");
+        let mut v = list_raw(ctx, VolsyncKind::Source).await?;
+        if args.include_destinations {
+            v.extend(list_raw(ctx, VolsyncKind::Destination).await?);
+        }
+        v
+    };
+    all.sort_by(|a, b| (&a.namespace, &a.name).cmp(&(&b.namespace, &b.name)));
+
+    let mut sources: Vec<RawVolsync> = all
+        .iter()
+        .filter(|o| o.kind == VolsyncKind::Source)
+        .cloned()
+        .collect();
     if let Some(name) = &args.name {
-        sources.retain(|o| o.metadata.name.as_deref() == Some(name));
+        sources.retain(|o| o.name == *name);
         if sources.is_empty() {
             return Err(CliError::NotFound {
                 kind: "ReplicationSource",
                 plural: "replicationsources",
                 name: name.clone(),
-                scope: crate::error::scope_suffix(Some(&ns)),
-                scope_flag: format!(" -n {ns}"),
+                scope: crate::error::scope_suffix(Some(&fallback_ns)),
+                scope_flag: if offline {
+                    String::new()
+                } else {
+                    format!(" -n {fallback_ns}")
+                },
             });
         }
     }
     if sources.is_empty() {
+        let location = if offline {
+            "the supplied files".to_string()
+        } else {
+            format!("namespace {fallback_ns}")
+        };
         return Ok(CmdOutput::ok(format!(
-            "no ReplicationSources found in namespace {ns}; nothing to migrate\n"
+            "no ReplicationSources found in {location}; nothing to migrate\n"
         )));
     }
+    let destinations: Vec<RawVolsync> = if args.include_destinations {
+        all.iter()
+            .filter(|o| o.kind == VolsyncKind::Destination)
+            .cloned()
+            .collect()
+    } else {
+        Vec::new()
+    };
 
-    let mut objects: Vec<serde_json::Value> = Vec::new();
+    // --- how repository Secrets resolve ---
+    let secret_source = if args.repository.is_some() {
+        SecretSource::None
+    } else if args.from_cluster_secrets || (!offline && args.resolve_secrets) {
+        SecretSource::Cluster {
+            client: ctx
+                .as_ref()
+                .expect("client present for cluster secrets")
+                .client
+                .clone(),
+        }
+    } else if offline && args.resolve_secrets {
+        SecretSource::Files(io::parse_secrets(&args.secrets, &fallback_ns)?)
+    } else {
+        // Unreachable: the repo_source group requires --repository or
+        // --resolve-secrets, both handled above.
+        SecretSource::None
+    };
+
+    // Shared (deduped) Repository/Secret objects vs per-source policy/schedule.
+    let mut shared: Vec<serde_json::Value> = Vec::new();
+    let (mut shared_restic, mut shared_kopia) = (false, false);
+    let mut groups: Vec<Group> = Vec::new();
     let mut translated: Vec<Translated> = Vec::new();
-    // (mover, Secret name) -> kopiur repository ref (emitted once per Secret).
-    // Keyed by mover too: a restic- and a kopia-derived Repository from the
-    // same Secret name would collide on the derived `<secret>-kopiur` name.
-    let mut emitted_repos: BTreeMap<(MoverKind, String), serde_json::Value> = BTreeMap::new();
-    // policy name per (mover, Secret), for destination pairing.
-    let mut policies_by_secret: BTreeMap<(MoverKind, String), Vec<String>> = BTreeMap::new();
+    let mut emitted_repos: BTreeMap<RepoKey, serde_json::Value> = BTreeMap::new();
+    // policy names per (mover, namespace, Secret), for destination pairing.
+    let mut policies_by_secret: BTreeMap<RepoKey, Vec<String>> = BTreeMap::new();
     let (mut saw_restic, mut saw_kopia) = (false, false);
 
     for source in &sources {
-        let name = source.metadata.name.clone().unwrap_or_default();
-        let spec: ReplicationSourceSpec = serde_json::from_value(
-            source.data.get("spec").cloned().unwrap_or_default(),
-        )
-        .map_err(|e| CliError::MigrationInput {
-            what: format!("ReplicationSource {ns}/{name}: cannot decode spec: {e}"),
-            fix: "check the object; only volsync.backube/v1alpha1 shapes are supported".into(),
-        })?;
+        let name = source.name.clone();
+        let ns = source.namespace.clone();
+        let spec: ReplicationSourceSpec =
+            serde_json::from_value(source.spec.clone()).map_err(|e| CliError::MigrationInput {
+                what: format!("ReplicationSource {ns}/{name}: cannot decode spec: {e}"),
+                fix: "check the object; only volsync.backube/v1alpha1 shapes are supported".into(),
+            })?;
 
         let mover = spec.mover().map_err(|what| CliError::MigrationInput {
             what: format!("ReplicationSource {ns}/{name} {what}"),
@@ -481,6 +668,23 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
             MoverBlock::Restic(r) => (MoverKind::Restic, r.repository.clone().unwrap_or_default()),
             MoverBlock::Kopia(k) => (MoverKind::Kopia, k.repository.clone().unwrap_or_default()),
         };
+        // Empty mover repository under --resolve-secrets would later try to GET a
+        // Secret with an empty name; name the offending source instead.
+        if args.repository.is_none() && secret_name.is_empty() {
+            let field = match mover_kind {
+                MoverKind::Restic => "spec.restic.repository",
+                MoverKind::Kopia => "spec.kopia.repository",
+            };
+            return Err(CliError::MigrationInput {
+                what: format!(
+                    "ReplicationSource {ns}/{name} uses --resolve-secrets but its {field} field \
+                     is empty/missing"
+                ),
+                fix: "set the mover's repository to the repository Secret name, or pass \
+                      --repository to point at an existing kopiur Repository"
+                    .into(),
+            });
+        }
         match mover_kind {
             MoverKind::Restic => saw_restic = true,
             MoverKind::Kopia => saw_kopia = true,
@@ -492,36 +696,32 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
             serde_json::json!({ "kind": format!("{kind:?}"), "name": existing })
         } else {
             // --resolve-secrets: derive (and emit, once per Secret).
-            match emitted_repos.get(&(mover_kind, secret_name.clone())) {
+            let key: RepoKey = (mover_kind, ns.clone(), secret_name.clone());
+            match emitted_repos.get(&key) {
                 Some(r) => r.clone(),
                 None => {
-                    check_cross_mover_collision(&emitted_repos, mover_kind, &secret_name)?;
-                    let secrets: Api<Secret> = Api::namespaced(ctx.client.clone(), &ns);
-                    let secret = secrets
-                        .get_opt(&secret_name)
-                        .await
-                        .map_err(|e| {
-                            classify_kube(
-                                "get",
-                                "Secret",
-                                "secrets",
-                                Some(&ns),
-                                Some(&secret_name),
-                                e,
-                            )
-                        })?
-                        .ok_or_else(|| CliError::MigrationInput {
+                    check_cross_mover_collision(&emitted_repos, mover_kind, &ns, &secret_name)?;
+                    let secret = secret_source.get(&ns, &secret_name).await?.ok_or_else(|| {
+                        CliError::MigrationInput {
                             what: format!(
                                 "ReplicationSource {ns}/{name} references repository Secret \
                                  {secret_name:?}, which does not exist"
                             ),
-                            fix: "fix the VolSync object or pass --repository to skip secret \
-                                  resolution"
-                                .into(),
-                        })?;
+                            fix: if offline && !args.from_cluster_secrets {
+                                "supply it via --secrets, or pass --repository to skip secret \
+                                 resolution"
+                                    .into()
+                            } else {
+                                "fix the VolSync object or pass --repository to skip secret \
+                                 resolution"
+                                    .into()
+                            },
+                        }
+                    })?;
                     let (repo_ref, repo_objects, notes, has_unmappable) = match &mover {
                         MoverBlock::Restic(_) => {
                             let (r, o, n) = emit_repository_objects(&ns, &secret_name, &secret)?;
+                            shared_restic = true;
                             (r, o, n, true) // the password placeholder
                         }
                         MoverBlock::Kopia(k) => {
@@ -531,6 +731,7 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
                                 &secret,
                                 k.mover_volumes.as_deref(),
                             )?;
+                            shared_kopia = true;
                             let unmappable = n.iter().any(|note| {
                                 matches!(
                                     note.disposition,
@@ -540,7 +741,7 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
                             (r, o, n, unmappable)
                         }
                     };
-                    objects.extend(repo_objects);
+                    shared.extend(repo_objects);
                     translated.push(Translated {
                         source: format!("secret/{secret_name}"),
                         translation: Translation {
@@ -549,7 +750,7 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
                             has_unmappable,
                         },
                     });
-                    emitted_repos.insert((mover_kind, secret_name.clone()), repo_ref.clone());
+                    emitted_repos.insert(key, repo_ref.clone());
                     repo_ref
                 }
             }
@@ -568,9 +769,14 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
                         fix: "check the ReplicationSource's spec.kopia block".into(),
                     })?,
             };
-        objects.extend(translation.objects.iter().cloned());
+        group_push(
+            &mut groups,
+            &name,
+            mover_kind,
+            translation.objects.iter().cloned(),
+        );
         policies_by_secret
-            .entry((mover_kind, secret_name))
+            .entry((mover_kind, ns.clone(), secret_name))
             .or_default()
             .push(name.clone());
         translated.push(Translated {
@@ -580,170 +786,158 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
     }
 
     // --- destinations (opt-in) ---
-    if args.include_destinations {
-        let dests_api = volsync_api(ctx, "ReplicationDestination");
-        let listed = dests_api.list(&ListParams::default()).await.map_err(|e| {
-            classify_kube(
-                "list",
-                "ReplicationDestination",
-                "replicationdestinations",
-                Some(&ns),
-                None,
-                e,
-            )
-        })?;
-        for dest in listed.items {
-            let name = dest.metadata.name.clone().unwrap_or_default();
-            let spec: ReplicationDestinationSpec =
-                serde_json::from_value(dest.data.get("spec").cloned().unwrap_or_default())
-                    .map_err(|e| CliError::MigrationInput {
-                        what: format!(
-                            "ReplicationDestination {ns}/{name}: cannot decode spec: {e}"
-                        ),
-                        fix: "check the object".into(),
-                    })?;
-            let mover = spec.mover().map_err(|what| CliError::MigrationInput {
-                what: format!("ReplicationDestination {ns}/{name} {what}"),
-                fix: "only restic- and (fork) kopia-mover ReplicationDestinations are \
-                      translatable"
-                    .into(),
+    for dest in &destinations {
+        let name = dest.name.clone();
+        let ns = dest.namespace.clone();
+        let spec: ReplicationDestinationSpec =
+            serde_json::from_value(dest.spec.clone()).map_err(|e| CliError::MigrationInput {
+                what: format!("ReplicationDestination {ns}/{name}: cannot decode spec: {e}"),
+                fix: "check the object".into(),
             })?;
-            let (mover_kind, dest_secret) = match &mover {
-                DestMoverBlock::Restic(r) => {
-                    (MoverKind::Restic, r.repository.clone().unwrap_or_default())
-                }
-                DestMoverBlock::Kopia(k) => {
-                    (MoverKind::Kopia, k.repository.clone().unwrap_or_default())
-                }
-            };
-            match mover_kind {
-                MoverKind::Restic => saw_restic = true,
-                MoverKind::Kopia => saw_kopia = true,
+        let mover = spec.mover().map_err(|what| CliError::MigrationInput {
+            what: format!("ReplicationDestination {ns}/{name} {what}"),
+            fix: "only restic- and (fork) kopia-mover ReplicationDestinations are translatable"
+                .into(),
+        })?;
+        let (mover_kind, dest_secret) = match &mover {
+            DestMoverBlock::Restic(r) => {
+                (MoverKind::Restic, r.repository.clone().unwrap_or_default())
             }
-            // Pair with a source policy via the shared Secret (the fromPolicy
-            // fallback; a kopia destination with an explicit identity does not
-            // use it).
-            let policy = match policies_by_secret
-                .get(&(mover_kind, dest_secret.clone()))
-                .map(Vec::as_slice)
-            {
-                Some([only]) => only.clone(),
-                _ => {
-                    // Ambiguous/unknown: emit with a loud placeholder the user
-                    // must edit (and --apply refuses).
-                    "REPLACE_ME-policy".to_string()
-                }
-            };
-            let mut translation = match &mover {
-                DestMoverBlock::Restic(_) => translate::translate_destination(
-                    &name, &ns, &spec, &policy,
-                )
-                .map_err(|what| CliError::MigrationInput {
-                    what,
-                    fix: "only restic-mover ReplicationDestinations are translatable".into(),
-                })?,
-                DestMoverBlock::Kopia(k) => {
-                    // An identity-source Restore needs spec.repository; resolve
-                    // it the same way sources do (emitting the Repository when
-                    // this Secret was not seen via a source).
-                    let repo_ref = if let Some(existing) = &args.repository {
-                        let kind: kopiur_api::common::RepositoryKind = args.repository_kind.into();
-                        serde_json::json!({ "kind": format!("{kind:?}"), "name": existing })
-                    } else {
-                        match emitted_repos.get(&(MoverKind::Kopia, dest_secret.clone())) {
-                            Some(r) => r.clone(),
-                            None => {
-                                check_cross_mover_collision(
-                                    &emitted_repos,
-                                    MoverKind::Kopia,
-                                    &dest_secret,
-                                )?;
-                                let secrets: Api<Secret> = Api::namespaced(ctx.client.clone(), &ns);
-                                let secret = secrets
-                                    .get_opt(&dest_secret)
-                                    .await
-                                    .map_err(|e| {
-                                        classify_kube(
-                                            "get",
-                                            "Secret",
-                                            "secrets",
-                                            Some(&ns),
-                                            Some(&dest_secret),
-                                            e,
-                                        )
-                                    })?
-                                    .ok_or_else(|| CliError::MigrationInput {
-                                        what: format!(
-                                            "ReplicationDestination {ns}/{name} references \
-                                             repository Secret {dest_secret:?}, which does not \
-                                             exist"
-                                        ),
-                                        fix: "fix the VolSync object or pass --repository".into(),
-                                    })?;
-                                let (repo_ref, repo_objects, notes) =
-                                    emit_kopia_repository_objects(
-                                        &ns,
-                                        &dest_secret,
-                                        &secret,
-                                        k.mover_volumes.as_deref(),
-                                    )?;
-                                let has_unmappable = notes.iter().any(|note| {
-                                    matches!(
-                                        note.disposition,
-                                        translate::Disposition::Unmappable { .. }
-                                    )
-                                });
-                                objects.extend(repo_objects);
-                                translated.push(Translated {
-                                    source: format!("secret/{dest_secret}"),
-                                    translation: Translation {
-                                        objects: Vec::new(),
-                                        notes,
-                                        has_unmappable,
-                                    },
-                                });
-                                emitted_repos.insert(
-                                    (MoverKind::Kopia, dest_secret.clone()),
-                                    repo_ref.clone(),
-                                );
-                                repo_ref
-                            }
+            DestMoverBlock::Kopia(k) => {
+                (MoverKind::Kopia, k.repository.clone().unwrap_or_default())
+            }
+        };
+        match mover_kind {
+            MoverKind::Restic => saw_restic = true,
+            MoverKind::Kopia => saw_kopia = true,
+        }
+        // Pair with a source policy via the shared Secret (the fromPolicy
+        // fallback; a kopia destination with an explicit identity does not
+        // use it).
+        let policy = match policies_by_secret
+            .get(&(mover_kind, ns.clone(), dest_secret.clone()))
+            .map(Vec::as_slice)
+        {
+            Some([only]) => only.clone(),
+            _ => "REPLACE_ME-policy".to_string(),
+        };
+        let mut translation = match &mover {
+            DestMoverBlock::Restic(_) => {
+                translate::translate_destination(&name, &ns, &spec, &policy).map_err(|what| {
+                    CliError::MigrationInput {
+                        what,
+                        fix: "only restic-mover ReplicationDestinations are translatable".into(),
+                    }
+                })?
+            }
+            DestMoverBlock::Kopia(k) => {
+                // An identity-source Restore needs spec.repository; resolve it
+                // the same way sources do (emitting the Repository when this
+                // Secret was not seen via a source).
+                let repo_ref = if let Some(existing) = &args.repository {
+                    let kind: kopiur_api::common::RepositoryKind = args.repository_kind.into();
+                    serde_json::json!({ "kind": format!("{kind:?}"), "name": existing })
+                } else {
+                    if dest_secret.is_empty() {
+                        return Err(CliError::MigrationInput {
+                            what: format!(
+                                "ReplicationDestination {ns}/{name} uses --resolve-secrets but its \
+                                 spec.kopia.repository field is empty/missing"
+                            ),
+                            fix: "set spec.kopia.repository, or pass --repository".into(),
+                        });
+                    }
+                    let key: RepoKey = (MoverKind::Kopia, ns.clone(), dest_secret.clone());
+                    match emitted_repos.get(&key) {
+                        Some(r) => r.clone(),
+                        None => {
+                            check_cross_mover_collision(
+                                &emitted_repos,
+                                MoverKind::Kopia,
+                                &ns,
+                                &dest_secret,
+                            )?;
+                            let secret = secret_source.get(&ns, &dest_secret).await?.ok_or_else(
+                                || CliError::MigrationInput {
+                                    what: format!(
+                                        "ReplicationDestination {ns}/{name} references repository \
+                                         Secret {dest_secret:?}, which does not exist"
+                                    ),
+                                    fix: "fix the VolSync object or pass --repository".into(),
+                                },
+                            )?;
+                            let (repo_ref, repo_objects, notes) = emit_kopia_repository_objects(
+                                &ns,
+                                &dest_secret,
+                                &secret,
+                                k.mover_volumes.as_deref(),
+                            )?;
+                            shared_kopia = true;
+                            let has_unmappable = notes.iter().any(|note| {
+                                matches!(
+                                    note.disposition,
+                                    translate::Disposition::Unmappable { .. }
+                                )
+                            });
+                            shared.extend(repo_objects);
+                            translated.push(Translated {
+                                source: format!("secret/{dest_secret}"),
+                                translation: Translation {
+                                    objects: Vec::new(),
+                                    notes,
+                                    has_unmappable,
+                                },
+                            });
+                            emitted_repos.insert(key, repo_ref.clone());
+                            repo_ref
                         }
-                    };
-                    kopia::translate_destination(&name, &ns, &spec, &repo_ref, &policy).map_err(
-                        |what| CliError::MigrationInput {
-                            what,
-                            fix: "check the ReplicationDestination's spec.kopia block".into(),
-                        },
-                    )?
-                }
-            };
-            // The fromPolicy fallback may have used the placeholder; surface it.
-            if policy == "REPLACE_ME-policy" && has_placeholder(&translation.objects) {
-                translation.has_unmappable = true;
-                let field = match mover_kind {
-                    MoverKind::Restic => "spec.restic.repository",
-                    MoverKind::Kopia => "spec.kopia.repository",
+                    }
                 };
-                translation.notes.push(FieldNote {
-                    field: field.into(),
-                    disposition: translate::Disposition::Unmappable {
-                        reason: format!(
-                            "could not pair Secret {dest_secret:?} with exactly one translated \
-                             source policy; edit fromPolicy.name before applying"
-                        ),
+                kopia::translate_destination(&name, &ns, &spec, &repo_ref, &policy).map_err(
+                    |what| CliError::MigrationInput {
+                        what,
+                        fix: "check the ReplicationDestination's spec.kopia block".into(),
                     },
-                });
+                )?
             }
-            objects.extend(translation.objects.iter().cloned());
-            translated.push(Translated {
-                source: format!("replicationdestination/{name}"),
-                translation,
+        };
+        // The fromPolicy fallback may have used the placeholder; surface it.
+        if policy == "REPLACE_ME-policy" && has_placeholder(&translation.objects) {
+            translation.has_unmappable = true;
+            let field = match mover_kind {
+                MoverKind::Restic => "spec.restic.repository",
+                MoverKind::Kopia => "spec.kopia.repository",
+            };
+            translation.notes.push(FieldNote {
+                field: field.into(),
+                disposition: translate::Disposition::Unmappable {
+                    reason: format!(
+                        "could not pair Secret {dest_secret:?} with exactly one translated source \
+                         policy; edit fromPolicy.name before applying"
+                    ),
+                },
             });
         }
+        // Group the Restore with its paired source's file, or its own file when
+        // unpaired.
+        let group_name = if policy == "REPLACE_ME-policy" {
+            format!("destination-{name}")
+        } else {
+            policy.clone()
+        };
+        group_push(
+            &mut groups,
+            &group_name,
+            mover_kind,
+            translation.objects.iter().cloned(),
+        );
+        translated.push(Translated {
+            source: format!("replicationdestination/{name}"),
+            translation,
+        });
     }
 
-    // --- report + emit ---
+    // --- report on stderr ---
     if saw_restic {
         eprintln!(
             "restic sources: CONFIG TRANSLATION ONLY — no backup data is migrated; the kopiur \
@@ -769,8 +963,16 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
         });
     }
 
+    // Flat view (shared first, then each source's objects), for --apply and the
+    // stdout stream.
+    let mut flat: Vec<serde_json::Value> = shared.clone();
+    for g in &groups {
+        flat.extend(g.objects.iter().cloned());
+    }
+
     if args.apply {
-        if has_placeholder(&objects) {
+        let ctx = ctx.as_ref().expect("client present for --apply");
+        if has_placeholder(&flat) {
             return Err(CliError::MigrationInput {
                 what: "the translated manifests still contain REPLACE_ME placeholders \
                        (kopia password and/or an unpaired restore policy)"
@@ -781,15 +983,19 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
             });
         }
         let params = PatchParams::apply(crate::consts::FIELD_MANAGER);
-        for obj in &objects {
+        for obj in &flat {
             let kind = obj["kind"].as_str().unwrap_or("?");
             let name = obj["metadata"]["name"].as_str().unwrap_or("?");
+            let obj_ns = obj["metadata"]["namespace"]
+                .as_str()
+                .unwrap_or(&ctx.namespace);
             let gvk = match obj["apiVersion"].as_str().unwrap_or_default() {
                 "v1" => GroupVersionKind::gvk("", "v1", kind),
                 _ => GroupVersionKind::gvk(kopiur_api::GROUP, kopiur_api::VERSION, kind),
             };
             let resource = ApiResource::from_gvk(&gvk);
-            let api: Api<DynamicObject> = Api::namespaced_with(ctx.client.clone(), &ns, &resource);
+            let api: Api<DynamicObject> =
+                Api::namespaced_with(ctx.client.clone(), obj_ns, &resource);
             api.patch(name, &params, &Patch::Apply(obj.clone()))
                 .await
                 .map_err(|e| {
@@ -797,7 +1003,7 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
                         "patch",
                         "translated object",
                         "objects",
-                        Some(&ns),
+                        Some(obj_ns),
                         Some(name),
                         e,
                     )
@@ -806,8 +1012,34 @@ pub async fn run(ctx: &KubeCtx, args: &MigrateVolsyncArgs) -> Result<CmdOutput, 
         }
     }
 
+    // --- emit: one file per source (+ _shared.yaml), or the stdout stream ---
+    if let Some(dir) = &args.out_dir {
+        let mut files: Vec<(String, String)> = Vec::new();
+        if !shared.is_empty() {
+            files.push((
+                crate::consts::MIGRATE_SHARED_FILE.to_string(),
+                render_yaml(&shared, &compose_banner(shared_restic, shared_kopia))?,
+            ));
+        }
+        for g in &groups {
+            if g.objects.is_empty() {
+                continue;
+            }
+            files.push((
+                format!("{}.yaml", g.name),
+                render_yaml(&g.objects, &compose_banner(g.restic, g.kopia))?,
+            ));
+        }
+        io::write_files(dir, &files, args.force).await?;
+        let mut summary = format!("wrote {} file(s) to {}:\n", files.len(), dir.display());
+        for (name, _) in &files {
+            summary.push_str(&format!("  {name}\n"));
+        }
+        return Ok(CmdOutput::ok(summary));
+    }
+
     Ok(CmdOutput::ok(render_yaml(
-        &objects,
+        &flat,
         &compose_banner(saw_restic, saw_kopia),
     )?))
 }
@@ -1015,19 +1247,24 @@ mod tests {
         // One Secret claimed by the OTHER mover ⇒ the derived `<secret>-kopiur`
         // Repository names would collide; both the source loop and the kopia
         // destination loop must refuse via this shared check.
-        let mut emitted: BTreeMap<(MoverKind, String), serde_json::Value> = BTreeMap::new();
+        let mut emitted: BTreeMap<RepoKey, serde_json::Value> = BTreeMap::new();
         emitted.insert(
-            (MoverKind::Restic, "shared".to_string()),
+            (MoverKind::Restic, "media".to_string(), "shared".to_string()),
             serde_json::json!({}),
         );
-        let err = check_cross_mover_collision(&emitted, MoverKind::Kopia, "shared").unwrap_err();
+        let err =
+            check_cross_mover_collision(&emitted, MoverKind::Kopia, "media", "shared").unwrap_err();
         assert!(
             err.to_string().contains("BOTH a restic and a kopia"),
             "{err}"
         );
         // Same mover re-using the Secret is fine (that is the dedup hit path).
-        assert!(check_cross_mover_collision(&emitted, MoverKind::Restic, "shared").is_ok());
-        assert!(check_cross_mover_collision(&emitted, MoverKind::Kopia, "other").is_ok());
+        assert!(
+            check_cross_mover_collision(&emitted, MoverKind::Restic, "media", "shared").is_ok()
+        );
+        assert!(check_cross_mover_collision(&emitted, MoverKind::Kopia, "media", "other").is_ok());
+        // A same-named Secret in a DIFFERENT namespace is a different repo.
+        assert!(check_cross_mover_collision(&emitted, MoverKind::Kopia, "db", "shared").is_ok());
     }
 
     #[test]
@@ -1047,6 +1284,289 @@ mod tests {
         .unwrap();
         let err = emit_kopia_repository_objects("ns", "s", &no_password, None).unwrap_err();
         assert!(err.to_string().contains("KOPIA_PASSWORD"), "{err}");
+    }
+
+    // --- offline / GitOps mode (end-to-end through run(), no cluster) ---
+
+    /// Parse a full CLI invocation into the global + migrate args run() takes.
+    fn parse(argv: &[&str]) -> (GlobalArgs, MigrateVolsyncArgs) {
+        use clap::Parser;
+        let cli = crate::Cli::parse_from(argv);
+        match cli.command {
+            crate::cli::Command::Migrate(crate::cli::MigrateCommand::Volsync(a)) => (cli.global, a),
+            _ => panic!("expected migrate volsync"),
+        }
+    }
+
+    /// A throwaway directory unique to `label`, recreated empty.
+    fn scratch(label: &str) -> std::path::PathBuf {
+        let dir = std::env::temp_dir().join(format!("kopiur-migrate-test-{label}"));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    const KOPIA_SOURCE: &str = "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app, namespace: media }
+spec:
+  sourcePVC: app-data
+  trigger: { schedule: \"0 * * * *\" }
+  kopia:
+    repository: vs-kopia
+";
+    const KOPIA_SECRET: &str = "\
+apiVersion: v1
+kind: Secret
+metadata: { name: vs-kopia, namespace: media }
+stringData:
+  KOPIA_REPOSITORY: s3://bucket/app
+  KOPIA_PASSWORD: the-real-password
+  AWS_ACCESS_KEY_ID: AK
+  AWS_SECRET_ACCESS_KEY: SK
+";
+    const RESTIC_SOURCE: &str = "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app, namespace: media }
+spec:
+  sourcePVC: app-data
+  trigger: { schedule: \"0 * * * *\" }
+  restic:
+    repository: vs-restic
+";
+    const RESTIC_SECRET: &str = "\
+apiVersion: v1
+kind: Secret
+metadata: { name: vs-restic, namespace: media }
+stringData:
+  RESTIC_REPOSITORY: s3:https://minio.local:9000/bucket/app
+  RESTIC_PASSWORD: old-restic-pass
+  AWS_ACCESS_KEY_ID: AK
+  AWS_SECRET_ACCESS_KEY: SK
+";
+
+    fn write(dir: &std::path::Path, name: &str, content: &str) -> String {
+        let path = dir.join(name);
+        std::fs::write(&path, content).unwrap();
+        path.display().to_string()
+    }
+
+    #[tokio::test]
+    async fn offline_mode_2a_repository_points_policy_at_existing_repo_with_no_secrets() {
+        let dir = scratch("2a");
+        let src = write(&dir, "src.yaml", KOPIA_SOURCE);
+        let (global, args) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            &src,
+            "--repository",
+            "nas",
+        ]);
+        let out = run(&global, &args).await.unwrap();
+        // No Repository object emitted (its tell is passwordSecretRef); the
+        // policy points at the named repo.
+        assert!(!out.text.contains("passwordSecretRef"), "{}", out.text);
+        assert!(out.text.contains("kind: SnapshotPolicy"), "{}", out.text);
+        assert!(out.text.contains("name: nas"), "{}", out.text);
+    }
+
+    #[tokio::test]
+    async fn offline_mode_2b_restic_resolves_secret_files_with_placeholder_password() {
+        let dir = scratch("2b-restic");
+        let src = write(&dir, "src.yaml", RESTIC_SOURCE);
+        let sec = write(&dir, "sec.yaml", RESTIC_SECRET);
+        let out_dir = dir.join("out");
+        let (global, args) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            &src,
+            "--resolve-secrets",
+            "--secrets",
+            &sec,
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        let out = run(&global, &args).await.unwrap();
+        assert!(out.text.contains("wrote"), "{}", out.text);
+        // _shared.yaml carries the Repository + creds + password placeholder.
+        let shared = std::fs::read_to_string(out_dir.join("_shared.yaml")).unwrap();
+        assert!(shared.contains("kind: Repository"), "{shared}");
+        assert!(shared.contains("REPLACE_ME"), "{shared}");
+        assert!(shared.contains("AWS_ACCESS_KEY_ID"), "{shared}");
+        // app.yaml carries the policy/schedule, not the Repository (whose tell
+        // is passwordSecretRef).
+        let app = std::fs::read_to_string(out_dir.join("app.yaml")).unwrap();
+        assert!(app.contains("kind: SnapshotPolicy"), "{app}");
+        assert!(!app.contains("passwordSecretRef"), "{app}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn offline_mode_2b_kopia_adopts_in_place_no_placeholder() {
+        let dir = scratch("2b-kopia");
+        let src = write(&dir, "src.yaml", KOPIA_SOURCE);
+        let sec = write(&dir, "sec.yaml", KOPIA_SECRET);
+        let (global, args) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            &src,
+            "--resolve-secrets",
+            "--secrets",
+            &sec,
+        ]);
+        let out = run(&global, &args).await.unwrap();
+        // Adopted in place: password referenced, never copied; no placeholder.
+        assert!(out.text.contains("kind: Repository"), "{}", out.text);
+        assert!(!out.text.contains("REPLACE_ME"), "{}", out.text);
+        assert!(!out.text.contains("the-real-password"), "{}", out.text);
+        assert!(out.text.contains("passwordSecretRef"), "{}", out.text);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn offline_shared_repository_is_deduped_across_two_sources() {
+        let dir = scratch("dedup");
+        // Two sources sharing one Secret.
+        let two = "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app-a, namespace: media }
+spec:
+  sourcePVC: a-data
+  kopia: { repository: vs-kopia }
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app-b, namespace: media }
+spec:
+  sourcePVC: b-data
+  kopia: { repository: vs-kopia }
+";
+        let src = write(&dir, "src.yaml", two);
+        let sec = write(&dir, "sec.yaml", KOPIA_SECRET);
+        let out_dir = dir.join("out");
+        let (global, args) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            &src,
+            "--resolve-secrets",
+            "--secrets",
+            &sec,
+            "--out-dir",
+            out_dir.to_str().unwrap(),
+        ]);
+        run(&global, &args).await.unwrap();
+        // Exactly one Repository, in _shared.yaml; one file per source.
+        let shared = std::fs::read_to_string(out_dir.join("_shared.yaml")).unwrap();
+        assert_eq!(shared.matches("kind: Repository").count(), 1, "{shared}");
+        assert!(out_dir.join("app-a.yaml").exists());
+        assert!(out_dir.join("app-b.yaml").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[tokio::test]
+    async fn empty_repository_field_names_the_offending_source() {
+        let dir = scratch("emptyname");
+        let bad = "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: { name: app, namespace: media }
+spec:
+  sourcePVC: app-data
+  kopia: {}
+";
+        let src = write(&dir, "src.yaml", bad);
+        let sec = write(&dir, "sec.yaml", KOPIA_SECRET);
+        let (global, args) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            &src,
+            "--resolve-secrets",
+            "--secrets",
+            &sec,
+        ]);
+        let err = run(&global, &args).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("media/app"), "{msg}");
+        assert!(msg.contains("spec.kopia.repository"), "{msg}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn validate_args_rejects_invalid_offline_combinations() {
+        // R1: --apply with offline input.
+        let (g, a) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            "x.yaml",
+            "--repository",
+            "r",
+            "--apply",
+        ]);
+        assert!(
+            validate_args(&g, &a)
+                .unwrap_err()
+                .to_string()
+                .contains("--apply")
+        );
+
+        // R3: offline --resolve-secrets with no Secret source.
+        let (g, a) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            "x.yaml",
+            "--resolve-secrets",
+        ]);
+        assert!(
+            validate_args(&g, &a)
+                .unwrap_err()
+                .to_string()
+                .contains("no Secret source")
+        );
+
+        // R4: secret flags without offline input.
+        let (g, a) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "--resolve-secrets",
+            "--secrets",
+            "s.yaml",
+        ]);
+        assert!(
+            validate_args(&g, &a)
+                .unwrap_err()
+                .to_string()
+                .contains("only apply to offline input")
+        );
+
+        // A clean offline combo validates.
+        let (g, a) = parse(&[
+            "kubectl-kopiur",
+            "migrate",
+            "volsync",
+            "-f",
+            "x.yaml",
+            "--repository",
+            "r",
+        ]);
+        assert!(validate_args(&g, &a).is_ok());
     }
 
     fn base64(s: &str) -> String {

--- a/crates/cli/src/consts.rs
+++ b/crates/cli/src/consts.rs
@@ -10,6 +10,15 @@ pub const FIELD_MANAGER: &str = "kubectl-kopiur";
 /// `tracing_subscriber::EnvFilter` expression. `-v`/`-vv` flags take precedence.
 pub const LOG_ENV: &str = "KOPIUR_LOG";
 
+/// Filename `migrate volsync --out-dir` writes shared (deduped) Repository and
+/// credential Secret objects to. The leading underscore cannot collide with a
+/// DNS-1123 ReplicationSource name (which is what per-source files are named).
+pub const MIGRATE_SHARED_FILE: &str = "_shared.yaml";
+
+/// Token meaning "read from stdin" for `migrate volsync -f`/`--secrets`,
+/// matching `kubectl -f -`.
+pub const STDIN_TOKEN: &str = "-";
+
 /// The plugin version: the release tag stamped at build time by CI
 /// (`KOPIUR_VERSION`), falling back to the workspace crate version for local
 /// builds. Mirrors how the operator images stamp `VERSION`.

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -29,6 +29,7 @@ use cli::{
 
 /// What a command hands back to the dispatcher: text for stdout (streaming
 /// commands write directly and return empty text) and the process exit code.
+#[derive(Debug)]
 pub struct CmdOutput {
     /// Final stdout payload.
     pub text: String,
@@ -61,6 +62,15 @@ fn init_tracing(verbose: u8) {
 /// `print!` in the crate — commands return their output so they stay testable.
 pub async fn run(cli: Cli) -> Result<ExitCode, CliError> {
     init_tracing(cli.global.verbose);
+
+    // `migrate volsync` manages its own (optional) connection: offline file
+    // input needs no kubeconfig, so it must not connect up front.
+    if let Command::Migrate(MigrateCommand::Volsync(args)) = &cli.command {
+        let out = cmd::migrate::run(&cli.global, args).await?;
+        print!("{}", out.text);
+        return Ok(ExitCode::from(out.exit));
+    }
+
     let ctx = context::connect(&cli.global).await?;
     let output = cli.global.output;
     let out = match &cli.command {
@@ -82,7 +92,9 @@ pub async fn run(cli: Cli) -> Result<ExitCode, CliError> {
         Command::Maintenance(MaintenanceCommand::Run(args)) => {
             cmd::maintenance::run(&ctx, args, chrono::Utc::now()).await?
         }
-        Command::Migrate(MigrateCommand::Volsync(args)) => cmd::migrate::run(&ctx, args).await?,
+        Command::Migrate(MigrateCommand::Volsync(_)) => {
+            unreachable!("migrate volsync is dispatched before connecting")
+        }
         Command::Status(args) => {
             CmdOutput::ok(cmd::status::run(&ctx, args, output, chrono::Utc::now()).await?)
         }

--- a/crates/e2e/tests/cli.rs
+++ b/crates/e2e/tests/cli.rs
@@ -1596,6 +1596,115 @@ async fn cli_migrate_volsync_kopia() {
     );
 }
 
+/// `migrate volsync` OFFLINE / GitOps mode, hybrid credentials: read the
+/// ReplicationSource from a YAML FILE (never applied to the cluster) while
+/// fetching its repository Secret from the LIVE cluster, and write one file per
+/// source to `--out-dir`. Proves the file-input + live-secret + file-output
+/// wiring end-to-end (the pure offline modes are hermetic unit tests).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + MinIO + built images + helm install"]
+async fn cli_migrate_volsync_offline_hybrid() {
+    use k8s_openapi::api::core::v1::Secret;
+    use kube::api::{Patch, PatchParams};
+
+    const HY_SECRET: &str = "vs-hybrid-secret";
+    const HY_RS: &str = "vs-hybrid-app";
+
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Minio])
+        .await
+        .expect("provision MinIO + buckets");
+    let client = world.client().clone();
+    ensure_volsync_crds(&client).await;
+
+    // The repository Secret lives in the cluster (as it would after Flux
+    // decrypted a SOPS Secret); the ReplicationSource does NOT — it stays a
+    // file, the GitOps source of truth.
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let params = PatchParams::apply("kopiur-e2e").force();
+    let secret: Secret = serde_json::from_value(serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": { "name": HY_SECRET, "namespace": E2E_NAMESPACE },
+        "stringData": {
+            "KOPIA_REPOSITORY": "s3://kopiur-hybrid",
+            "KOPIA_PASSWORD": kopiur_e2e::consts::KOPIA_PASSWORD,
+            "AWS_ACCESS_KEY_ID": kopiur_e2e::consts::MINIO_USER,
+            "AWS_SECRET_ACCESS_KEY": kopiur_e2e::consts::MINIO_PASS,
+            "AWS_S3_ENDPOINT": format!("http://{}", kopiur_e2e::consts::MINIO_ENDPOINT),
+            "AWS_REGION": "us-east-1"
+        }
+    }))
+    .unwrap();
+    secrets
+        .patch(HY_SECRET, &params, &Patch::Apply(&secret))
+        .await
+        .expect("apply hybrid kopia Secret");
+
+    // Write the ReplicationSource to a file (NOT the cluster).
+    let dir = std::env::temp_dir().join("kopiur-e2e-hybrid");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let rs_file = dir.join("source.yaml");
+    std::fs::write(
+        &rs_file,
+        format!(
+            "\
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata: {{ name: {HY_RS}, namespace: {E2E_NAMESPACE} }}
+spec:
+  sourcePVC: app-data
+  trigger: {{ schedule: \"0 3 * * *\" }}
+  kopia:
+    repository: {HY_SECRET}
+"
+        ),
+    )
+    .unwrap();
+    let out_dir = dir.join("out");
+
+    let out = run_cli(&[
+        "-n",
+        E2E_NAMESPACE,
+        "migrate",
+        "volsync",
+        "-f",
+        rs_file.to_str().unwrap(),
+        "--resolve-secrets",
+        "--from-cluster-secrets",
+        "--out-dir",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(out.success, "hybrid migrate failed: {}", out.stderr);
+
+    // _shared.yaml: a Repository adopting the fork repo in place (NO create
+    // block, password referenced not copied), built from the LIVE Secret.
+    let shared = std::fs::read_to_string(out_dir.join("_shared.yaml")).expect("_shared.yaml");
+    assert!(shared.contains("kind: Repository"), "{shared}");
+    assert!(shared.contains("bucket: kopiur-hybrid"), "{shared}");
+    assert!(shared.contains("passwordSecretRef"), "{shared}");
+    assert!(
+        !shared.contains("create:"),
+        "adopt-in-place: no create block: {shared}"
+    );
+    assert!(
+        !shared.contains(kopiur_e2e::consts::KOPIA_PASSWORD),
+        "the password value must never be copied into emitted YAML"
+    );
+
+    // One file per source carries the policy/schedule.
+    let app =
+        std::fs::read_to_string(out_dir.join(format!("{HY_RS}.yaml"))).expect("per-source file");
+    assert!(app.contains("kind: SnapshotPolicy"), "{app}");
+    assert!(app.contains("kind: SnapshotSchedule"), "{app}");
+
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
 /// Kill-on-drop guard for a background `kubectl port-forward`.
 struct PortForward(std::process::Child);
 impl Drop for PortForward {

--- a/deploy/examples/tryit/volsync-offline.yaml
+++ b/deploy/examples/tryit/volsync-offline.yaml
@@ -1,0 +1,98 @@
+# Try it OFFLINE — migrate VolSync into GitOps files (docs/cli/migrate-volsync.md)
+#
+# A GitOps-shaped INPUT for `kubectl kopiur migrate volsync -f` (offline mode).
+# TWO perfectra1n/volsync FORK ReplicationSources (`spec.kopia`) in the `apps`
+# namespace, plus the repository Secrets they reference. Unlike the live tryit
+# (volsync-source.yaml), this models what lives in a Git repo: you migrate it on
+# your laptop with NO cluster connection and commit the result.
+#
+# This is INPUT for the CLI, not a kopiur manifest. The migrate command reads it
+# from disk and writes one kopiur file per source to --out-dir:
+#
+#   # Point policies at an EXISTING kopiur Repository (no Secret reads at all):
+#   kubectl kopiur migrate volsync -f deploy/examples/tryit/volsync-offline.yaml \
+#     --repository nas --out-dir ./migrated
+#
+#   # Or derive the Repository from the plaintext Secrets in THIS SAME file
+#   # (`-f` reads only the ReplicationSources; `--secrets` reads only the
+#   # Secrets — so one bundle file feeds both flags):
+#   kubectl kopiur migrate volsync -f deploy/examples/tryit/volsync-offline.yaml \
+#     --resolve-secrets --secrets deploy/examples/tryit/volsync-offline.yaml \
+#     --out-dir ./migrated
+#
+# Result: ./migrated/blog.yaml, ./migrated/forum.yaml, and (with
+# --resolve-secrets) ./migrated/_shared.yaml carrying the derived Repositories.
+#
+# Fill in each REPLACE_ME backend key and the EXISTING repo KOPIA_PASSWORD (the
+# fork already initialized these repos — reuse their passwords). The
+# `# --8<-- [start:NAME]` / `[end:NAME]` lines are MkDocs snippet markers; they
+# are plain YAML comments.
+---
+# --8<-- [start:sources]
+# Two fork-kopia ReplicationSources — one file per app comes out, named after
+# each source (blog.yaml, forum.yaml). `repository` names the Secret below.
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: blog
+  namespace: apps
+spec:
+  sourcePVC: blog-data
+  trigger:
+    schedule: "0 2 * * *"
+  kopia:
+    repository: blog-kopia-repo # -> Secret blog-kopia-repo (below)
+    copyMethod: Direct
+    retain:
+      daily: 7
+      weekly: 4
+---
+apiVersion: volsync.backube/v1alpha1
+kind: ReplicationSource
+metadata:
+  name: forum
+  namespace: apps
+spec:
+  sourcePVC: forum-data
+  trigger:
+    schedule: "30 3 * * *"
+  kopia:
+    repository: forum-kopia-repo # -> Secret forum-kopia-repo (below)
+    copyMethod: Direct
+    retain:
+      daily: 14
+      monthly: 6
+# --8<-- [end:sources]
+---
+# --8<-- [start:secrets]
+# The repository Secrets, as plaintext for offline `--resolve-secrets --secrets`.
+# In a real GitOps repo these are SOPS-encrypted; decrypt them to a scratch file
+# for the migrate run, or skip them entirely with `--repository`/
+# `--from-cluster-secrets`. KOPIA_REPOSITORY picks the backend to ADOPT;
+# KOPIA_PASSWORD + AWS_* are referenced in place by the emitted Repository.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: blog-kopia-repo
+  namespace: apps
+type: Opaque
+stringData:
+  KOPIA_REPOSITORY: "s3://my-kopia-bucket/blog/"
+  KOPIA_PASSWORD: "REPLACE_ME" # the EXISTING repo password — reuse it
+  AWS_ACCESS_KEY_ID: "REPLACE_ME"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_ME"
+  AWS_S3_ENDPOINT: "s3.us-east-1.amazonaws.com"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: forum-kopia-repo
+  namespace: apps
+type: Opaque
+stringData:
+  KOPIA_REPOSITORY: "s3://my-kopia-bucket/forum/"
+  KOPIA_PASSWORD: "REPLACE_ME" # the EXISTING repo password — reuse it
+  AWS_ACCESS_KEY_ID: "REPLACE_ME"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_ME"
+  AWS_S3_ENDPOINT: "s3.us-east-1.amazonaws.com"
+# --8<-- [end:secrets]

--- a/docs/cli/migrate-volsync.md
+++ b/docs/cli/migrate-volsync.md
@@ -73,6 +73,54 @@ straight from Git):
 `metadata.namespace`; `-n` only supplies a fallback for namespace-less objects
 and never filters offline input.
 
+### Try it offline
+
+[`deploy/examples/tryit/volsync-offline.yaml`](https://github.com/home-operations/kopiur/blob/main/deploy/examples/tryit/volsync-offline.yaml) is a GitOps-shaped bundle: two fork-kopia `ReplicationSource`s in the `apps` namespace plus the repository Secrets they reference. Nothing here touches a cluster — you can run the whole arc on your laptop with no kubeconfig.
+
+```yaml
+--8<-- "deploy/examples/tryit/volsync-offline.yaml:sources"
+```
+
+**1. Point the policies at an existing kopiur `Repository`** — the simplest path, no Secret reads at all:
+
+```console
+$ kubectl kopiur migrate volsync -f deploy/examples/tryit/volsync-offline.yaml --repository nas --out-dir ./migrated
+wrote 2 file(s) to ./migrated:
+  blog.yaml
+  forum.yaml
+```
+
+You get one file per source — `migrated/blog.yaml` and `migrated/forum.yaml` — each a `SnapshotPolicy` + `SnapshotSchedule` pointing at the `nas` repository, ready to commit.
+
+**2. Or derive the `Repository` from the Secrets** with `--resolve-secrets`. The Secrets live in the same bundle: `-f` reads only the `ReplicationSource`s and `--secrets` reads only the `Secret`s, so one file feeds both flags (in a real repo, decrypt your SOPS Secrets to a scratch file first):
+
+```yaml
+--8<-- "deploy/examples/tryit/volsync-offline.yaml:secrets"
+```
+
+```console
+$ kubectl kopiur migrate volsync -f deploy/examples/tryit/volsync-offline.yaml \
+    --resolve-secrets --secrets deploy/examples/tryit/volsync-offline.yaml --out-dir ./migrated --force
+wrote 3 file(s) to ./migrated:
+  _shared.yaml
+  blog.yaml
+  forum.yaml
+```
+
+Now `migrated/_shared.yaml` carries the two derived `Repository` objects (each **adopting** the fork repo in place — no `create` block, the Secret referenced where it sits), and the per-source files reference them. Fork-kopia has no password placeholder, so the result is apply-ready.
+
+/// tip | Already running against the cluster?
+
+Drop `--secrets` for `--from-cluster-secrets` and the same command reads the live Secrets instead — handy when Flux has already decrypted them into the cluster. Or pipe the cluster's objects straight in: `kubectl get replicationsource -A -o yaml | kubectl kopiur migrate volsync -f - --repository nas`.
+
+///
+
+**3. Review and apply.** `--apply` is refused offline by design; commit the files, or apply them yourself:
+
+```console
+$ kubectl apply -f ./migrated
+```
+
 ## restic sources (upstream VolSync)
 
 /// danger | Config translation ONLY — no data is migrated

--- a/docs/cli/migrate-volsync.md
+++ b/docs/cli/migrate-volsync.md
@@ -26,12 +26,52 @@ $ kubectl kopiur migrate volsync -n media --resolve-secrets --apply
 | `--include-destinations` | Also translate ReplicationDestinations into `Restore`s. restic (and kopia without an identity): deploy-or-restore `fromPolicy` + `onMissingSnapshot: Continue`. kopia with `sourceIdentity` or `username`/`hostname`: a raw-identity restore (`source.identity`), no policy pairing needed. |
 | `--strict` | Exit 1 (emitting nothing) when any field has no kopiur equivalent. A minimal fork-kopia source is fully mappable and passes. |
 | `--apply` | Server-side-apply the translated objects. |
+| `-f, --filename PATH` | Read VolSync objects from a YAML file, a directory, or `-` (stdin) instead of the cluster — **no kubeconfig required**. Repeatable. See [Offline / GitOps mode](#offline--gitops-mode). |
+| `--secrets PATH` | In offline mode, resolve repository Secrets from plaintext Secret YAML on disk (file/dir/`-`). Repeatable; needs `--resolve-secrets`. |
+| `--from-cluster-secrets` | In offline mode, fetch the referenced Secrets from the live cluster instead of `--secrets`. |
+| `--out-dir DIR` | Write one YAML file per ReplicationSource (plus `_shared.yaml` for derived Repositories/Secrets) into `DIR` instead of stdout. |
+| `--force` | Allow `--out-dir` to overwrite existing files. |
 
 Every VolSync field the translator reads is accounted for on stderr as
 `mapped` (with the kopiur destination), `UNMAPPABLE` (with why and what to do
 instead — e.g. restic's `retain.within` has no kopia equivalent), or
 `ignored` (with why it isn't needed — e.g. `pruneIntervalDays`: kopiur
 maintenance is default-managed). Nothing is silently dropped.
+
+## Offline / GitOps mode
+
+If your VolSync objects live as YAML in a Git repository (not just in the
+cluster), point `migrate volsync` at the files with `-f`/`--filename` — a file,
+a directory (every `*.yaml`/`*.yml` in it), or `-` for stdin. With `-f`, the
+command reads **nothing from the cluster** unless you ask it to, so it needs no
+kubeconfig:
+
+```console
+$ kubectl kopiur migrate volsync -f ./apps/media/volsync.yaml --repository nas --out-dir ./apps/media/kopiur
+wrote 2 file(s) to ./apps/media/kopiur:
+  _shared.yaml
+  media-app.yaml
+```
+
+`--out-dir` writes **one file per ReplicationSource** (named after it), plus a
+`_shared.yaml` holding any derived `Repository`/credential Secrets shared across
+sources — ready to commit. Without `--out-dir`, the manifests stream to stdout as
+before. You can also pipe the cluster's objects through it:
+`kubectl get replicationsource -A -o yaml | kubectl kopiur migrate volsync -f - --repository nas` (a `kind: List` is unwrapped automatically).
+
+Credentials offline have three options (your SOPS-encrypted Secrets can't be read
+straight from Git):
+
+| You want | Use |
+|---|---|
+| Point policies at a kopiur `Repository` you author/migrate separately — no Secret reads | `--repository NAME` |
+| Derive the `Repository` from **plaintext** Secret YAML on disk | `--resolve-secrets --secrets ./secrets.yaml` |
+| Read VolSync from files but fetch Secrets from the **live** cluster (e.g. Flux already decrypted them) | `--resolve-secrets --from-cluster-secrets` |
+
+`--apply` is rejected with offline input — review the emitted files and
+`kubectl apply -f` them yourself. Each object's namespace comes from its own
+`metadata.namespace`; `-n` only supplies a fallback for namespace-less objects
+and never filters offline input.
 
 ## restic sources (upstream VolSync)
 


### PR DESCRIPTION
## What & why

`migrate volsync` was **cluster-only**: it listed `ReplicationSource`s and read repository Secrets over the API, then streamed manifests to stdout. That's a poor fit for GitOps users whose VolSync objects live as YAML in Git and whose Secrets are SOPS-encrypted. This adds an **offline / GitOps mode** and fixes the latent bug behind a confusing `A non-empty name is required` error.

## Bug fix (the symptom that started this)

`--resolve-secrets` against a mover block with an empty `repository` field hit `get_opt("")` → cryptic `A non-empty name is required`. It now fails fast naming the object:
> `ReplicationSource <ns>/<name> uses --resolve-secrets but its spec.kopia.repository field is empty/missing. Fix: set the mover's repository… or pass --repository…`

## Feature

- **`-f, --filename`** — read VolSync objects from a file, directory, or `-` (stdin); **no kubeconfig required**. Unwraps a `kubectl get -o yaml` `kind: List`.
- **`--out-dir`** — write **one `<source>.yaml` per ReplicationSource** plus `_shared.yaml` for deduped `Repository`/credential Secrets; **`--force`** guards overwriting hand-authored files.
- **Three credential modes offline**: `--repository` (no secret reads), `--secrets` (plaintext Secret YAML on disk), `--from-cluster-secrets` (read VolSync from files, fetch Secrets live).
- `--apply` rejected with offline input; deterministic `(namespace, name)` ordering for reproducible, committable output.

Input/secret/output are abstracted behind exhaustively-`match`ed enums in a new `crates/cli/src/cmd/migrate/io.rs`; the translation core is untouched. `lib.rs` dispatches `migrate volsync` **before** connecting, so offline truly needs no cluster.

## Tests

Hermetic unit tests cover file parsing (incl. List unwrap, multi-namespace, `stringData` fold, malformed docs), the three credential modes (restic + kopia), shared-secret dedup, `--out-dir` layout + overwrite guard, `validate_args` rejections, and the empty-name regression. An `#[ignore]`-gated e2e (`cli_migrate_volsync_offline_hybrid`) covers the hybrid path against kind.

## Verification

`mise run fmt-check` · `mise run clippy` · `mise run test` · `mise run gen-check` (no drift) · `mkdocs build --strict` — all green. Also exercised all three modes live (including `KUBECONFIG=/dev/null` to prove no cluster contact).

## Docs

New "Offline / GitOps mode" section in `docs/cli/migrate-volsync.md` (flags, the three credential modes, namespace-fallback semantics).