### PR TITLE
fix(restore): provision empty volume on onMissingSnapshot=Continue

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -52,8 +52,8 @@ pub use repository_replication::{
     RepositoryReplicationStatus,
 };
 pub use restore::{
-    OnMissingSnapshot, PopulatorTarget, Restore, RestorePhase, RestoreSource, RestoreSpec,
-    RestoreStatus, RestoreTarget,
+    OnMissingSnapshot, PopulatorTarget, ResolutionOutcome, Restore, RestorePhase, RestoreSource,
+    RestoreSpec, RestoreStatus, RestoreTarget,
 };
 pub use server::{
     ClusterServerSpec, ServerAuth, ServerService, ServerSpec, ServerStatus, ServiceType,

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -362,10 +362,31 @@ pub struct RestoreStatus {
     pub failure: Option<crate::common::FailureBlock>,
 }
 
+/// Which outcome the source resolution pinned. Closed enum so the decision is a
+/// single, exhaustively-matched value rather than an inferred combination of optional
+/// fields — `Snapshot` means a concrete snapshot was found (its details live in the
+/// sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
+/// source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
+/// (the volume comes up empty). Pinned once and never re-resolved, exactly like a
+/// snapshot id, so a later-appearing snapshot can never silently retarget an
+/// already-provisioned volume (ADR §4.6).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
+pub enum ResolutionOutcome {
+    /// The source resolved to a concrete kopia snapshot (see `kopiaSnapshotID`).
+    Snapshot,
+    /// The source matched no snapshot; `Continue` chose an empty (deploy-or-restore) volume.
+    NoSnapshot,
+}
+
 /// The source resolved and pinned at admission, so a restore never silently retargets. ADR §4.6.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedRestore {
+    /// Which outcome the resolution pinned (`Snapshot`/`NoSnapshot`). A legacy pin
+    /// written before this field existed leaves it `None` with `kopiaSnapshotID` set,
+    /// which is read as `Snapshot`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolution: Option<ResolutionOutcome>,
     /// The exact kopia snapshot manifest id the source resolved to. Pinned once;
     /// subsequent reconciles restore THIS id even if newer snapshots appear, so a
     /// restore never silently retargets (ADR §4.6). Matches

--- a/crates/controller/src/restore.rs
+++ b/crates/controller/src/restore.rs
@@ -17,9 +17,11 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 
+use kopiur_api::restore::ResolvedRestore;
 use kopiur_api::snapshot::Snapshot;
 use kopiur_api::{
-    OnMissingSnapshot, Restore, RestorePhase, RestoreSource, RestoreTarget, validate,
+    OnMissingSnapshot, ResolutionOutcome, Restore, RestorePhase, RestoreSource, RestoreTarget,
+    validate,
 };
 use kopiur_mover::workspec::{
     MoverOptions, MoverWorkSpec, Operation, RepositoryConnect, ResolvedIdentity as MoverIdentity,
@@ -98,6 +100,46 @@ pub fn populator_state(target: &RestoreTarget) -> PopulatorState {
     match target {
         RestoreTarget::Populator(_) => PopulatorState::AwaitingClaim,
         RestoreTarget::Pvc(_) | RestoreTarget::PvcRef(_) => PopulatorState::DirectTarget,
+    }
+}
+
+/// The pinned source-resolution decision the reconcile loop acts on: a concrete
+/// snapshot id, or a deliberate "no snapshot, come up empty" (deploy-or-restore).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// The source resolved to (or was pinned to) this kopia snapshot id.
+    Snapshot(String),
+    /// `onMissingSnapshot: Continue` with no matching snapshot — provision an empty volume.
+    Empty,
+}
+
+/// The already-pinned resolution decision, or `None` when the source still has to be
+/// resolved. Pure + exhaustive, so the data-safety invariant (ADR §4.6: "pinned once,
+/// never re-resolved") lives in one testable place. Cases:
+/// - `resolution: NoSnapshot` pinned → [`Resolution::Empty`] (a later snapshot never retargets).
+/// - `kopiaSnapshotID` pinned (with or without the newer `resolution: Snapshot`, so a
+///   legacy pin written before that field existed still reads correctly) → [`Resolution::Snapshot`].
+/// - **No pin at all but the populator is already `Completed`**: the pre-fix buggy
+///   `Continue` arm stamped `Completed` without pinning anything. A snapshot-resolved
+///   populator ALWAYS pins before it can reach `Completed`, so `Completed` + unpinned ⟹ the
+///   decision was "empty". Treat it as [`Resolution::Empty`] and re-pin it on the next write
+///   — DO NOT re-resolve, or a snapshot that appeared after the original decision would
+///   silently restore over the (possibly already-bound, in-use) volume.
+/// - Otherwise → `None` (resolve now).
+fn pinned_decision(
+    resolved: Option<&ResolvedRestore>,
+    phase: Option<RestorePhase>,
+    state: PopulatorState,
+) -> Option<Resolution> {
+    match resolved {
+        Some(r) if r.resolution == Some(ResolutionOutcome::NoSnapshot) => Some(Resolution::Empty),
+        Some(r) => r.kopia_snapshot_id.clone().map(Resolution::Snapshot),
+        None if phase == Some(RestorePhase::Completed)
+            && state == PopulatorState::AwaitingClaim =>
+        {
+            Some(Resolution::Empty)
+        }
+        None => None,
     }
 }
 
@@ -335,26 +377,25 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
         &restore.spec.source,
     );
 
-    // ADR §4.6: the resolution is pinned ONCE and never re-resolved — a restore
-    // must not silently retarget when newer snapshots appear mid-flight. Reuse a
-    // previously pinned id; resolve only while no pin exists yet.
-    let pinned_id = restore
-        .status
-        .as_ref()
-        .and_then(|s| s.resolved.as_ref())
-        .and_then(|r| r.kopia_snapshot_id.clone());
-    let snapshot_id = if let Some(id) = pinned_id {
-        id
-    } else {
-        match resolve_snapshot(ctx, restore, &namespace).await? {
+    // ADR §4.6: the resolution is pinned ONCE and never re-resolved — a restore must
+    // not silently retarget when newer snapshots appear mid-flight. The pinned decision
+    // is a snapshot id OR a deliberate "no snapshot, deploy-or-restore" (`Resolution`);
+    // `pinned_decision` reads it (incl. legacy pins + the pre-fix stuck-populator
+    // back-fill), returning `None` only when the source still has to be resolved.
+    let resolved = restore.status.as_ref().and_then(|s| s.resolved.as_ref());
+    let phase = restore.status.as_ref().and_then(|s| s.phase);
+    let decision = match pinned_decision(resolved, phase, state) {
+        Some(d) => d,
+        None => match resolve_snapshot(ctx, restore, &namespace).await? {
             Some(res) => {
-                // Pin the FULL resolution (id + provenance + timestamp) exactly
-                // once; the no-pin check above makes this a single write, so it
-                // cannot churn status.
+                // Pin the FULL resolution (outcome + id + provenance + timestamp) exactly
+                // once; the no-pin check above makes this a single write, so it cannot
+                // churn status.
                 let mut resolved = serde_json::json!({
                     "kopiaSnapshotID": res.kopia_snapshot_id,
                     "pinnedAt": chrono::Utc::now().to_rfc3339(),
                 });
+                resolved["resolution"] = serde_json::to_value(ResolutionOutcome::Snapshot)?;
                 if let Some(r) = &res.snapshot_ref {
                     resolved["snapshotRef"] = serde_json::to_value(r)?;
                 }
@@ -370,7 +411,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                 );
                 status["resolved"] = resolved;
                 io::patch_status(&api, &name, status).await?;
-                res.kopia_snapshot_id
+                Resolution::Snapshot(res.kopia_snapshot_id)
             }
             None => {
                 // No snapshot matched. While the `waitTimeout` window (anchored at
@@ -423,7 +464,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                     )));
                 }
                 // Window closed (or none configured): honor the closed enum exhaustively.
-                return match on_missing {
+                match on_missing {
                     OnMissingSnapshot::Fail => {
                         let msg = "no snapshot matched the restore source within the \
                                    waitTimeout window; fix spec.source (or create the missing \
@@ -449,47 +490,47 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                             ),
                         )
                         .await?;
-                        Err(Error::MissingDependency(
+                        return Err(Error::MissingDependency(
                             "no snapshot matched restore source".into(),
-                        ))
+                        ));
                     }
-                    OnMissingSnapshot::Continue => {
-                        // Deploy-or-restore: nothing to restore, complete cleanly.
-                        let msg = "no snapshot found; continuing without restoring \
-                                   (deploy-or-restore)";
-                        let conditions = io::upsert_condition(
-                            &existing_conditions(restore),
-                            "Resolved",
-                            true,
-                            "NoSnapshotContinue",
-                            msg,
-                            restore.metadata.generation,
-                        );
-                        io::patch_status(
-                            &api,
-                            &name,
-                            restore_ready_status_on(
-                                restore,
-                                &conditions,
-                                RestorePhase::Completed,
-                                "NoSnapshotContinue",
-                                msg,
-                            ),
-                        )
-                        .await?;
-                        Ok(Action::requeue(std::time::Duration::from_secs(600)))
-                    }
-                };
+                    // Deploy-or-restore: no snapshot, so the volume comes up empty. Do NOT
+                    // complete-and-return here — fall through to the target driver, which
+                    // provisions the empty volume (an empty prime PVC for a populator; an
+                    // empty `target.pvc` for a direct restore). The decision is pinned
+                    // below so a later-appearing snapshot never retargets it (ADR §4.6).
+                    OnMissingSnapshot::Continue => Resolution::Empty,
+                }
             }
-        }
+        },
+    };
+
+    // Pin the deploy-or-restore "no snapshot" decision exactly once. This durably records
+    // the choice (so a snapshot that appears later can never silently restore over the
+    // provisioned volume) AND back-fills the pre-fix stuck-populator state that
+    // `pinned_decision` inferred from a `Completed`+unpinned Restore. Idempotent: re-pinning
+    // an already-`NoSnapshot` resolution is a server-side no-op. A bare `{resolved}` merge
+    // patch leaves phase/conditions to the target driver below (the `Resolved` domain
+    // condition is stamped at the driver's empty completion).
+    if decision == Resolution::Empty
+        && resolved.and_then(|r| r.resolution) != Some(ResolutionOutcome::NoSnapshot)
+    {
+        let mut pin = serde_json::json!({ "pinnedAt": chrono::Utc::now().to_rfc3339() });
+        pin["resolution"] = serde_json::to_value(ResolutionOutcome::NoSnapshot)?;
+        io::patch_status(&api, &name, serde_json::json!({ "resolved": pin })).await?;
+    }
+
+    let snapshot_id = match &decision {
+        Resolution::Snapshot(id) => Some(id.as_str()),
+        Resolution::Empty => None,
     };
 
     match state {
         PopulatorState::DirectTarget => {
-            drive_direct_restore(ctx, restore, &api, &namespace, &name, &snapshot_id).await
+            drive_direct_restore(ctx, restore, &api, &namespace, &name, snapshot_id).await
         }
         PopulatorState::AwaitingClaim => {
-            drive_populator_restore(ctx, restore, &api, &namespace, &name, &snapshot_id).await
+            drive_populator_restore(ctx, restore, &api, &namespace, &name, snapshot_id).await
         }
     }
 }
@@ -523,13 +564,17 @@ async fn park_awaiting_claim(
 /// kubernetes-csi/lib-volume-populator). Each step keys off observed state so requeues
 /// are idempotent; the prime PV is set `Retain` before its PVC is deleted so the
 /// volume survives the swap.
+///
+/// `snapshot_id` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
+/// matching snapshot): the empty, freshly-provisioned prime PVC IS the result, so the
+/// mover is skipped and the empty prime is rebound straight to the claiming PVC.
 async fn drive_populator_restore(
     ctx: &Context,
     restore: &Restore,
     api: &Api<Restore>,
     namespace: &str,
     name: &str,
-    snapshot_id: &str,
+    snapshot_id: Option<&str>,
 ) -> Result<Action> {
     use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 
@@ -587,17 +632,36 @@ async fn drive_populator_restore(
                 == Some(pv_name.as_str())
         {
             finalize_populator(ctx, namespace, &populate_job, &prime_name, Some(&pv_name)).await?;
-            io::patch_status(
-                api,
-                name,
+            // Branch the completion on whether there was a snapshot: a restore stamps
+            // `RestoreSucceeded`; deploy-or-restore (no snapshot) stamps `NoSnapshotContinue`
+            // + a `Resolved=True` domain condition so the empty outcome is self-describing.
+            let status = if snapshot_id.is_some() {
                 restore_ready_status(
                     restore,
                     RestorePhase::Completed,
                     crate::consts::RESTORE_POPULATED_REASON,
                     "populator: restored the snapshot into the claiming PVC and rebound the volume",
-                ),
-            )
-            .await?;
+                )
+            } else {
+                let msg = "populator: no snapshot found; provisioned an empty volume for the \
+                           claiming PVC (deploy-or-restore)";
+                let conditions = io::upsert_condition(
+                    &existing_conditions(restore),
+                    "Resolved",
+                    true,
+                    "NoSnapshotContinue",
+                    msg,
+                    restore.metadata.generation,
+                );
+                restore_ready_status_on(
+                    restore,
+                    &conditions,
+                    RestorePhase::Completed,
+                    "NoSnapshotContinue",
+                    msg,
+                )
+            };
+            io::patch_status(api, name, status).await?;
             return Ok(Action::requeue(std::time::Duration::from_secs(600)));
         }
         // Rebind issued; wait for the PV controller to bind our PV to the consumer.
@@ -624,8 +688,9 @@ async fn drive_populator_restore(
         return Ok(Action::requeue(std::time::Duration::from_secs(15)));
     }
 
-    // Provision the prime PVC (mirrors the claim's spec, no dataSourceRef), then run
-    // the restore mover into it.
+    // Provision the prime PVC (mirrors the claim's spec, no dataSourceRef). For a real
+    // restore, run the mover into it; for deploy-or-restore (no snapshot) the empty prime
+    // IS the result — skip the mover and rebind it straight to the consumer.
     ensure_prime_pvc(
         ctx,
         restore,
@@ -636,70 +701,97 @@ async fn drive_populator_restore(
     )
     .await?;
 
-    match run_restore_mover(
-        ctx,
-        restore,
-        api,
-        namespace,
-        &populate_job,
-        &prime_name,
-        snapshot_id,
-    )
-    .await?
-    {
-        MoverOutcome::Running { created } => {
-            let phase = restore.status.as_ref().and_then(|s| s.phase);
-            if created || phase != Some(RestorePhase::Restoring) {
-                io::patch_status(
-                    api,
-                    name,
-                    restore_ready_status(
-                        restore,
-                        RestorePhase::Restoring,
-                        "PopulatingPrimePvc",
-                        "populator: restoring the snapshot into the prime PVC",
-                    ),
-                )
-                .await?;
+    if let Some(snapshot_id) = snapshot_id {
+        match run_restore_mover(
+            ctx,
+            restore,
+            api,
+            namespace,
+            &populate_job,
+            &prime_name,
+            snapshot_id,
+        )
+        .await?
+        {
+            MoverOutcome::Running { created } => {
+                let phase = restore.status.as_ref().and_then(|s| s.phase);
+                if created || phase != Some(RestorePhase::Restoring) {
+                    io::patch_status(
+                        api,
+                        name,
+                        restore_ready_status(
+                            restore,
+                            RestorePhase::Restoring,
+                            "PopulatingPrimePvc",
+                            "populator: restoring the snapshot into the prime PVC",
+                        ),
+                    )
+                    .await?;
+                }
+                return Ok(Action::requeue(std::time::Duration::from_secs(15)));
             }
-            return Ok(Action::requeue(std::time::Duration::from_secs(15)));
-        }
-        MoverOutcome::Failed => {
-            let phase = restore.status.as_ref().and_then(|s| s.phase);
-            if phase != Some(RestorePhase::Failed) {
-                io::patch_status(
-                    api,
-                    name,
-                    restore_ready_status(
-                        restore,
-                        RestorePhase::Failed,
-                        "MoverJobFailed",
-                        "the populator restore mover Job failed; see the Job/pod logs, fix the \
-                         cause, and re-create the claiming PVC — a Failed Restore is terminal",
-                    ),
-                )
-                .await?;
+            MoverOutcome::Failed => {
+                let phase = restore.status.as_ref().and_then(|s| s.phase);
+                if phase != Some(RestorePhase::Failed) {
+                    io::patch_status(
+                        api,
+                        name,
+                        restore_ready_status(
+                            restore,
+                            RestorePhase::Failed,
+                            "MoverJobFailed",
+                            "the populator restore mover Job failed; see the Job/pod logs, fix \
+                             the cause, and re-create the claiming PVC — a Failed Restore is \
+                             terminal",
+                        ),
+                    )
+                    .await?;
+                }
+                return Ok(Action::requeue(std::time::Duration::from_secs(120)));
             }
-            return Ok(Action::requeue(std::time::Duration::from_secs(120)));
-        }
-        MoverOutcome::Wedged { message } => {
-            let phase = restore.status.as_ref().and_then(|s| s.phase);
-            if phase != Some(RestorePhase::Failed) {
-                io::patch_status(
-                    api,
-                    name,
-                    restore_ready_status(restore, RestorePhase::Failed, "MoverPodWedged", &message),
-                )
-                .await?;
+            MoverOutcome::Wedged { message } => {
+                let phase = restore.status.as_ref().and_then(|s| s.phase);
+                if phase != Some(RestorePhase::Failed) {
+                    io::patch_status(
+                        api,
+                        name,
+                        restore_ready_status(
+                            restore,
+                            RestorePhase::Failed,
+                            "MoverPodWedged",
+                            &message,
+                        ),
+                    )
+                    .await?;
+                }
+                return Ok(Action::requeue(std::time::Duration::from_secs(120)));
             }
-            return Ok(Action::requeue(std::time::Duration::from_secs(120)));
+            MoverOutcome::Succeeded { .. } => {}
         }
-        MoverOutcome::Succeeded { .. } => {}
+    } else {
+        // Deploy-or-restore: no mover. Pin an observable in-flight phase once (so
+        // `kubectl get restore` shows progress, not a stale `Pending`, while the empty
+        // prime is rebound), then fall through to the rebind.
+        let phase = restore.status.as_ref().and_then(|s| s.phase);
+        if phase != Some(RestorePhase::Restoring) {
+            io::patch_status(
+                api,
+                name,
+                restore_ready_status(
+                    restore,
+                    RestorePhase::Restoring,
+                    "NoSnapshotContinue",
+                    "populator: no snapshot found; provisioning an empty volume \
+                     (deploy-or-restore)",
+                ),
+            )
+            .await?;
+        }
     }
 
-    // Mover done: hand the prime PV to the consumer, then requeue so the next pass
-    // observes the bind and finalizes. `rebind_prime_to_consumer` returns `false`
-    // (requeue soon) while the prime PV hasn't appeared yet.
+    // Mover done (or skipped for an empty volume): hand the prime PV to the consumer, then
+    // requeue so the next pass observes the bind and finalizes. `rebind_prime_to_consumer`
+    // returns `false` (requeue soon) while the prime PV hasn't appeared yet.
     if !rebind_prime_to_consumer(ctx, namespace, &prime_name, &consumer_name, &consumer_uid).await?
     {
         return Ok(Action::requeue(std::time::Duration::from_secs(5)));
@@ -989,13 +1081,18 @@ async fn finalize_populator(
 
 /// Drive a restore-with-explicit-target: create the restore mover Job (writing
 /// into the target PVC), then track it to terminal.
+///
+/// `snapshot_id` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
+/// matching snapshot): the target PVC is still ensured (so `target.pvc` is provisioned
+/// empty rather than left missing), but the mover is skipped and the restore completes
+/// cleanly with a fresh, empty volume.
 async fn drive_direct_restore(
     ctx: &Context,
     restore: &Restore,
     api: &Api<Restore>,
     namespace: &str,
     name: &str,
-    snapshot_id: &str,
+    snapshot_id: Option<&str>,
 ) -> Result<Action> {
     // Resolve the target PVC for the restore Job. DirectTarget is only reached for
     // an explicit PVC target (populator routes to AwaitingClaim in the reconcile
@@ -1004,7 +1101,8 @@ async fn drive_direct_restore(
         RestoreTarget::PvcRef(r) => r.name.clone(),
         // `target.pvc` means the operator CREATES the PVC (ADR §3.6) — without
         // this the mover Job references a claim nobody made and sits Pending
-        // forever (FailedScheduling: persistentvolumeclaim not found).
+        // forever (FailedScheduling: persistentvolumeclaim not found). This also
+        // provisions the empty volume for the deploy-or-restore (no-snapshot) case.
         RestoreTarget::Pvc(t) => {
             ensure_restore_target_pvc(ctx, namespace, t).await?;
             t.name.clone()
@@ -1018,9 +1116,42 @@ async fn drive_direct_restore(
         }
     };
 
+    let phase = restore.status.as_ref().and_then(|s| s.phase);
+
+    // Deploy-or-restore: no snapshot to write. The target PVC is ensured above (so a
+    // `target.pvc` comes up empty rather than missing); a `pvcRef` already exists. Stamp
+    // a terminal `Completed` via `restore_ready_status_on` (Ready=True) so the entry-guard
+    // heal does NOT clobber this message with "the snapshot data was written" — there is no
+    // mover here, so the controller is the sole writer (no two-writer race).
+    let Some(snapshot_id) = snapshot_id else {
+        if phase != Some(RestorePhase::Completed) {
+            let msg = "no snapshot found; provisioned an empty target volume (deploy-or-restore)";
+            let conditions = io::upsert_condition(
+                &existing_conditions(restore),
+                "Resolved",
+                true,
+                "NoSnapshotContinue",
+                msg,
+                restore.metadata.generation,
+            );
+            io::patch_status(
+                api,
+                name,
+                restore_ready_status_on(
+                    restore,
+                    &conditions,
+                    RestorePhase::Completed,
+                    "NoSnapshotContinue",
+                    msg,
+                ),
+            )
+            .await?;
+        }
+        return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+    };
+
     // The Job is named after the Restore and writes into the explicit target PVC;
     // the helper creates/tracks it, the phase writes stay here.
-    let phase = restore.status.as_ref().and_then(|s| s.phase);
     match run_restore_mover(ctx, restore, api, namespace, name, &target_pvc, snapshot_id).await? {
         MoverOutcome::Succeeded { duration_secs } => {
             if let Some(secs) = duration_secs {
@@ -2223,6 +2354,73 @@ mod tests {
             assert!(!phase_is_terminal_at_guard(p, AwaitingClaim));
             assert!(!phase_is_terminal_at_guard(p, DirectTarget));
         }
+    }
+
+    fn resolved_with(
+        resolution: Option<ResolutionOutcome>,
+        kopia_snapshot_id: Option<&str>,
+    ) -> ResolvedRestore {
+        ResolvedRestore {
+            resolution,
+            kopia_snapshot_id: kopia_snapshot_id.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn pinned_decision_reads_the_pinned_outcome_and_never_re_resolves() {
+        use PopulatorState::{AwaitingClaim, DirectTarget};
+        use RestorePhase::{Completed, Pending};
+
+        // A pinned `NoSnapshot` is always the deploy-or-restore Empty decision — even
+        // if a kopiaSnapshotID somehow co-exists, NoSnapshot wins (data-safety: a later
+        // snapshot must never retarget a volume that already came up empty).
+        assert_eq!(
+            pinned_decision(
+                Some(&resolved_with(Some(ResolutionOutcome::NoSnapshot), None)),
+                Some(Completed),
+                AwaitingClaim,
+            ),
+            Some(Resolution::Empty)
+        );
+
+        // A pinned snapshot id resolves to that id (with the explicit Snapshot outcome…).
+        assert_eq!(
+            pinned_decision(
+                Some(&resolved_with(
+                    Some(ResolutionOutcome::Snapshot),
+                    Some("k7")
+                )),
+                Some(Pending),
+                DirectTarget,
+            ),
+            Some(Resolution::Snapshot("k7".into()))
+        );
+        // …and a LEGACY pin (id present, `resolution` field absent) reads the same,
+        // so an in-flight restore pinned before this field existed keeps its target.
+        assert_eq!(
+            pinned_decision(
+                Some(&resolved_with(None, Some("k7"))),
+                Some(Pending),
+                DirectTarget,
+            ),
+            Some(Resolution::Snapshot("k7".into()))
+        );
+
+        // The pre-fix stuck populator: `Completed` with NOTHING pinned. A snapshot-
+        // resolved populator ALWAYS pins before Completed, so this unambiguously means
+        // the decision was "empty" — back-fill Empty, do NOT re-resolve.
+        assert_eq!(
+            pinned_decision(None, Some(Completed), AwaitingClaim),
+            Some(Resolution::Empty)
+        );
+        // The same shape on a DIRECT target is not a stuck populator (its `Completed`
+        // is terminal at the guard, so it never reaches here): require fresh resolution.
+        assert_eq!(pinned_decision(None, Some(Completed), DirectTarget), None);
+
+        // A fresh, un-pinned restore must resolve.
+        assert_eq!(pinned_decision(None, Some(Pending), AwaitingClaim), None);
+        assert_eq!(pinned_decision(None, None, DirectTarget), None);
     }
 
     // --- kstatus Ready conditions (ADR-0005 §2) -----------------------------

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -58,6 +58,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "pinrestore",
     "populator",
     "populator2",
+    "popempty",
     "readonly",
     "kstatus",
     "verify",

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -59,6 +59,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "populator",
     "populator2",
     "popempty",
+    "popempty2",
     "readonly",
     "kstatus",
     "verify",

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -466,3 +466,39 @@ pub async fn ensure_seed(client: &Client, repo: &str, policy: &str, backup: &str
         .await
         .expect("seed Snapshot Succeeded");
 }
+
+/// Like [`ensure_seed`] but with NO snapshot: a Ready filesystem `Repository` over an
+/// isolated, never-snapshotted `subpath` plus a `SnapshotPolicy`. A `fromPolicy` restore
+/// against `policy` therefore resolves to NO snapshot — the deploy-or-restore
+/// (`onMissingSnapshot: Continue`) case. Use a dedicated `subpath` so no other scenario's
+/// snapshot leaks into this policy's identity. Idempotent.
+pub async fn ensure_empty_policy(client: &Client, repo: &str, policy: &str, subpath: &str) {
+    ensure_repo(client, subpath).await;
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if repos.get_opt(repo).await.ok().flatten().is_none() {
+        let _ = repos
+            .create(
+                &PostParams::default(),
+                &cr(repository_json(repo, subpath, serde_json::json!({}))),
+            )
+            .await;
+    }
+    wait_phase(&repos, repo, "Ready")
+        .await
+        .expect("empty-policy repo Ready");
+    if policies.get_opt(policy).await.ok().flatten().is_none() {
+        let _ = policies
+            .create(
+                &PostParams::default(),
+                &cr(snapshot_policy_json(
+                    E2E_NAMESPACE,
+                    policy,
+                    "Repository",
+                    repo,
+                    serde_json::json!({}),
+                )),
+            )
+            .await;
+    }
+}

--- a/crates/e2e/tests/repository_lifecycle.rs
+++ b/crates/e2e/tests/repository_lifecycle.rs
@@ -285,6 +285,402 @@ async fn restore_populator_wffc_binds_pvc_and_restores_data() {
     .await;
 }
 
+/// The `Resolved` condition's reason on a Restore status, if present.
+fn resolved_reason(status: &serde_json::Value) -> Option<String> {
+    status["conditions"]
+        .as_array()?
+        .iter()
+        .find(|c| c["type"] == "Resolved")
+        .and_then(|c| c["reason"].as_str())
+        .map(str::to_string)
+}
+
+/// Shared body for the deploy-or-restore (`onMissingSnapshot: Continue`) populator
+/// regression: given an already-seeded EMPTY `policy` (a Ready repo with NO snapshot),
+/// create a populator `Restore` whose `fromPolicy` source resolves to nothing, a claiming
+/// PVC on `storage_class`, and a pod that writes+reads a file in the mount. With no
+/// snapshot the controller must STILL provision an empty volume (an empty prime PVC +
+/// rebind) so the claim BINDS and the pod runs — pre-fix the claim hung `Pending` forever
+/// ("Assuming an external populator will provision the volume"). Also asserts the
+/// no-snapshot decision is pinned to `status.resolved.resolution: NoSnapshot`, so a
+/// snapshot that appears later can never silently restore over the in-use volume.
+async fn assert_populator_continue_provisions_empty(
+    client: &kube::Client,
+    storage_class: &str,
+    policy: &str,
+    prefix: &str,
+) {
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let restore_name = format!("{prefix}-restore");
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "Restore",
+                "metadata": { "name": restore_name, "namespace": E2E_NAMESPACE },
+                "spec": {
+                    "source": { "fromPolicy": { "name": policy } },
+                    // explicit for clarity (it's also the fromPolicy default)
+                    "policy": { "onMissingSnapshot": "Continue" },
+                    "target": { "populator": {} }
+                }
+            })),
+        )
+        .await
+        .expect("create deploy-or-restore populator Restore");
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let claim = format!("{prefix}-data");
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": { "name": claim, "namespace": E2E_NAMESPACE },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": storage_class,
+                "resources": { "requests": { "storage": "1Gi" } },
+                "dataSourceRef": {
+                    "apiGroup": "kopiur.home-operations.com",
+                    "kind": "Restore",
+                    "name": restore_name,
+                }
+            }
+        })),
+    )
+    .await
+    .expect("create claiming PVC");
+
+    // The pod writes then reads a file in the empty mount: it schedules the claim (so a
+    // WaitForFirstConsumer class gets its `selected-node`) and can only run once the claim
+    // BINDS, so its success proves the empty volume was provisioned, rebound, and is usable.
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let probe = format!("{prefix}-probe");
+    pods.create(
+        &PostParams::default(),
+        &builders::one_shot_pod(
+            E2E_NAMESPACE,
+            &probe,
+            &[
+                "sh",
+                "-c",
+                "echo ok > /mnt/probe && test \"$(cat /mnt/probe)\" = ok",
+            ],
+            &[(claim.as_str(), "/mnt")],
+        ),
+    )
+    .await
+    .expect("create probe pod");
+
+    wait::pod_succeeded(client, E2E_NAMESPACE, &probe)
+        .await
+        .expect("the claiming PVC binds to a fresh empty volume and is writable");
+    wait_phase(&restores, &restore_name, "Completed")
+        .await
+        .expect("the deploy-or-restore populator Restore reaches Completed");
+
+    let s = status_json(&restores, &restore_name).await;
+    assert_eq!(
+        s["resolved"]["resolution"],
+        serde_json::json!("NoSnapshot"),
+        "the no-snapshot decision must be pinned so a later snapshot can't retarget it: {s}"
+    );
+    assert_eq!(
+        resolved_reason(&s).as_deref(),
+        Some("NoSnapshotContinue"),
+        "status: {s}"
+    );
+
+    let _ = pods.delete(&probe, &DeleteParams::default()).await;
+    let _ = pvcs.delete(&claim, &DeleteParams::default()).await;
+    let _ = restores
+        .delete(&restore_name, &DeleteParams::default())
+        .await;
+}
+
+/// Deploy-or-restore, the user-reported regression (WaitForFirstConsumer, mirroring the
+/// reporter's `openebs-zfspv`): a populator `Restore` over a policy with NO snapshot +
+/// `onMissingSnapshot: Continue` must provision a FRESH EMPTY volume so the claiming PVC
+/// binds and the workload pod starts. Pre-fix the controller stamped the Restore
+/// `Completed` but returned before the populator handshake, leaving the PVC `Pending`
+/// forever. The pod scheduling the claim drives the WFFC `selected-node` path (the empty
+/// prime PVC is pinned to that node, provisioned pod-less, then rebound).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn restore_populator_continue_provisions_empty_volume_wffc() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS_WFFC).await {
+        return;
+    }
+
+    ensure_empty_policy(
+        &client,
+        "e2e-popempty-repo",
+        "e2e-popempty-policy",
+        "popempty",
+    )
+    .await;
+    assert_populator_continue_provisions_empty(
+        &client,
+        CSI_STORAGE_CLASS_WFFC,
+        "e2e-popempty-policy",
+        "e2e-popempty-wffc",
+    )
+    .await;
+}
+
+/// Deploy-or-restore, Immediate-binding variant: the empty prime PVC provisions as soon as
+/// it's created (no pod-schedule dance), so the claim binds without the WFFC `selected-node`
+/// step. Same invariant: a populator `Continue` with no snapshot comes up as an empty,
+/// usable volume.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn restore_populator_continue_provisions_empty_volume_immediate() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS).await {
+        return;
+    }
+
+    ensure_empty_policy(
+        &client,
+        "e2e-popempty-repo",
+        "e2e-popempty-policy",
+        "popempty",
+    )
+    .await;
+    assert_populator_continue_provisions_empty(
+        &client,
+        CSI_STORAGE_CLASS,
+        "e2e-popempty-policy",
+        "e2e-popempty-imm",
+    )
+    .await;
+}
+
+/// Deploy-or-restore for a DIRECT `target.pvc`: the same early-return also stranded an
+/// operator-created target PVC (it was never created when there was no snapshot). With the
+/// fix the controller creates the empty PVC and completes. Asserts the target PVC now
+/// exists and the Restore completes with the empty-volume reason (NOT "snapshot data was
+/// written"). No CSI provisioner needed — the default storage class provisions the PVC.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn restore_direct_pvc_continue_provisions_empty_volume() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    ensure_empty_policy(
+        &client,
+        "e2e-popempty-repo",
+        "e2e-popempty-policy",
+        "popempty",
+    )
+    .await;
+
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let name = "e2e-direct-empty";
+    let target_pvc = "e2e-direct-empty-dst";
+    let _ = restores.delete(name, &DeleteParams::default()).await;
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "Restore",
+                "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+                "spec": {
+                    "source": { "fromPolicy": { "name": "e2e-popempty-policy" } },
+                    "policy": { "onMissingSnapshot": "Continue" },
+                    "target": { "pvc": { "name": target_pvc, "capacity": "1Gi" } }
+                }
+            })),
+        )
+        .await
+        .expect("create direct target.pvc deploy-or-restore Restore");
+
+    wait_phase(&restores, name, "Completed")
+        .await
+        .expect("direct deploy-or-restore must complete by provisioning an empty PVC");
+
+    // The operator-created target PVC must now exist (pre-fix it was never created).
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let created = pvcs
+        .get_opt(target_pvc)
+        .await
+        .expect("get target PVC")
+        .is_some();
+    assert!(
+        created,
+        "deploy-or-restore must provision the operator-created target PVC {target_pvc}"
+    );
+
+    let s = status_json(&restores, name).await;
+    assert_eq!(
+        resolved_reason(&s).as_deref(),
+        Some("NoSnapshotContinue"),
+        "the empty completion must keep the deploy-or-restore reason (not 'RestoreSucceeded'): {s}"
+    );
+
+    let _ = restores.delete(name, &DeleteParams::default()).await;
+    let _ = pvcs.delete(target_pvc, &DeleteParams::default()).await;
+}
+
+/// Data-safety: once deploy-or-restore comes up empty, the pinned `resolution: NoSnapshot`
+/// decision must hold even if a snapshot for the policy appears LATER — the controller must
+/// NOT re-resolve and restore over the (now bound, in-use) volume. Provisions the empty
+/// volume, then seeds a snapshot for the same policy, forces a Restore reconcile, and
+/// asserts the Restore stays `Completed`/`NoSnapshot` and the consumer keeps its same PV.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn restore_populator_continue_pins_decision_against_late_snapshot() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS).await {
+        return;
+    }
+
+    let policy = "e2e-popempty-policy";
+    ensure_empty_policy(&client, "e2e-popempty-repo", policy, "popempty").await;
+
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let prefix = "e2e-popempty-pin";
+    let restore_name = format!("{prefix}-restore");
+    let claim = format!("{prefix}-data");
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "Restore",
+                "metadata": { "name": restore_name, "namespace": E2E_NAMESPACE },
+                "spec": {
+                    "source": { "fromPolicy": { "name": policy } },
+                    "policy": { "onMissingSnapshot": "Continue" },
+                    "target": { "populator": {} }
+                }
+            })),
+        )
+        .await
+        .expect("create populator Restore");
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": { "name": claim, "namespace": E2E_NAMESPACE },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": CSI_STORAGE_CLASS,
+                "resources": { "requests": { "storage": "1Gi" } },
+                "dataSourceRef": {
+                    "apiGroup": "kopiur.home-operations.com",
+                    "kind": "Restore",
+                    "name": restore_name,
+                }
+            }
+        })),
+    )
+    .await
+    .expect("create claiming PVC");
+
+    wait_phase(&restores, &restore_name, "Completed")
+        .await
+        .expect("empty volume provisioned + bound");
+    let bound_pv = wait_until(
+        &format!("{claim} bound to a PV"),
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(pvcs
+                .get_opt(&claim)
+                .await?
+                .and_then(|p| p.spec?.volume_name))
+        },
+    )
+    .await
+    .expect("the claim binds to a PV");
+
+    // Now a snapshot for the SAME policy appears (the app took its first backup).
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let late = format!("{prefix}-late-snap");
+    let _ = backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                &late,
+                policy,
+                serde_json::json!({}),
+            )),
+        )
+        .await;
+    wait_phase(&backups, &late, "Succeeded")
+        .await
+        .expect("a later snapshot for the policy now exists");
+
+    // Force the Restore to reconcile (its post-Completed requeue is long) by touching an
+    // annotation; the pinned NoSnapshot decision must make it a no-op — no re-resolve.
+    restores
+        .patch(
+            &restore_name,
+            &PatchParams::default(),
+            &Patch::Merge(serde_json::json!({
+                "metadata": { "annotations": { "e2e.kopiur/poke": "1" } }
+            })),
+        )
+        .await
+        .expect("poke the Restore to force a reconcile");
+
+    // Give the controller several reconcile cycles, then assert nothing retargeted.
+    for _ in 0..10 {
+        tokio::time::sleep(poll_interval()).await;
+        let s = status_json(&restores, &restore_name).await;
+        assert_eq!(s["phase"], serde_json::json!("Completed"), "status: {s}");
+        assert_eq!(
+            s["resolved"]["resolution"],
+            serde_json::json!("NoSnapshot"),
+            "the pinned decision must not flip to a snapshot: {s}"
+        );
+    }
+    let still = pvcs
+        .get(&claim)
+        .await
+        .expect("get claim")
+        .spec
+        .and_then(|s| s.volume_name);
+    assert_eq!(
+        still.as_deref(),
+        Some(bound_pv.as_str()),
+        "the consumer must keep its original empty PV — no destructive re-restore"
+    );
+
+    let _ = backups.delete(&late, &DeleteParams::default()).await;
+    let _ = pvcs.delete(&claim, &DeleteParams::default()).await;
+    let _ = restores
+        .delete(&restore_name, &DeleteParams::default())
+        .await;
+}
+
 /// `mode: ReadOnly` (ADR-0005 §11): a ReadOnly repository serves restores but the
 /// controller REFUSES backups against it. A Snapshot whose policy points at a ReadOnly
 /// repo must not produce a snapshot; a Restore against it works.

--- a/crates/e2e/tests/repository_lifecycle.rs
+++ b/crates/e2e/tests/repository_lifecycle.rs
@@ -557,8 +557,11 @@ async fn restore_populator_continue_pins_decision_against_late_snapshot() {
         return;
     }
 
-    let policy = "e2e-popempty-policy";
-    ensure_empty_policy(&client, "e2e-popempty-repo", policy, "popempty").await;
+    // Own ISOLATED repo (popempty2): this test seeds a snapshot partway through, which
+    // shares the policy source's kopia identity — reusing the shared `popempty` repo would
+    // make it non-empty and break the sibling empty-volume tests depending on run order.
+    let policy = "e2e-popempty2-policy";
+    ensure_empty_policy(&client, "e2e-popempty2-repo", policy, "popempty2").await;
 
     let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let prefix = "e2e-popempty-pin";

--- a/crates/e2e/tests/restore.rs
+++ b/crates/e2e/tests/restore.rs
@@ -1079,7 +1079,20 @@ async fn restore_missing_snapshot_fail_vs_continue() {
     );
     // kstatus: deploy-or-restore completed cleanly → Ready.
     assert_eq!(condition_status(&s, "Ready"), "True", "status: {s}");
+    // Deploy-or-restore must actually PROVISION the empty volume, not just mark Completed:
+    // the operator-created `target.pvc` must now exist (the bug: it never was created).
+    let dst = format!("{cont_name}-dst");
+    let dst_pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    assert!(
+        dst_pvcs
+            .get_opt(&dst)
+            .await
+            .expect("get target PVC")
+            .is_some(),
+        "deploy-or-restore must create the empty target PVC {dst}"
+    );
     cleanup_restore(&restores, cont_name).await;
+    let _ = dst_pvcs.delete(&dst, &DeleteParams::default()).await;
 
     // (c) explicit onMissingSnapshot: Fail overrides the fromPolicy default.
     let strict_name = "e2e-r-missing-strict";

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -18373,6 +18373,21 @@ spec:
                     required:
                     - name
                     type: object
+                  resolution:
+                    description: |-
+                      Which outcome the source resolution pinned. Closed enum so the decision is a
+                      single, exhaustively-matched value rather than an inferred combination of optional
+                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
+                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
+                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
+                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
+                      snapshot id, so a later-appearing snapshot can never silently retarget an
+                      already-provisioned volume (ADR §4.6).
+                    enum:
+                    - Snapshot
+                    - NoSnapshot
+                    nullable: true
+                    type: string
                   snapshotRef:
                     description: The concrete `Snapshot` CR the source resolved to, when applicable.
                     nullable: true

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -869,6 +869,21 @@ spec:
                     required:
                     - name
                     type: object
+                  resolution:
+                    description: |-
+                      Which outcome the source resolution pinned. Closed enum so the decision is a
+                      single, exhaustively-matched value rather than an inferred combination of optional
+                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
+                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
+                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
+                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
+                      snapshot id, so a later-appearing snapshot can never silently retarget an
+                      already-provisioned volume (ADR §4.6).
+                    enum:
+                    - Snapshot
+                    - NoSnapshot
+                    nullable: true
+                    type: string
                   snapshotRef:
                     description: The concrete `Snapshot` CR the source resolved to, when applicable.
                     nullable: true

--- a/deploy/helm/kopiur/files/crds/restores.yaml
+++ b/deploy/helm/kopiur/files/crds/restores.yaml
@@ -869,6 +869,21 @@ spec:
                     required:
                     - name
                     type: object
+                  resolution:
+                    description: |-
+                      Which outcome the source resolution pinned. Closed enum so the decision is a
+                      single, exhaustively-matched value rather than an inferred combination of optional
+                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
+                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
+                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
+                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
+                      snapshot id, so a later-appearing snapshot can never silently retarget an
+                      already-provisioned volume (ADR §4.6).
+                    enum:
+                    - Snapshot
+                    - NoSnapshot
+                    nullable: true
+                    type: string
                   snapshotRef:
                     description: The concrete `Snapshot` CR the source resolved to, when applicable.
                     nullable: true

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -166,9 +166,17 @@ By default a restore is **additive** — it writes the snapshot's files and leav
 | Value      | Behavior                                                                      | Default for                                  |
 | ---------- | ----------------------------------------------------------------------------- | -------------------------------------------- |
 | `Fail`     | No matching snapshot ⇒ the restore fails.                                     | `snapshotRef` / `identity` (explicit sources). |
-| `Continue` | No matching snapshot ⇒ proceed without restoring (the volume comes up empty). | `fromPolicy`.                                |
+| `Continue` | No matching snapshot ⇒ provision a **fresh, empty** volume and complete.      | `fromPolicy`.                                |
 
 The defaults are the point: an _explicit_ restore that finds nothing is an error you want surfaced; a _deploy-or-restore_ that finds nothing should let the app start with a fresh volume.
+
+On `Continue` with no snapshot, Kopiur **actually provisions the empty volume** — it doesn't just mark the `Restore` complete. For `target.populator: {}` it provisions an empty prime PVC and rebinds it to the claiming PVC (so a workload pod can bind and start); for `target.pvc` it creates the empty PVC. The "no snapshot ⇒ empty" decision is **pinned to `status.resolved` (`resolution: NoSnapshot`) once and never re-resolved**, so a snapshot that appears *later* can never silently restore over a volume the app is already using — re-create the `Restore` if you want to pick up a new snapshot. The Restore reports `Completed` with `Resolved=True reason=NoSnapshotContinue`.
+
+/// note | Deploy-or-restore-to-empty needs a filesystem-backed repository
+
+The empty-volume path applies to `fromPolicy`/`identity` sources against a **filesystem** repository. For object-store backends (S3/Azure/GCS/B2), an in-controller source resolution isn't supported, so `fromPolicy` with no snapshot surfaces an error rather than coming up empty — use an explicit `snapshotRef`, or seed the first snapshot.
+
+///
 
 ### `waitTimeout` — wait before giving up
 


### PR DESCRIPTION
## Problem

A deploy-or-restore `Restore` (`onMissingSnapshot: Continue`) whose source matches **no snapshot** stamped the Restore `Completed` but **returned before the target driver ran**. Reported by a user (Faustvii/home-ops) deploying a new app whose repo had no snapshot yet:

```yaml
spec:
  source: { fromPolicy: { name: qui } }
  target: { populator: {} }
  policy: { onMissingSnapshot: Continue }
```

The `Restore` showed `Completed` / `NoSnapshotContinue`, but the claiming PVC hung `Pending` forever — *"Assuming an external populator will provision the volume"* — and the workload never started. The same early return also stranded a `target.pvc` template (the empty PVC was never created). The documented intent ("the volume comes up empty") was never realized.

**Root cause:** the `OnMissingSnapshot::Continue` arm in `reconcile_inner` did an early `return` before the populator/direct dispatch, so `drive_populator_restore` (prime PVC + rebind) and `ensure_restore_target_pvc` never ran.

## Fix

Fall through to the existing target drivers with a typed "no snapshot" signal instead of bailing out:

- **`reconcile_inner`** computes a `Resolution` (`Snapshot(id)` | `Empty`) and **pins the decision once**. A new closed enum `ResolvedRestore.resolution` (`Snapshot`/`NoSnapshot`) durably records the deploy-or-restore choice, so a snapshot that appears *later* can never silently restore over an already-bound, in-use volume (ADR §4.6 "pinned once, never re-resolved"). `pinned_decision` also **back-fills the pre-fix stuck state** (a `Completed`+unpinned populator) — existing broken Restores self-heal on upgrade without re-resolving.
- **`drive_populator_restore` / `drive_direct_restore`** take `Option<&str>`: when `None`, the empty freshly-provisioned prime PVC (or `target.pvc`) *is* the result — skip the mover, then rebind / complete. Direct completion routes through `restore_ready_status_on` (Ready=True) so the entry-guard heal doesn't clobber the empty-volume message.

Filesystem-backend only (object-store source resolution is unsupported in-controller and fails loudly); documented in `docs/restores.md`. `pvcRef` targets are unaffected (the PVC pre-exists).

## Type-safety / data-safety

- New variant added to a closed enum; all target/state/decision matches stay exhaustive.
- The no-snapshot decision is pinned exactly like a snapshot id — no destructive re-restore over a bound volume.

## Tests

- **Unit:** `pinned_decision` table — pinned `NoSnapshot`/`Snapshot`, legacy pin (id without the new field), the stuck-CR migration, and fresh-must-resolve.
- **E2E** (`crates/e2e/tests/repository_lifecycle.rs`): populator empty-volume on **WFFC** (mirrors the reporter's `openebs-zfspv`) and **Immediate**; a **pinned-decision-vs-late-snapshot** data-safety test (no re-restore); a direct `target.pvc` empty-PVC assertion; plus a strengthened assertion in the existing missing-snapshot test.

## Verification

`mise run fmt-check`, `clippy`, `test` (hermetic), and `gen-check` all green. CRDs regenerated.