### PR TITLE
feat(crds): trim CRD descriptions to one sentence; move detail to docs

### DIFF
--- a/crates/api/src/backend.rs
+++ b/crates/api/src/backend.rs
@@ -11,81 +11,36 @@ use crate::common::{SecretRef, TlsConfig};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Credentials for a cloud object-store backend with an IAM plane (S3 / Azure /
-/// GCS): **exactly one of** a static-key Secret reference or a workload-identity
-/// binding. Both are `Option` because the forms share the `auth` key, so the
-/// exactly-one rule is webhook-enforced (`validate::validate_backend_auth`), like
-/// the snapshot `Source`. An absent `auth` is also legal — the well-known keys may
-/// ride the encryption-password Secret. Backends without cloud IAM (B2, SFTP,
-/// WebDAV) use [`SecretAuth`] instead, so a workload identity on them is
-/// unrepresentable. ADR §3.1 / §4.11.
+/// Credentials for a cloud object-store backend with an IAM plane (S3 / Azure / GCS).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct BackendAuth {
-    /// Secret holding the backend's access credentials. The operator reads
-    /// well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-    /// Mutually exclusive with `workloadIdentity`. ADR §3.1.
+    /// Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret_ref: Option<SecretRef>,
-    /// Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-    /// and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-    /// AKS Workload Identity, GKE Workload Identity) — no static keys in the
-    /// cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+    /// Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub workload_identity: Option<WorkloadIdentity>,
 }
 
-/// Cloud workload-identity binding (IRSA/EKS Pod Identity, AKS Workload
-/// Identity, GKE Workload Identity): the mover Job runs as a user-supplied
-/// Kubernetes `ServiceAccount` federated to the cloud IAM role/identity that
-/// grants backend access, instead of reading static keys from a Secret. The
-/// ServiceAccount must already exist in each namespace mover Jobs run in (the
-/// operator never creates it — its cloud annotations are the user's contract
-/// with the cloud webhook) and carries the cloud-specific annotation
-/// (`eks.amazonaws.com/role-arn`, `azure.workload.identity/client-id`,
-/// `iam.gke.io/gcp-service-account`). ADR §4.11.
+/// Cloud workload-identity binding: the mover runs as a federated `ServiceAccount`, not static keys.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkloadIdentity {
-    /// Name of the `ServiceAccount` the mover pod runs as, federated to the
-    /// cloud IAM role/identity that grants backend access. Resolved in the
-    /// mover Job's own namespace.
+    /// Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
     pub service_account_name: String,
 }
 
-/// Credentials for a backend **without** a cloud IAM plane (B2, SFTP, WebDAV):
-/// only a static Secret reference. A separate type from [`BackendAuth`] so a
-/// `workloadIdentity` on these backends is structurally unrepresentable — there
-/// is no cloud federation that could honor it. ADR §3.1 / §5.5.
+/// Credentials for a backend **without** a cloud IAM plane (B2, SFTP, WebDAV): static Secret only.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretAuth {
-    /// Secret holding the backend's access credentials, read by well-known keys
-    /// (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+    /// Secret holding the backend's access credentials, read by well-known keys.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub secret_ref: Option<SecretRef>,
 }
 
-/// The discriminated backend union. Exactly one variant by construction.
-///
-/// ## Representation choice
-///
-/// ADR-0003 §3.1 *sketches* this as `#[serde(tag = "kind")]` (a `kind: S3` inline
-/// discriminant). In practice an internally-tagged enum cannot produce a valid
-/// Kubernetes *structural* schema: kube's schema rewriter hoists `oneOf` branch
-/// properties to the root and requires the shared `kind` property to be identical
-/// across branches, but each variant needs a distinct `kind` const — a hard
-/// conflict. We therefore use serde's **externally-tagged** representation
-/// (`backend: { s3: {...} }`), which:
-///   * is exactly the YAML shape ADR-0001 §3.1 actually used (`backend.s3.bucket`);
-///   * generates a valid structural schema (a `oneOf` of distinct optional
-///     properties — kubectl enforces "exactly one backend");
-///   * preserves the ADR's type-safety thesis verbatim — this is still a Rust
-///     `enum`, a value is still exactly one variant, and reconcilers still
-///     `match` it exhaustively.
-///
-/// The webhook (`api::validate`) validates *content* (bucket-name format,
-/// credential-secret reachability) that the schema can't express.
+/// The discriminated backend union (`backend: { s3: {...} }`); exactly one variant by construction.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Backend {
@@ -145,7 +100,7 @@ impl Backend {
     }
 }
 
-/// S3 / S3-compatible object-store backend. ADR §3.1.
+/// S3 / S3-compatible object-store backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct S3Backend {
@@ -162,7 +117,7 @@ pub struct S3Backend {
     /// S3 region. Required by AWS and some compatible providers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub region: Option<String>,
-    /// Access credentials (Secret ref / workload identity). ADR §3.1.
+    /// Access credentials (Secret ref / workload identity).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<BackendAuth>,
     /// TLS overrides for self-signed CAs or HTTP-only endpoints.
@@ -170,7 +125,7 @@ pub struct S3Backend {
     pub tls: Option<TlsConfig>,
 }
 
-/// Azure Blob Storage backend. ADR §3.1.
+/// Azure Blob Storage backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AzureBackend {
@@ -187,7 +142,7 @@ pub struct AzureBackend {
     pub auth: Option<BackendAuth>,
 }
 
-/// Google Cloud Storage backend. ADR §3.1.
+/// Google Cloud Storage backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GcsBackend {
@@ -201,7 +156,7 @@ pub struct GcsBackend {
     pub auth: Option<BackendAuth>,
 }
 
-/// Backblaze B2 backend. ADR §3.1.
+/// Backblaze B2 backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct B2Backend {
@@ -210,37 +165,23 @@ pub struct B2Backend {
     /// Object-name prefix within the bucket; empty/absent means the bucket root.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prefix: Option<String>,
-    /// Access credentials (application key ID/key Secret). B2 has no cloud IAM
-    /// federation, so this is Secret-only.
+    /// Access credentials (application key ID/key Secret); Secret-only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<SecretAuth>,
 }
 
-/// Local-filesystem backend: kopia writes the repository to a path inside the
-/// mover pod. The path is populated by a [`RepoVolume`] the operator mounts — a
-/// `PersistentVolumeClaim` or an inline NFS export. ADR §3.1.
+/// Local-filesystem backend: kopia writes the repository to a path inside the mover pod.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FilesystemBackend {
     /// Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
     pub path: String,
-    /// What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-    /// (`{ nfs: { server, path } }`). Absent for a path already present on the
-    /// node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+    /// What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume: Option<RepoVolume>,
 }
 
-/// What backs a filesystem repository's mount path. Externally-tagged; exactly
-/// one variant. ADR §3.1.
-///
-/// Wire shape: `volume: { pvc: { name: "repo-pvc" } }` or
-/// `volume: { nfs: { server: "nas.lan", path: "/export/kopia" } }`.
-///
-/// kopia has no NFS backend — NFS is reached through the *filesystem* backend by
-/// mounting the export at `path`. Modeling it as a volume source (not a `Backend`
-/// variant) keeps that truth: the kopia connect spec is `Filesystem { path }`
-/// regardless, and the mover is transparent to how the path is mounted.
+/// What backs a filesystem repository's mount path (a PVC or an inline NFS export).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum RepoVolume {
@@ -260,7 +201,7 @@ impl RepoVolume {
     }
 }
 
-/// A `PersistentVolumeClaim` mounted into the mover pod. ADR §3.1.
+/// A `PersistentVolumeClaim` mounted into the mover pod.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PvcVolume {
@@ -268,9 +209,7 @@ pub struct PvcVolume {
     pub name: String,
 }
 
-/// An inline NFS export mounted directly into the mover pod — no PVC, no
-/// StorageClass. Used both as a filesystem-repo volume and as a backup source.
-/// ADR §3.1/§3.3.
+/// An inline NFS export mounted directly into the mover pod — no PVC, no StorageClass.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NfsVolume {
@@ -280,7 +219,7 @@ pub struct NfsVolume {
     pub path: String,
 }
 
-/// SFTP backend. ADR §3.1.
+/// SFTP backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SftpBackend {
@@ -294,26 +233,23 @@ pub struct SftpBackend {
     /// SSH username to connect as.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    /// Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-    /// has no cloud IAM federation, so this is Secret-only.
+    /// Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<SecretAuth>,
 }
 
-/// WebDAV backend. ADR §3.1.
+/// WebDAV backend.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WebDavBackend {
     /// WebDAV collection URL holding the kopia repository.
     pub url: String,
-    /// HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-    /// IAM federation, so this is Secret-only.
+    /// HTTP basic-auth credentials sourced from a Secret; Secret-only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<SecretAuth>,
 }
 
-/// rclone-remote backend; kopia shells out to `rclone` so any rclone-supported
-/// provider is reachable. ADR §3.1.
+/// rclone-remote backend; kopia shells out to `rclone` so any rclone-supported provider is reachable.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RcloneBackend {

--- a/crates/api/src/cluster_repository.rs
+++ b/crates/api/src/cluster_repository.rs
@@ -18,11 +18,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A shared kopia repository referenceable from allow-listed namespaces. ADR §3.2.
-///
-/// Cluster-scoped: note the absence of `namespaced` in `#[kube(...)]`. Secret/config
-/// references in `backend`/`encryption` therefore MUST carry an explicit `namespace`
-/// (webhook-enforced — the type system cannot express that requirement here).
+/// A cluster-scoped kopia repository referenceable from allow-listed namespaces.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -54,93 +50,59 @@ use serde::{Deserialize, Serialize};
 ]))]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterRepositorySpec {
-    /// Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+    /// Exactly one storage backend.
     pub backend: Backend,
-    /// Repository password, always a Secret reference. As this CR is cluster-scoped,
-    /// the ref MUST carry an explicit `namespace` (webhook-enforced). ADR §3.1/§3.2.
+    /// Repository password (a Secret reference that must carry an explicit `namespace`).
     pub encryption: Encryption,
-    /// What to do when the repository does not yet exist. Same semantics as
-    /// `Repository.spec.create`. ADR §3.1/§3.2.
+    /// What to do when the repository does not yet exist (absent means it must already exist).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub create: Option<CreateBehavior>,
-    /// Mover defaults inherited by **every** mover this repository spawns — bootstrap,
-    /// consumer backup/restore, and maintenance — overridable per-recipe and merged
-    /// field-wise (ADR-0004 §1/§2). Absorbs the former `cacheDefaults`
-    /// (now `moverDefaults.cache`).
+    /// Base mover configuration inherited by every mover this repository spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover_defaults: Option<MoverDefaults>,
-    /// Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-    /// catalog. For a shared repo this also picks where to land discovered snapshots
-    /// via `catalog.fallbackNamespace`. ADR §3.1/§3.2.
+    /// Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub catalog: Option<CatalogBounds>,
-    /// Tenancy gate — webhook-enforced on every consumer CR. ADR §3.2.
+    /// Which namespaces are permitted to reference this repository.
     pub allowed_namespaces: AllowedNamespaces,
     /// Identity defaults (CEL `*Expr`) applied when consumers don't override.
-    /// ADR §3.2 / ADR-0004 §5.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity_defaults: Option<IdentityDefaults>,
-    /// Optional kopia web-UI server. Cluster-scoped, so the target `namespace` is
-    /// required (see [`ClusterServerSpec`]). Presence means enabled.
+    /// Optional kopia web-UI server (the target `namespace` is required).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ClusterServerSpec>,
-    /// Maintenance control. Default-managed: when absent or `enabled: true`, the
-    /// reconciler creates and owns a `Maintenance` CR for this cluster repository.
-    /// As `Maintenance` is namespaced, `maintenance.namespace` selects where it
-    /// lands (defaulting to the operator's namespace). ADR §3.2/§3.7.
+    /// Maintenance control; `maintenance.namespace` selects where the owned `Maintenance` CR lands.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maintenance: Option<RepositoryMaintenanceSpec>,
-    /// What happens to this repository's snapshots when a consuming **namespace** is
-    /// deleted: `Orphan` (default — keep history) or `Delete` (cascade). BREAKING
-    /// default change in ADR-0005 §5. Carries a real OpenAPI `default: Orphan`.
+    /// What happens to this repository's snapshots when a consuming namespace is deleted.
     #[serde(default = "default_namespace_delete_policy")]
     #[schemars(default = "default_namespace_delete_policy")]
     pub on_namespace_delete: NamespaceDeletePolicy,
-    /// Repository-owner gate for credential-Secret projection into a foreign consumer
-    /// namespace. **Default off** (`allowed: false`): a consumer's
-    /// `credentialProjection.enabled` is necessary but not sufficient — the
-    /// `ClusterRepository` owner must also allow it. BREAKING (ADR-0005 §8). A
-    /// namespaced `Repository` has no such gate (projection there is a same-namespace
-    /// no-op).
+    /// Repository-owner gate for projecting credential Secrets into a foreign consumer namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_projection: Option<ClusterRepoCredentialProjection>,
-    /// Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-    /// cluster repository serves restores only — backups and maintenance are refused.
-    /// Carries a real OpenAPI `default: ReadWrite`.
+    /// Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).
     #[serde(default = "default_repository_mode")]
     #[schemars(default = "default_repository_mode")]
     pub mode: RepositoryMode,
-    /// Pause this cluster repository declaratively (ADR-0005 §14(e)): skips
-    /// connect/bootstrap and maintenance projection. Surfaced via a condition.
+    /// Pause this cluster repository: skip connect/bootstrap and maintenance projection.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
-    /// Repository health thresholds (ADR-0005 §13), shared with `Repository` — see
-    /// [`RepositoryHealthSpec`]. Tunes the index-blob-count warning. Absent uses
-    /// the built-in defaults.
+    /// Repository health thresholds (tunes the index-blob-count warning).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health: Option<RepositoryHealthSpec>,
 }
 
-/// The repository-OWNER side of credential projection on a `ClusterRepository`
-/// (ADR-0005 §8) — distinct from the consumer `credentialProjection.enabled` on a
-/// `SnapshotPolicy`/`Restore`. A sub-object (not a bare `bool`) so future knobs
-/// (allow-listed consumer namespaces, key remapping) slot in without API breakage.
+/// The repository-owner side of credential projection on a `ClusterRepository`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterRepoCredentialProjection {
-    /// When `true`, the repository owner permits projecting this repository's
-    /// credential Secret(s) into a foreign consumer namespace (still requires the
-    /// consumer opt-in AND operator RBAC — fail-closed). Off by default.
+    /// When `true`, the owner permits projecting this repository's credential Secret(s) into a consumer namespace.
     #[serde(default)]
     pub allowed: bool,
 }
 
-/// The set of namespaces permitted to reference this `ClusterRepository`. ADR §3.2.
-///
-/// Externally-tagged: wire shape is `allowedNamespaces: { list: [...] }`,
-/// `{ selector: {...} }`, or `{ all: true }`. Exactly one variant by construction.
-///
-/// Not `Eq`: the `Selector` variant embeds `LabelSelector` (k8s-openapi, `PartialEq` only).
+/// The set of namespaces permitted to reference this `ClusterRepository` (exactly one of).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum AllowedNamespaces {
@@ -148,7 +110,7 @@ pub enum AllowedNamespaces {
     List(Vec<String>),
     /// Match namespaces by label.
     Selector(LabelSelector),
-    /// Allow all namespaces (must be `true`; `false` is meaningless and rejected by webhook).
+    /// Allow all namespaces (must be `true`).
     All(bool),
 }
 
@@ -171,25 +133,19 @@ impl AllowedNamespaces {
     }
 }
 
-/// CEL expressions evaluated at admission to derive consumer identity when a
-/// `SnapshotPolicy` doesn't override (ADR-0004 §5). Each `*Expr` returns a string
-/// and is evaluated against the environment `namespace`, `policyName`, `labels`,
-/// `annotations` (the consuming `SnapshotPolicy`'s metadata). Sandboxed, no I/O;
-/// validated at admission so a typo/out-of-scope variable is rejected on apply.
+/// CEL expressions evaluated at admission to derive consumer identity when a `SnapshotPolicy` doesn't override.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentityDefaults {
-    /// CEL expression for the kopia identity *hostname* (e.g. `"namespace"`).
-    /// Returns a string. ADR-0004 §5.
+    /// CEL expression for the kopia identity hostname (e.g. `"namespace"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname_expr: Option<String>,
-    /// CEL expression for the kopia identity *username*
-    /// (e.g. `"namespace + '-' + policyName"`). Returns a string. ADR-0004 §5.
+    /// CEL expression for the kopia identity username (e.g. `"namespace + '-' + policyName"`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username_expr: Option<String>,
 }
 
-/// Mirrors `RepositoryStatus` (ADR §3.1) plus `allowedNamespaceCount`. ADR §3.2.
+/// Observed state of a `ClusterRepository`; mirrors `RepositoryStatus` plus `allowedNamespaceCount`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterRepositoryStatus {
@@ -200,9 +156,6 @@ pub struct ClusterRepositoryStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
     /// `resourceVersion` of the password Secret observed at the last connect attempt.
-    /// The terminal-failure hard-stop reopens when this changes, so editing the
-    /// Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-    /// connect instead of parking the repository as `Failed` forever.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_credential_version: Option<String>,
     /// Kopia repository unique ID.
@@ -211,7 +164,7 @@ pub struct ClusterRepositoryStatus {
     /// Mirror of `spec.backend` discriminant for the print column.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend: Option<String>,
-    /// Number of namespaces currently resolved by `spec.allowedNamespaces`. ADR §3.2.
+    /// Number of namespaces currently resolved by `spec.allowedNamespaces`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub allowed_namespace_count: Option<i64>,
     /// Repository size and snapshot counts from the last catalog scan.
@@ -223,7 +176,7 @@ pub struct ClusterRepositoryStatus {
     /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
-    /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.2.
+    /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
 }

--- a/crates/api/src/common/cache.rs
+++ b/crates/api/src/common/cache.rs
@@ -1,20 +1,17 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// How a mover's kopia cache volume is provisioned. ADR §3.1.
+/// How a mover's kopia cache volume is provisioned.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum CacheVolumeMode {
-    /// Cache lives only for the run: an inline generic ephemeral volume (when
-    /// `capacity` is set) or an `emptyDir`, provisioned and garbage-collected with
-    /// the mover `Job`. Fresh each run. The default.
+    /// Cache lives only for the run (ephemeral volume or `emptyDir`), fresh each run; the default.
     #[default]
     Ephemeral,
-    /// Cache persists across runs in a controller-owned PVC (a warm kopia cache).
-    /// `ReadWriteOnce`, so it assumes non-overlapping runs for a given owner.
+    /// Cache persists across runs in a controller-owned `ReadWriteOnce` PVC (a warm kopia cache).
     Persistent,
 }
 
-/// Cache defaults inherited by `Snapshot`/`Restore` movers unless overridden. ADR §3.1.
+/// kopia cache defaults inherited by every mover unless overridden per-recipe.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CacheDefaults {
@@ -30,8 +27,7 @@ pub struct CacheDefaults {
     /// kopia content cache budget in MiB (`--content-cache-size-mb`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub content_cache_size_mb: Option<i64>,
-    /// How the cache volume is provisioned (`Ephemeral` default, or `Persistent`
-    /// for a warm cache reused across runs). ADR §3.1.
+    /// How the cache volume is provisioned (`Ephemeral` default, or `Persistent`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mode: Option<CacheVolumeMode>,
 }
@@ -68,25 +64,14 @@ impl CacheDefaults {
     }
 }
 
-/// Repository-wide defaults for the deep-verification **scratch** volume — the
-/// throwaway restore target a `deep` restore-test writes into and then discards.
-/// Inherited by `SnapshotPolicy.spec.verification.deep` unless overridden there,
-/// the same `moverDefaults ⊂ recipe` field-wise overlay as [`CacheDefaults`].
-///
-/// Distinct from [`CacheDefaults`]: scratch is **always ephemeral** (auto-deleted
-/// with the verify Job), so unlike the cache it has no `mode` / persistent-PVC form.
-/// `storageClassName` only takes effect when `capacity` is set — an `emptyDir` has
-/// no StorageClass (the capacity gate, mirrored from the cache).
+/// Defaults for the deep-verification **scratch** volume — the throwaway restore-test target.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ScratchDefaults {
-    /// StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-    /// Only applies when `capacity` is set.
+    /// StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_class_name: Option<String>,
-    /// Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-    /// the restored snapshot. When absent (here and on `verification.deep`), scratch
-    /// falls back to a node-ephemeral `emptyDir`.
+    /// Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capacity: Option<String>,
 }
@@ -116,24 +101,17 @@ impl ScratchDefaults {
     }
 }
 
-/// Bounds on materialization of `origin: discovered` `Snapshot` CRs. ADR §3.1 `catalog`.
+/// Bounds on materialization of `origin: discovered` `Snapshot` CRs.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogBounds {
-    /// How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-    /// for large repositories. Expiring a CR row never deletes the kopia snapshot
-    /// behind it (discovered snapshots are always `deletionPolicy: Retain`).
-    /// ADR §3.1/§4.5.
+    /// How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retain: Option<CatalogRetain>,
-    /// How often to re-scan the repository for snapshots to materialize as (or
-    /// expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-    /// (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+    /// How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh_interval: Option<String>,
-    /// Where to materialize discovered `Snapshot`s whose identity hostname does not
-    /// map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-    /// `Repository`, which always materializes into its own namespace). ADR §3.2.
+    /// Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub fallback_namespace: Option<String>,
 }
@@ -151,20 +129,14 @@ impl CatalogBounds {
     }
 }
 
-/// Bounds on the *number* of discovered `Snapshot` CRs kept materialized. ADR §3.1 `catalog.retain`.
+/// Bounds on the *number* of discovered `Snapshot` CRs kept materialized.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogRetain {
-    /// Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-    /// identity (snapshots this cluster produced don't count against N). `0` disables
-    /// discovered-Snapshot materialization entirely; negative values are rejected by
-    /// the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-    /// is untouched and stays restorable via `Restore.source.identity`).
+    /// Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub per_identity: Option<i64>,
-    /// Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-    /// end time is older than this many days. Minimum 1 (webhook-enforced). The
-    /// kopia snapshots themselves are untouched.
+    /// Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_age_days: Option<i64>,
 }

--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -39,37 +39,32 @@ pub trait PhaseLabel: Copy + PartialEq + 'static {
     fn label(&self) -> &'static str;
 }
 
-/// Reference to a key within a `Secret` in the same namespace as the referrer,
-/// unless `namespace` is given (required for cluster-scoped CRs — ADR §3.2).
+/// Reference to a key within a `Secret`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretKeyRef {
     /// Name of the `Secret`.
     pub name: String,
-    /// Namespace of the `Secret`. Absent = same namespace as the referrer;
-    /// required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+    /// Namespace of the `Secret`; absent = same namespace as the referrer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
-    /// Which key inside the `Secret` to read. Defaults are documented per-field on
-    /// the consuming struct.
+    /// Which key inside the `Secret` to read.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub key: Option<String>,
 }
 
-/// Reference to an entire `Secret` (the operator reads well-known keys from it,
-/// e.g. `AWS_ACCESS_KEY_ID`). See ADR §3.1 backend `auth.secretRef`.
+/// Reference to an entire `Secret` (the operator reads well-known keys from it).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SecretRef {
     /// Name of the `Secret`.
     pub name: String,
-    /// Namespace of the `Secret`. Absent = same namespace as the referrer;
-    /// required for cluster-scoped CRs (ADR §3.2).
+    /// Namespace of the `Secret`; absent = same namespace as the referrer.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 }
 
-/// Reference to a key within a `ConfigMap` (e.g. a CA bundle). ADR §3.1 `tls.caBundleRef`.
+/// Reference to a key within a `ConfigMap` (e.g. a CA bundle).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ConfigMapKeyRef {
@@ -81,30 +76,22 @@ pub struct ConfigMapKeyRef {
     pub key: Option<String>,
 }
 
-/// TLS settings for object-store backends. ADR §3.1.
+/// TLS settings for object-store backends.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TlsConfig {
-    /// CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-    /// `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+    /// CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ca_bundle_ref: Option<ConfigMapKeyRef>,
-    /// Skip TLS certificate verification (still uses TLS). Maps to kopia's
-    /// `--disable-tls-verification`. For self-signed endpoints; prefer
-    /// `caBundleRef` in production.
+    /// Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub insecure_skip_verify: bool,
-    /// Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-    /// Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-    /// kopia's S3 path otherwise assumes HTTPS. Off by default.
+    /// Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub disable_tls: bool,
 }
 
-/// Which kind of repository a consumer CR references. ADR §3.2/§3.3.
-///
-/// This is a closed enum: a consumer's `repository.kind` is always exactly one
-/// of these two values, so reconcilers `match` it exhaustively.
+/// Which kind of repository a consumer CR references (`Repository` or `ClusterRepository`).
 ///
 /// ```
 /// use kopiur_api::common::RepositoryKind;
@@ -126,12 +113,7 @@ pub enum RepositoryKind {
     ClusterRepository,
 }
 
-/// Discriminated reference from a consumer CR (`SnapshotPolicy`, `Snapshot`,
-/// `Restore`, `Maintenance`) to a `Repository` or `ClusterRepository`. ADR §3.2.
-///
-/// When `kind == ClusterRepository`, `namespace` MUST be absent — enforced by the
-/// admission webhook (`api::validate`), since the type system cannot express
-/// "this field is forbidden only for one variant of a sibling field".
+/// Reference from a consumer CR to a `Repository` or `ClusterRepository`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryRef {
@@ -145,71 +127,45 @@ pub struct RepositoryRef {
     pub namespace: Option<String>,
 }
 
-/// Repository encryption settings. A sub-object so future rotation fields
-/// (`rotation`, `previousPasswords`) slot in without breakage (ADR §4.11).
+/// Repository encryption settings.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Encryption {
-    /// Always a Secret ref; never inline. ADR §3.1.
+    /// Repository password, always a Secret reference (never inline).
     pub password_secret_ref: SecretKeyRef,
 }
 
-/// Opt-in projection of a repository's credential `Secret`(s) into the namespace
-/// where each mover Job runs. **Default off.** ADR §3.1/§4.11.
-///
-/// Kopiur's baseline contract — like VolSync and K8up — is that the credential
-/// Secret already exists in the namespace where a mover runs (it loads creds via
-/// namespace-local `envFrom`). For a shared `ClusterRepository` whose Secret is
-/// pinned to one namespace, that means placing a copy in each consuming namespace.
-/// When `enabled`, the operator does that for you: before each run it reads the
-/// source Secret(s) and writes a kopiur-managed copy into the Job's namespace,
-/// owned by the consuming CR (garbage-collected with it) and refreshed from source
-/// every run. (Cross-namespace secret distribution is opt-in across the ecosystem;
-/// keeping it off by default preserves the namespace-as-trust-boundary posture.)
-///
-/// Even when enabled, projection is a no-op where the source Secret already lives
-/// in the Job's namespace (the common namespaced-`Repository` layout): there is
-/// nothing to copy, so the operator just verifies it is present. It only actually
-/// copies for the cross-namespace case (a shared `ClusterRepository`).
-///
-/// A sub-object (not a bare `bool`) so future knobs (key remapping, a copy-name
-/// template, immutability) slot in without API breakage (ADR §4.11).
+/// Opt-in projection of a repository's credential `Secret`(s) into each mover Job's namespace.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialProjection {
-    /// When true, the operator copies the repository's credential Secret(s) into
-    /// the namespace of each mover Job that uses this repository. Off by default.
+    /// Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
     #[serde(default)]
     pub enabled: bool,
 }
 
-/// Behavior when the repository does not yet exist. ADR §3.1 `create`.
+/// Behavior when the repository does not yet exist.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBehavior {
-    /// Create the repository if it does not exist yet. Off by default, so a typo'd
-    /// backend can't silently spin up a brand-new empty repository.
+    /// Create the repository if it does not exist yet; off by default.
     #[serde(default)]
     pub enabled: bool,
-    /// kopia encryption algorithm for a freshly-created repository (e.g.
-    /// `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+    /// kopia encryption algorithm for a freshly-created repository (creation-time only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub encryption: Option<String>,
-    /// kopia object splitter for a freshly-created repository; creation-time only.
+    /// kopia object splitter for a freshly-created repository (creation-time only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub splitter: Option<String>,
-    /// kopia content hash algorithm for a freshly-created repository; creation-time only.
+    /// kopia content hash algorithm for a freshly-created repository (creation-time only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hash: Option<String>,
-    /// Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-    /// (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-    /// only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+    /// Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ecc: Option<Ecc>,
 }
 
-/// Reed-Solomon error-correcting-code parity for a freshly-created repository
-/// (ADR-0005 §13(a)). Both fields creation-time-fixed; immutable post-create (§7).
+/// Reed-Solomon error-correcting-code parity for a freshly-created repository.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Ecc {
@@ -221,7 +177,7 @@ pub struct Ecc {
     pub overhead_percent: Option<i64>,
 }
 
-/// GFS retention policy. The single successful-retention driver (ADR §4.4).
+/// GFS retention policy — how many snapshots to keep per time bucket.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Retention {
@@ -245,18 +201,14 @@ pub struct Retention {
     pub keep_annual: Option<u32>,
 }
 
-/// Identity overrides — what kopia records as `username@hostname:path`. ADR §3.3/§4.2.
+/// Identity overrides — what kopia records as `username@hostname:path`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Identity {
-    /// Override the `username` portion of `username@hostname:path`; absent uses the
-    /// resolved default (the repository's `identityDefaults` CEL expression, or the
-    /// object name). Used verbatim and pinned at admission (ADR §4.2).
+    /// Override the `username` portion of `username@hostname:path`; absent uses the resolved default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub username: Option<String>,
-    /// Override the `hostname` portion of `username@hostname:path`; absent uses the
-    /// resolved default (the repository's `identityDefaults` CEL expression, or the
-    /// namespace). Used verbatim and pinned at admission (ADR §4.2).
+    /// Override the `hostname` portion of `username@hostname:path`; absent uses the resolved default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hostname: Option<String>,
 }
@@ -267,11 +219,7 @@ pub struct Identity {
 /// logs live in the mover Job's pod. ADR §3.4/§4.10.
 pub const MAX_LOG_TAIL_BYTES: usize = 4096;
 
-/// A structured terminal-failure block written by the mover to `status.failure`
-/// (ADR §4.10): the kopia error class, a human-readable message, the last
-/// stderr lines, and a retry recommendation. Defined in `kopiur-api` (not the
-/// mover) so the field names cannot drift from the CRD structural schema — a
-/// mismatched name is silently pruned by the API server.
+/// A structured terminal-failure block written by the mover to `status.failure`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FailureBlock {
@@ -290,7 +238,7 @@ pub struct FailureBlock {
     pub retry_recommended: bool,
 }
 
-/// Fully-resolved identity pinned into status; never re-rendered after admission. ADR §4.2.
+/// Fully-resolved identity pinned into status; never re-rendered after admission.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedIdentity {
@@ -303,25 +251,17 @@ pub struct ResolvedIdentity {
     pub source_path: Option<String>,
 }
 
-/// Per-run failure controls passed through to the mover `Job`. ADR §3.4/§4.10 (G6).
+/// Per-run failure controls passed through to the mover `Job`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FailurePolicy {
-    /// Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-    /// run is retried before the Job is marked failed.
+    /// Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backoff_limit: Option<i32>,
-    /// Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-    /// after which a still-running run is killed.
+    /// Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_deadline_seconds: Option<i64>,
-    /// How long (seconds) a mover **pod** may sit in a non-starting state — a container
-    /// `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-    /// `Unschedulable` — before the controller fails the run with an actionable reason,
-    /// rather than waiting out `active_deadline_seconds` (which can be many hours and
-    /// is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-    /// terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-    /// it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+    /// Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pod_startup_deadline_seconds: Option<i64>,
 }
@@ -342,8 +282,7 @@ pub fn pod_startup_deadline_seconds(failure_policy: Option<&FailurePolicy>) -> i
         .unwrap_or(DEFAULT_POD_STARTUP_DEADLINE_SECONDS)
 }
 
-/// Reference to a `SnapshotPolicy` CR (used by `Snapshot.spec.policyRef` and
-/// `SnapshotSchedule.spec.policyRef`). May cross namespaces, subject to RBAC. ADR §3.4/§3.5.
+/// Reference to a `SnapshotPolicy` CR.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PolicyRef {
@@ -354,8 +293,7 @@ pub struct PolicyRef {
     pub namespace: Option<String>,
 }
 
-/// Generic name/namespace reference to another namespaced object — e.g. a `Snapshot`
-/// CR (`Restore.spec.source.snapshotRef`) or a PVC (`Restore.spec.target.pvcRef`). ADR §3.6.
+/// Generic name/namespace reference to another namespaced object (e.g. a `Snapshot` CR or PVC).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ObjectRef {
@@ -367,13 +305,6 @@ pub struct ObjectRef {
 }
 
 /// Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-/// Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-/// ADR-0003 §4.5 / ADR-0001 §4.5.
-///
-/// The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-/// enforces that any new variant added later must be handled in every match site,
-/// preventing the class of bug where a new policy slips into production without a
-/// corresponding reconcile branch.
 ///
 /// ```
 /// use kopiur_api::common::DeletionPolicy;
@@ -386,28 +317,16 @@ pub struct ObjectRef {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum DeletionPolicy {
-    /// Default for `origin: scheduled`/`manual`. Finalizer runs
-    /// `kopia snapshot delete <id>` then removes the finalizer.
+    /// Finalizer runs `kopia snapshot delete <id>` then removes the finalizer; default for produced snapshots.
     #[default]
     Delete,
-    /// Default for `origin: discovered`. CR is removed; snapshot stays.
-    /// Forced via webhook for discovered snapshots; cannot be overridden.
+    /// CR is removed; the kopia snapshot stays. Forced for discovered snapshots.
     Retain,
-    /// CR is removed without contacting the repository at all (escape hatch
-    /// for "the bucket is gone, just let me delete the CR"). Status records
-    /// `orphaned: true` for the snapshot ID before removal.
+    /// CR is removed without contacting the repository at all (escape hatch).
     Orphan,
 }
 
-/// What happens to a repository's snapshots when a consuming **namespace** is
-/// deleted. Closed enum, default `Orphan` (fail-safe). ADR-0005 §5.
-///
-/// A `kubectl delete ns` must not silently destroy off-site backup history (and
-/// must not hang the namespace teardown on N `kopia snapshot delete` calls). So the
-/// repository owner opts *in* to cascade-delete; the default releases ownership
-/// (removes the finalizer) without touching the snapshots. This is distinct from a
-/// single `kubectl delete snapshot`, which still honors that `Snapshot`'s own
-/// `deletionPolicy`.
+/// What happens to a repository's snapshots when a consuming **namespace** is deleted; default `Orphan`.
 ///
 /// ```
 /// use kopiur_api::common::NamespaceDeletePolicy;
@@ -419,20 +338,14 @@ pub enum DeletionPolicy {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum NamespaceDeletePolicy {
-    /// Release ownership (remove the `Snapshot` finalizers) without deleting the
-    /// underlying kopia snapshots. The fail-safe default — `kubectl delete ns` keeps
-    /// history.
+    /// Release ownership without deleting the kopia snapshots; the fail-safe default.
     #[default]
     Orphan,
-    /// Cascade: when a namespace is deleted, the per-`Snapshot` `deletionPolicy`
-    /// applies (so produced snapshots are `kopia snapshot delete`d). Opt-in only.
+    /// Cascade: each `Snapshot`'s own `deletionPolicy` applies when the namespace is deleted.
     Delete,
 }
 
-/// Repository access mode (ADR-0005 §11). A `ReadOnly` repository serves restores
-/// only — no backups, no maintenance — for decommissioning a backend or migrating
-/// between repositories without risking writes. Maps to kopia's read-only
-/// connection. Closed enum, default `ReadWrite`.
+/// Repository access mode; `ReadOnly` serves restores only (no backups, no maintenance).
 ///
 /// ```
 /// use kopiur_api::common::RepositoryMode;
@@ -448,7 +361,7 @@ pub enum RepositoryMode {
     /// Normal read-write repository (default): backups, restores, maintenance.
     #[default]
     ReadWrite,
-    /// Read-only: restores only. Backup Jobs and maintenance are refused. §11.
+    /// Read-only: restores only. Backup Jobs and maintenance are refused.
     ReadOnly,
 }
 
@@ -476,16 +389,13 @@ pub(crate) fn default_namespace_delete_policy() -> NamespaceDeletePolicy {
     NamespaceDeletePolicy::Orphan
 }
 
-/// A single cron entry with optional deterministic jitter. Shared by `Maintenance`'s
-/// quick/full schedules. ADR §3.7. `jitter` is a Go-style duration string (e.g. `30m`).
+/// A single cron entry with optional deterministic jitter.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CronSpec {
-    /// The cron expression, parsed by `croner`. May contain an `H` placeholder for
-    /// deterministic per-schedule jitter (ADR §3.7).
+    /// The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
     pub cron: String,
-    /// Optional deterministic jitter window as a Go-style duration string (e.g.
-    /// `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+    /// Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jitter: Option<String>,
 }

--- a/crates/api/src/common/mover.rs
+++ b/crates/api/src/common/mover.rs
@@ -7,15 +7,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// Per-recipe mover overrides (resources, cache, security context). ADR §3.3.
-///
-/// These overlay the repository's [`MoverDefaults`] **field-wise** (recipe wins, the
-/// repo default fills, the hardened base underneath) via [`resolve_mover`] — they are
-/// merged, never replace-the-whole-context (ADR-0004 §2). A partial `securityContext`
-/// here can therefore only *tighten*; it never drops the hardened `drop:[ALL]`/seccomp.
-///
-/// Not `Eq`: embeds `k8s-openapi` types (`ResourceRequirements`, `SecurityContext`)
-/// which only implement `PartialEq`.
+/// Per-recipe mover overrides (resources, cache, security context).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MoverSpec {
@@ -25,31 +17,19 @@ pub struct MoverSpec {
     /// Override the repository's [`CacheDefaults`] for this recipe's movers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<CacheDefaults>,
-    /// Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-    /// capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-    /// and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+    /// Container security context for the mover; merged field-wise over the defaults and hardened base.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_context: Option<k8s_openapi::api::core::v1::SecurityContext>,
-    /// Security context applied to the mover **pod** — notably `fsGroup`, which makes
-    /// a freshly-provisioned volume group-writable so an unprivileged
-    /// (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-    /// from the container-level [`MoverSpec::security_context`]; a pod-level
-    /// `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+    /// Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pod_security_context: Option<k8s_openapi::api::core::v1::PodSecurityContext>,
-    /// Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+    /// Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub privileged_mode: Option<bool>,
-    /// Opt-in: copy security context from a live workload pod instead of setting an
-    /// explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-    /// Either name the workload by label (`workloadSelector`) or, on a **backup**
-    /// source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+    /// Copy the UID/GID security context from a live workload instead of setting it explicitly.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub inherit_security_context_from: Option<InheritSecurityContextFrom>,
-    /// Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-    /// `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-    /// backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-    /// is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+    /// Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_seconds_after_finished: Option<i64>,
 }
@@ -75,38 +55,19 @@ impl MoverSpec {
     }
 }
 
-/// How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-/// PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-///
-/// A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-/// *can* be mounted by multiple pods **on that same node**. When an app pod already
-/// holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-/// attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-/// resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-/// `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+/// How the mover co-locates with the node an RWO source/destination PVC is attached to.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum SourceColocationMode {
-    /// Pin an RWO PVC's mover to the node the PVC is attached to **when** that node
-    /// is discoverable; otherwise schedule freely (nothing holds the volume, so the
-    /// mover can attach it anywhere). `ReadWriteMany`/`ReadOnlyMany` are never pinned.
-    /// A `ReadWriteOncePod` PVC that is already held by a live pod fails with guidance
-    /// (a second pod cannot mount it even on the same node). The default — fixes the
-    /// Multi-Attach error with no configuration.
+    /// Pin to the attached node when discoverable, else schedule freely; the default.
     #[default]
     Auto,
-    /// Like `Auto`, but if an RWO PVC's node cannot be determined, **fail** the run
-    /// with an actionable error instead of scheduling freely. Use when an RWO source
-    /// must never be backed up from the wrong node.
+    /// Like `Auto`, but fail the run when an RWO PVC's node cannot be determined.
     Required,
-    /// Never compute a node pin; the mover uses only the explicit
-    /// `nodeSelector`/`affinity`/`tolerations`. The pre-fix behavior — an escape hatch
-    /// for topologies that manage placement themselves.
+    /// Never compute a node pin; use only the explicit `nodeSelector`/`affinity`/`tolerations`.
     Disabled,
 }
 
-/// Controls mover/source-PVC node co-location (RWO Multi-Attach avoidance). A
-/// sub-object (not a bare enum) so future knobs — e.g. a custom hostname label key
-/// for non-standard topologies — slot in without an API break (ADR §4.11).
+/// Controls mover/source-PVC node co-location (RWO Multi-Attach avoidance).
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceColocation {
@@ -115,42 +76,23 @@ pub struct SourceColocation {
     pub mode: Option<SourceColocationMode>,
 }
 
-/// Repository-wide mover defaults inherited by **every** mover the repository spawns —
-/// bootstrap, backup, restore, maintenance — overridable per-recipe via `mover`
-/// (ADR-0004 §1). Replaces the former `cacheDefaults`: the cache lives at
-/// [`MoverDefaults::cache`] now.
-///
-/// `securityContext`/`podSecurityContext`/`resources`/`cache` resolve by **field-wise
-/// merge** (`hardened ⊂ moverDefaults ⊂ recipe`, ADR-0004 §2) via [`resolve_mover`];
-/// they are never replaced wholesale, so a repo-wide default composes with a partial
-/// per-recipe override. This is the single place a repository defines mover
-/// identity/hardening/resources/cache — closing the drift between maintenance and
-/// backup/restore movers and the bootstrap-mover gap (a filesystem/NFS repo on a
-/// non-`65532`-owned directory becomes bootstrappable with no special-case knob).
-///
-/// Not `Eq`: embeds `k8s-openapi` types (`SecurityContext`, `PodSecurityContext`,
-/// `ResourceRequirements`, `Toleration`, `Affinity`) which are `PartialEq` only.
+/// Repository-wide mover defaults inherited by every mover, overridable per-recipe via `mover`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MoverDefaults {
-    /// Container security-context base for every mover, merged *under* the recipe's
-    /// `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+    /// Container security-context base for every mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_context: Option<SecurityContext>,
-    /// Pod security-context base (notably `fsGroup`) for every mover, merged under the
-    /// recipe's `mover.podSecurityContext`.
+    /// Pod security-context base (notably `fsGroup`) for every mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pod_security_context: Option<PodSecurityContext>,
     /// Resource requests/limits base for the mover container.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resources: Option<ResourceRequirements>,
-    /// kopia cache defaults (the former repository `cacheDefaults`).
+    /// kopia cache defaults for every mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache: Option<CacheDefaults>,
-    /// Defaults for the deep-verification scratch (restore-test) volume, inherited by
-    /// `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-    /// ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-    /// applies only when a `capacity` is set.
+    /// Defaults for the deep-verification scratch (restore-test) volume.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scratch: Option<ScratchDefaults>,
     /// Pod `nodeSelector` for every mover.
@@ -162,19 +104,13 @@ pub struct MoverDefaults {
     /// Pod affinity for every mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub affinity: Option<Affinity>,
-    /// How a mover co-locates with the node its RWO source/destination PVC is
-    /// attached to, to avoid a Multi-Attach error. Defaults to
-    /// [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+    /// How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_colocation: Option<SourceColocation>,
-    /// `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-    /// backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-    /// `mover` can override it.
+    /// `Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ttl_seconds_after_finished: Option<i64>,
-    /// Repository throttle limits (`kopia repository throttle set`) applied by every
-    /// mover after it connects, so a run doesn't saturate the link / hammer the
-    /// object store. ADR-0005 §13(e).
+    /// Repository throttle limits applied by every mover after it connects.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub throttle: Option<Throttle>,
 }
@@ -185,8 +121,7 @@ pub struct MoverDefaults {
 /// their pods self-GC instead of lingering (ADR-0005 §12).
 pub const DEFAULT_JOB_TTL_SECONDS: i64 = 3600;
 
-/// Repository-wide throttling for a mover's kopia connection (ADR-0005 §13(e)).
-/// Each `None` leaves kopia's current limit. Maps to `kopia repository throttle set`.
+/// Repository-wide throttling for a mover's kopia connection; each `None` leaves kopia's current limit.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Throttle {
@@ -325,9 +260,7 @@ pub fn resolve_mover(
     }
 }
 
-/// Selects workload pods by label. Reuses k8s-openapi `LabelSelector`. ADR §3.3 hooks.
-///
-/// Not `Eq`: `LabelSelector` only implements `PartialEq`.
+/// Selects workload pods by label.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PodSelector {
@@ -338,37 +271,21 @@ pub struct PodSelector {
     pub container: Option<String>,
 }
 
-/// Where the mover copies its security context from (instead of an explicit
-/// `securityContext`/`podSecurityContext`). **Externally tagged** — exactly one variant,
-/// so the source of the inherited identity is unambiguous and a `match` must handle every
-/// case (convention #1; NOT a bool + optional selector). Mutually exclusive with explicit
-/// contexts (webhook/[`crate::validate::validate_mover`]-enforced). The resolved context
-/// enters [`resolve_mover`] as the *recipe layer*, so the hardened base still applies.
-///
-/// Not `Eq`: `WorkloadSelector` embeds [`PodSelector`] → `LabelSelector` (`PartialEq` only).
+/// Where the mover copies its security context from instead of an explicit context.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum InheritSecurityContextFrom {
-    /// Match the workload pod(s) by an explicit label selector and inherit the chosen
-    /// container's `securityContext` plus the pod's `spec.securityContext`. Works for
-    /// both backup and restore (restore inherits from the pod that will *read* the data).
+    /// Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
     WorkloadSelector(PodSelector),
-    /// **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-    /// backs up: the operator finds the pod(s) mounting the source claim and inherits
-    /// their securityContext, so the mover's UID/GID matches the workload *by
-    /// construction* — no hand-written selector. Meaningless on a restore (the consuming
-    /// pod may not exist yet, exactly like a populator), so restore must use
-    /// `workloadSelector`.
+    /// Backup sources only: auto-derive the workload from the PVC this snapshot backs up.
     PvcConsumer(PvcConsumerInherit),
 }
 
-/// Tuning for [`InheritSecurityContextFrom::PvcConsumer`]. A sub-object (not a bare flag)
-/// so future knobs slot in without an API break (ADR §4.11).
+/// Tuning for [`InheritSecurityContextFrom::PvcConsumer`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PvcConsumerInherit {
-    /// Which container within the matched consumer pod to inherit from; absent uses the
-    /// first/only container (same semantics as [`PodSelector::container`]).
+    /// Which container within the matched consumer pod to inherit from; absent uses the first/only.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container: Option<String>,
 }

--- a/crates/api/src/maintenance.rs
+++ b/crates/api/src/maintenance.rs
@@ -37,7 +37,7 @@ pub fn default_maintenance_schedule() -> MaintenanceSchedule {
     }
 }
 
-/// Maintenance schedule + ownership lease for one `Repository`/`ClusterRepository`. ADR §3.7.
+/// Maintenance schedule and ownership lease for one `Repository`/`ClusterRepository`.
 ///
 /// Not `Eq`: `mover` transitively embeds k8s-openapi types.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -55,51 +55,43 @@ pub fn default_maintenance_schedule() -> MaintenanceSchedule {
 )]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceSpec {
-    /// Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+    /// Reference to the `Repository` or `ClusterRepository` to maintain.
     pub repository: RepositoryRef,
-    /// Quick + full cron schedules (with a shared timezone) for `kopia
-    /// maintenance run`. ADR §3.7.
+    /// quick (cheap) and full (`--full`, reclamation) maintenance crons.
     pub schedule: MaintenanceSchedule,
-    /// Ownership-lease configuration; at most one `Maintenance` may own a
-    /// repository at a time. ADR §3.7.
+    /// Maintenance ownership lease holder and takeover policy.
     pub ownership: Ownership,
-    /// Mover (Job pod) overrides for the maintenance run — resources, scheduling,
-    /// etc. Object-store repositories typically tune this. ADR §3.7.
+    /// Mover (Job pod) overrides for the maintenance run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover: Option<MoverSpec>,
-    /// How a failed maintenance run is retried/bounded (backoff, deadline). ADR §3.7.
+    /// How a failed maintenance run is retried and bounded (backoff, deadline).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_policy: Option<FailurePolicy>,
-    /// Opt-in credential-Secret projection for this maintenance run's mover
-    /// (default off). When `enabled: true`, the operator copies the referenced
-    /// repository's credential Secret(s) into the namespace this `Maintenance`
-    /// runs in (a no-op when they already live there) — useful when maintaining a
-    /// shared `ClusterRepository` from a namespace that lacks the Secret. ADR §4.11.
+    /// Opt-in projection of the repository's credential Secret(s) into this run's namespace (default off).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_projection: Option<CredentialProjection>,
 }
 
-/// Quick + full cron schedules plus a shared timezone. ADR §3.7.
+/// quick (cheap) and full (`--full`, reclamation) maintenance crons and a shared timezone.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceSchedule {
-    /// Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+    /// Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
     pub quick: CronSpec,
-    /// Cron + jitter for `kopia maintenance run --full` (content reclamation).
+    /// Cron and jitter for `kopia maintenance run --full` (content reclamation).
     pub full: CronSpec,
-    /// IANA timezone both crons are evaluated in; absent means controller default.
+    /// IANA timezone both crons are evaluated in; absent means the controller default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
 }
 
-/// Ownership-lease configuration. At most one `Maintenance` may own a repository. ADR §3.7.
+/// Maintenance ownership lease holder and takeover policy.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Ownership {
-    /// Stable lease holder identity (e.g. `kopia-operator/nas-primary`). Two
-    /// `Maintenance` CRs claiming the same repository compare this. ADR §3.7.
+    /// Stable lease holder identity (e.g. `kopia-operator/nas-primary`).
     pub owner: String,
-    /// What to do if the lease is already held by a different `owner`. ADR §3.7.
+    /// What to do when the lease is already held by a different `owner`.
     #[serde(default)]
     pub takeover_policy: TakeoverPolicy,
 }
@@ -118,7 +110,7 @@ pub struct Ownership {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum TakeoverPolicy {
-    /// Never take over an existing lease (default — safest).
+    /// Never take over a lease another owner holds (default, safest).
     #[default]
     Never,
     /// Surface a condition prompting an operator to decide.
@@ -288,45 +280,28 @@ pub fn parse_run_annotations(
     Ok(Some((at, mode)))
 }
 
-/// Inline maintenance control on a `Repository`/`ClusterRepository`
-/// (`spec.maintenance`). ADR §3.1/§3.7.
-///
-/// Maintenance is **default-managed**: when this is absent (or `enabled: true`),
-/// the repository reconciler projects it into an *owned* `Maintenance` child CR,
-/// so kopia storage is reclaimed without the user remembering to author a
-/// separate `Maintenance`. The reconciler honors an externally-authored
-/// `Maintenance` referencing the repository regardless of `enabled` — setting
-/// `enabled: false` only tells the operator not to create its own; it never
-/// deletes, ignores, or warns about a user-managed one.
+/// Inline maintenance control on a `Repository`/`ClusterRepository` (`spec.maintenance`).
 ///
 /// Not `Eq`: `mover` transitively embeds k8s-openapi types.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryMaintenanceSpec {
-    /// Whether the operator manages a `Maintenance` CR for this repository.
-    /// Defaults to `true` (default-on). When `false`, the operator does not
-    /// create or manage one — but an externally-authored `Maintenance` is still
-    /// honored.
+    /// Whether the operator manages a `Maintenance` CR for this repository (default `true`).
     #[serde(default = "crate::common::default_true")]
     pub enabled: bool,
-    /// Schedule override. When absent, the operator uses
-    /// [`default_maintenance_schedule`] (quick 6h / full daily).
+    /// Schedule override; absent uses the default quick-6h / full-daily schedule.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schedule: Option<MaintenanceSchedule>,
-    /// Mover overrides for the managed `Maintenance` (object-store repositories).
+    /// Mover overrides for the managed `Maintenance`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover: Option<MoverSpec>,
     /// Failure handling (backoff/deadline) for the managed `Maintenance` run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_policy: Option<FailurePolicy>,
-    /// Lease takeover policy for the managed `Maintenance`. Defaults to
-    /// [`TakeoverPolicy::Never`].
+    /// Lease takeover policy for the managed `Maintenance` (default `Never`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub takeover_policy: Option<TakeoverPolicy>,
-    /// **ClusterRepository only** — namespace the managed (namespaced)
-    /// `Maintenance` CR is created in. Defaults to the operator's own namespace.
-    /// Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-    /// the repository's namespace), rejected by the admission webhook.
+    /// ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator's namespace).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 }
@@ -346,27 +321,26 @@ impl Default for RepositoryMaintenanceSpec {
     }
 }
 
-/// Observed maintenance state: lease holder plus per-kind run results. ADR §3.7.
+/// Observed maintenance state: lease holder and per-kind run results.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MaintenanceStatus {
     /// The `metadata.generation` this status reflects, for staleness detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// Current lease holder, if the lease has been claimed. ADR §3.7.
+    /// Current lease holder, if the lease has been claimed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ownership: Option<OwnershipStatus>,
-    /// Last/next-run state for the quick maintenance schedule. ADR §3.7.
+    /// Last/next-run state for the quick maintenance schedule.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quick: Option<RunStatus>,
-    /// Last/next-run state for the full maintenance schedule. ADR §3.7.
+    /// Last/next-run state for the full maintenance schedule.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub full: Option<RunStatus>,
-    /// Standard Kubernetes conditions surfacing maintenance health. ADR §5.
+    /// Standard Kubernetes conditions surfacing maintenance health.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
-    /// State of the most recent annotation-requested out-of-band run
-    /// (`kopiur.home-operations.com/run-requested`); absent until one is requested.
+    /// State of the most recent annotation-requested out-of-band run; absent until one is requested.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manual_run: Option<ManualRunStatus>,
 }
@@ -385,7 +359,7 @@ pub struct MaintenanceStatus {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ManualRunMode {
-    /// `kopia maintenance run` (quick). The default when `run-mode` is absent.
+    /// `kopia maintenance run` (quick); the default when `run-mode` is absent.
     #[default]
     Quick,
     /// `kopia maintenance run --full`.
@@ -417,16 +391,13 @@ impl ManualRunMode {
 pub enum ManualRunPhase {
     /// The mover Job for this request is in flight.
     Running,
-    /// The run finished successfully (or yielded the lease cleanly — see the
-    /// `LeaseOwned` condition for which).
+    /// The run finished successfully or yielded the lease cleanly (see the `LeaseOwned` condition).
     Succeeded,
     /// The run's Job failed; conditions carry the detail.
     Failed,
 }
 
-/// Bookkeeping for the most recent annotation-requested run. `requestedAt`
-/// pins WHICH request this status answers, so re-applying the same annotation
-/// value is a no-op and a new timestamp starts a new run.
+/// Bookkeeping for the most recent annotation-requested run.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ManualRunStatus {
@@ -444,7 +415,7 @@ pub struct ManualRunStatus {
     pub completed_at: Option<String>,
 }
 
-/// Observed ownership-lease state: who holds it and since when. ADR §3.7.
+/// Observed ownership-lease state: who holds it and since when.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct OwnershipStatus {
@@ -456,7 +427,7 @@ pub struct OwnershipStatus {
     pub claimed_at: Option<String>,
 }
 
-/// Per-kind (quick/full) run status. ADR §3.7.
+/// Per-kind (quick/full) run status.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunStatus {
@@ -466,24 +437,13 @@ pub struct RunStatus {
     /// RFC3339 instant of the next scheduled run of this kind (cron + jitter, pinned).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_scheduled_at: Option<String>,
-    /// RFC3339 instant the controller last observed one of this kind's per-slot
-    /// Jobs reach terminal success — the mover either ran maintenance (which
-    /// also advances `lastRunAt`) or deliberately *yielded* the lease (which
-    /// does not). The scheduler measures the next slot from
-    /// `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-    /// its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-    /// slot's only record was the (self-reaping) Job itself, and the same slot
-    /// respawned a yield Job every TTL period, forever. The stamp is the
-    /// *observation instant*, not the (possibly year-old, first-ever) slot
-    /// itself — anchoring at the slot would make a yield-only Maintenance march
-    /// through the entire backlog of historic slots one Job at a time. Same
-    /// catch-up-once semantics as the mover's `lastRunAt = now`.
+    /// RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_handled_at: Option<String>,
     /// Count of back-to-back failed runs of this kind; resets on success.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub consecutive_failures: Option<i64>,
-    /// The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+    /// Bytes of storage reclaimed by the most recent run of this kind.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_content_reclaimed_bytes: Option<i64>,
 }

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -12,9 +12,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A kopia repository owned by one namespace: credentials, backend, encryption,
-/// and optional catalog-materialization bounds. Many `SnapshotPolicy`s / `Restore`s
-/// reference one. ADR §3.1.
+/// A kopia repository owned by one namespace, referenced by `SnapshotPolicy`s and `Restore`s.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -50,73 +48,46 @@ use serde::{Deserialize, Serialize};
 ]))]
 #[serde(rename_all = "camelCase")]
 pub struct RepositorySpec {
-    /// Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+    /// Exactly one storage backend.
     pub backend: Backend,
-    /// Repository password, always a Secret reference. A sub-object so future
-    /// rotation fields slot in without API breakage. ADR §3.1/§4.11.
+    /// Repository password (a Secret reference).
     pub encryption: Encryption,
-    /// What to do when the repository does not yet exist. Absent/disabled means
-    /// it must already exist; enabled means the operator creates it with the
-    /// given encryption/splitter/hash algorithms. ADR §3.1.
+    /// What to do when the repository does not yet exist (absent means it must already exist).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub create: Option<CreateBehavior>,
-    /// Mover defaults (security context, pod security context, resources, cache,
-    /// nodeSelector/tolerations/affinity, Job TTL) inherited by **every** mover this
-    /// repository spawns — bootstrap, backup, restore, maintenance — overridable
-    /// per-recipe via `mover` and merged field-wise (ADR-0004 §1/§2). Absorbs the
-    /// former `cacheDefaults` (now `moverDefaults.cache`).
+    /// Base mover configuration inherited by every mover this repository spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover_defaults: Option<MoverDefaults>,
-    /// Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-    /// catalog, keeping etcd footprint sane for large repositories. ADR §3.1.
+    /// Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub catalog: Option<CatalogBounds>,
-    /// Optional kopia web-UI server, exposed via a `Service` in this Repository's
-    /// own namespace. Presence means enabled. ADR §3.1 (server addendum).
+    /// Optional kopia web-UI server, exposed via a `Service` in this namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerSpec>,
-    /// Maintenance control. Default-managed: when absent or `enabled: true`, the
-    /// reconciler creates and owns a `Maintenance` CR for this repository in this
-    /// namespace. ADR §3.1/§3.7.
+    /// Maintenance control; when absent or enabled the reconciler creates and owns a `Maintenance` CR.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub maintenance: Option<RepositoryMaintenanceSpec>,
-    /// What happens to this repository's snapshots when a consuming **namespace** is
-    /// deleted: `Orphan` (default — keep history, release ownership) or `Delete`
-    /// (cascade per-`Snapshot` `deletionPolicy`). BREAKING default change in
-    /// ADR-0005 §5 — `kubectl delete ns` no longer destroys snapshots by default.
-    /// Carries a real OpenAPI `default: Orphan`.
+    /// What happens to this repository's snapshots when a consuming namespace is deleted.
     #[serde(default = "default_namespace_delete_policy")]
     #[schemars(default = "default_namespace_delete_policy")]
     pub on_namespace_delete: NamespaceDeletePolicy,
-    /// Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-    /// repository serves restores only — the reconciler refuses backup Jobs and skips
-    /// maintenance projection — for decommissioning/migration without write risk.
-    /// Carries a real OpenAPI `default: ReadWrite`.
+    /// Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).
     #[serde(default = "default_repository_mode")]
     #[schemars(default = "default_repository_mode")]
     pub mode: RepositoryMode,
-    /// Pause this repository declaratively (ADR-0005 §14(e)): a suspended repository
-    /// skips connect/bootstrap and maintenance projection. Surfaced via a condition.
+    /// Pause this repository: skip connect/bootstrap and maintenance projection.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
-    /// Repository health thresholds (ADR-0005 §13): tuning for the warnings the
-    /// reconciler raises about a degrading-but-still-usable repository (currently
-    /// the index-blob-count warning). A sub-object so future health knobs slot in
-    /// without API breakage. Absent uses the built-in defaults.
+    /// Repository health thresholds (tunes the index-blob-count warning).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health: Option<RepositoryHealthSpec>,
 }
 
-/// Repository health thresholds (ADR-0005 §13). A sub-object on
-/// `Repository`/`ClusterRepository` `spec.health` so future health knobs slot in
-/// without API breakage. Shared by both kinds.
+/// Repository health thresholds, shared by `Repository` and `ClusterRepository`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryHealthSpec {
-    /// Index-blob count above which the reconciler raises the `IndexBlobHealth`
-    /// condition + a Warning event (maintenance isn't compacting fast enough).
-    /// Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-    /// warning entirely; negative is rejected by the admission webhook.
+    /// Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index_blob_warn_threshold: Option<i64>,
 }
@@ -193,8 +164,7 @@ impl crate::common::PhaseLabel for RepositoryPhase {
     }
 }
 
-/// Observed state of a [`Repository`]. Carries resolved values pinned by the
-/// reconciler. ADR §3.1 status.
+/// Observed state of a `Repository`, carrying resolved values pinned by the reconciler.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryStatus {
@@ -205,9 +175,6 @@ pub struct RepositoryStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
     /// `resourceVersion` of the password Secret observed at the last connect attempt.
-    /// The terminal-failure hard-stop reopens when this changes, so editing the
-    /// Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-    /// connect instead of parking the repository as `Failed` forever.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved_credential_version: Option<String>,
     /// Kopia repository unique ID.
@@ -222,15 +189,15 @@ pub struct RepositoryStatus {
     /// Catalog-materialization status (how many discovered `Snapshot`s, last refresh).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub catalog: Option<CatalogStatus>,
-    /// Resolved kopia server endpoint/auth, pinned by the reconciler. ADR §3.1.
+    /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
-    /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.1.
+    /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
 }
 
-/// Aggregate repository storage figures from the last catalog scan. ADR §3.1 status.
+/// Aggregate repository storage figures from the last catalog scan.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct StorageStats {
@@ -243,16 +210,12 @@ pub struct StorageStats {
     /// RFC 3339 timestamp these stats were last observed.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_observed_at: Option<String>,
-    /// Number of content-index blobs (`kopia index list`) observed at the last
-    /// bootstrap. kopia compacts these during maintenance; an unbounded climb
-    /// means maintenance isn't keeping up. The reconciler raises the
-    /// `IndexBlobHealth` condition + a Warning event when this crosses
-    /// `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+    /// Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub index_blob_count: Option<i64>,
 }
 
-/// Status of catalog materialization for `origin: discovered` `Snapshot` CRs. ADR §3.1 status.
+/// Status of catalog materialization for `origin: discovered` `Snapshot` CRs.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CatalogStatus {

--- a/crates/api/src/repository_replication.rs
+++ b/crates/api/src/repository_replication.rs
@@ -15,8 +15,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Mirror a source repository's blobs to a destination backend on a schedule
-/// (`kopia repository sync-to`), ADR-0005 §13(d).
+/// Mirror a source repository's blobs to a destination backend on a schedule (`kopia repository sync-to`).
 ///
 /// Not `Eq`: `mover` transitively embeds k8s-openapi types.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -37,31 +36,19 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryReplicationSpec {
-    /// The repository to mirror *from* — a `Repository` or `ClusterRepository`
-    /// reference (ADR §3.2). Credentials/connect are resolved from it.
+    /// Reference to the `Repository` or `ClusterRepository` to mirror from.
     pub source_ref: RepositoryRef,
-    /// The backend to mirror *to* (`kopia repository sync-to <destination>`).
-    /// Exactly one backend by construction (the externally-tagged `Backend` enum,
-    /// reused). Must differ from the source's backend (webhook-enforced).
+    /// The backend to mirror to; must differ from the source's backend (webhook-enforced).
     pub destination: Backend,
-    /// Encryption/password for the destination repository when it needs its own
-    /// (e.g. a freshly-created mirror with a distinct password). Absent ⇒ the
-    /// destination uses the **source** repository's password — the common case for a
-    /// true mirror, where `sync-to` copies blobs verbatim and the format (including
-    /// the encryption material) is identical. Document this in the example.
+    /// Encryption for the destination; omit to reuse the source repository password.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub destination_encryption: Option<Encryption>,
-    /// Cron + deterministic jitter for the replication runs (ADR §3.7 scheduling
-    /// kernel, shared with `Maintenance`).
+    /// Cron and deterministic jitter for the replication runs.
     pub schedule: CronSpec,
-    /// Mover (Job pod) overrides for the replication run — resources, scheduling,
-    /// security context. Inherits the source repository's `moverDefaults` underneath
-    /// (ADR-0004 §1/§2).
+    /// Mover (Job pod) overrides for the replication run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover: Option<MoverSpec>,
-    /// Pause this replication declaratively (ADR-0005 §14(e)): a suspended
-    /// `RepositoryReplication` is skipped by its own reconcile (no sync runs),
-    /// surfaced via a condition. Default `false`.
+    /// Pause this replication; a suspended replication runs no syncs (default `false`).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
 }
@@ -111,7 +98,7 @@ impl crate::common::PhaseLabel for RepositoryReplicationPhase {
     }
 }
 
-/// Observed state of a [`RepositoryReplication`]. ADR-0005 §13(d).
+/// Observed state of a `RepositoryReplication`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RepositoryReplicationStatus {
@@ -121,12 +108,10 @@ pub struct RepositoryReplicationStatus {
     /// `metadata.generation` last reconciled, for staleness detection / kstatus.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// The destination backend kind (mirror of `spec.destination` discriminant),
-    /// for the `DESTINATION` print column.
+    /// The destination backend kind, for the `DESTINATION` print column.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub destination_backend: Option<String>,
-    /// RFC3339 timestamp of the most recent successful replication run. Backs the
-    /// `LAST` print column.
+    /// RFC3339 timestamp of the most recent successful replication run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_replicated: Option<String>,
     /// RFC3339 timestamp of the next scheduled replication run (cron + jitter, pinned).
@@ -138,7 +123,7 @@ pub struct RepositoryReplicationStatus {
     /// Blobs replicated by the last successful run (best-effort).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_replicated_blobs: Option<i64>,
-    /// Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). ADR-0005 §2.
+    /// Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
 }

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -9,9 +9,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// A restore operation. `target` is **required** (ADR-0005 §9): explicit
-/// `pvc`/`pvcRef`, or `populator: {}` for passive populator mode (consumed by a
-/// PVC's `spec.dataSourceRef`). The empty-`target` form is removed. ADR §3.6/§4.7.
+/// A restore operation from a snapshot/identity into a PVC, or a passive populator source.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -34,59 +32,41 @@ use serde::{Deserialize, Serialize};
     "message": "exactly one of target.pvc, target.pvcRef, target.populator"
 }]))]
 #[serde(rename_all = "camelCase")]
-/// Desired state of a [`Restore`]: where to read from, where to write to, and how
-/// to behave when the snapshot is missing. ADR §3.6/§4.6.
+/// Desired state of a Restore: where to read from, where to write to, and how to behave when the snapshot is missing.
 pub struct RestoreSpec {
-    /// Derived from `source` when omitted; REQUIRED only with `source.identity`. ADR §3.6/§4.6.
+    /// The repository to read from; derived from `source` when omitted, required only with `source.identity`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<RepositoryRef>,
-    /// Exactly one source mode; webhook-enforced. ADR §3.6.
+    /// Where to read data from (snapshotRef, fromPolicy, or identity).
     pub source: RestoreSource,
-    /// Where to restore to — **required** (ADR-0005 §9): `pvc` (operator creates),
-    /// `pvcRef` (existing PVC), or `populator: {}` (passive populator mode, claimed
-    /// via a PVC's `spec.dataSourceRef`). The former empty-`target` form is removed;
-    /// a `Restore` with no `target` is now invalid (deserialization fails).
+    /// Where to write the restored data (pvc, pvcRef, or populator).
     pub target: RestoreTarget,
-    /// kopia restore behavior (file deletion, permission/atomicity handling). ADR §4.6.
+    /// kopia restore behavior (file deletion, permission/atomicity handling).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub options: Option<RestoreOptions>,
-    /// Missing-snapshot handling and wait timeout. ADR §4.6 (G7).
+    /// What to do when the referenced snapshot doesn't exist yet, and how long to wait.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy: Option<RestorePolicy>,
-    /// Opt-in credential-Secret projection for this restore's mover (default off).
-    /// When `enabled: true`, the operator copies the referenced repository's
-    /// credential Secret(s) into the restore mover's namespace (a no-op when they
-    /// already live there) — so restoring from a shared `ClusterRepository` into a
-    /// fresh namespace need not pre-create the Secret there. ADR §4.11.
+    /// Opt-in copying of the repository's credential Secret(s) into the mover's namespace (default off).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_projection: Option<CredentialProjection>,
-    /// Per-run mover overrides for this restore's Job — resource requests/limits,
-    /// kopia cache sizing, container `securityContext` (UID/GID match), `privilegedMode`,
-    /// and `inheritSecurityContextFrom`. The same surface `SnapshotPolicy.spec.mover`
-    /// gives a backup. An elevated context is namespace-gated exactly like a backup's
-    /// (ADR §4.11/§G16); `securityContext` and `inheritSecurityContextFrom` are
-    /// mutually exclusive.
+    /// Per-run mover overrides for this restore's Job (resources, cache, `securityContext`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover: Option<MoverSpec>,
-    /// Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`),
-    /// mirroring `Snapshot.spec.failurePolicy`. Absent uses the ADR defaults.
+    /// Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_policy: Option<FailurePolicy>,
 }
 
-/// Where to restore from. Externally-tagged; exactly one variant. ADR §3.6/§4.6.
-///
-/// Wire shape: `source: { snapshotRef: {...} }`, `{ fromPolicy: {...} }`, or
-/// `{ identity: {...} }`.
+/// Where to restore from; exactly one variant.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum RestoreSource {
-    /// A `Snapshot` CR (scheduled, manual, or discovered — all the same kind). Default mode.
+    /// A `Snapshot` CR (scheduled, manual, or discovered).
     SnapshotRef(ObjectRef),
-    /// A `SnapshotPolicy` CR — resolves via identity even with no `Snapshot` CR present
-    /// (deploy-or-restore). Default `onMissingSnapshot: Continue`. ADR §4.6.
+    /// A `SnapshotPolicy` CR, resolved via identity even with no `Snapshot` CR present (deploy-or-restore).
     FromPolicy(FromPolicy),
-    /// A raw kopia identity (foreign writers / aged-out catalog). Requires `spec.repository`.
+    /// A raw kopia identity (foreign writers / aged-out catalog); requires `spec.repository`.
     Identity(IdentitySource),
 }
 
@@ -114,8 +94,7 @@ impl RestoreSource {
     }
 }
 
-/// The `fromPolicy` source: resolve a snapshot via a `SnapshotPolicy`'s identity,
-/// even when no `Snapshot` CR exists yet (deploy-or-restore). ADR §4.6.
+/// The `fromPolicy` source: resolve a snapshot via a `SnapshotPolicy`'s identity, even when no `Snapshot` CR exists yet.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FromPolicy {
@@ -127,11 +106,7 @@ pub struct FromPolicy {
     /// Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub as_of: Option<String>,
-    /// 0 = latest, 1 = previous, ... ADR §3.6.
-    ///
-    /// Carries a real OpenAPI `default: 0` (ADR-0005 §1): unconditional, so it
-    /// materializes into the stored object / `kubectl explain` and GitOps stops
-    /// diff-thrashing. A bare `i64` (not `Option`) so the default is never dropped.
+    /// Which snapshot to pick: 0 = latest, 1 = previous, and so on.
     #[serde(default = "default_offset")]
     #[schemars(default = "default_offset")]
     pub offset: i64,
@@ -145,8 +120,7 @@ fn default_offset() -> i64 {
     0
 }
 
-/// The `identity` source: a raw kopia `username@hostname:path` identity for
-/// foreign writers or snapshots aged out of the catalog. Requires `spec.repository`.
+/// The `identity` source: a raw kopia `username@hostname:path` identity; requires `spec.repository`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentitySource {
@@ -157,8 +131,7 @@ pub struct IdentitySource {
     /// The kopia source path to match; absent matches any path for the identity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
-    /// Pin an exact kopia snapshot by ID. Renamed to match the ADR wire shape
-    /// exactly (`snapshotID`, capital `ID`).
+    /// Pin an exact kopia snapshot by ID.
     #[serde(
         default,
         rename = "snapshotID",
@@ -168,16 +141,12 @@ pub struct IdentitySource {
     /// Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub as_of: Option<String>,
-    /// 0 = latest, 1 = previous, ... mutually exclusive with `snapshotID`/`asOf` in practice.
+    /// Which snapshot to pick: 0 = latest, 1 = previous, and so on.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub offset: Option<i64>,
 }
 
-/// Where to restore to. Externally-tagged; exactly one variant. ADR §3.6 / ADR-0005 §9.
-///
-/// Wire shape: `target: { pvc: {...} }`, `{ pvcRef: {...} }`, or `{ populator: {} }`.
-/// The `populator` variant is **explicit** passive-populator mode (claimed via a
-/// PVC's `spec.dataSourceRef`); the former empty-`target` form is removed (ADR-0005 §9).
+/// Where to restore to; exactly one variant.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum RestoreTarget {
@@ -185,9 +154,7 @@ pub enum RestoreTarget {
     Pvc(PvcTemplate),
     /// Write into an existing PVC.
     PvcRef(ObjectRef),
-    /// Passive populator mode: no workload target at provision time — the restore is
-    /// claimed by a PVC's `spec.dataSourceRef` (ADR-0005 §9). An (empty) sub-object so
-    /// future populator knobs slot in without API breakage.
+    /// Passive populator mode: the restore is claimed by a PVC's `spec.dataSourceRef`.
     Populator(PopulatorTarget),
 }
 
@@ -215,13 +182,12 @@ impl RestoreTarget {
     }
 }
 
-/// Passive-populator target marker (ADR-0005 §9). An empty sub-object — its presence
-/// selects populator mode; fields slot in later without an API break. Wire: `{}`.
+/// Passive-populator target marker; its presence selects populator mode.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PopulatorTarget {}
 
-/// Template for a PVC the operator creates as the restore target. ADR §3.6.
+/// Template for a PVC the operator creates as the restore target.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PvcTemplate {
@@ -238,31 +204,29 @@ pub struct PvcTemplate {
     pub access_modes: Vec<String>,
 }
 
-/// kopia restore behavior knobs. ADR §4.6.
+/// kopia restore behavior knobs.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreOptions {
-    /// Delete files in the target that are not present in the snapshot (make the
-    /// target an exact mirror). Off by default — additive restore is the safe default.
+    /// Delete files in the target that are not present in the snapshot (exact mirror); off by default.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub enable_file_deletion: bool,
-    /// Default true; surfaces a condition if any errors occurred. ADR §4.6.
+    /// Continue past permission errors during restore (default true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ignore_permission_errors: Option<bool>,
-    /// Default true. ADR §4.6.
+    /// Write files atomically via a temp file + rename (default true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub write_files_atomically: Option<bool>,
 }
 
-/// How the restore reacts to a missing snapshot and how long it waits. ADR §4.6 (G7).
+/// How the restore reacts to a missing snapshot and how long it waits.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestorePolicy {
-    /// Default `Fail` for explicit sources; `Continue` for `fromPolicy`. ADR §4.6 (G7).
+    /// What to do when the resolved source matches no snapshot (`Fail`/`Continue`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub on_missing_snapshot: Option<OnMissingSnapshot>,
-    /// How long to wait for the source snapshot to appear before giving up
-    /// (Go-style duration string, e.g. `5m`).
+    /// How long to wait for the source snapshot to appear before giving up (e.g. `5m`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub wait_timeout: Option<String>,
 }
@@ -281,11 +245,11 @@ pub enum OnMissingSnapshot {
     /// Fail-closed; the default for explicit `snapshotRef`/`identity` sources.
     #[default]
     Fail,
-    /// Proceed (deploy-or-restore); the default for `fromPolicy`.
+    /// Proceed with an empty volume (deploy-or-restore); the default for `fromPolicy`.
     Continue,
 }
 
-/// Lifecycle phase of a restore. Closed enum. ADR §3.6 status.
+/// Lifecycle phase of a restore.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum RestorePhase {
     /// Admitted but not yet acted on; the default initial phase.
@@ -320,22 +284,20 @@ impl crate::common::PhaseLabel for RestorePhase {
     }
 }
 
-/// Observed state of a [`Restore`], written by the controller/mover. ADR §3.6 status.
+/// Observed state of a Restore, written by the controller/mover.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreStatus {
     /// Current lifecycle phase.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase: Option<RestorePhase>,
-    /// The pinned source kind (`RestoreSource::kind_str` — `SnapshotRef`/`FromPolicy`/
-    /// `Identity`), set by the reconciler. Backs the `SOURCE` printer column so
-    /// `kubectl get restores` shows where a restore reads from. ADR-0005 §3.
+    /// The pinned source kind (`SnapshotRef`/`FromPolicy`/`Identity`); backs the `SOURCE` printer column.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_kind: Option<String>,
     /// `metadata.generation` last reconciled, so stale status is detectable.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// Pinned at admission; never re-resolved. ADR §3.6/§4.6.
+    /// The source resolved and pinned at admission; never re-resolved.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved: Option<ResolvedRestore>,
     /// Resolved target details (the PVC written to / populator handshake).
@@ -350,26 +312,15 @@ pub struct RestoreStatus {
     /// Standard Kubernetes conditions carrying the human-readable status/reason.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
-    /// The last lines of the run's output, written by the mover at the terminal
-    /// transition (success: the `Restore completed: snapshot <id>` line; failure:
-    /// the actionable error + kopia stderr tail). Capped at
-    /// [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
+    /// The last lines of the run's output, written by the mover at the terminal transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_tail: Option<String>,
-    /// Structured terminal-failure detail (kopia error class, stderr tail, retry
-    /// hint), written by the mover before it exits non-zero. ADR §4.10.
+    /// Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure: Option<crate::common::FailureBlock>,
 }
 
-/// Which outcome the source resolution pinned. Closed enum so the decision is a
-/// single, exhaustively-matched value rather than an inferred combination of optional
-/// fields — `Snapshot` means a concrete snapshot was found (its details live in the
-/// sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
-/// source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
-/// (the volume comes up empty). Pinned once and never re-resolved, exactly like a
-/// snapshot id, so a later-appearing snapshot can never silently retarget an
-/// already-provisioned volume (ADR §4.6).
+/// Which outcome the source resolution pinned, once and never re-resolved.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
 pub enum ResolutionOutcome {
     /// The source resolved to a concrete kopia snapshot (see `kopiaSnapshotID`).
@@ -378,19 +329,14 @@ pub enum ResolutionOutcome {
     NoSnapshot,
 }
 
-/// The source resolved and pinned at admission, so a restore never silently retargets. ADR §4.6.
+/// The source resolved and pinned at admission, so a restore never silently retargets.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedRestore {
-    /// Which outcome the resolution pinned (`Snapshot`/`NoSnapshot`). A legacy pin
-    /// written before this field existed leaves it `None` with `kopiaSnapshotID` set,
-    /// which is read as `Snapshot`.
+    /// Which outcome the resolution pinned (`Snapshot`/`NoSnapshot`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolution: Option<ResolutionOutcome>,
-    /// The exact kopia snapshot manifest id the source resolved to. Pinned once;
-    /// subsequent reconciles restore THIS id even if newer snapshots appear, so a
-    /// restore never silently retargets (ADR §4.6). Matches
-    /// `Snapshot.status.snapshot.kopiaSnapshotID`.
+    /// The exact kopia snapshot manifest id the source resolved to; pinned once.
     #[serde(
         default,
         rename = "kopiaSnapshotID",
@@ -411,11 +357,11 @@ pub struct ResolvedRestore {
     pub identity: Option<ResolvedIdentity>,
 }
 
-/// Resolved restore target details written to status. ADR §3.6.
+/// Resolved restore target details written to status.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreTargetStatus {
-    /// Populator handshake (passive / pvc-create modes). ADR §3.6.
+    /// Populator handshake (passive / pvc-create modes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc_prime: Option<String>,
     /// The PVC actually written to (created or pre-existing).
@@ -423,7 +369,7 @@ pub struct RestoreTargetStatus {
     pub pvc_ref: Option<ObjectRef>,
 }
 
-/// Start/end timestamps of a restore run. ADR §3.6 status.
+/// Start/end timestamps of a restore run.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreTiming {
@@ -435,7 +381,7 @@ pub struct RestoreTiming {
     pub end_time: Option<String>,
 }
 
-/// Live progress counters patched by the mover during a restore. ADR §3.6 status.
+/// Live progress counters patched by the mover during a restore.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreProgress {

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -44,26 +44,14 @@ use std::collections::BTreeMap;
 /// kopia's default server listen port; the resolved value is pinned to status.
 pub const DEFAULT_SERVER_PORT: u16 = 51515;
 
-/// Namespace-agnostic kopia web-UI server configuration. Embedded directly by
-/// `RepositorySpec.server`; wrapped (with a required `namespace`) by
-/// [`ClusterServerSpec`] for the cluster-scoped CRD.
-///
-/// Presence of `spec.server` means **enabled** — there is no `enabled` bool (it
-/// would create two ways to express "off"). Not `Eq`: embeds k8s-openapi
-/// `ResourceRequirements`/`SecurityContext` (`PartialEq` only).
+/// Namespace-agnostic kopia web-UI server configuration; presence of `spec.server` means enabled.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerSpec {
-    /// UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-    /// admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+    /// UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth: Option<ServerAuth>,
-    /// Connect the server's repository **read-only** so the UI cannot create, delete, or
-    /// alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-    /// with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-    /// explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-    /// Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-    /// key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+    /// Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
     /// How the server is exposed as a Kubernetes `Service`.
@@ -75,25 +63,12 @@ pub struct ServerSpec {
     /// Override the hardened default container security context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub security_context: Option<SecurityContext>,
-    /// Pod-level security context for the server pod. The hardened base
-    /// (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-    /// resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-    /// so the server can write a filesystem backend whose export is owned by a
-    /// shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-    /// recursively chown in-tree NFS mounts), so a group-writable export + a
-    /// supplemental group is the way to grant the long-lived server write access.
-    /// `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+    /// Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pod_security_context: Option<PodSecurityContext>,
 }
 
-/// `ClusterRepository`-only server config: a cluster-scoped server has no implicit
-/// namespace, so the target `namespace` is **required** (a cluster-scoped owner also
-/// cannot own the namespaced Deployment/Service via ownerReferences — the controller
-/// cleans them up via a finalizer + label selector instead).
-///
-/// The shared [`ServerSpec`] is flattened in, so the wire shape stays flat:
-/// `server: { namespace, auth, service, ... }`.
+/// `ClusterRepository`-only server config; the target `namespace` is required.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ClusterServerSpec {
@@ -104,20 +79,15 @@ pub struct ClusterServerSpec {
     pub server: ServerSpec,
 }
 
-/// UI authentication mode. Externally-tagged; exactly one variant by construction.
-///
-/// `Eq` is fine here — none of the variants embed a k8s-openapi type.
+/// UI authentication mode; exactly one variant by construction.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ServerAuth {
-    /// The operator mints random UI credentials into an owned `Secret` and pins the
-    /// reference to `status.server.generatedSecretRef`. The safe default.
+    /// The operator mints random UI credentials into an owned `Secret`; the safe default.
     Generate(GenerateAuth),
     /// The user supplies UI credentials via a `Secret` (`name` + the two keys).
     SecretRef(ServerSecretRef),
-    /// No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-    /// (webhook-rejected otherwise) because it exposes full read/write/delete of the
-    /// repository with no login.
+    /// No UI authentication; requires an explicit `acknowledgeInsecure: true`.
     Insecure(InsecureAuth),
 }
 
@@ -132,8 +102,7 @@ impl ServerAuth {
     }
 }
 
-/// Marker payload for [`ServerAuth::Generate`]. Empty today; a sub-object so future
-/// knobs (username, rotation) slot in without an API break (ADR §4.11).
+/// Payload for [`ServerAuth::Generate`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GenerateAuth {
@@ -142,8 +111,7 @@ pub struct GenerateAuth {
     pub username: Option<String>,
 }
 
-/// User-supplied UI credentials. All fields required so "keys are present" is a
-/// structural guarantee, not a runtime validator.
+/// User-supplied UI credentials.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerSecretRef {
@@ -155,8 +123,7 @@ pub struct ServerSecretRef {
     pub password_key: String,
 }
 
-/// Payload for [`ServerAuth::Insecure`]; the acknowledgement lives *inside* the
-/// variant so it is unreachable unless no-auth is explicitly chosen.
+/// Payload for [`ServerAuth::Insecure`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct InsecureAuth {
@@ -188,8 +155,7 @@ impl ServerService {
     }
 }
 
-/// Kubernetes `Service.spec.type`. A closed enum; variants serialize as Kubernetes'
-/// **exact** casing (so **no** `#[serde(rename_all)]` here — `clusterIp` would be wrong).
+/// Kubernetes `Service.spec.type`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum ServiceType {
     /// In-cluster only (default); routing to the outside is the user's job.
@@ -212,23 +178,20 @@ impl ServiceType {
     }
 }
 
-/// Status block for the kopia server, pinned by the reconciler. Never carries a
-/// password — only the resolved mode and (for `Generate`) the secret reference.
+/// Status block for the kopia server, pinned by the reconciler; never carries a password.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ServerStatus {
     /// In-cluster endpoint, `<service>.<namespace>.svc:<port>`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub endpoint: Option<String>,
-    /// Namespace the server objects were last applied to. **Load-bearing**: lets the
-    /// reconciler detect a `server.namespace` change and delete the stale objects.
+    /// Namespace the server objects were last applied to.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     /// Resolved auth mode discriminant (`Generate`/`SecretRef`/`Insecure`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_mode: Option<String>,
-    /// **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-    /// `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+    /// Effective read-only state of the served connection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub read_only: Option<bool>,
     /// For `Generate` mode: the operator-owned Secret holding the UI credentials.

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -13,10 +13,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-/// A single kopia snapshot represented as a Kubernetes object. ADR §3.4.
-///
-/// For `scheduled`/`manual` backups the spec carries `policyRef` (+ optional
-/// overrides). For `discovered` backups the spec is empty — every field is optional.
+/// A single kopia snapshot represented as a Kubernetes object.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -33,23 +30,19 @@ use std::collections::BTreeMap;
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotSpec {
-    /// The recipe to run. Absent for `discovered` backups. ADR §3.4.
+    /// The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<PolicyRef>,
-    /// Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). ADR §3.4.
+    /// Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<BTreeMap<String, String>>,
-    /// Per-run failure controls passed to the mover `Job`. ADR §3.4 (G6).
+    /// Mover Job retry and deadline limits for this run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure_policy: Option<FailurePolicy>,
-    /// Lifecycle of the underlying snapshot when this CR is deleted. Origin-aware
-    /// default (§4.5): `Delete` for scheduled/manual, forced `Retain` for discovered.
+    /// What happens to the kopia snapshot when this CR is deleted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deletion_policy: Option<DeletionPolicy>,
-    /// Pin this snapshot to exempt it from GFS retention (ADR-0005 §13(c)). When
-    /// `true` the reconciler applies a kopia snapshot pin and the GFS pruner never
-    /// selects it for deletion — for pre-migration / compliance holds. Clearing it
-    /// removes the pin. Default `false`.
+    /// Exempt this snapshot from GFS retention.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub pin: bool,
 }
@@ -70,13 +63,12 @@ pub struct SnapshotSpec {
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Origin {
-    /// Created by a `SnapshotSchedule`; spec carries `policyRef`. ADR §3.4.
+    /// Created by a `SnapshotSchedule`; spec carries `policyRef`.
     #[default]
     Scheduled,
-    /// Created by `kubectl create` / external automation; spec carries `policyRef`. ADR §3.4.
+    /// Created by `kubectl create` / external automation; spec carries `policyRef`.
     Manual,
-    /// Materialized by the catalog scan for a snapshot kopiur didn't produce;
-    /// spec is empty and `deletionPolicy` is forced to `Retain`. ADR §3.4/§4.5.
+    /// Materialized by the catalog scan for a snapshot kopiur didn't produce.
     Discovered,
 }
 
@@ -93,18 +85,18 @@ pub enum Origin {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum SnapshotPhase {
-    /// Admitted, not yet started (also the default). ADR §3.4 status.
+    /// Admitted, not yet started (also the default).
     #[default]
     Pending,
-    /// Mover Job is in flight. ADR §3.4 status.
+    /// Mover Job is in flight.
     Running,
-    /// Snapshot created successfully. ADR §3.4 status.
+    /// Snapshot created successfully.
     Succeeded,
-    /// Mover Job exhausted its retries. ADR §3.4 status.
+    /// Mover Job exhausted its retries.
     Failed,
-    /// CR is being deleted; finalizer is reclaiming the snapshot. ADR §3.4 status/§4.5.
+    /// CR is being deleted; finalizer is reclaiming the snapshot.
     Deleting,
-    /// Catalog-materialized backup kopiur didn't produce. ADR §3.4 status.
+    /// Catalog-materialized backup kopiur didn't produce.
     Discovered,
 }
 
@@ -146,95 +138,69 @@ impl crate::common::PhaseLabel for SnapshotPhase {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotStatus {
-    /// Current lifecycle phase. ADR §3.4 status.
+    /// Current lifecycle phase.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub phase: Option<SnapshotPhase>,
-    /// Canonical origin (also mirrored to the `origin` label). ADR §3.4 status.
+    /// Canonical origin (also mirrored to the `origin` label).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub origin: Option<Origin>,
-    /// `metadata.generation` last reconciled, for staleness detection. ADR §3.4 status.
+    /// `metadata.generation` last reconciled, for staleness detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// The kopia artifact this CR represents. ADR §3.4.
+    /// The kopia artifact this CR represents.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot: Option<SnapshotInfo>,
-    /// Start/end/duration of the snapshot run. ADR §3.4 status.
+    /// Start/end/duration of the snapshot run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timing: Option<SnapshotTiming>,
-    /// Byte/file counts parsed from kopia's JSON output. ADR §3.4 status.
+    /// Byte/file counts parsed from kopia's JSON output.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stats: Option<SnapshotStats>,
-    /// Present for scheduled/manual; absent for discovered. ADR §3.4.
+    /// The mover Job backing this run; absent for discovered.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub job: Option<JobStatus>,
-    /// Frozen recipe values at run time (scheduled/manual). ADR §3.4.
+    /// Frozen recipe values at run time (scheduled/manual).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved: Option<ResolvedSnapshot>,
     /// Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
-    /// ADR §3.4 status.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
-    /// The last lines of the run's output, written by the mover at the terminal
-    /// transition (success: the `Snapshot created: <id>` line; failure: the
-    /// actionable error + kopia stderr tail). Capped at
-    /// [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
-    /// ADR §3.4/§4.10.
+    /// The last lines of the run's output, written by the mover at the terminal transition.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_tail: Option<String>,
-    /// Structured terminal-failure detail (kopia error class, stderr tail, retry
-    /// hint), written by the mover before it exits non-zero. ADR §4.10.
+    /// Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure: Option<crate::common::FailureBlock>,
-    /// The observed kopia-side pin state (ADR-0005 §13(c)): `Some(true)` once the
-    /// operator has applied the pin, `Some(false)` once it has removed it, `None`
-    /// before any pin reconcile. The reconciler compares `spec.pin` against this to
-    /// decide whether to issue a `kopia snapshot pin`/`unpin`, so a redundant op is
-    /// never spawned.
+    /// The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pinned: Option<bool>,
-    /// Hook-execution bookkeeping (ADR §4.8): completion timestamps the
-    /// reconciler stamps so each hook list runs exactly once per Snapshot across
-    /// requeues and controller restarts (hooks have side effects — quiesce,
-    /// resume — that must not repeat).
+    /// Hook-execution bookkeeping so each hook list runs exactly once per Snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hooks: Option<HookExecutionStatus>,
-    /// The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`
-    /// (ADR §3.3). Pinned once when the stage is provisioned so the reconciler can
-    /// (a) reuse the same VolumeSnapshot/PVC across mover-Job retries idempotently
-    /// and (b) reap them on the terminal transition. Absent for `Direct` (and NFS),
-    /// which mount the live source with no staging.
+    /// The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub staged: Option<StagedSources>,
 }
 
-/// The CSI staging objects a backup created so kopia reads a point-in-time copy
-/// instead of the live source PVC (`copyMethod: Snapshot`/`Clone`, ADR §3.3).
-///
-/// Recorded once the stage is provisioned (stable values — never re-stamped, per the
-/// status-churn rule) so the controller reaps exactly these objects on completion and
-/// never double-creates them across requeues / controller restarts.
+/// The CSI staging objects a backup created so kopia reads a point-in-time copy of the source PVC.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct StagedSources {
     /// The resolved capture method (`Snapshot` or `Clone`) that produced this stage.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub copy_method: Option<String>,
-    /// Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot`
-    /// only; absent for `Clone`, which stages directly from the source PVC).
+    /// Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume_snapshot_name: Option<String>,
-    /// Name of the staged `PersistentVolumeClaim` the mover mounts in place of the
-    /// live source PVC.
+    /// Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc_name: Option<String>,
-    /// `true` once the stage is ready for the mover (VolumeSnapshot `readyToUse` and
-    /// the staged PVC applied). Before that the reconcile is still provisioning it.
+    /// `true` once the stage is ready for the mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ready: Option<bool>,
 }
 
-/// When each hook list completed (ADR §4.8). Written once per list, at the
-/// transition — never re-stamped — per the status-churn rule.
+/// When each hook list completed.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HookExecutionStatus {
@@ -246,95 +212,88 @@ pub struct HookExecutionStatus {
     pub post_completed_at: Option<String>,
 }
 
-/// Identifies the kopia snapshot a [`Snapshot`] CR owns. ADR §3.4.
+/// Identifies the kopia snapshot a [`Snapshot`] CR owns.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotInfo {
     /// kopia's snapshot ID — the handle the finalizer uses to delete content.
-    ///
-    /// Renamed to match the ADR wire shape exactly (`kopiaSnapshotID`, capital `ID`);
-    /// serde's `camelCase` would otherwise produce `kopiaSnapshotId`.
     #[serde(rename = "kopiaSnapshotID")]
     pub kopia_snapshot_id: String,
-    /// The `username@hostname:path` identity recorded for this snapshot. ADR §3.4/§4.2.
+    /// The `username@hostname:path` identity recorded for this snapshot.
     pub identity: ResolvedIdentity,
 }
 
-/// Timing of a snapshot run. ADR §3.4 status.
+/// Timing of a snapshot run.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotTiming {
-    /// RFC3339 start time of the run. ADR §3.4 status.
+    /// RFC3339 start time of the run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub start_time: Option<String>,
-    /// RFC3339 end time of the run. ADR §3.4 status.
+    /// RFC3339 end time of the run.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub end_time: Option<String>,
-    /// Wall-clock duration in seconds. ADR §3.4 status.
+    /// Wall-clock duration in seconds.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub duration_seconds: Option<i64>,
 }
 
-/// Stats populated from kopia's JSON output. ADR §3.4.
+/// Stats populated from kopia's JSON output.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotStats {
-    /// Total logical size of the snapshot in bytes. ADR §3.4 status.
+    /// Total logical size of the snapshot in bytes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub size_bytes: Option<i64>,
-    /// Bytes newly uploaded this run (after dedup/compression). ADR §3.4 status.
+    /// Bytes newly uploaded this run (after dedup/compression).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bytes_new: Option<i64>,
-    /// Count of files new since the previous snapshot. ADR §3.4 status.
+    /// Count of files new since the previous snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files_new: Option<i64>,
-    /// Count of files changed since the previous snapshot. ADR §3.4 status.
+    /// Count of files changed since the previous snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files_modified: Option<i64>,
-    /// Count of files unchanged since the previous snapshot. ADR §3.4 status.
+    /// Count of files unchanged since the previous snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files_unchanged: Option<i64>,
-    /// Count of source entries kopia could **not** read and therefore EXCLUDED from the
-    /// snapshot (`rootEntry.summ.errors`), making it *incomplete*. Present (and `> 0`) only
-    /// when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite
-    /// unreadable files — the otherwise-silent partial-backup case. The controller surfaces
-    /// it as a warning condition + Event. Usually a UID/GID mismatch with the workload.
+    /// Count of source entries kopia could not read and excluded, making the snapshot incomplete.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files_failed: Option<i64>,
 }
 
-/// The mover Job backing a scheduled/manual `Snapshot`; absent for discovered. ADR §3.4 status.
+/// The mover Job backing a scheduled/manual `Snapshot`; absent for discovered.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct JobStatus {
-    /// Name of the mover `Job`. ADR §3.4 status.
+    /// Name of the mover `Job`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
-    /// Number of attempts so far (bounded by `failurePolicy.backoffLimit`). ADR §3.4 status.
+    /// Number of attempts so far (bounded by `failurePolicy.backoffLimit`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attempts: Option<i32>,
 }
 
-/// Frozen recipe values pinned at run time. ADR §3.4.
+/// Frozen recipe values pinned at run time.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedSnapshot {
-    /// The repository this run targeted, frozen at run time. ADR §3.4 status.
+    /// The repository this run targeted, frozen at run time.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub repository: Option<RepositoryRef>,
-    /// The concrete PVCs + source paths backed up this run. ADR §3.4 status.
+    /// The concrete PVCs + source paths backed up this run.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<ResolvedSource>,
 }
 
-/// One resolved source backed up by a run — a concrete PVC and its kopia path. ADR §3.4 status.
+/// One resolved source backed up by a run — a concrete PVC and its kopia path.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedSource {
-    /// `namespace/name` of the PVC, as kopia sees it. ADR §3.4.
+    /// `namespace/name` of the PVC, as kopia sees it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc: Option<String>,
-    /// The source path kopia recorded for this PVC. ADR §3.4/§4.2.
+    /// The source path kopia recorded for this PVC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 }

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -12,9 +12,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// *What* to back up: sources, identity, retention, policy, hooks. ADR §3.3.
-///
-/// Not `Eq`: transitively embeds k8s-openapi types via `mover` and `hooks` (`JobSpec`).
+/// What to back up: sources, identity, retention, policy, hooks.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -33,100 +31,64 @@ use serde::{Deserialize, Serialize};
 )]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotPolicySpec {
-    /// Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+    /// Discriminated reference to a `Repository` or `ClusterRepository`.
     pub repository: RepositoryRef,
-    /// Identity overrides — what kopia records as `username@hostname:path`. ADR §3.3/§4.2.
+    /// Identity overrides — what kopia records as `username@hostname:path`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<Identity>,
-    /// What to back up. At least one source; webhook-enforced. ADR §3.3.
-    ///
-    /// `maxItems` is set so the apiserver can bound the cost of the per-item
-    /// `x-kubernetes-validations` exactly-one-of rule on [`Source`] (CEL rule cost is
-    /// `rule_cost × maxItems`; without a bound the apiserver assumes a huge array and
-    /// rejects the CRD as over budget). 100 sources per recipe is far past any real
-    /// use.
+    /// What to back up (at least one source; webhook-enforced).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(length(max = 100))]
     pub sources: Vec<Source>,
-    /// How the source volume is captured before kopia reads it: `Direct` (read the live
-    /// PVC, the **default** — works on any storage), `Snapshot` (point-in-time CSI
-    /// snapshot, opt-in), or `Clone` (CSI clone, opt-in). ADR §3.3 / [Copy methods].
-    ///
-    /// Carries a real OpenAPI `default: Direct` so it materializes into the stored object
-    /// and `kubectl explain`, and GitOps engines stop diff-thrashing on a controller-set
-    /// value. A bare value (not `Option`) so the default is never dropped by
-    /// `skip_serializing_if`.
-    ///
-    /// [Copy methods]: https://github.com/home-operations/kopiur/blob/main/docs/copy-methods.md
+    /// How the source volume is captured before kopia reads it: `Direct` (default), `Snapshot`, or `Clone`.
     #[serde(default = "default_copy_method")]
     #[schemars(default = "default_copy_method")]
     pub copy_method: CopyMethod,
     /// `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.
-    /// ADR §3.3.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume_snapshot_class_name: Option<String>,
-    /// Default `VolumeGroupSnapshot` for multi-PVC sources; `None` opts into per-PVC. ADR §4.9.
+    /// Multi-PVC consistency grouping; `None` opts into independent per-PVC snapshots.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub group_by: Option<GroupBy>,
-    /// GFS retention — enforced by the operator pruning `Snapshot` CRs. ADR §4.4.
+    /// GFS retention, enforced by the operator pruning `Snapshot` CRs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention: Option<Retention>,
-    /// Default `deletionPolicy` for `Snapshot` CRs created against this config. ADR §3.3/§4.5.
+    /// Default `deletionPolicy` for `Snapshot` CRs created against this config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub default_deletion_policy: Option<DeletionPolicy>,
-    /// Compression algorithm + per-extension opt-outs. ADR §3.3 (G12).
+    /// Compression algorithm + per-extension opt-outs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compression: Option<Compression>,
-    /// Paths/patterns kopia should skip while snapshotting. ADR §3.3 (G12).
+    /// Paths/patterns kopia should skip while snapshotting.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub files: Option<Files>,
-    /// Escape hatch for kopia flags not yet modeled. ADR §3.3 (G12).
+    /// Escape hatch for kopia flags not yet modeled.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_args: Vec<String>,
-    /// Backup-side error handling — the missing analog of restore's
-    /// `ignorePermissionErrors`. Lets a snapshot complete-with-errors instead of
-    /// failing outright (`--ignore-file-errors` / `--ignore-dir-errors` /
-    /// `--ignore-unknown-types`). ADR-0005 §13(b).
+    /// Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub error_handling: Option<ErrorHandling>,
-    /// Upload parallelism (kopia's upload policy: `--max-parallel-snapshots`,
-    /// `--max-parallel-file-reads`). ADR-0005 §13(f).
+    /// Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upload: Option<Upload>,
-    /// First-class backup verification (ADR-0005 §4). Opt-in: when absent, no
-    /// verification runs (no behavior change). When set, the controller schedules
-    /// periodic `kopia snapshot verify` (quick) and/or a scratch-restore test (deep),
-    /// gated by an optional CEL `successExpr` predicate over the result, and surfaces
-    /// `status.lastVerified`.
+    /// First-class backup verification; opt-in (absent ⇒ no verification runs).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verification: Option<Verification>,
-    /// Pause this recipe declaratively: a suspended `SnapshotPolicy` is skipped by
-    /// schedules and by its own reconcile (no retention prune, no backup creation),
-    /// surfaced via a condition/column. ADR-0005 §14(e).
+    /// Pause this recipe declaratively (schedules and reconcile skip a suspended policy).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
-    /// Pre/post snapshot hooks that run in the workload, not the mover. ADR §4.8 (G13).
+    /// Pre/post snapshot hooks that run in the workload, not the mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub hooks: Option<Hooks>,
-    /// Per-recipe mover overrides (resources, cache, security context). ADR §3.3.
+    /// Per-recipe mover overrides (resources, cache, security context).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover: Option<MoverSpec>,
-    /// Opt-in credential-Secret projection for this recipe's backup movers
-    /// (default off). When `enabled: true`, the operator copies the referenced
-    /// repository's credential Secret(s) into the namespace where each backup
-    /// mover runs (a no-op when they already live there) — so a workload backing
-    /// up to a shared `ClusterRepository` need not pre-create the Secret in its
-    /// own namespace. Inherited by `Snapshot`s produced from this config. ADR §4.11.
+    /// Opt-in credential-Secret projection into each backup mover's namespace (default off).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_projection: Option<CredentialProjection>,
 }
 
-/// A single backup source. `pvc`, `pvcSelector`, and `nfs` are mutually exclusive
-/// (webhook-enforced — NOT an enum, because the forms share the sibling
-/// `sourcePath*` keys and YAML lists them as optional siblings). ADR §3.3.
-///
-/// §15: an operator-authored `x-kubernetes-validations` rule enforces exactly-one-of
-/// in the apiserver + CI, complementing `validate_source`.
+/// A single backup source; exactly one of `pvc`, `pvcSelector`, `nfs` (webhook-enforced).
 // The exactly-one-of rule is written as an integer sum of `has()` ternaries rather
 // than `[...].filter(x,x).size()==1`: the apiserver estimates per-item CEL cost ×
 // `maxItems`, and a list-construction + lambda `filter` blows the budget on the
@@ -138,63 +100,49 @@ pub struct SnapshotPolicySpec {
 }]))]
 #[serde(rename_all = "camelCase")]
 pub struct Source {
-    /// Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`. ADR §3.3.
+    /// Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc: Option<PvcSource>,
-    /// Label/namespace selector matching many PVCs (multi-PVC sources).
-    /// Mutually exclusive with `pvc`/`nfs`. ADR §3.3/§5.4.
+    /// Label/namespace selector matching many PVCs. Mutually exclusive with `pvc`/`nfs`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc_selector: Option<PvcSelector>,
-    /// An inline NFS export to back up directly — no PVC. Mounted read-only at the
-    /// source path (default: the export's `path`). Mutually exclusive with
-    /// `pvc`/`pvcSelector`. ADR §3.3.
+    /// An inline NFS export to back up directly, mounted read-only. Mutually exclusive with `pvc`/`pvcSelector`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub nfs: Option<NfsVolume>,
-    /// What kopia records as the source path (default `/pvc/<name>` for a PVC, or
-    /// the NFS export `path` for an NFS source). ADR §3.3/§4.2.
-    ///
-    /// `maxLength` bounds the per-item cost of the exactly-one-of CEL rule on this
-    /// struct (an unbounded string makes the apiserver assume a huge value and blow
-    /// the rule's cost budget). A filesystem path is far shorter than 4096.
+    /// What kopia records as the source path (default `/pvc/<name>`, or the NFS export `path`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(max = 4096))]
     pub source_path_override: Option<String>,
-    /// How a selector-matched PVC's source path is derived (`pvcName` vs
-    /// `pvcNamespacedName`). Applies to `pvcSelector` sources. ADR §3.3/§4.2.
+    /// How a `pvcSelector`-matched PVC's source path is derived (`pvcName` vs `pvcNamespacedName`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path_strategy: Option<SourcePathStrategy>,
 }
 
-/// A single backup source addressed by PVC name. ADR §3.3.
+/// A single backup source addressed by PVC name.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PvcSource {
-    /// Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s
-    /// namespace). ADR §3.3.
+    /// Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s namespace).
     pub name: String,
 }
 
-/// Selects PVCs across namespaces by label. ADR §3.3/§5.4.
-///
-/// Not `Eq`: embeds `LabelSelector` (k8s-openapi, `PartialEq` only).
+/// Selects PVCs across namespaces by label.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct PvcSelector {
-    /// Restricts the search to specific namespaces; absent means the
-    /// `SnapshotPolicy`'s own namespace. ADR §3.3/§5.4.
+    /// Restricts the search to specific namespaces; absent means the policy's own namespace.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace_selector: Option<NamespaceSelector>,
-    /// Standard Kubernetes label selector matching the PVCs to include. ADR §3.3/§5.4.
+    /// Standard Kubernetes label selector matching the PVCs to include.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub label_selector: Option<LabelSelector>,
 }
 
-/// Restricts a [`PvcSelector`] to an explicit set of namespaces. ADR §3.3/§5.4.
+/// Restricts a `PvcSelector` to an explicit set of namespaces.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct NamespaceSelector {
-    /// Exact namespace names to search; empty means the `SnapshotPolicy`'s own
-    /// namespace. ADR §3.3/§5.4.
+    /// Exact namespace names to search; empty means the policy's own namespace.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub match_names: Vec<String>,
 }
@@ -229,15 +177,11 @@ fn default_copy_method() -> CopyMethod {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum CopyMethod {
-    /// Point-in-time CSI volume snapshot. Opt-in: requires the CSI snapshot stack + a
-    /// `VolumeSnapshotClass` for the source's driver.
+    /// Point-in-time CSI volume snapshot (opt-in; requires the CSI snapshot stack + a `VolumeSnapshotClass`).
     Snapshot,
-    /// CSI volume clone of the source, mounted read-only for the snapshot. Opt-in:
-    /// requires a CSI driver that supports cloning.
+    /// CSI volume clone of the source, mounted read-only (opt-in; requires a cloning-capable CSI driver).
     Clone,
-    /// Read the live PVC directly with no intermediate snapshot/clone (no point-in-time
-    /// guarantee; the mover co-locates on the volume's node for RWO). The **default** —
-    /// works on any storage. ADR §3.3.
+    /// Read the live PVC directly with no intermediate snapshot/clone (the default; works on any storage).
     #[default]
     Direct,
 }
@@ -259,7 +203,7 @@ pub enum GroupBy {
     /// Consistent group snapshot across all PVCs (default for multi-PVC).
     #[default]
     VolumeGroupSnapshot,
-    /// Opt into independent per-PVC snapshots. ADR §4.9.
+    /// Opt into independent per-PVC snapshots.
     None,
 }
 
@@ -279,47 +223,41 @@ pub enum GroupBy {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum SourcePathStrategy {
-    /// Path derived from the PVC name alone (default). ADR §3.3.
+    /// Path derived from the PVC name alone (default).
     #[default]
     PvcName,
-    /// Path derived from `<namespace>/<name>` to disambiguate same-named PVCs
-    /// across namespaces. ADR §3.3.
+    /// Path derived from `<namespace>/<name>` to disambiguate same-named PVCs across namespaces.
     PvcNamespacedName,
 }
 
-/// Compression policy (flattened onto [`SnapshotPolicySpec`], ADR-0004 §4b). ADR §3.3.
+/// Compression policy.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Compression {
-    /// kopia compressor name (e.g. `zstd`); absent leaves kopia's default. ADR §3.3.
+    /// kopia compressor name (e.g. `zstd`); absent leaves kopia's default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compressor: Option<String>,
-    /// Filename globs to leave uncompressed (e.g. already-compressed media). ADR §3.3.
+    /// Filename globs to leave uncompressed (e.g. already-compressed media).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub never_compress: Vec<String>,
 }
 
-/// File-ignore policy (flattened onto [`SnapshotPolicySpec`], ADR-0004 §4b). ADR §3.3.
+/// File-ignore policy.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Files {
-    /// Filename/path globs to exclude from the snapshot (e.g. `*.tmp`,
-    /// `*/cache/*`, `lost+found`). ADR §3.3.
+    /// Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub ignore_rules: Vec<String>,
     /// Honor `CACHEDIR.TAG`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub ignore_cache_dirs: bool,
-    /// fork issue #13.
+    /// Skip taking a new snapshot when the source is identical to the previous one.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub ignore_identical_snapshots: bool,
 }
 
-/// Backup-side error-handling policy (ADR-0005 §13(b)). The missing backup-side
-/// analog of restore's `ignorePermissionErrors`: lets kopia complete a snapshot
-/// with errors rather than aborting. Each bool defaults `false` (kopia's
-/// fail-on-error default). Maps to `--ignore-file-errors` / `--ignore-dir-errors`
-/// / `--ignore-unknown-types`.
+/// Backup-side error-handling policy: let kopia complete a snapshot with errors rather than aborting.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ErrorHandling {
@@ -334,9 +272,7 @@ pub struct ErrorHandling {
     pub ignore_unknown_types: bool,
 }
 
-/// Upload parallelism (kopia's upload policy, ADR-0005 §13(f)). Both knobs are
-/// optional; absent leaves kopia's default. Maps to `--max-parallel-snapshots` /
-/// `--max-parallel-file-reads`.
+/// Upload parallelism (kopia's upload policy); absent knobs leave kopia's default.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Upload {
@@ -348,70 +284,46 @@ pub struct Upload {
     pub max_parallel_file_reads: Option<i64>,
 }
 
-/// First-class backup verification (ADR-0005 §4). Opt-in capability that proves a
-/// repository's snapshots are *restorable*, not just that maintenance ran. Two
-/// tiers (mirroring `Maintenance` quick/full): a frequent blob-level
-/// `kopia snapshot verify` (`quick`) and an optional, rarer scratch-restore test
-/// (`deep`). Each tier is scheduled with cron + deterministic jitter just like
-/// maintenance, and an optional `successExpr` (CEL) asserts the result is good —
-/// killing the silent "0 files" success.
+/// First-class backup verification proving snapshots are restorable; opt-in, with quick and deep tiers.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Verification {
-    /// Schedule for the frequent blob-level `kopia snapshot verify`. Absent ⇒ no
-    /// quick verification.
+    /// Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub quick: Option<CronSpec>,
-    /// Schedule + knobs for the rarer scratch-restore restorability test. Absent ⇒
-    /// no deep verification.
+    /// Schedule + knobs for the rarer scratch-restore test; absent ⇒ no deep verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deep: Option<DeepVerification>,
-    /// A CEL pass/fail predicate over the verify result (ADR-0005 §15). Environment:
-    /// `stats{files,bytes,errors}`, `snapshot`, and (deep only) `restored{files,
-    /// checksumMatches}`. Returns a bool; when it evaluates `false` the verification
-    /// run fails. Validated at admission (`validate_success_expr`). Applies to both
-    /// tiers. Example: `"stats.files > 0 && stats.errors == 0"`.
+    /// CEL pass/fail predicate over the verify result; applies to both tiers.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub success_expr: Option<String>,
-    /// How many files `quick` verifies fully (`--verify-files-percent`); absent
-    /// leaves kopia's default. Tuning knob for the quick tier.
+    /// How many files `quick` verifies fully (`--verify-files-percent`); absent leaves kopia's default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify_files_percent: Option<u8>,
 }
 
-/// Deep (scratch-restore) verification (ADR-0005 §4): restore the latest snapshot
-/// into an ephemeral volume, sanity-check it, then discard. The most thorough
-/// restorability proof; scheduled rarely.
+/// Deep (scratch-restore) verification: restore the latest snapshot into an ephemeral volume, then discard.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct DeepVerification {
     /// Cron + jitter for the deep restore-test (e.g. weekly).
     pub schedule: CronSpec,
-    /// StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-    /// Only applies when `capacity` is set (an `emptyDir` has no StorageClass).
+    /// StorageClass for the ephemeral scratch PVC; absent uses the cluster default (only with `capacity`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub storage_class_name: Option<String>,
-    /// Size of the ephemeral scratch PVC (e.g. `10Gi`). When set, the operator
-    /// mounts a fresh generic-ephemeral PVC of this size at the scratch path
-    /// (auto-deleted with the Job) — size it to comfortably hold the restored
-    /// snapshot. When absent, scratch falls back to a node-ephemeral `emptyDir`
-    /// (zero-config, but bounded by node disk).
+    /// Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capacity: Option<String>,
 }
 
-/// Pre/post snapshot hook lists. ADR §3.3/§4.8.
-///
-/// Not `Eq`: `Hook::RunJob` embeds `JobSpec`.
+/// Pre/post snapshot hook lists.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Hooks {
-    /// Hooks run (in order) before the snapshot is taken — e.g. quiescing a
-    /// database. ADR §4.8.
+    /// Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub before_snapshot: Vec<Hook>,
-    /// Hooks run (in order) after the snapshot completes — e.g. resuming the
-    /// workload. ADR §4.8.
+    /// Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub after_snapshot: Vec<Hook>,
 }
@@ -443,14 +355,9 @@ pub struct Hooks {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Hook {
-    /// `kubectl exec`-style into a matched workload pod/container (the default form,
-    /// fork #22).
+    /// `kubectl exec`-style into a matched workload pod/container (the default form).
     WorkloadExec(WorkloadExecHook),
     /// Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-    ///
-    /// Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-    /// every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-    /// serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
     RunJob(Box<RunJobHook>),
     /// Typed POST to a URL for cross-system orchestration.
     HttpRequest(HttpRequestHook),
@@ -481,128 +388,117 @@ impl Hook {
     }
 }
 
-/// Hook failures abort the backup by default; `continueOnFailure: true` is opt-in. ADR §4.8.
-///
-/// Not `Eq`: embeds `LabelSelector` via `PodSelector`.
+/// `kubectl exec`-style hook into a matched workload pod/container.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkloadExecHook {
     /// Selects the workload pod/container to exec into (flattened onto the hook).
-    /// ADR §4.8.
     #[serde(flatten)]
     pub selector: PodSelector,
-    /// Command + args to run inside the selected container. ADR §4.8.
+    /// Command + args to run inside the selected container.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub command: Vec<String>,
-    /// Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+    /// Max time to wait for the command (Go duration string, e.g. `2m`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
-    /// If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.
+    /// If `true`, a failed hook does not abort the backup (default: abort).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub continue_on_failure: bool,
 }
 
-/// A hook that materializes a full one-shot Job (k8up `PreBackupPod` analog). ADR §4.8.
-///
-/// Not `Eq`: embeds `JobSpec`.
+/// A hook that materializes a full one-shot Job (k8up `PreBackupPod` analog).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RunJobHook {
-    /// The full Kubernetes `JobSpec` to run. ADR §4.8.
+    /// The full Kubernetes `JobSpec` to run.
     pub job_spec: JobSpec,
-    /// Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+    /// Max time to wait for the Job to complete (Go duration string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
-    /// If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.
+    /// If `true`, a failed Job does not abort the backup (default: abort).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub continue_on_failure: bool,
 }
 
-/// A hook that issues an HTTP request for cross-system orchestration. ADR §4.8.
+/// A hook that issues an HTTP request for cross-system orchestration.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct HttpRequestHook {
-    /// Target URL to call. ADR §4.8.
+    /// Target URL to call.
     pub url: String,
-    /// HTTP method (default `POST`). ADR §4.8.
+    /// HTTP method (default `POST`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub method: Option<String>,
-    /// Optional request body. ADR §4.8.
+    /// Optional request body.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
-    /// Max time to wait for the response (Go duration string). ADR §4.8.
+    /// Max time to wait for the response (Go duration string).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
-    /// If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.
+    /// If `true`, a failed request does not abort the backup (default: abort).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub continue_on_failure: bool,
 }
 
-/// Observed state of a [`SnapshotPolicy`]. ADR §3.3 status.
+/// Observed state of a `SnapshotPolicy`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotPolicyStatus {
-    /// `metadata.generation` last reconciled, for staleness detection. ADR §3.3 status.
+    /// `metadata.generation` last reconciled, for staleness detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// What would be passed to kopia — pinned at admission. ADR §3.3/§4.2.
+    /// What would be passed to kopia — pinned at admission.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resolved: Option<ResolvedPolicy>,
     /// Summary of GFS retention pruning against this config's `Snapshot` CRs.
-    /// ADR §3.3 status/§4.4.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention: Option<RetentionSummary>,
-    /// RFC3339 timestamp of the most recent successful child `Snapshot` produced
-    /// from this recipe. Backs the `LAST-SNAPSHOT` printer column and the
-    /// `prometheusRule` staleness alert (ADR-0005 §3).
+    /// RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_successful_snapshot: Option<String>,
-    /// RFC3339 timestamp of the most recent successful verification (any tier),
-    /// ADR-0005 §4. Backs the `kopiur_snapshot_verified_timestamp_seconds` gauge.
+    /// RFC3339 timestamp of the most recent successful verification (any tier).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_verified: Option<String>,
-    /// Standard Kubernetes conditions (e.g. `RepositoryReachable`,
-    /// `GroupSnapshotSupported`). ADR §3.3 status.
+    /// Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
 }
 
-/// The recipe as kopia would see it, pinned at admission and never re-rendered
-/// (ADR §4.2). ADR §3.3 status.
+/// The recipe as kopia would see it, pinned at admission and never re-rendered.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedPolicy {
-    /// The resolved `username@hostname` identity. ADR §3.3/§4.2.
+    /// The resolved `username@hostname` identity.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub identity: Option<ResolvedIdentity>,
-    /// The concrete PVCs + source paths after selector expansion. ADR §3.3 status.
+    /// The concrete PVCs + source paths after selector expansion.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub sources: Vec<ResolvedPolicySource>,
 }
 
-/// One resolved source — a concrete PVC and the path kopia records for it. ADR §3.3 status.
+/// One resolved source — a concrete PVC and the path kopia records for it.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedPolicySource {
-    /// `namespace/name` of the PVC, as kopia sees it. ADR §3.3 status.
+    /// `namespace/name` of the PVC, as kopia sees it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub pvc: Option<String>,
-    /// The source path kopia records for this PVC. ADR §3.3/§4.2.
+    /// The source path kopia records for this PVC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source_path: Option<String>,
 }
 
-/// Summary of the most recent GFS retention prune for a [`SnapshotPolicy`]. ADR §3.3 status/§4.4.
+/// Summary of the most recent GFS retention prune for a `SnapshotPolicy`.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RetentionSummary {
-    /// CRs currently inside the GFS window. ADR §3.3 status.
+    /// CRs currently inside the GFS window.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_snapshot_count: Option<i64>,
-    /// RFC3339 timestamp of the last prune pass. ADR §3.3 status.
+    /// RFC3339 timestamp of the last prune pass.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_prune_at: Option<String>,
-    /// Number of `Snapshot` CRs deleted by the last prune pass. ADR §3.3 status/§4.4.
+    /// Number of `Snapshot` CRs deleted by the last prune pass.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_prune_deleted: Option<i64>,
 }

--- a/crates/api/src/snapshot_schedule.rs
+++ b/crates/api/src/snapshot_schedule.rs
@@ -23,8 +23,7 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-/// Cron + `policyRef`. One source of `Snapshot` CRs; pausing it doesn't affect
-/// in-flight or completed runs. ADR §3.5.
+/// Cron schedule that fires `Snapshot` CRs from a `SnapshotPolicy`.
 #[derive(CustomResource, Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[kube(
     group = "kopiur.home-operations.com",
@@ -47,23 +46,15 @@ use serde::{Deserialize, Serialize};
 }]))]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotScheduleSpec {
-    /// The single `SnapshotPolicy` (recipe) this schedule invokes; resolved in the
-    /// schedule's own namespace. ADR §3.5 separates recipe from schedule. **Mutually
-    /// exclusive** with `policySelector` — exactly one is required (webhook-enforced,
-    /// ADR-0005 §10). Optional at the type level so `policySelector` can be used instead.
+    /// The single `SnapshotPolicy` this schedule invokes; mutually exclusive with `policySelector`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<PolicyRef>,
-    /// Fan-out form (ADR-0005 §10): a label selector over `SnapshotPolicy` objects in
-    /// the schedule's namespace. Each matching policy gets a `Snapshot` per firing
-    /// ("back up everything tagged `tier=critical` nightly" in one object). **Mutually
-    /// exclusive** with `policyRef`. Mirrors the `pvcSelector` pattern.
+    /// Label selector fanning out over `SnapshotPolicy` objects; mutually exclusive with `policyRef`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_selector: Option<LabelSelector>,
-    /// Cron, jitter, timezone, and concurrency for the firing cadence. ADR §3.5.
+    /// Cron, jitter, timezone, and concurrency for the firing cadence.
     pub schedule: ScheduleSpec,
-    /// Bounds *failed* `Snapshot` CRs from this schedule. Successful retention is
-    /// GFS-driven on `SnapshotPolicy.spec.retention` — there is deliberately NO
-    /// `successfulJobsHistoryLimit` (ADR-0003 §4.4, ADR-0001 §4.4).
+    /// Maximum number of failed `Snapshot` CRs from this schedule to retain.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failed_jobs_history_limit: Option<u32>,
 }
@@ -82,39 +73,30 @@ fn default_concurrency_policy() -> ConcurrencyPolicy {
     ConcurrencyPolicy::Forbid
 }
 
-/// Cron schedule with deterministic jitter, timezone, and concurrency controls. ADR §3.5/§4.1.
+/// Cron schedule with deterministic jitter, timezone, and concurrency controls.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ScheduleSpec {
-    /// Cron expression with Jenkins-style `H` substitution. ADR §4.1 (G4).
+    /// Cron expression with Jenkins-style `H` substitution.
     pub cron: String,
-    /// Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`. ADR §4.1.
+    /// Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jitter: Option<String>,
-    /// IANA timezone the cron is evaluated in (e.g. `America/Los_Angeles`).
-    /// Absent means the controller's configured default. ADR §4.1.
+    /// IANA timezone the cron is evaluated in; absent uses the controller's default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<String>,
-    /// GitOps-friendly default: do NOT fire immediately on create. ADR §4.1 (G3).
-    ///
-    /// Carries a real OpenAPI `default: false` (ADR-0005 §1) so it materializes into
-    /// the stored object / `kubectl explain` and GitOps stops diff-thrashing. NOT
-    /// `skip_serializing_if`-elided, so the materialized value round-trips.
+    /// Whether to fire immediately on create (default `false`).
     #[serde(default = "default_run_on_create")]
     #[schemars(default = "default_run_on_create")]
     pub run_on_create: bool,
-    /// Skip future firings while true. ADR §5.9.
+    /// Skip future firings while true.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
-    /// How to handle a firing while a prior run is still in flight. ADR §4.1.
-    ///
-    /// Carries a real OpenAPI `default: Forbid` (ADR-0005 §1) — unconditional, so it
-    /// materializes into the stored object / `kubectl explain`.
+    /// How to handle a firing while a prior run is still in flight (default `Forbid`).
     #[serde(default = "default_concurrency_policy")]
     #[schemars(default = "default_concurrency_policy")]
     pub concurrency_policy: ConcurrencyPolicy,
-    /// If a slot is missed by more than this many seconds (e.g. operator was
-    /// down), skip it instead of firing late. ADR §4.1.
+    /// If a slot is missed by more than this many seconds, skip it instead of firing late.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub starting_deadline_seconds: Option<i64>,
 }
@@ -134,7 +116,7 @@ pub struct ScheduleSpec {
 /// ```
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum ConcurrencyPolicy {
-    /// Skip the new run; surface a condition rather than pile up (default).
+    /// Skip the new run rather than let runs pile up (default).
     #[default]
     Forbid,
     /// Allow the new run to start alongside the in-flight one.
@@ -143,41 +125,35 @@ pub enum ConcurrencyPolicy {
     Replace,
 }
 
-/// Observed state of a `SnapshotSchedule`: pinned firing slots and failure run. ADR §3.5.
+/// Observed state of a `SnapshotSchedule`: pinned firing slots and failure run.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotScheduleStatus {
     /// The `metadata.generation` this status reflects, for staleness detection.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub observed_generation: Option<i64>,
-    /// Most recent firing (cron + jitter, pinned). ADR §3.5.
+    /// Most recent firing (cron + jitter, pinned).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_schedule: Option<ScheduleRef>,
     /// The next firing slot the controller has computed (cron + jitter, pinned).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub next_schedule: Option<ScheduleRef>,
-    /// The most recent firing whose `Snapshot` succeeded. ADR §3.5.
+    /// The most recent firing whose `Snapshot` succeeded.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_successful_schedule: Option<ScheduleRef>,
-    /// Count of back-to-back failed runs; resets on success. Drives alerting.
+    /// Count of back-to-back failed runs; resets on success.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub consecutive_failures: Option<i64>,
-    /// Standard Kubernetes conditions surfacing schedule health. ADR §5 status conventions.
+    /// Standard Kubernetes conditions surfacing schedule health.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,
 }
 
-/// A pinned schedule slot and (optionally) the `Snapshot` it created. ADR §3.5.
-///
-/// `at`/`scheduledAt` are both accepted on the wire: ADR uses `scheduledAt` for
-/// `lastSchedule` and `at` for `next`/`lastSuccessful`. We model both as the single
-/// `at` field with a serde alias so either spelling round-trips.
+/// A pinned schedule slot and (optionally) the `Snapshot` it created.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ScheduleRef {
-    /// The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-    /// `scheduledAt` alias on the wire (see the struct docs) but always
-    /// serializes back as `at`.
+    /// The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
     #[serde(
         default,
         alias = "scheduledAt",
@@ -189,7 +165,7 @@ pub struct ScheduleRef {
     pub snapshot_ref: Option<SnapshotReference>,
 }
 
-/// A by-name reference to a `Snapshot` CR created by a schedule slot. ADR §3.5.
+/// A by-name reference to a `Snapshot` CR created by a schedule slot.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotReference {

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -41,13 +42,10 @@ spec:
         description: Auto-generated derived type for RepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A kopia repository owned by one namespace: credentials, backend, encryption,
-              and optional catalog-materialization bounds. Many `SnapshotPolicy`s / `Restore`s
-              reference one. ADR §3.1.
+            description: A kopia repository owned by one namespace, referenced by `SnapshotPolicy`s and `Restore`s.
             properties:
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -74,37 +72,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -128,24 +114,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -169,10 +149,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -214,37 +191,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -275,9 +240,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -295,41 +258,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -359,9 +310,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -374,16 +323,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -393,24 +336,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -442,24 +379,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -474,65 +405,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog, keeping etcd footprint sane for large repositories. ADR §3.1.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Absent/disabled means
-                  it must already exist; enabled means the operator creates it with the
-                  given encryption/splitter/hash algorithms. ADR §3.1.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -547,46 +452,36 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. A sub-object so future
-                  rotation fields slot in without API breakage. ADR §3.1/§4.11.
+                description: Repository password (a Secret reference).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -596,71 +491,45 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13): tuning for the warnings the
-                  reconciler raises about a degrading-but-still-usable repository (currently
-                  the index-blob-count warning). A sub-object so future health knobs slot in
-                  without API breakage. Absent uses the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this repository in this
-                  namespace. ADR §3.1/§3.7.
+                description: Maintenance control; when absent or enabled the reconciler creates and owns a `Maintenance` CR.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -682,7 +551,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -694,11 +563,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -707,26 +572,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -767,12 +621,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -902,7 +751,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -943,10 +792,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1051,65 +897,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1139,22 +967,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  repository serves restores only — the reconciler refuses backup Jobs and skips
-                  maintenance projection — for decommissioning/migration without write risk.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults (security context, pod security context, resources, cache,
-                  nodeSelector/tolerations/affinity, Job TTL) inherited by **every** mover this
-                  repository spawns — bootstrap, backup, restore, maintenance — overridable
-                  per-recipe via `mover` and merged field-wise (ADR-0004 §1/§2). Absorbs the
-                  former `cacheDefaults` (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1660,7 +1479,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1678,7 +1497,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1696,9 +1515,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1865,31 +1682,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -1994,23 +1800,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2019,10 +1813,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2071,36 +1862,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history, release ownership) or `Delete`
-                  (cascade per-`Snapshot` `deletionPolicy`). BREAKING default change in
-                  ADR-0005 §5 — `kubectl delete ns` no longer destroys snapshots by default.
-                  Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server, exposed via a `Service` in this Repository's
-                  own namespace. Presence means enabled. ADR §3.1 (server addendum).
+                description: Optional kopia web-UI server, exposed via a `Service` in this namespace.
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2111,9 +1890,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2121,10 +1898,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2150,15 +1924,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2288,13 +2054,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2468,9 +2228,7 @@ spec:
                     type: object
                 type: object
               suspend:
-                description: |-
-                  Pause this repository declaratively (ADR-0005 §14(e)): a suspended repository
-                  skips connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - backend
@@ -2486,9 +2244,7 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: |-
-              Observed state of a [`Repository`]. Carries resolved values pinned by the
-              reconciler. ADR §3.1 status.
+            description: Observed state of a `Repository`, carrying resolved values pinned by the reconciler.
             nullable: true
             properties:
               backend:
@@ -2510,7 +2266,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.1.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2572,15 +2328,11 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
-                description: Resolved kopia server endpoint/auth, pinned by the reconciler. ADR §3.1.
+                description: Resolved kopia server endpoint/auth, pinned by the reconciler.
                 nullable: true
                 properties:
                   authMode:
@@ -2599,24 +2351,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2625,12 +2371,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 38
 expression: "body(&artifacts, \"repositoryreplications\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -41,16 +42,12 @@ spec:
         properties:
           spec:
             description: |-
-              Mirror a source repository's blobs to a destination backend on a schedule
-              (`kopia repository sync-to`), ADR-0005 §13(d).
+              Mirror a source repository's blobs to a destination backend on a schedule (`kopia repository sync-to`).
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               destination:
-                description: |-
-                  The backend to mirror *to* (`kopia repository sync-to <destination>`).
-                  Exactly one backend by construction (the externally-tagged `Backend` enum,
-                  reused). Must differ from the source's backend (webhook-enforced).
+                description: The backend to mirror to; must differ from the source's backend (webhook-enforced).
                 oneOf:
                 - required:
                   - s3
@@ -77,37 +74,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -131,24 +116,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -172,10 +151,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -217,37 +193,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -278,9 +242,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -298,41 +260,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -362,9 +312,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -377,16 +325,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -396,24 +338,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -445,24 +381,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -477,30 +407,21 @@ spec:
                     type: object
                 type: object
               destinationEncryption:
-                description: |-
-                  Encryption/password for the destination repository when it needs its own
-                  (e.g. a freshly-created mirror with a distinct password). Absent ⇒ the
-                  destination uses the **source** repository's password — the common case for a
-                  true mirror, where `sync-to` copies blobs verbatim and the format (including
-                  the encryption material) is identical. Document this in the example.
+                description: Encryption for the destination; omit to reuse the source repository password.
                 nullable: true
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -510,10 +431,7 @@ spec:
                 - passwordSecretRef
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the replication run — resources, scheduling,
-                  security context. Inherits the source repository's `moverDefaults` underneath
-                  (ADR-0004 §1/§2).
+                description: Mover (Job pod) overrides for the replication run.
                 nullable: true
                 properties:
                   cache:
@@ -535,7 +453,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -547,11 +465,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -560,26 +474,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -620,12 +523,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -755,7 +653,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -796,10 +694,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -904,38 +799,26 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               schedule:
-                description: |-
-                  Cron + deterministic jitter for the replication runs (ADR §3.7 scheduling
-                  kernel, shared with `Maintenance`).
+                description: Cron and deterministic jitter for the replication runs.
                 properties:
                   cron:
-                    description: |-
-                      The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                      deterministic per-schedule jitter (ADR §3.7).
+                    description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                     type: string
                   jitter:
-                    description: |-
-                      Optional deterministic jitter window as a Go-style duration string (e.g.
-                      `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                    description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
                 required:
                 - cron
                 type: object
               sourceRef:
-                description: |-
-                  The repository to mirror *from* — a `Repository` or `ClusterRepository`
-                  reference (ADR §3.2). Credentials/connect are resolved from it.
+                description: Reference to the `Repository` or `ClusterRepository` to mirror from.
                 properties:
                   kind:
                     default: Repository
@@ -955,10 +838,7 @@ spec:
                 - name
                 type: object
               suspend:
-                description: |-
-                  Pause this replication declaratively (ADR-0005 §14(e)): a suspended
-                  `RepositoryReplication` is skipped by its own reconcile (no sync runs),
-                  surfaced via a condition. Default `false`.
+                description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
             required:
             - destination
@@ -966,11 +846,11 @@ spec:
             - sourceRef
             type: object
           status:
-            description: Observed state of a [`RepositoryReplication`]. ADR-0005 §13(d).
+            description: Observed state of a `RepositoryReplication`.
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). ADR-0005 §2.
+                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -1003,15 +883,11 @@ spec:
                   type: object
                 type: array
               destinationBackend:
-                description: |-
-                  The destination backend kind (mirror of `spec.destination` discriminant),
-                  for the `DESTINATION` print column.
+                description: The destination backend kind, for the `DESTINATION` print column.
                 nullable: true
                 type: string
               lastReplicated:
-                description: |-
-                  RFC3339 timestamp of the most recent successful replication run. Backs the
-                  `LAST` print column.
+                description: RFC3339 timestamp of the most recent successful replication run.
                 nullable: true
                 type: string
               lastReplicatedBlobs:

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 30
 expression: "body(&artifacts, \"snapshots\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -37,22 +38,11 @@ spec:
         description: Auto-generated derived type for SnapshotSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A single kopia snapshot represented as a Kubernetes object. ADR §3.4.
-
-              For `scheduled`/`manual` backups the spec carries `policyRef` (+ optional
-              overrides). For `discovered` backups the spec is empty — every field is optional.
+            description: A single kopia snapshot represented as a Kubernetes object.
             properties:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -70,45 +60,30 @@ spec:
                 nullable: true
                 type: string
               failurePolicy:
-                description: Per-run failure controls passed to the mover `Job`. ADR §3.4 (G6).
+                description: Mover Job retry and deadline limits for this run.
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               pin:
-                description: |-
-                  Pin this snapshot to exempt it from GFS retention (ADR-0005 §13(c)). When
-                  `true` the reconciler applies a kopia snapshot pin and the GFS pruner never
-                  selects it for deletion — for pre-migration / compliance holds. Clearing it
-                  removes the pin. Default `false`.
+                description: Exempt this snapshot from GFS retention.
                 type: boolean
               policyRef:
-                description: The recipe to run. Absent for `discovered` backups. ADR §3.4.
+                description: The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
                 nullable: true
                 properties:
                   name:
@@ -124,7 +99,7 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). ADR §3.4.'
+                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
                 nullable: true
                 type: object
             type: object
@@ -133,9 +108,7 @@ spec:
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
-                  ADR §3.4 status.
+                description: Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -168,9 +141,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -199,11 +170,7 @@ spec:
                 - retryRecommended
                 type: object
               hooks:
-                description: |-
-                  Hook-execution bookkeeping (ADR §4.8): completion timestamps the
-                  reconciler stamps so each hook list runs exactly once per Snapshot across
-                  requeues and controller restarts (hooks have side effects — quiesce,
-                  resume — that must not repeat).
+                description: Hook-execution bookkeeping so each hook list runs exactly once per Snapshot.
                 nullable: true
                 properties:
                   postCompletedAt:
@@ -216,30 +183,25 @@ spec:
                     type: string
                 type: object
               job:
-                description: Present for scheduled/manual; absent for discovered. ADR §3.4.
+                description: The mover Job backing this run; absent for discovered.
                 nullable: true
                 properties:
                   attempts:
-                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`). ADR §3.4 status.
+                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`).
                     format: int32
                     nullable: true
                     type: integer
                   name:
-                    description: Name of the mover `Job`. ADR §3.4 status.
+                    description: Name of the mover `Job`.
                     nullable: true
                     type: string
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Snapshot created: <id>` line; failure: the
-                  actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
-                  ADR §3.4/§4.10.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.4 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
@@ -287,20 +249,15 @@ spec:
                 nullable: true
                 type: string
               pinned:
-                description: |-
-                  The observed kopia-side pin state (ADR-0005 §13(c)): `Some(true)` once the
-                  operator has applied the pin, `Some(false)` once it has removed it, `None`
-                  before any pin reconcile. The reconciler compares `spec.pin` against this to
-                  decide whether to issue a `kopia snapshot pin`/`unpin`, so a redundant op is
-                  never spawned.
+                description: 'The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile.'
                 nullable: true
                 type: boolean
               resolved:
-                description: Frozen recipe values at run time (scheduled/manual). ADR §3.4.
+                description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
                 properties:
                   repository:
-                    description: The repository this run targeted, frozen at run time. ADR §3.4 status.
+                    description: The repository this run targeted, frozen at run time.
                     nullable: true
                     properties:
                       kind:
@@ -321,27 +278,27 @@ spec:
                     - name
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths backed up this run. ADR §3.4 status.
+                    description: The concrete PVCs + source paths backed up this run.
                     items:
-                      description: One resolved source backed up by a run — a concrete PVC and its kopia path. ADR §3.4 status.
+                      description: One resolved source backed up by a run — a concrete PVC and its kopia path.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.4.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia recorded for this PVC. ADR §3.4/§4.2.
+                          description: The source path kopia recorded for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               snapshot:
-                description: The kopia artifact this CR represents. ADR §3.4.
+                description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
                   identity:
-                    description: The `username@hostname:path` identity recorded for this snapshot. ADR §3.4/§4.2.
+                    description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:
                       hostname:
                         description: The final `hostname` kopia records, fixed at admission.
@@ -358,23 +315,14 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      kopia's snapshot ID — the handle the finalizer uses to delete content.
-
-                      Renamed to match the ADR wire shape exactly (`kopiaSnapshotID`, capital `ID`);
-                      serde's `camelCase` would otherwise produce `kopiaSnapshotId`.
+                    description: kopia's snapshot ID — the handle the finalizer uses to delete content.
                     type: string
                 required:
                 - identity
                 - kopiaSnapshotID
                 type: object
               staged:
-                description: |-
-                  The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`
-                  (ADR §3.3). Pinned once when the stage is provisioned so the reconciler can
-                  (a) reuse the same VolumeSnapshot/PVC across mover-Job retries idempotently
-                  and (b) reap them on the terminal transition. Absent for `Direct` (and NFS),
-                  which mount the live source with no staging.
+                description: 'The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`.'
                 nullable: true
                 properties:
                   copyMethod:
@@ -382,79 +330,68 @@ spec:
                     nullable: true
                     type: string
                   pvcName:
-                    description: |-
-                      Name of the staged `PersistentVolumeClaim` the mover mounts in place of the
-                      live source PVC.
+                    description: Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC.
                     nullable: true
                     type: string
                   ready:
-                    description: |-
-                      `true` once the stage is ready for the mover (VolumeSnapshot `readyToUse` and
-                      the staged PVC applied). Before that the reconcile is still provisioning it.
+                    description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
                   volumeSnapshotName:
-                    description: |-
-                      Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot`
-                      only; absent for `Clone`, which stages directly from the source PVC).
+                    description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true
                     type: string
                 type: object
               stats:
-                description: Byte/file counts parsed from kopia's JSON output. ADR §3.4 status.
+                description: Byte/file counts parsed from kopia's JSON output.
                 nullable: true
                 properties:
                   bytesNew:
-                    description: Bytes newly uploaded this run (after dedup/compression). ADR §3.4 status.
+                    description: Bytes newly uploaded this run (after dedup/compression).
                     format: int64
                     nullable: true
                     type: integer
                   filesFailed:
-                    description: |-
-                      Count of source entries kopia could **not** read and therefore EXCLUDED from the
-                      snapshot (`rootEntry.summ.errors`), making it *incomplete*. Present (and `> 0`) only
-                      when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite
-                      unreadable files — the otherwise-silent partial-backup case. The controller surfaces
-                      it as a warning condition + Event. Usually a UID/GID mismatch with the workload.
+                    description: Count of source entries kopia could not read and excluded, making the snapshot incomplete.
                     format: int64
                     nullable: true
                     type: integer
                   filesModified:
-                    description: Count of files changed since the previous snapshot. ADR §3.4 status.
+                    description: Count of files changed since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesNew:
-                    description: Count of files new since the previous snapshot. ADR §3.4 status.
+                    description: Count of files new since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesUnchanged:
-                    description: Count of files unchanged since the previous snapshot. ADR §3.4 status.
+                    description: Count of files unchanged since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   sizeBytes:
-                    description: Total logical size of the snapshot in bytes. ADR §3.4 status.
+                    description: Total logical size of the snapshot in bytes.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               timing:
-                description: Start/end/duration of the snapshot run. ADR §3.4 status.
+                description: Start/end/duration of the snapshot run.
                 nullable: true
                 properties:
                   durationSeconds:
-                    description: Wall-clock duration in seconds. ADR §3.4 status.
+                    description: Wall-clock duration in seconds.
                     format: int64
                     nullable: true
                     type: integer
                   endTime:
-                    description: RFC3339 end time of the run. ADR §3.4 status.
+                    description: RFC3339 end time of the run.
                     nullable: true
                     type: string
                   startTime:
-                    description: RFC3339 start time of the run. ADR §3.4 status.
+                    description: RFC3339 start time of the run.
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -38,13 +38,10 @@ spec:
         description: Auto-generated derived type for RepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A kopia repository owned by one namespace: credentials, backend, encryption,
-              and optional catalog-materialization bounds. Many `SnapshotPolicy`s / `Restore`s
-              reference one. ADR §3.1.
+            description: A kopia repository owned by one namespace, referenced by `SnapshotPolicy`s and `Restore`s.
             properties:
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -71,37 +68,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -125,24 +110,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -166,10 +145,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -211,37 +187,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -272,9 +236,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -292,41 +254,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -356,9 +306,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -371,16 +319,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -390,24 +332,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -439,24 +375,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -471,65 +401,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog, keeping etcd footprint sane for large repositories. ADR §3.1.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Absent/disabled means
-                  it must already exist; enabled means the operator creates it with the
-                  given encryption/splitter/hash algorithms. ADR §3.1.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -544,46 +448,36 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. A sub-object so future
-                  rotation fields slot in without API breakage. ADR §3.1/§4.11.
+                description: Repository password (a Secret reference).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -593,71 +487,45 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13): tuning for the warnings the
-                  reconciler raises about a degrading-but-still-usable repository (currently
-                  the index-blob-count warning). A sub-object so future health knobs slot in
-                  without API breakage. Absent uses the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this repository in this
-                  namespace. ADR §3.1/§3.7.
+                description: Maintenance control; when absent or enabled the reconciler creates and owns a `Maintenance` CR.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -679,7 +547,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -691,11 +559,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -704,26 +568,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -764,12 +617,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -899,7 +747,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -940,10 +788,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1048,65 +893,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1136,22 +963,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  repository serves restores only — the reconciler refuses backup Jobs and skips
-                  maintenance projection — for decommissioning/migration without write risk.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults (security context, pod security context, resources, cache,
-                  nodeSelector/tolerations/affinity, Job TTL) inherited by **every** mover this
-                  repository spawns — bootstrap, backup, restore, maintenance — overridable
-                  per-recipe via `mover` and merged field-wise (ADR-0004 §1/§2). Absorbs the
-                  former `cacheDefaults` (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1657,7 +1475,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1675,7 +1493,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1693,9 +1511,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1862,31 +1678,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -1991,23 +1796,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2016,10 +1809,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2068,36 +1858,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history, release ownership) or `Delete`
-                  (cascade per-`Snapshot` `deletionPolicy`). BREAKING default change in
-                  ADR-0005 §5 — `kubectl delete ns` no longer destroys snapshots by default.
-                  Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server, exposed via a `Service` in this Repository's
-                  own namespace. Presence means enabled. ADR §3.1 (server addendum).
+                description: Optional kopia web-UI server, exposed via a `Service` in this namespace.
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2108,9 +1886,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2118,10 +1894,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2147,15 +1920,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2285,13 +2050,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2465,9 +2224,7 @@ spec:
                     type: object
                 type: object
               suspend:
-                description: |-
-                  Pause this repository declaratively (ADR-0005 §14(e)): a suspended repository
-                  skips connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - backend
@@ -2483,9 +2240,7 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: |-
-              Observed state of a [`Repository`]. Carries resolved values pinned by the
-              reconciler. ADR §3.1 status.
+            description: Observed state of a `Repository`, carrying resolved values pinned by the reconciler.
             nullable: true
             properties:
               backend:
@@ -2507,7 +2262,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.1.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2569,15 +2324,11 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
-                description: Resolved kopia server endpoint/auth, pinned by the reconciler. ADR §3.1.
+                description: Resolved kopia server endpoint/auth, pinned by the reconciler.
                 nullable: true
                 properties:
                   authMode:
@@ -2596,24 +2347,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2622,12 +2367,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer
@@ -2701,15 +2441,10 @@ spec:
         description: Auto-generated derived type for ClusterRepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A shared kopia repository referenceable from allow-listed namespaces. ADR §3.2.
-
-              Cluster-scoped: note the absence of `namespaced` in `#[kube(...)]`. Secret/config
-              references in `backend`/`encryption` therefore MUST carry an explicit `namespace`
-              (webhook-enforced — the type system cannot express that requirement here).
+            description: A cluster-scoped kopia repository referenceable from allow-listed namespaces.
             properties:
               allowedNamespaces:
-                description: Tenancy gate — webhook-enforced on every consumer CR. ADR §3.2.
+                description: Which namespaces are permitted to reference this repository.
                 oneOf:
                 - required:
                   - list
@@ -2719,7 +2454,7 @@ spec:
                   - all
                 properties:
                   all:
-                    description: Allow all namespaces (must be `true`; `false` is meaningless and rejected by webhook).
+                    description: Allow all namespaces (must be `true`).
                     type: boolean
                   list:
                     description: Explicit namespace names.
@@ -2758,7 +2493,7 @@ spec:
                     type: object
                 type: object
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -2785,37 +2520,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -2839,24 +2562,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -2880,10 +2597,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -2925,37 +2639,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -2986,9 +2688,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -3006,41 +2706,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -3070,9 +2758,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -3085,16 +2771,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -3104,24 +2784,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -3153,24 +2827,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -3185,65 +2853,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog. For a shared repo this also picks where to land discovered snapshots
-                  via `catalog.fallbackNamespace`. ADR §3.1/§3.2.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Same semantics as
-                  `Repository.spec.create`. ADR §3.1/§3.2.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -3258,64 +2900,45 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               credentialProjection:
-                description: |-
-                  Repository-owner gate for credential-Secret projection into a foreign consumer
-                  namespace. **Default off** (`allowed: false`): a consumer's
-                  `credentialProjection.enabled` is necessary but not sufficient — the
-                  `ClusterRepository` owner must also allow it. BREAKING (ADR-0005 §8). A
-                  namespaced `Repository` has no such gate (projection there is a same-namespace
-                  no-op).
+                description: Repository-owner gate for projecting credential Secrets into a foreign consumer namespace.
                 nullable: true
                 properties:
                   allowed:
                     default: false
-                    description: |-
-                      When `true`, the repository owner permits projecting this repository's
-                      credential Secret(s) into a foreign consumer namespace (still requires the
-                      consumer opt-in AND operator RBAC — fail-closed). Off by default.
+                    description: When `true`, the owner permits projecting this repository's credential Secret(s) into a consumer namespace.
                     type: boolean
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. As this CR is cluster-scoped,
-                  the ref MUST carry an explicit `namespace` (webhook-enforced). ADR §3.1/§3.2.
+                description: Repository password (a Secret reference that must carry an explicit `namespace`).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -3325,90 +2948,58 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13), shared with `Repository` — see
-                  [`RepositoryHealthSpec`]. Tunes the index-blob-count warning. Absent uses
-                  the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               identityDefaults:
-                description: |-
-                  Identity defaults (CEL `*Expr`) applied when consumers don't override.
-                  ADR §3.2 / ADR-0004 §5.
+                description: Identity defaults (CEL `*Expr`) applied when consumers don't override.
                 nullable: true
                 properties:
                   hostnameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *hostname* (e.g. `"namespace"`).
-                      Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity hostname (e.g. `"namespace"`).
                     nullable: true
                     type: string
                   usernameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *username*
-                      (e.g. `"namespace + '-' + policyName"`). Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity username (e.g. `"namespace + '-' + policyName"`).
                     nullable: true
                     type: string
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this cluster repository.
-                  As `Maintenance` is namespaced, `maintenance.namespace` selects where it
-                  lands (defaulting to the operator's namespace). ADR §3.2/§3.7.
+                description: Maintenance control; `maintenance.namespace` selects where the owned `Maintenance` CR lands.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -3430,7 +3021,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -3442,11 +3033,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -3455,26 +3042,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -3515,12 +3091,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -3650,7 +3221,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -3691,10 +3262,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -3799,65 +3367,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -3887,20 +3437,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  cluster repository serves restores only — backups and maintenance are refused.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults inherited by **every** mover this repository spawns — bootstrap,
-                  consumer backup/restore, and maintenance — overridable per-recipe and merged
-                  field-wise (ADR-0004 §1/§2). Absorbs the former `cacheDefaults`
-                  (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -4406,7 +3949,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -4424,7 +3967,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -4442,9 +3985,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -4611,31 +4152,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -4740,23 +4270,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -4765,10 +4283,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -4817,34 +4332,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history) or `Delete` (cascade). BREAKING
-                  default change in ADR-0005 §5. Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server. Cluster-scoped, so the target `namespace` is
-                  required (see [`ClusterServerSpec`]). Presence means enabled.
+                description: Optional kopia web-UI server (the target `namespace` is required).
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -4855,9 +4360,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -4865,10 +4368,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -4897,15 +4397,7 @@ spec:
                     description: Target namespace for the server Deployment/Service (and generated Secret).
                     type: string
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -5035,13 +4527,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -5217,9 +4703,7 @@ spec:
                 - namespace
                 type: object
               suspend:
-                description: |-
-                  Pause this cluster repository declaratively (ADR-0005 §14(e)): skips
-                  connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this cluster repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - allowedNamespaces
@@ -5236,11 +4720,11 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: Mirrors `RepositoryStatus` (ADR §3.1) plus `allowedNamespaceCount`. ADR §3.2.
+            description: Observed state of a `ClusterRepository`; mirrors `RepositoryStatus` plus `allowedNamespaceCount`.
             nullable: true
             properties:
               allowedNamespaceCount:
-                description: Number of namespaces currently resolved by `spec.allowedNamespaces`. ADR §3.2.
+                description: Number of namespaces currently resolved by `spec.allowedNamespaces`.
                 format: int64
                 nullable: true
                 type: integer
@@ -5263,7 +4747,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.2.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -5325,11 +4809,7 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
@@ -5352,24 +4832,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -5378,12 +4852,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer
@@ -5453,70 +4922,42 @@ spec:
         description: Auto-generated derived type for SnapshotPolicySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              *What* to back up: sources, identity, retention, policy, hooks. ADR §3.3.
-
-              Not `Eq`: transitively embeds k8s-openapi types via `mover` and `hooks` (`JobSpec`).
+            description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
               compression:
-                description: Compression algorithm + per-extension opt-outs. ADR §3.3 (G12).
+                description: Compression algorithm + per-extension opt-outs.
                 nullable: true
                 properties:
                   compressor:
-                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default. ADR §3.3.
+                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default.
                     nullable: true
                     type: string
                   neverCompress:
-                    description: Filename globs to leave uncompressed (e.g. already-compressed media). ADR §3.3.
+                    description: Filename globs to leave uncompressed (e.g. already-compressed media).
                     items:
                       type: string
                     type: array
                 type: object
               copyMethod:
                 default: Direct
-                description: |-
-                  How the source volume is captured before kopia reads it: `Direct` (read the live
-                  PVC, the **default** — works on any storage), `Snapshot` (point-in-time CSI
-                  snapshot, opt-in), or `Clone` (CSI clone, opt-in). ADR §3.3 / [Copy methods].
-
-                  Carries a real OpenAPI `default: Direct` so it materializes into the stored object
-                  and `kubectl explain`, and GitOps engines stop diff-thrashing on a controller-set
-                  value. A bare value (not `Option`) so the default is never dropped by
-                  `skip_serializing_if`.
-
-                  [Copy methods]: https://github.com/home-operations/kopiur/blob/main/docs/copy-methods.md
+                description: 'How the source volume is captured before kopia reads it: `Direct` (default), `Snapshot`, or `Clone`.'
                 enum:
                 - Snapshot
                 - Clone
                 - Direct
                 type: string
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this recipe's backup movers
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace where each backup
-                  mover runs (a no-op when they already live there) — so a workload backing
-                  up to a shared `ClusterRepository` need not pre-create the Secret in its
-                  own namespace. Inherited by `Snapshot`s produced from this config. ADR §4.11.
+                description: Opt-in credential-Secret projection into each backup mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               defaultDeletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -5534,11 +4975,7 @@ spec:
                 nullable: true
                 type: string
               errorHandling:
-                description: |-
-                  Backup-side error handling — the missing analog of restore's
-                  `ignorePermissionErrors`. Lets a snapshot complete-with-errors instead of
-                  failing outright (`--ignore-file-errors` / `--ignore-dir-errors` /
-                  `--ignore-unknown-types`). ADR-0005 §13(b).
+                description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
                   ignoreDirErrors:
@@ -5552,24 +4989,22 @@ spec:
                     type: boolean
                 type: object
               extraArgs:
-                description: Escape hatch for kopia flags not yet modeled. ADR §3.3 (G12).
+                description: Escape hatch for kopia flags not yet modeled.
                 items:
                   type: string
                 type: array
               files:
-                description: Paths/patterns kopia should skip while snapshotting. ADR §3.3 (G12).
+                description: Paths/patterns kopia should skip while snapshotting.
                 nullable: true
                 properties:
                   ignoreCacheDirs:
                     description: Honor `CACHEDIR.TAG`.
                     type: boolean
                   ignoreIdenticalSnapshots:
-                    description: 'fork issue #13.'
+                    description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: |-
-                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`,
-                      `*/cache/*`, `lost+found`). ADR §3.3.
+                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
                     items:
                       type: string
                     type: array
@@ -5594,13 +5029,11 @@ spec:
                 nullable: true
                 type: string
               hooks:
-                description: Pre/post snapshot hooks that run in the workload, not the mover. ADR §4.8 (G13).
+                description: Pre/post snapshot hooks that run in the workload, not the mover.
                 nullable: true
                 properties:
                   afterSnapshot:
-                    description: |-
-                      Hooks run (in order) after the snapshot completes — e.g. resuming the
-                      workload. ADR §4.8.
+                    description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -5639,39 +5072,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -10682,19 +10110,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -10703,7 +10129,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -10736,7 +10162,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -10745,9 +10171,7 @@ spec:
                       type: object
                     type: array
                   beforeSnapshot:
-                    description: |-
-                      Hooks run (in order) before the snapshot is taken — e.g. quiescing a
-                      database. ADR §4.8.
+                    description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -10786,39 +10210,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -15829,19 +15248,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -15850,7 +15267,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -15883,7 +15300,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -15893,26 +15310,20 @@ spec:
                     type: array
                 type: object
               identity:
-                description: Identity overrides — what kopia records as `username@hostname:path`. ADR §3.3/§4.2.
+                description: Identity overrides — what kopia records as `username@hostname:path`.
                 nullable: true
                 properties:
                   hostname:
-                    description: |-
-                      Override the `hostname` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      namespace). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `hostname` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                   username:
-                    description: |-
-                      Override the `username` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      object name). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `username` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                 type: object
               mover:
-                description: Per-recipe mover overrides (resources, cache, security context). ADR §3.3.
+                description: Per-recipe mover overrides (resources, cache, security context).
                 nullable: true
                 properties:
                   cache:
@@ -15934,7 +15345,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -15946,11 +15357,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -15959,26 +15366,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -16019,12 +15415,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -16154,7 +15545,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -16195,10 +15586,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -16303,17 +15691,13 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Discriminated reference to a `Repository` or `ClusterRepository`.
                 properties:
                   kind:
                     default: Repository
@@ -16333,7 +15717,7 @@ spec:
                 - name
                 type: object
               retention:
-                description: GFS retention — enforced by the operator pruning `Snapshot` CRs. ADR §4.4.
+                description: GFS retention, enforced by the operator pruning `Snapshot` CRs.
                 nullable: true
                 properties:
                   keepAnnual:
@@ -16374,28 +15758,12 @@ spec:
                     type: integer
                 type: object
               sources:
-                description: |-
-                  What to back up. At least one source; webhook-enforced. ADR §3.3.
-
-                  `maxItems` is set so the apiserver can bound the cost of the per-item
-                  `x-kubernetes-validations` exactly-one-of rule on [`Source`] (CEL rule cost is
-                  `rule_cost × maxItems`; without a bound the apiserver assumes a huge array and
-                  rejects the CRD as over budget). 100 sources per recipe is far past any real
-                  use.
+                description: What to back up (at least one source; webhook-enforced).
                 items:
-                  description: |-
-                    A single backup source. `pvc`, `pvcSelector`, and `nfs` are mutually exclusive
-                    (webhook-enforced — NOT an enum, because the forms share the sibling
-                    `sourcePath*` keys and YAML lists them as optional siblings). ADR §3.3.
-
-                    §15: an operator-authored `x-kubernetes-validations` rule enforces exactly-one-of
-                    in the apiserver + CI, complementing `validate_source`.
+                  description: A single backup source; exactly one of `pvc`, `pvcSelector`, `nfs` (webhook-enforced).
                   properties:
                     nfs:
-                      description: |-
-                        An inline NFS export to back up directly — no PVC. Mounted read-only at the
-                        source path (default: the export's `path`). Mutually exclusive with
-                        `pvc`/`pvcSelector`. ADR §3.3.
+                      description: An inline NFS export to back up directly, mounted read-only. Mutually exclusive with `pvc`/`pvcSelector`.
                       nullable: true
                       properties:
                         path:
@@ -16409,25 +15777,21 @@ spec:
                       - server
                       type: object
                     pvc:
-                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`. ADR §3.3.
+                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`.
                       nullable: true
                       properties:
                         name:
-                          description: |-
-                            Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s
-                            namespace). ADR §3.3.
+                          description: Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s namespace).
                           type: string
                       required:
                       - name
                       type: object
                     pvcSelector:
-                      description: |-
-                        Label/namespace selector matching many PVCs (multi-PVC sources).
-                        Mutually exclusive with `pvc`/`nfs`. ADR §3.3/§5.4.
+                      description: Label/namespace selector matching many PVCs. Mutually exclusive with `pvc`/`nfs`.
                       nullable: true
                       properties:
                         labelSelector:
-                          description: Standard Kubernetes label selector matching the PVCs to include. ADR §3.3/§5.4.
+                          description: Standard Kubernetes label selector matching the PVCs to include.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -16458,28 +15822,18 @@ spec:
                               type: object
                           type: object
                         namespaceSelector:
-                          description: |-
-                            Restricts the search to specific namespaces; absent means the
-                            `SnapshotPolicy`'s own namespace. ADR §3.3/§5.4.
+                          description: Restricts the search to specific namespaces; absent means the policy's own namespace.
                           nullable: true
                           properties:
                             matchNames:
-                              description: |-
-                                Exact namespace names to search; empty means the `SnapshotPolicy`'s own
-                                namespace. ADR §3.3/§5.4.
+                              description: Exact namespace names to search; empty means the policy's own namespace.
                               items:
                                 type: string
                               type: array
                           type: object
                       type: object
                     sourcePathOverride:
-                      description: |-
-                        What kopia records as the source path (default `/pvc/<name>` for a PVC, or
-                        the NFS export `path` for an NFS source). ADR §3.3/§4.2.
-
-                        `maxLength` bounds the per-item cost of the exactly-one-of CEL rule on this
-                        struct (an unbounded string makes the apiserver assume a huge value and blow
-                        the rule's cost budget). A filesystem path is far shorter than 4096.
+                      description: What kopia records as the source path (default `/pvc/<name>`, or the NFS export `path`).
                       maxLength: 4096
                       nullable: true
                       type: string
@@ -16511,15 +15865,10 @@ spec:
                 maxItems: 100
                 type: array
               suspend:
-                description: |-
-                  Pause this recipe declaratively: a suspended `SnapshotPolicy` is skipped by
-                  schedules and by its own reconcile (no retention prune, no backup creation),
-                  surfaced via a condition/column. ADR-0005 §14(e).
+                description: Pause this recipe declaratively (schedules and reconcile skip a suspended policy).
                 type: boolean
               upload:
-                description: |-
-                  Upload parallelism (kopia's upload policy: `--max-parallel-snapshots`,
-                  `--max-parallel-file-reads`). ADR-0005 §13(f).
+                description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
                   maxParallelFileReads:
@@ -16534,88 +15883,57 @@ spec:
                     type: integer
                 type: object
               verification:
-                description: |-
-                  First-class backup verification (ADR-0005 §4). Opt-in: when absent, no
-                  verification runs (no behavior change). When set, the controller schedules
-                  periodic `kopia snapshot verify` (quick) and/or a scratch-restore test (deep),
-                  gated by an optional CEL `successExpr` predicate over the result, and surfaces
-                  `status.lastVerified`.
+                description: First-class backup verification; opt-in (absent ⇒ no verification runs).
                 nullable: true
                 properties:
                   deep:
-                    description: |-
-                      Schedule + knobs for the rarer scratch-restore restorability test. Absent ⇒
-                      no deep verification.
+                    description: Schedule + knobs for the rarer scratch-restore test; absent ⇒ no deep verification.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `10Gi`). When set, the operator
-                          mounts a fresh generic-ephemeral PVC of this size at the scratch path
-                          (auto-deleted with the Job) — size it to comfortably hold the restored
-                          snapshot. When absent, scratch falls back to a node-ephemeral `emptyDir`
-                          (zero-config, but bounded by node disk).
+                        description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set (an `emptyDir` has no StorageClass).
+                        description: StorageClass for the ephemeral scratch PVC; absent uses the cluster default (only with `capacity`).
                         nullable: true
                         type: string
                     required:
                     - schedule
                     type: object
                   quick:
-                    description: |-
-                      Schedule for the frequent blob-level `kopia snapshot verify`. Absent ⇒ no
-                      quick verification.
+                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
                     nullable: true
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   successExpr:
-                    description: |-
-                      A CEL pass/fail predicate over the verify result (ADR-0005 §15). Environment:
-                      `stats{files,bytes,errors}`, `snapshot`, and (deep only) `restored{files,
-                      checksumMatches}`. Returns a bool; when it evaluates `false` the verification
-                      run fails. Validated at admission (`validate_success_expr`). Applies to both
-                      tiers. Example: `"stats.files > 0 && stats.errors == 0"`.
+                    description: CEL pass/fail predicate over the verify result; applies to both tiers.
                     nullable: true
                     type: string
                   verifyFilesPercent:
-                    description: |-
-                      How many files `quick` verifies fully (`--verify-files-percent`); absent
-                      leaves kopia's default. Tuning knob for the quick tier.
+                    description: How many files `quick` verifies fully (`--verify-files-percent`); absent leaves kopia's default.
                     format: uint8
                     maximum: 255.0
                     minimum: 0.0
@@ -16623,22 +15941,18 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: |-
-                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.
-                  ADR §3.3.
+                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
                 nullable: true
                 type: string
             required:
             - repository
             type: object
           status:
-            description: Observed state of a [`SnapshotPolicy`]. ADR §3.3 status.
+            description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `RepositoryReachable`,
-                  `GroupSnapshotSupported`). ADR §3.3 status.
+                description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -16671,29 +15985,24 @@ spec:
                   type: object
                 type: array
               lastSuccessfulSnapshot:
-                description: |-
-                  RFC3339 timestamp of the most recent successful child `Snapshot` produced
-                  from this recipe. Backs the `LAST-SNAPSHOT` printer column and the
-                  `prometheusRule` staleness alert (ADR-0005 §3).
+                description: RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe.
                 nullable: true
                 type: string
               lastVerified:
-                description: |-
-                  RFC3339 timestamp of the most recent successful verification (any tier),
-                  ADR-0005 §4. Backs the `kopiur_snapshot_verified_timestamp_seconds` gauge.
+                description: RFC3339 timestamp of the most recent successful verification (any tier).
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.3 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
               resolved:
-                description: What would be passed to kopia — pinned at admission. ADR §3.3/§4.2.
+                description: What would be passed to kopia — pinned at admission.
                 nullable: true
                 properties:
                   identity:
-                    description: The resolved `username@hostname` identity. ADR §3.3/§4.2.
+                    description: The resolved `username@hostname` identity.
                     nullable: true
                     properties:
                       hostname:
@@ -16711,38 +16020,36 @@ spec:
                     - username
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths after selector expansion. ADR §3.3 status.
+                    description: The concrete PVCs + source paths after selector expansion.
                     items:
-                      description: One resolved source — a concrete PVC and the path kopia records for it. ADR §3.3 status.
+                      description: One resolved source — a concrete PVC and the path kopia records for it.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.3 status.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia records for this PVC. ADR §3.3/§4.2.
+                          description: The source path kopia records for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               retention:
-                description: |-
-                  Summary of GFS retention pruning against this config's `Snapshot` CRs.
-                  ADR §3.3 status/§4.4.
+                description: Summary of GFS retention pruning against this config's `Snapshot` CRs.
                 nullable: true
                 properties:
                   activeSnapshotCount:
-                    description: CRs currently inside the GFS window. ADR §3.3 status.
+                    description: CRs currently inside the GFS window.
                     format: int64
                     nullable: true
                     type: integer
                   lastPruneAt:
-                    description: RFC3339 timestamp of the last prune pass. ADR §3.3 status.
+                    description: RFC3339 timestamp of the last prune pass.
                     nullable: true
                     type: string
                   lastPruneDeleted:
-                    description: Number of `Snapshot` CRs deleted by the last prune pass. ADR §3.3 status/§4.4.
+                    description: Number of `Snapshot` CRs deleted by the last prune pass.
                     format: int64
                     nullable: true
                     type: integer
@@ -16792,22 +16099,11 @@ spec:
         description: Auto-generated derived type for SnapshotSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A single kopia snapshot represented as a Kubernetes object. ADR §3.4.
-
-              For `scheduled`/`manual` backups the spec carries `policyRef` (+ optional
-              overrides). For `discovered` backups the spec is empty — every field is optional.
+            description: A single kopia snapshot represented as a Kubernetes object.
             properties:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -16825,45 +16121,30 @@ spec:
                 nullable: true
                 type: string
               failurePolicy:
-                description: Per-run failure controls passed to the mover `Job`. ADR §3.4 (G6).
+                description: Mover Job retry and deadline limits for this run.
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               pin:
-                description: |-
-                  Pin this snapshot to exempt it from GFS retention (ADR-0005 §13(c)). When
-                  `true` the reconciler applies a kopia snapshot pin and the GFS pruner never
-                  selects it for deletion — for pre-migration / compliance holds. Clearing it
-                  removes the pin. Default `false`.
+                description: Exempt this snapshot from GFS retention.
                 type: boolean
               policyRef:
-                description: The recipe to run. Absent for `discovered` backups. ADR §3.4.
+                description: The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
                 nullable: true
                 properties:
                   name:
@@ -16879,7 +16160,7 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). ADR §3.4.'
+                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
                 nullable: true
                 type: object
             type: object
@@ -16888,9 +16169,7 @@ spec:
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
-                  ADR §3.4 status.
+                description: Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -16923,9 +16202,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -16954,11 +16231,7 @@ spec:
                 - retryRecommended
                 type: object
               hooks:
-                description: |-
-                  Hook-execution bookkeeping (ADR §4.8): completion timestamps the
-                  reconciler stamps so each hook list runs exactly once per Snapshot across
-                  requeues and controller restarts (hooks have side effects — quiesce,
-                  resume — that must not repeat).
+                description: Hook-execution bookkeeping so each hook list runs exactly once per Snapshot.
                 nullable: true
                 properties:
                   postCompletedAt:
@@ -16971,30 +16244,25 @@ spec:
                     type: string
                 type: object
               job:
-                description: Present for scheduled/manual; absent for discovered. ADR §3.4.
+                description: The mover Job backing this run; absent for discovered.
                 nullable: true
                 properties:
                   attempts:
-                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`). ADR §3.4 status.
+                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`).
                     format: int32
                     nullable: true
                     type: integer
                   name:
-                    description: Name of the mover `Job`. ADR §3.4 status.
+                    description: Name of the mover `Job`.
                     nullable: true
                     type: string
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Snapshot created: <id>` line; failure: the
-                  actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
-                  ADR §3.4/§4.10.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.4 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
@@ -17042,20 +16310,15 @@ spec:
                 nullable: true
                 type: string
               pinned:
-                description: |-
-                  The observed kopia-side pin state (ADR-0005 §13(c)): `Some(true)` once the
-                  operator has applied the pin, `Some(false)` once it has removed it, `None`
-                  before any pin reconcile. The reconciler compares `spec.pin` against this to
-                  decide whether to issue a `kopia snapshot pin`/`unpin`, so a redundant op is
-                  never spawned.
+                description: 'The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile.'
                 nullable: true
                 type: boolean
               resolved:
-                description: Frozen recipe values at run time (scheduled/manual). ADR §3.4.
+                description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
                 properties:
                   repository:
-                    description: The repository this run targeted, frozen at run time. ADR §3.4 status.
+                    description: The repository this run targeted, frozen at run time.
                     nullable: true
                     properties:
                       kind:
@@ -17076,27 +16339,27 @@ spec:
                     - name
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths backed up this run. ADR §3.4 status.
+                    description: The concrete PVCs + source paths backed up this run.
                     items:
-                      description: One resolved source backed up by a run — a concrete PVC and its kopia path. ADR §3.4 status.
+                      description: One resolved source backed up by a run — a concrete PVC and its kopia path.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.4.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia recorded for this PVC. ADR §3.4/§4.2.
+                          description: The source path kopia recorded for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               snapshot:
-                description: The kopia artifact this CR represents. ADR §3.4.
+                description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
                   identity:
-                    description: The `username@hostname:path` identity recorded for this snapshot. ADR §3.4/§4.2.
+                    description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:
                       hostname:
                         description: The final `hostname` kopia records, fixed at admission.
@@ -17113,23 +16376,14 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      kopia's snapshot ID — the handle the finalizer uses to delete content.
-
-                      Renamed to match the ADR wire shape exactly (`kopiaSnapshotID`, capital `ID`);
-                      serde's `camelCase` would otherwise produce `kopiaSnapshotId`.
+                    description: kopia's snapshot ID — the handle the finalizer uses to delete content.
                     type: string
                 required:
                 - identity
                 - kopiaSnapshotID
                 type: object
               staged:
-                description: |-
-                  The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`
-                  (ADR §3.3). Pinned once when the stage is provisioned so the reconciler can
-                  (a) reuse the same VolumeSnapshot/PVC across mover-Job retries idempotently
-                  and (b) reap them on the terminal transition. Absent for `Direct` (and NFS),
-                  which mount the live source with no staging.
+                description: 'The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`.'
                 nullable: true
                 properties:
                   copyMethod:
@@ -17137,79 +16391,68 @@ spec:
                     nullable: true
                     type: string
                   pvcName:
-                    description: |-
-                      Name of the staged `PersistentVolumeClaim` the mover mounts in place of the
-                      live source PVC.
+                    description: Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC.
                     nullable: true
                     type: string
                   ready:
-                    description: |-
-                      `true` once the stage is ready for the mover (VolumeSnapshot `readyToUse` and
-                      the staged PVC applied). Before that the reconcile is still provisioning it.
+                    description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
                   volumeSnapshotName:
-                    description: |-
-                      Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot`
-                      only; absent for `Clone`, which stages directly from the source PVC).
+                    description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true
                     type: string
                 type: object
               stats:
-                description: Byte/file counts parsed from kopia's JSON output. ADR §3.4 status.
+                description: Byte/file counts parsed from kopia's JSON output.
                 nullable: true
                 properties:
                   bytesNew:
-                    description: Bytes newly uploaded this run (after dedup/compression). ADR §3.4 status.
+                    description: Bytes newly uploaded this run (after dedup/compression).
                     format: int64
                     nullable: true
                     type: integer
                   filesFailed:
-                    description: |-
-                      Count of source entries kopia could **not** read and therefore EXCLUDED from the
-                      snapshot (`rootEntry.summ.errors`), making it *incomplete*. Present (and `> 0`) only
-                      when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite
-                      unreadable files — the otherwise-silent partial-backup case. The controller surfaces
-                      it as a warning condition + Event. Usually a UID/GID mismatch with the workload.
+                    description: Count of source entries kopia could not read and excluded, making the snapshot incomplete.
                     format: int64
                     nullable: true
                     type: integer
                   filesModified:
-                    description: Count of files changed since the previous snapshot. ADR §3.4 status.
+                    description: Count of files changed since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesNew:
-                    description: Count of files new since the previous snapshot. ADR §3.4 status.
+                    description: Count of files new since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesUnchanged:
-                    description: Count of files unchanged since the previous snapshot. ADR §3.4 status.
+                    description: Count of files unchanged since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   sizeBytes:
-                    description: Total logical size of the snapshot in bytes. ADR §3.4 status.
+                    description: Total logical size of the snapshot in bytes.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               timing:
-                description: Start/end/duration of the snapshot run. ADR §3.4 status.
+                description: Start/end/duration of the snapshot run.
                 nullable: true
                 properties:
                   durationSeconds:
-                    description: Wall-clock duration in seconds. ADR §3.4 status.
+                    description: Wall-clock duration in seconds.
                     format: int64
                     nullable: true
                     type: integer
                   endTime:
-                    description: RFC3339 end time of the run. ADR §3.4 status.
+                    description: RFC3339 end time of the run.
                     nullable: true
                     type: string
                   startTime:
-                    description: RFC3339 start time of the run. ADR §3.4 status.
+                    description: RFC3339 start time of the run.
                     nullable: true
                     type: string
                 type: object
@@ -17258,25 +16501,16 @@ spec:
         description: Auto-generated derived type for SnapshotScheduleSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              Cron + `policyRef`. One source of `Snapshot` CRs; pausing it doesn't affect
-              in-flight or completed runs. ADR §3.5.
+            description: Cron schedule that fires `Snapshot` CRs from a `SnapshotPolicy`.
             properties:
               failedJobsHistoryLimit:
-                description: |-
-                  Bounds *failed* `Snapshot` CRs from this schedule. Successful retention is
-                  GFS-driven on `SnapshotPolicy.spec.retention` — there is deliberately NO
-                  `successfulJobsHistoryLimit` (ADR-0003 §4.4, ADR-0001 §4.4).
+                description: Maximum number of failed `Snapshot` CRs from this schedule to retain.
                 format: uint32
                 minimum: 0.0
                 nullable: true
                 type: integer
               policyRef:
-                description: |-
-                  The single `SnapshotPolicy` (recipe) this schedule invokes; resolved in the
-                  schedule's own namespace. ADR §3.5 separates recipe from schedule. **Mutually
-                  exclusive** with `policySelector` — exactly one is required (webhook-enforced,
-                  ADR-0005 §10). Optional at the type level so `policySelector` can be used instead.
+                description: The single `SnapshotPolicy` this schedule invokes; mutually exclusive with `policySelector`.
                 nullable: true
                 properties:
                   name:
@@ -17290,11 +16524,7 @@ spec:
                 - name
                 type: object
               policySelector:
-                description: |-
-                  Fan-out form (ADR-0005 §10): a label selector over `SnapshotPolicy` objects in
-                  the schedule's namespace. Each matching policy gets a `Snapshot` per firing
-                  ("back up everything tagged `tier=critical` nightly" in one object). **Mutually
-                  exclusive** with `policyRef`. Mirrors the `pvcSelector` pattern.
+                description: Label selector fanning out over `SnapshotPolicy` objects; mutually exclusive with `policyRef`.
                 nullable: true
                 properties:
                   matchExpressions:
@@ -17325,50 +16555,37 @@ spec:
                     type: object
                 type: object
               schedule:
-                description: Cron, jitter, timezone, and concurrency for the firing cadence. ADR §3.5.
+                description: Cron, jitter, timezone, and concurrency for the firing cadence.
                 properties:
                   concurrencyPolicy:
                     default: Forbid
-                    description: |-
-                      How to handle a firing while a prior run is still in flight. ADR §4.1.
-
-                      Carries a real OpenAPI `default: Forbid` (ADR-0005 §1) — unconditional, so it
-                      materializes into the stored object / `kubectl explain`.
+                    description: How to handle a firing while a prior run is still in flight (default `Forbid`).
                     enum:
                     - Forbid
                     - Allow
                     - Replace
                     type: string
                   cron:
-                    description: Cron expression with Jenkins-style `H` substitution. ADR §4.1 (G4).
+                    description: Cron expression with Jenkins-style `H` substitution.
                     type: string
                   jitter:
-                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`. ADR §4.1.
+                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`.
                     nullable: true
                     type: string
                   runOnCreate:
                     default: false
-                    description: |-
-                      GitOps-friendly default: do NOT fire immediately on create. ADR §4.1 (G3).
-
-                      Carries a real OpenAPI `default: false` (ADR-0005 §1) so it materializes into
-                      the stored object / `kubectl explain` and GitOps stops diff-thrashing. NOT
-                      `skip_serializing_if`-elided, so the materialized value round-trips.
+                    description: Whether to fire immediately on create (default `false`).
                     type: boolean
                   startingDeadlineSeconds:
-                    description: |-
-                      If a slot is missed by more than this many seconds (e.g. operator was
-                      down), skip it instead of firing late. ADR §4.1.
+                    description: If a slot is missed by more than this many seconds, skip it instead of firing late.
                     format: int64
                     nullable: true
                     type: integer
                   suspend:
-                    description: Skip future firings while true. ADR §5.9.
+                    description: Skip future firings while true.
                     type: boolean
                   timezone:
-                    description: |-
-                      IANA timezone the cron is evaluated in (e.g. `America/Los_Angeles`).
-                      Absent means the controller's configured default. ADR §4.1.
+                    description: IANA timezone the cron is evaluated in; absent uses the controller's default.
                     nullable: true
                     type: string
                 required:
@@ -17381,11 +16598,11 @@ spec:
             - message: exactly one of policyRef or policySelector
               rule: '[has(self.policyRef), has(self.policySelector)].filter(x, x).size() == 1'
           status:
-            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run. ADR §3.5.'
+            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing schedule health. ADR §5 status conventions.
+                description: Standard Kubernetes conditions surfacing schedule health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -17418,19 +16635,16 @@ spec:
                   type: object
                 type: array
               consecutiveFailures:
-                description: Count of back-to-back failed runs; resets on success. Drives alerting.
+                description: Count of back-to-back failed runs; resets on success.
                 format: int64
                 nullable: true
                 type: integer
               lastSchedule:
-                description: Most recent firing (cron + jitter, pinned). ADR §3.5.
+                description: Most recent firing (cron + jitter, pinned).
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -17445,14 +16659,11 @@ spec:
                     type: object
                 type: object
               lastSuccessfulSchedule:
-                description: The most recent firing whose `Snapshot` succeeded. ADR §3.5.
+                description: The most recent firing whose `Snapshot` succeeded.
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -17471,10 +16682,7 @@ spec:
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -17536,69 +16744,40 @@ spec:
         properties:
           spec:
             description: |-
-              A restore operation. `target` is **required** (ADR-0005 §9): explicit
-              `pvc`/`pvcRef`, or `populator: {}` for passive populator mode (consumed by a
-              PVC's `spec.dataSourceRef`). The empty-`target` form is removed. ADR §3.6/§4.7.
-              Desired state of a [`Restore`]: where to read from, where to write to, and how
-              to behave when the snapshot is missing. ADR §3.6/§4.6.
+              A restore operation from a snapshot/identity into a PVC, or a passive populator source.
+              Desired state of a Restore: where to read from, where to write to, and how to behave when the snapshot is missing.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this restore's mover (default off).
-                  When `enabled: true`, the operator copies the referenced repository's
-                  credential Secret(s) into the restore mover's namespace (a no-op when they
-                  already live there) — so restoring from a shared `ClusterRepository` into a
-                  fresh namespace need not pre-create the Secret there. ADR §4.11.
+                description: Opt-in copying of the repository's credential Secret(s) into the mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: |-
-                  Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`),
-                  mirroring `Snapshot.spec.failurePolicy`. Absent uses the ADR defaults.
+                description: Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Per-run mover overrides for this restore's Job — resource requests/limits,
-                  kopia cache sizing, container `securityContext` (UID/GID match), `privilegedMode`,
-                  and `inheritSecurityContextFrom`. The same surface `SnapshotPolicy.spec.mover`
-                  gives a backup. An elevated context is namespace-gated exactly like a backup's
-                  (ADR §4.11/§G16); `securityContext` and `inheritSecurityContextFrom` are
-                  mutually exclusive.
+                description: Per-run mover overrides for this restore's Job (resources, cache, `securityContext`).
                 nullable: true
                 properties:
                   cache:
@@ -17620,7 +16799,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -17632,11 +16811,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -17645,26 +16820,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -17705,12 +16869,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -17840,7 +16999,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -17881,10 +17040,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -17989,35 +17145,29 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               options:
-                description: kopia restore behavior (file deletion, permission/atomicity handling). ADR §4.6.
+                description: kopia restore behavior (file deletion, permission/atomicity handling).
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: |-
-                      Delete files in the target that are not present in the snapshot (make the
-                      target an exact mirror). Off by default — additive restore is the safe default.
+                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
                     type: boolean
                   ignorePermissionErrors:
-                    description: Default true; surfaces a condition if any errors occurred. ADR §4.6.
+                    description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
                   writeFilesAtomically:
-                    description: Default true. ADR §4.6.
+                    description: Write files atomically via a temp file + rename (default true).
                     nullable: true
                     type: boolean
                 type: object
               policy:
-                description: Missing-snapshot handling and wait timeout. ADR §4.6 (G7).
+                description: What to do when the referenced snapshot doesn't exist yet, and how long to wait.
                 nullable: true
                 properties:
                   onMissingSnapshot:
@@ -18037,14 +17187,12 @@ spec:
                     nullable: true
                     type: string
                   waitTimeout:
-                    description: |-
-                      How long to wait for the source snapshot to appear before giving up
-                      (Go-style duration string, e.g. `5m`).
+                    description: How long to wait for the source snapshot to appear before giving up (e.g. `5m`).
                     nullable: true
                     type: string
                 type: object
               repository:
-                description: Derived from `source` when omitted; REQUIRED only with `source.identity`. ADR §3.6/§4.6.
+                description: The repository to read from; derived from `source` when omitted, required only with `source.identity`.
                 nullable: true
                 properties:
                   kind:
@@ -18065,7 +17213,7 @@ spec:
                 - name
                 type: object
               source:
-                description: Exactly one source mode; webhook-enforced. ADR §3.6.
+                description: Where to read data from (snapshotRef, fromPolicy, or identity).
                 oneOf:
                 - required:
                   - snapshotRef
@@ -18075,9 +17223,7 @@ spec:
                   - identity
                 properties:
                   fromPolicy:
-                    description: |-
-                      A `SnapshotPolicy` CR — resolves via identity even with no `Snapshot` CR present
-                      (deploy-or-restore). Default `onMissingSnapshot: Continue`. ADR §4.6.
+                    description: A `SnapshotPolicy` CR, resolved via identity even with no `Snapshot` CR present (deploy-or-restore).
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -18092,19 +17238,14 @@ spec:
                         type: string
                       offset:
                         default: 0
-                        description: |-
-                          0 = latest, 1 = previous, ... ADR §3.6.
-
-                          Carries a real OpenAPI `default: 0` (ADR-0005 §1): unconditional, so it
-                          materializes into the stored object / `kubectl explain` and GitOps stops
-                          diff-thrashing. A bare `i64` (not `Option`) so the default is never dropped.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         type: integer
                     required:
                     - name
                     type: object
                   identity:
-                    description: A raw kopia identity (foreign writers / aged-out catalog). Requires `spec.repository`.
+                    description: A raw kopia identity (foreign writers / aged-out catalog); requires `spec.repository`.
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -18114,14 +17255,12 @@ spec:
                         description: The kopia `hostname` to match.
                         type: string
                       offset:
-                        description: 0 = latest, 1 = previous, ... mutually exclusive with `snapshotID`/`asOf` in practice.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         nullable: true
                         type: integer
                       snapshotID:
-                        description: |-
-                          Pin an exact kopia snapshot by ID. Renamed to match the ADR wire shape
-                          exactly (`snapshotID`, capital `ID`).
+                        description: Pin an exact kopia snapshot by ID.
                         nullable: true
                         type: string
                       sourcePath:
@@ -18136,7 +17275,7 @@ spec:
                     - username
                     type: object
                   snapshotRef:
-                    description: A `Snapshot` CR (scheduled, manual, or discovered — all the same kind). Default mode.
+                    description: A `Snapshot` CR (scheduled, manual, or discovered).
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -18150,11 +17289,7 @@ spec:
                     type: object
                 type: object
               target:
-                description: |-
-                  Where to restore to — **required** (ADR-0005 §9): `pvc` (operator creates),
-                  `pvcRef` (existing PVC), or `populator: {}` (passive populator mode, claimed
-                  via a PVC's `spec.dataSourceRef`). The former empty-`target` form is removed;
-                  a `Restore` with no `target` is now invalid (deserialization fails).
+                description: Where to write the restored data (pvc, pvcRef, or populator).
                 oneOf:
                 - required:
                   - pvc
@@ -18164,10 +17299,7 @@ spec:
                   - populator
                 properties:
                   populator:
-                    description: |-
-                      Passive populator mode: no workload target at provision time — the restore is
-                      claimed by a PVC's `spec.dataSourceRef` (ADR-0005 §9). An (empty) sub-object so
-                      future populator knobs slot in without API breakage.
+                    description: 'Passive populator mode: the restore is claimed by a PVC''s `spec.dataSourceRef`.'
                     type: object
                   pvc:
                     description: Operator creates the PVC.
@@ -18213,7 +17345,7 @@ spec:
             - message: exactly one of target.pvc, target.pvcRef, target.populator
               rule: '[has(self.target.pvc), has(self.target.pvcRef), has(self.target.populator)].filter(x, x).size() == 1'
           status:
-            description: Observed state of a [`Restore`], written by the controller/mover. ADR §3.6 status.
+            description: Observed state of a Restore, written by the controller/mover.
             nullable: true
             properties:
               conditions:
@@ -18250,9 +17382,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -18281,11 +17411,7 @@ spec:
                 - retryRecommended
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Restore completed: snapshot <id>` line; failure:
-                  the actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
@@ -18294,7 +17420,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: Lifecycle phase of a restore. Closed enum. ADR §3.6 status.
+                description: Lifecycle phase of a restore.
                 enum:
                 - Pending
                 - Resolving
@@ -18319,7 +17445,7 @@ spec:
                     type: integer
                 type: object
               resolved:
-                description: Pinned at admission; never re-resolved. ADR §3.6/§4.6.
+                description: The source resolved and pinned at admission; never re-resolved.
                 nullable: true
                 properties:
                   identity:
@@ -18341,11 +17467,7 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      The exact kopia snapshot manifest id the source resolved to. Pinned once;
-                      subsequent reconciles restore THIS id even if newer snapshots appear, so a
-                      restore never silently retargets (ADR §4.6). Matches
-                      `Snapshot.status.snapshot.kopiaSnapshotID`.
+                    description: The exact kopia snapshot manifest id the source resolved to; pinned once.
                     nullable: true
                     type: string
                   pinnedAt:
@@ -18374,15 +17496,7 @@ spec:
                     - name
                     type: object
                   resolution:
-                    description: |-
-                      Which outcome the source resolution pinned. Closed enum so the decision is a
-                      single, exhaustively-matched value rather than an inferred combination of optional
-                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
-                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
-                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
-                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
-                      snapshot id, so a later-appearing snapshot can never silently retarget an
-                      already-provisioned volume (ADR §4.6).
+                    description: Which outcome the source resolution pinned, once and never re-resolved.
                     enum:
                     - Snapshot
                     - NoSnapshot
@@ -18404,10 +17518,7 @@ spec:
                     type: object
                 type: object
               sourceKind:
-                description: |-
-                  The pinned source kind (`RestoreSource::kind_str` — `SnapshotRef`/`FromPolicy`/
-                  `Identity`), set by the reconciler. Backs the `SOURCE` printer column so
-                  `kubectl get restores` shows where a restore reads from. ADR-0005 §3.
+                description: The pinned source kind (`SnapshotRef`/`FromPolicy`/`Identity`); backs the `SOURCE` printer column.
                 nullable: true
                 type: string
               target:
@@ -18415,7 +17526,7 @@ spec:
                 nullable: true
                 properties:
                   pvcPrime:
-                    description: Populator handshake (passive / pvc-create modes). ADR §3.6.
+                    description: Populator handshake (passive / pvc-create modes).
                     nullable: true
                     type: string
                   pvcRef:
@@ -18489,61 +17600,41 @@ spec:
         properties:
           spec:
             description: |-
-              Maintenance schedule + ownership lease for one `Repository`/`ClusterRepository`. ADR §3.7.
+              Maintenance schedule and ownership lease for one `Repository`/`ClusterRepository`.
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this maintenance run's mover
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace this `Maintenance`
-                  runs in (a no-op when they already live there) — useful when maintaining a
-                  shared `ClusterRepository` from a namespace that lacks the Secret. ADR §4.11.
+                description: Opt-in projection of the repository's credential Secret(s) into this run's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: How a failed maintenance run is retried/bounded (backoff, deadline). ADR §3.7.
+                description: How a failed maintenance run is retried and bounded (backoff, deadline).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the maintenance run — resources, scheduling,
-                  etc. Object-store repositories typically tune this. ADR §3.7.
+                description: Mover (Job pod) overrides for the maintenance run.
                 nullable: true
                 properties:
                   cache:
@@ -18565,7 +17656,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -18577,11 +17668,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -18590,26 +17677,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -18650,12 +17726,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -18785,7 +17856,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -18826,10 +17897,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -18934,28 +18002,20 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               ownership:
-                description: |-
-                  Ownership-lease configuration; at most one `Maintenance` may own a
-                  repository at a time. ADR §3.7.
+                description: Maintenance ownership lease holder and takeover policy.
                 properties:
                   owner:
-                    description: |-
-                      Stable lease holder identity (e.g. `kopia-operator/nas-primary`). Two
-                      `Maintenance` CRs claiming the same repository compare this. ADR §3.7.
+                    description: Stable lease holder identity (e.g. `kopia-operator/nas-primary`).
                     type: string
                   takeoverPolicy:
                     default: Never
-                    description: What to do if the lease is already held by a different `owner`. ADR §3.7.
+                    description: What to do when the lease is already held by a different `owner`.
                     enum:
                     - Never
                     - PromptCondition
@@ -18965,7 +18025,7 @@ spec:
                 - owner
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Reference to the `Repository` or `ClusterRepository` to maintain.
                 properties:
                   kind:
                     default: Repository
@@ -18985,46 +18045,36 @@ spec:
                 - name
                 type: object
               schedule:
-                description: |-
-                  Quick + full cron schedules (with a shared timezone) for `kopia
-                  maintenance run`. ADR §3.7.
+                description: quick (cheap) and full (`--full`, reclamation) maintenance crons.
                 properties:
                   full:
-                    description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                    description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   quick:
-                    description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                    description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   timezone:
-                    description: IANA timezone both crons are evaluated in; absent means controller default.
+                    description: IANA timezone both crons are evaluated in; absent means the controller default.
                     nullable: true
                     type: string
                 required:
@@ -19037,11 +18087,11 @@ spec:
             - schedule
             type: object
           status:
-            description: 'Observed maintenance state: lease holder plus per-kind run results. ADR §3.7.'
+            description: 'Observed maintenance state: lease holder and per-kind run results.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing maintenance health. ADR §5.
+                description: Standard Kubernetes conditions surfacing maintenance health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -19074,7 +18124,7 @@ spec:
                   type: object
                 type: array
               full:
-                description: Last/next-run state for the full maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the full maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -19083,24 +18133,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:
@@ -19113,9 +18151,7 @@ spec:
                     type: string
                 type: object
               manualRun:
-                description: |-
-                  State of the most recent annotation-requested out-of-band run
-                  (`kopiur.home-operations.com/run-requested`); absent until one is requested.
+                description: State of the most recent annotation-requested out-of-band run; absent until one is requested.
                 nullable: true
                 properties:
                   completedAt:
@@ -19159,7 +18195,7 @@ spec:
                 nullable: true
                 type: integer
               ownership:
-                description: Current lease holder, if the lease has been claimed. ADR §3.7.
+                description: Current lease holder, if the lease has been claimed.
                 nullable: true
                 properties:
                   claimedAt:
@@ -19172,7 +18208,7 @@ spec:
                     type: string
                 type: object
               quick:
-                description: Last/next-run state for the quick maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the quick maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -19181,24 +18217,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:
@@ -19259,16 +18283,12 @@ spec:
         properties:
           spec:
             description: |-
-              Mirror a source repository's blobs to a destination backend on a schedule
-              (`kopia repository sync-to`), ADR-0005 §13(d).
+              Mirror a source repository's blobs to a destination backend on a schedule (`kopia repository sync-to`).
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               destination:
-                description: |-
-                  The backend to mirror *to* (`kopia repository sync-to <destination>`).
-                  Exactly one backend by construction (the externally-tagged `Backend` enum,
-                  reused). Must differ from the source's backend (webhook-enforced).
+                description: The backend to mirror to; must differ from the source's backend (webhook-enforced).
                 oneOf:
                 - required:
                   - s3
@@ -19295,37 +18315,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -19349,24 +18357,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -19390,10 +18392,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -19435,37 +18434,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -19496,9 +18483,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -19516,41 +18501,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -19580,9 +18553,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -19595,16 +18566,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -19614,24 +18579,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -19663,24 +18622,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -19695,30 +18648,21 @@ spec:
                     type: object
                 type: object
               destinationEncryption:
-                description: |-
-                  Encryption/password for the destination repository when it needs its own
-                  (e.g. a freshly-created mirror with a distinct password). Absent ⇒ the
-                  destination uses the **source** repository's password — the common case for a
-                  true mirror, where `sync-to` copies blobs verbatim and the format (including
-                  the encryption material) is identical. Document this in the example.
+                description: Encryption for the destination; omit to reuse the source repository password.
                 nullable: true
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -19728,10 +18672,7 @@ spec:
                 - passwordSecretRef
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the replication run — resources, scheduling,
-                  security context. Inherits the source repository's `moverDefaults` underneath
-                  (ADR-0004 §1/§2).
+                description: Mover (Job pod) overrides for the replication run.
                 nullable: true
                 properties:
                   cache:
@@ -19753,7 +18694,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -19765,11 +18706,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -19778,26 +18715,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -19838,12 +18764,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -19973,7 +18894,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -20014,10 +18935,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -20122,38 +19040,26 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               schedule:
-                description: |-
-                  Cron + deterministic jitter for the replication runs (ADR §3.7 scheduling
-                  kernel, shared with `Maintenance`).
+                description: Cron and deterministic jitter for the replication runs.
                 properties:
                   cron:
-                    description: |-
-                      The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                      deterministic per-schedule jitter (ADR §3.7).
+                    description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                     type: string
                   jitter:
-                    description: |-
-                      Optional deterministic jitter window as a Go-style duration string (e.g.
-                      `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                    description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
                 required:
                 - cron
                 type: object
               sourceRef:
-                description: |-
-                  The repository to mirror *from* — a `Repository` or `ClusterRepository`
-                  reference (ADR §3.2). Credentials/connect are resolved from it.
+                description: Reference to the `Repository` or `ClusterRepository` to mirror from.
                 properties:
                   kind:
                     default: Repository
@@ -20173,10 +19079,7 @@ spec:
                 - name
                 type: object
               suspend:
-                description: |-
-                  Pause this replication declaratively (ADR-0005 §14(e)): a suspended
-                  `RepositoryReplication` is skipped by its own reconcile (no sync runs),
-                  surfaced via a condition. Default `false`.
+                description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
             required:
             - destination
@@ -20184,11 +19087,11 @@ spec:
             - sourceRef
             type: object
           status:
-            description: Observed state of a [`RepositoryReplication`]. ADR-0005 §13(d).
+            description: Observed state of a `RepositoryReplication`.
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). ADR-0005 §2.
+                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -20221,15 +19124,11 @@ spec:
                   type: object
                 type: array
               destinationBackend:
-                description: |-
-                  The destination backend kind (mirror of `spec.destination` discriminant),
-                  for the `DESTINATION` print column.
+                description: The destination backend kind, for the `DESTINATION` print column.
                 nullable: true
                 type: string
               lastReplicated:
-                description: |-
-                  RFC3339 timestamp of the most recent successful replication run. Backs the
-                  `LAST` print column.
+                description: RFC3339 timestamp of the most recent successful replication run.
                 nullable: true
                 type: string
               lastReplicatedBlobs:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -41,15 +41,10 @@ spec:
         description: Auto-generated derived type for ClusterRepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A shared kopia repository referenceable from allow-listed namespaces. ADR §3.2.
-
-              Cluster-scoped: note the absence of `namespaced` in `#[kube(...)]`. Secret/config
-              references in `backend`/`encryption` therefore MUST carry an explicit `namespace`
-              (webhook-enforced — the type system cannot express that requirement here).
+            description: A cluster-scoped kopia repository referenceable from allow-listed namespaces.
             properties:
               allowedNamespaces:
-                description: Tenancy gate — webhook-enforced on every consumer CR. ADR §3.2.
+                description: Which namespaces are permitted to reference this repository.
                 oneOf:
                 - required:
                   - list
@@ -59,7 +54,7 @@ spec:
                   - all
                 properties:
                   all:
-                    description: Allow all namespaces (must be `true`; `false` is meaningless and rejected by webhook).
+                    description: Allow all namespaces (must be `true`).
                     type: boolean
                   list:
                     description: Explicit namespace names.
@@ -98,7 +93,7 @@ spec:
                     type: object
                 type: object
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -125,37 +120,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -179,24 +162,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -220,10 +197,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -265,37 +239,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -326,9 +288,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -346,41 +306,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -410,9 +358,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -425,16 +371,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -444,24 +384,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -493,24 +427,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -525,65 +453,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog. For a shared repo this also picks where to land discovered snapshots
-                  via `catalog.fallbackNamespace`. ADR §3.1/§3.2.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Same semantics as
-                  `Repository.spec.create`. ADR §3.1/§3.2.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -598,64 +500,45 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               credentialProjection:
-                description: |-
-                  Repository-owner gate for credential-Secret projection into a foreign consumer
-                  namespace. **Default off** (`allowed: false`): a consumer's
-                  `credentialProjection.enabled` is necessary but not sufficient — the
-                  `ClusterRepository` owner must also allow it. BREAKING (ADR-0005 §8). A
-                  namespaced `Repository` has no such gate (projection there is a same-namespace
-                  no-op).
+                description: Repository-owner gate for projecting credential Secrets into a foreign consumer namespace.
                 nullable: true
                 properties:
                   allowed:
                     default: false
-                    description: |-
-                      When `true`, the repository owner permits projecting this repository's
-                      credential Secret(s) into a foreign consumer namespace (still requires the
-                      consumer opt-in AND operator RBAC — fail-closed). Off by default.
+                    description: When `true`, the owner permits projecting this repository's credential Secret(s) into a consumer namespace.
                     type: boolean
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. As this CR is cluster-scoped,
-                  the ref MUST carry an explicit `namespace` (webhook-enforced). ADR §3.1/§3.2.
+                description: Repository password (a Secret reference that must carry an explicit `namespace`).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -665,90 +548,58 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13), shared with `Repository` — see
-                  [`RepositoryHealthSpec`]. Tunes the index-blob-count warning. Absent uses
-                  the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               identityDefaults:
-                description: |-
-                  Identity defaults (CEL `*Expr`) applied when consumers don't override.
-                  ADR §3.2 / ADR-0004 §5.
+                description: Identity defaults (CEL `*Expr`) applied when consumers don't override.
                 nullable: true
                 properties:
                   hostnameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *hostname* (e.g. `"namespace"`).
-                      Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity hostname (e.g. `"namespace"`).
                     nullable: true
                     type: string
                   usernameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *username*
-                      (e.g. `"namespace + '-' + policyName"`). Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity username (e.g. `"namespace + '-' + policyName"`).
                     nullable: true
                     type: string
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this cluster repository.
-                  As `Maintenance` is namespaced, `maintenance.namespace` selects where it
-                  lands (defaulting to the operator's namespace). ADR §3.2/§3.7.
+                description: Maintenance control; `maintenance.namespace` selects where the owned `Maintenance` CR lands.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -770,7 +621,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -782,11 +633,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -795,26 +642,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -855,12 +691,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -990,7 +821,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -1031,10 +862,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1139,65 +967,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1227,20 +1037,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  cluster repository serves restores only — backups and maintenance are refused.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults inherited by **every** mover this repository spawns — bootstrap,
-                  consumer backup/restore, and maintenance — overridable per-recipe and merged
-                  field-wise (ADR-0004 §1/§2). Absorbs the former `cacheDefaults`
-                  (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1746,7 +1549,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1764,7 +1567,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1782,9 +1585,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1951,31 +1752,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -2080,23 +1870,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2105,10 +1883,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2157,34 +1932,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history) or `Delete` (cascade). BREAKING
-                  default change in ADR-0005 §5. Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server. Cluster-scoped, so the target `namespace` is
-                  required (see [`ClusterServerSpec`]). Presence means enabled.
+                description: Optional kopia web-UI server (the target `namespace` is required).
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2195,9 +1960,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2205,10 +1968,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2237,15 +1997,7 @@ spec:
                     description: Target namespace for the server Deployment/Service (and generated Secret).
                     type: string
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2375,13 +2127,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2557,9 +2303,7 @@ spec:
                 - namespace
                 type: object
               suspend:
-                description: |-
-                  Pause this cluster repository declaratively (ADR-0005 §14(e)): skips
-                  connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this cluster repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - allowedNamespaces
@@ -2576,11 +2320,11 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: Mirrors `RepositoryStatus` (ADR §3.1) plus `allowedNamespaceCount`. ADR §3.2.
+            description: Observed state of a `ClusterRepository`; mirrors `RepositoryStatus` plus `allowedNamespaceCount`.
             nullable: true
             properties:
               allowedNamespaceCount:
-                description: Number of namespaces currently resolved by `spec.allowedNamespaces`. ADR §3.2.
+                description: Number of namespaces currently resolved by `spec.allowedNamespaces`.
                 format: int64
                 nullable: true
                 type: integer
@@ -2603,7 +2347,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.2.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2665,11 +2409,7 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
@@ -2692,24 +2432,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2718,12 +2452,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/crds/maintenances.yaml
+++ b/deploy/crds/maintenances.yaml
@@ -32,61 +32,41 @@ spec:
         properties:
           spec:
             description: |-
-              Maintenance schedule + ownership lease for one `Repository`/`ClusterRepository`. ADR §3.7.
+              Maintenance schedule and ownership lease for one `Repository`/`ClusterRepository`.
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this maintenance run's mover
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace this `Maintenance`
-                  runs in (a no-op when they already live there) — useful when maintaining a
-                  shared `ClusterRepository` from a namespace that lacks the Secret. ADR §4.11.
+                description: Opt-in projection of the repository's credential Secret(s) into this run's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: How a failed maintenance run is retried/bounded (backoff, deadline). ADR §3.7.
+                description: How a failed maintenance run is retried and bounded (backoff, deadline).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the maintenance run — resources, scheduling,
-                  etc. Object-store repositories typically tune this. ADR §3.7.
+                description: Mover (Job pod) overrides for the maintenance run.
                 nullable: true
                 properties:
                   cache:
@@ -108,7 +88,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -120,11 +100,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -133,26 +109,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -193,12 +158,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -328,7 +288,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -369,10 +329,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -477,28 +434,20 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               ownership:
-                description: |-
-                  Ownership-lease configuration; at most one `Maintenance` may own a
-                  repository at a time. ADR §3.7.
+                description: Maintenance ownership lease holder and takeover policy.
                 properties:
                   owner:
-                    description: |-
-                      Stable lease holder identity (e.g. `kopia-operator/nas-primary`). Two
-                      `Maintenance` CRs claiming the same repository compare this. ADR §3.7.
+                    description: Stable lease holder identity (e.g. `kopia-operator/nas-primary`).
                     type: string
                   takeoverPolicy:
                     default: Never
-                    description: What to do if the lease is already held by a different `owner`. ADR §3.7.
+                    description: What to do when the lease is already held by a different `owner`.
                     enum:
                     - Never
                     - PromptCondition
@@ -508,7 +457,7 @@ spec:
                 - owner
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Reference to the `Repository` or `ClusterRepository` to maintain.
                 properties:
                   kind:
                     default: Repository
@@ -528,46 +477,36 @@ spec:
                 - name
                 type: object
               schedule:
-                description: |-
-                  Quick + full cron schedules (with a shared timezone) for `kopia
-                  maintenance run`. ADR §3.7.
+                description: quick (cheap) and full (`--full`, reclamation) maintenance crons.
                 properties:
                   full:
-                    description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                    description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   quick:
-                    description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                    description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   timezone:
-                    description: IANA timezone both crons are evaluated in; absent means controller default.
+                    description: IANA timezone both crons are evaluated in; absent means the controller default.
                     nullable: true
                     type: string
                 required:
@@ -580,11 +519,11 @@ spec:
             - schedule
             type: object
           status:
-            description: 'Observed maintenance state: lease holder plus per-kind run results. ADR §3.7.'
+            description: 'Observed maintenance state: lease holder and per-kind run results.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing maintenance health. ADR §5.
+                description: Standard Kubernetes conditions surfacing maintenance health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -617,7 +556,7 @@ spec:
                   type: object
                 type: array
               full:
-                description: Last/next-run state for the full maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the full maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -626,24 +565,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:
@@ -656,9 +583,7 @@ spec:
                     type: string
                 type: object
               manualRun:
-                description: |-
-                  State of the most recent annotation-requested out-of-band run
-                  (`kopiur.home-operations.com/run-requested`); absent until one is requested.
+                description: State of the most recent annotation-requested out-of-band run; absent until one is requested.
                 nullable: true
                 properties:
                   completedAt:
@@ -702,7 +627,7 @@ spec:
                 nullable: true
                 type: integer
               ownership:
-                description: Current lease holder, if the lease has been claimed. ADR §3.7.
+                description: Current lease holder, if the lease has been claimed.
                 nullable: true
                 properties:
                   claimedAt:
@@ -715,7 +640,7 @@ spec:
                     type: string
                 type: object
               quick:
-                description: Last/next-run state for the quick maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the quick maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -724,24 +649,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -38,13 +38,10 @@ spec:
         description: Auto-generated derived type for RepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A kopia repository owned by one namespace: credentials, backend, encryption,
-              and optional catalog-materialization bounds. Many `SnapshotPolicy`s / `Restore`s
-              reference one. ADR §3.1.
+            description: A kopia repository owned by one namespace, referenced by `SnapshotPolicy`s and `Restore`s.
             properties:
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -71,37 +68,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -125,24 +110,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -166,10 +145,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -211,37 +187,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -272,9 +236,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -292,41 +254,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -356,9 +306,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -371,16 +319,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -390,24 +332,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -439,24 +375,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -471,65 +401,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog, keeping etcd footprint sane for large repositories. ADR §3.1.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Absent/disabled means
-                  it must already exist; enabled means the operator creates it with the
-                  given encryption/splitter/hash algorithms. ADR §3.1.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -544,46 +448,36 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. A sub-object so future
-                  rotation fields slot in without API breakage. ADR §3.1/§4.11.
+                description: Repository password (a Secret reference).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -593,71 +487,45 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13): tuning for the warnings the
-                  reconciler raises about a degrading-but-still-usable repository (currently
-                  the index-blob-count warning). A sub-object so future health knobs slot in
-                  without API breakage. Absent uses the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this repository in this
-                  namespace. ADR §3.1/§3.7.
+                description: Maintenance control; when absent or enabled the reconciler creates and owns a `Maintenance` CR.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -679,7 +547,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -691,11 +559,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -704,26 +568,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -764,12 +617,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -899,7 +747,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -940,10 +788,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1048,65 +893,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1136,22 +963,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  repository serves restores only — the reconciler refuses backup Jobs and skips
-                  maintenance projection — for decommissioning/migration without write risk.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults (security context, pod security context, resources, cache,
-                  nodeSelector/tolerations/affinity, Job TTL) inherited by **every** mover this
-                  repository spawns — bootstrap, backup, restore, maintenance — overridable
-                  per-recipe via `mover` and merged field-wise (ADR-0004 §1/§2). Absorbs the
-                  former `cacheDefaults` (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1657,7 +1475,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1675,7 +1493,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1693,9 +1511,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1862,31 +1678,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -1991,23 +1796,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2016,10 +1809,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2068,36 +1858,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history, release ownership) or `Delete`
-                  (cascade per-`Snapshot` `deletionPolicy`). BREAKING default change in
-                  ADR-0005 §5 — `kubectl delete ns` no longer destroys snapshots by default.
-                  Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server, exposed via a `Service` in this Repository's
-                  own namespace. Presence means enabled. ADR §3.1 (server addendum).
+                description: Optional kopia web-UI server, exposed via a `Service` in this namespace.
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2108,9 +1886,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2118,10 +1894,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2147,15 +1920,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2285,13 +2050,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2465,9 +2224,7 @@ spec:
                     type: object
                 type: object
               suspend:
-                description: |-
-                  Pause this repository declaratively (ADR-0005 §14(e)): a suspended repository
-                  skips connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - backend
@@ -2483,9 +2240,7 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: |-
-              Observed state of a [`Repository`]. Carries resolved values pinned by the
-              reconciler. ADR §3.1 status.
+            description: Observed state of a `Repository`, carrying resolved values pinned by the reconciler.
             nullable: true
             properties:
               backend:
@@ -2507,7 +2262,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.1.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2569,15 +2324,11 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
-                description: Resolved kopia server endpoint/auth, pinned by the reconciler. ADR §3.1.
+                description: Resolved kopia server endpoint/auth, pinned by the reconciler.
                 nullable: true
                 properties:
                   authMode:
@@ -2596,24 +2347,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2622,12 +2367,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -38,16 +38,12 @@ spec:
         properties:
           spec:
             description: |-
-              Mirror a source repository's blobs to a destination backend on a schedule
-              (`kopia repository sync-to`), ADR-0005 §13(d).
+              Mirror a source repository's blobs to a destination backend on a schedule (`kopia repository sync-to`).
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               destination:
-                description: |-
-                  The backend to mirror *to* (`kopia repository sync-to <destination>`).
-                  Exactly one backend by construction (the externally-tagged `Backend` enum,
-                  reused). Must differ from the source's backend (webhook-enforced).
+                description: The backend to mirror to; must differ from the source's backend (webhook-enforced).
                 oneOf:
                 - required:
                   - s3
@@ -74,37 +70,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -128,24 +112,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -169,10 +147,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -214,37 +189,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -275,9 +238,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -295,41 +256,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -359,9 +308,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -374,16 +321,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -393,24 +334,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -442,24 +377,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -474,30 +403,21 @@ spec:
                     type: object
                 type: object
               destinationEncryption:
-                description: |-
-                  Encryption/password for the destination repository when it needs its own
-                  (e.g. a freshly-created mirror with a distinct password). Absent ⇒ the
-                  destination uses the **source** repository's password — the common case for a
-                  true mirror, where `sync-to` copies blobs verbatim and the format (including
-                  the encryption material) is identical. Document this in the example.
+                description: Encryption for the destination; omit to reuse the source repository password.
                 nullable: true
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -507,10 +427,7 @@ spec:
                 - passwordSecretRef
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the replication run — resources, scheduling,
-                  security context. Inherits the source repository's `moverDefaults` underneath
-                  (ADR-0004 §1/§2).
+                description: Mover (Job pod) overrides for the replication run.
                 nullable: true
                 properties:
                   cache:
@@ -532,7 +449,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -544,11 +461,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -557,26 +470,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -617,12 +519,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -752,7 +649,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -793,10 +690,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -901,38 +795,26 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               schedule:
-                description: |-
-                  Cron + deterministic jitter for the replication runs (ADR §3.7 scheduling
-                  kernel, shared with `Maintenance`).
+                description: Cron and deterministic jitter for the replication runs.
                 properties:
                   cron:
-                    description: |-
-                      The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                      deterministic per-schedule jitter (ADR §3.7).
+                    description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                     type: string
                   jitter:
-                    description: |-
-                      Optional deterministic jitter window as a Go-style duration string (e.g.
-                      `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                    description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
                 required:
                 - cron
                 type: object
               sourceRef:
-                description: |-
-                  The repository to mirror *from* — a `Repository` or `ClusterRepository`
-                  reference (ADR §3.2). Credentials/connect are resolved from it.
+                description: Reference to the `Repository` or `ClusterRepository` to mirror from.
                 properties:
                   kind:
                     default: Repository
@@ -952,10 +834,7 @@ spec:
                 - name
                 type: object
               suspend:
-                description: |-
-                  Pause this replication declaratively (ADR-0005 §14(e)): a suspended
-                  `RepositoryReplication` is skipped by its own reconcile (no sync runs),
-                  surfaced via a condition. Default `false`.
+                description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
             required:
             - destination
@@ -963,11 +842,11 @@ spec:
             - sourceRef
             type: object
           status:
-            description: Observed state of a [`RepositoryReplication`]. ADR-0005 §13(d).
+            description: Observed state of a `RepositoryReplication`.
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). ADR-0005 §2.
+                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -1000,15 +879,11 @@ spec:
                   type: object
                 type: array
               destinationBackend:
-                description: |-
-                  The destination backend kind (mirror of `spec.destination` discriminant),
-                  for the `DESTINATION` print column.
+                description: The destination backend kind, for the `DESTINATION` print column.
                 nullable: true
                 type: string
               lastReplicated:
-                description: |-
-                  RFC3339 timestamp of the most recent successful replication run. Backs the
-                  `LAST` print column.
+                description: RFC3339 timestamp of the most recent successful replication run.
                 nullable: true
                 type: string
               lastReplicatedBlobs:

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -32,69 +32,40 @@ spec:
         properties:
           spec:
             description: |-
-              A restore operation. `target` is **required** (ADR-0005 §9): explicit
-              `pvc`/`pvcRef`, or `populator: {}` for passive populator mode (consumed by a
-              PVC's `spec.dataSourceRef`). The empty-`target` form is removed. ADR §3.6/§4.7.
-              Desired state of a [`Restore`]: where to read from, where to write to, and how
-              to behave when the snapshot is missing. ADR §3.6/§4.6.
+              A restore operation from a snapshot/identity into a PVC, or a passive populator source.
+              Desired state of a Restore: where to read from, where to write to, and how to behave when the snapshot is missing.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this restore's mover (default off).
-                  When `enabled: true`, the operator copies the referenced repository's
-                  credential Secret(s) into the restore mover's namespace (a no-op when they
-                  already live there) — so restoring from a shared `ClusterRepository` into a
-                  fresh namespace need not pre-create the Secret there. ADR §4.11.
+                description: Opt-in copying of the repository's credential Secret(s) into the mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: |-
-                  Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`),
-                  mirroring `Snapshot.spec.failurePolicy`. Absent uses the ADR defaults.
+                description: Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Per-run mover overrides for this restore's Job — resource requests/limits,
-                  kopia cache sizing, container `securityContext` (UID/GID match), `privilegedMode`,
-                  and `inheritSecurityContextFrom`. The same surface `SnapshotPolicy.spec.mover`
-                  gives a backup. An elevated context is namespace-gated exactly like a backup's
-                  (ADR §4.11/§G16); `securityContext` and `inheritSecurityContextFrom` are
-                  mutually exclusive.
+                description: Per-run mover overrides for this restore's Job (resources, cache, `securityContext`).
                 nullable: true
                 properties:
                   cache:
@@ -116,7 +87,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -128,11 +99,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -141,26 +108,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -201,12 +157,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -336,7 +287,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -377,10 +328,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -485,35 +433,29 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               options:
-                description: kopia restore behavior (file deletion, permission/atomicity handling). ADR §4.6.
+                description: kopia restore behavior (file deletion, permission/atomicity handling).
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: |-
-                      Delete files in the target that are not present in the snapshot (make the
-                      target an exact mirror). Off by default — additive restore is the safe default.
+                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
                     type: boolean
                   ignorePermissionErrors:
-                    description: Default true; surfaces a condition if any errors occurred. ADR §4.6.
+                    description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
                   writeFilesAtomically:
-                    description: Default true. ADR §4.6.
+                    description: Write files atomically via a temp file + rename (default true).
                     nullable: true
                     type: boolean
                 type: object
               policy:
-                description: Missing-snapshot handling and wait timeout. ADR §4.6 (G7).
+                description: What to do when the referenced snapshot doesn't exist yet, and how long to wait.
                 nullable: true
                 properties:
                   onMissingSnapshot:
@@ -533,14 +475,12 @@ spec:
                     nullable: true
                     type: string
                   waitTimeout:
-                    description: |-
-                      How long to wait for the source snapshot to appear before giving up
-                      (Go-style duration string, e.g. `5m`).
+                    description: How long to wait for the source snapshot to appear before giving up (e.g. `5m`).
                     nullable: true
                     type: string
                 type: object
               repository:
-                description: Derived from `source` when omitted; REQUIRED only with `source.identity`. ADR §3.6/§4.6.
+                description: The repository to read from; derived from `source` when omitted, required only with `source.identity`.
                 nullable: true
                 properties:
                   kind:
@@ -561,7 +501,7 @@ spec:
                 - name
                 type: object
               source:
-                description: Exactly one source mode; webhook-enforced. ADR §3.6.
+                description: Where to read data from (snapshotRef, fromPolicy, or identity).
                 oneOf:
                 - required:
                   - snapshotRef
@@ -571,9 +511,7 @@ spec:
                   - identity
                 properties:
                   fromPolicy:
-                    description: |-
-                      A `SnapshotPolicy` CR — resolves via identity even with no `Snapshot` CR present
-                      (deploy-or-restore). Default `onMissingSnapshot: Continue`. ADR §4.6.
+                    description: A `SnapshotPolicy` CR, resolved via identity even with no `Snapshot` CR present (deploy-or-restore).
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -588,19 +526,14 @@ spec:
                         type: string
                       offset:
                         default: 0
-                        description: |-
-                          0 = latest, 1 = previous, ... ADR §3.6.
-
-                          Carries a real OpenAPI `default: 0` (ADR-0005 §1): unconditional, so it
-                          materializes into the stored object / `kubectl explain` and GitOps stops
-                          diff-thrashing. A bare `i64` (not `Option`) so the default is never dropped.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         type: integer
                     required:
                     - name
                     type: object
                   identity:
-                    description: A raw kopia identity (foreign writers / aged-out catalog). Requires `spec.repository`.
+                    description: A raw kopia identity (foreign writers / aged-out catalog); requires `spec.repository`.
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -610,14 +543,12 @@ spec:
                         description: The kopia `hostname` to match.
                         type: string
                       offset:
-                        description: 0 = latest, 1 = previous, ... mutually exclusive with `snapshotID`/`asOf` in practice.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         nullable: true
                         type: integer
                       snapshotID:
-                        description: |-
-                          Pin an exact kopia snapshot by ID. Renamed to match the ADR wire shape
-                          exactly (`snapshotID`, capital `ID`).
+                        description: Pin an exact kopia snapshot by ID.
                         nullable: true
                         type: string
                       sourcePath:
@@ -632,7 +563,7 @@ spec:
                     - username
                     type: object
                   snapshotRef:
-                    description: A `Snapshot` CR (scheduled, manual, or discovered — all the same kind). Default mode.
+                    description: A `Snapshot` CR (scheduled, manual, or discovered).
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -646,11 +577,7 @@ spec:
                     type: object
                 type: object
               target:
-                description: |-
-                  Where to restore to — **required** (ADR-0005 §9): `pvc` (operator creates),
-                  `pvcRef` (existing PVC), or `populator: {}` (passive populator mode, claimed
-                  via a PVC's `spec.dataSourceRef`). The former empty-`target` form is removed;
-                  a `Restore` with no `target` is now invalid (deserialization fails).
+                description: Where to write the restored data (pvc, pvcRef, or populator).
                 oneOf:
                 - required:
                   - pvc
@@ -660,10 +587,7 @@ spec:
                   - populator
                 properties:
                   populator:
-                    description: |-
-                      Passive populator mode: no workload target at provision time — the restore is
-                      claimed by a PVC's `spec.dataSourceRef` (ADR-0005 §9). An (empty) sub-object so
-                      future populator knobs slot in without API breakage.
+                    description: 'Passive populator mode: the restore is claimed by a PVC''s `spec.dataSourceRef`.'
                     type: object
                   pvc:
                     description: Operator creates the PVC.
@@ -709,7 +633,7 @@ spec:
             - message: exactly one of target.pvc, target.pvcRef, target.populator
               rule: '[has(self.target.pvc), has(self.target.pvcRef), has(self.target.populator)].filter(x, x).size() == 1'
           status:
-            description: Observed state of a [`Restore`], written by the controller/mover. ADR §3.6 status.
+            description: Observed state of a Restore, written by the controller/mover.
             nullable: true
             properties:
               conditions:
@@ -746,9 +670,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -777,11 +699,7 @@ spec:
                 - retryRecommended
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Restore completed: snapshot <id>` line; failure:
-                  the actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
@@ -790,7 +708,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: Lifecycle phase of a restore. Closed enum. ADR §3.6 status.
+                description: Lifecycle phase of a restore.
                 enum:
                 - Pending
                 - Resolving
@@ -815,7 +733,7 @@ spec:
                     type: integer
                 type: object
               resolved:
-                description: Pinned at admission; never re-resolved. ADR §3.6/§4.6.
+                description: The source resolved and pinned at admission; never re-resolved.
                 nullable: true
                 properties:
                   identity:
@@ -837,11 +755,7 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      The exact kopia snapshot manifest id the source resolved to. Pinned once;
-                      subsequent reconciles restore THIS id even if newer snapshots appear, so a
-                      restore never silently retargets (ADR §4.6). Matches
-                      `Snapshot.status.snapshot.kopiaSnapshotID`.
+                    description: The exact kopia snapshot manifest id the source resolved to; pinned once.
                     nullable: true
                     type: string
                   pinnedAt:
@@ -870,15 +784,7 @@ spec:
                     - name
                     type: object
                   resolution:
-                    description: |-
-                      Which outcome the source resolution pinned. Closed enum so the decision is a
-                      single, exhaustively-matched value rather than an inferred combination of optional
-                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
-                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
-                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
-                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
-                      snapshot id, so a later-appearing snapshot can never silently retarget an
-                      already-provisioned volume (ADR §4.6).
+                    description: Which outcome the source resolution pinned, once and never re-resolved.
                     enum:
                     - Snapshot
                     - NoSnapshot
@@ -900,10 +806,7 @@ spec:
                     type: object
                 type: object
               sourceKind:
-                description: |-
-                  The pinned source kind (`RestoreSource::kind_str` — `SnapshotRef`/`FromPolicy`/
-                  `Identity`), set by the reconciler. Backs the `SOURCE` printer column so
-                  `kubectl get restores` shows where a restore reads from. ADR-0005 §3.
+                description: The pinned source kind (`SnapshotRef`/`FromPolicy`/`Identity`); backs the `SOURCE` printer column.
                 nullable: true
                 type: string
               target:
@@ -911,7 +814,7 @@ spec:
                 nullable: true
                 properties:
                   pvcPrime:
-                    description: Populator handshake (passive / pvc-create modes). ADR §3.6.
+                    description: Populator handshake (passive / pvc-create modes).
                     nullable: true
                     type: string
                   pvcRef:

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -37,70 +37,42 @@ spec:
         description: Auto-generated derived type for SnapshotPolicySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              *What* to back up: sources, identity, retention, policy, hooks. ADR §3.3.
-
-              Not `Eq`: transitively embeds k8s-openapi types via `mover` and `hooks` (`JobSpec`).
+            description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
               compression:
-                description: Compression algorithm + per-extension opt-outs. ADR §3.3 (G12).
+                description: Compression algorithm + per-extension opt-outs.
                 nullable: true
                 properties:
                   compressor:
-                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default. ADR §3.3.
+                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default.
                     nullable: true
                     type: string
                   neverCompress:
-                    description: Filename globs to leave uncompressed (e.g. already-compressed media). ADR §3.3.
+                    description: Filename globs to leave uncompressed (e.g. already-compressed media).
                     items:
                       type: string
                     type: array
                 type: object
               copyMethod:
                 default: Direct
-                description: |-
-                  How the source volume is captured before kopia reads it: `Direct` (read the live
-                  PVC, the **default** — works on any storage), `Snapshot` (point-in-time CSI
-                  snapshot, opt-in), or `Clone` (CSI clone, opt-in). ADR §3.3 / [Copy methods].
-
-                  Carries a real OpenAPI `default: Direct` so it materializes into the stored object
-                  and `kubectl explain`, and GitOps engines stop diff-thrashing on a controller-set
-                  value. A bare value (not `Option`) so the default is never dropped by
-                  `skip_serializing_if`.
-
-                  [Copy methods]: https://github.com/home-operations/kopiur/blob/main/docs/copy-methods.md
+                description: 'How the source volume is captured before kopia reads it: `Direct` (default), `Snapshot`, or `Clone`.'
                 enum:
                 - Snapshot
                 - Clone
                 - Direct
                 type: string
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this recipe's backup movers
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace where each backup
-                  mover runs (a no-op when they already live there) — so a workload backing
-                  up to a shared `ClusterRepository` need not pre-create the Secret in its
-                  own namespace. Inherited by `Snapshot`s produced from this config. ADR §4.11.
+                description: Opt-in credential-Secret projection into each backup mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               defaultDeletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -118,11 +90,7 @@ spec:
                 nullable: true
                 type: string
               errorHandling:
-                description: |-
-                  Backup-side error handling — the missing analog of restore's
-                  `ignorePermissionErrors`. Lets a snapshot complete-with-errors instead of
-                  failing outright (`--ignore-file-errors` / `--ignore-dir-errors` /
-                  `--ignore-unknown-types`). ADR-0005 §13(b).
+                description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
                   ignoreDirErrors:
@@ -136,24 +104,22 @@ spec:
                     type: boolean
                 type: object
               extraArgs:
-                description: Escape hatch for kopia flags not yet modeled. ADR §3.3 (G12).
+                description: Escape hatch for kopia flags not yet modeled.
                 items:
                   type: string
                 type: array
               files:
-                description: Paths/patterns kopia should skip while snapshotting. ADR §3.3 (G12).
+                description: Paths/patterns kopia should skip while snapshotting.
                 nullable: true
                 properties:
                   ignoreCacheDirs:
                     description: Honor `CACHEDIR.TAG`.
                     type: boolean
                   ignoreIdenticalSnapshots:
-                    description: 'fork issue #13.'
+                    description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: |-
-                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`,
-                      `*/cache/*`, `lost+found`). ADR §3.3.
+                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
                     items:
                       type: string
                     type: array
@@ -178,13 +144,11 @@ spec:
                 nullable: true
                 type: string
               hooks:
-                description: Pre/post snapshot hooks that run in the workload, not the mover. ADR §4.8 (G13).
+                description: Pre/post snapshot hooks that run in the workload, not the mover.
                 nullable: true
                 properties:
                   afterSnapshot:
-                    description: |-
-                      Hooks run (in order) after the snapshot completes — e.g. resuming the
-                      workload. ADR §4.8.
+                    description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -223,39 +187,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -5266,19 +5225,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -5287,7 +5244,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -5320,7 +5277,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -5329,9 +5286,7 @@ spec:
                       type: object
                     type: array
                   beforeSnapshot:
-                    description: |-
-                      Hooks run (in order) before the snapshot is taken — e.g. quiescing a
-                      database. ADR §4.8.
+                    description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -5370,39 +5325,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -10413,19 +10363,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -10434,7 +10382,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -10467,7 +10415,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -10477,26 +10425,20 @@ spec:
                     type: array
                 type: object
               identity:
-                description: Identity overrides — what kopia records as `username@hostname:path`. ADR §3.3/§4.2.
+                description: Identity overrides — what kopia records as `username@hostname:path`.
                 nullable: true
                 properties:
                   hostname:
-                    description: |-
-                      Override the `hostname` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      namespace). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `hostname` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                   username:
-                    description: |-
-                      Override the `username` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      object name). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `username` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                 type: object
               mover:
-                description: Per-recipe mover overrides (resources, cache, security context). ADR §3.3.
+                description: Per-recipe mover overrides (resources, cache, security context).
                 nullable: true
                 properties:
                   cache:
@@ -10518,7 +10460,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -10530,11 +10472,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -10543,26 +10481,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -10603,12 +10530,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -10738,7 +10660,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -10779,10 +10701,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -10887,17 +10806,13 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Discriminated reference to a `Repository` or `ClusterRepository`.
                 properties:
                   kind:
                     default: Repository
@@ -10917,7 +10832,7 @@ spec:
                 - name
                 type: object
               retention:
-                description: GFS retention — enforced by the operator pruning `Snapshot` CRs. ADR §4.4.
+                description: GFS retention, enforced by the operator pruning `Snapshot` CRs.
                 nullable: true
                 properties:
                   keepAnnual:
@@ -10958,28 +10873,12 @@ spec:
                     type: integer
                 type: object
               sources:
-                description: |-
-                  What to back up. At least one source; webhook-enforced. ADR §3.3.
-
-                  `maxItems` is set so the apiserver can bound the cost of the per-item
-                  `x-kubernetes-validations` exactly-one-of rule on [`Source`] (CEL rule cost is
-                  `rule_cost × maxItems`; without a bound the apiserver assumes a huge array and
-                  rejects the CRD as over budget). 100 sources per recipe is far past any real
-                  use.
+                description: What to back up (at least one source; webhook-enforced).
                 items:
-                  description: |-
-                    A single backup source. `pvc`, `pvcSelector`, and `nfs` are mutually exclusive
-                    (webhook-enforced — NOT an enum, because the forms share the sibling
-                    `sourcePath*` keys and YAML lists them as optional siblings). ADR §3.3.
-
-                    §15: an operator-authored `x-kubernetes-validations` rule enforces exactly-one-of
-                    in the apiserver + CI, complementing `validate_source`.
+                  description: A single backup source; exactly one of `pvc`, `pvcSelector`, `nfs` (webhook-enforced).
                   properties:
                     nfs:
-                      description: |-
-                        An inline NFS export to back up directly — no PVC. Mounted read-only at the
-                        source path (default: the export's `path`). Mutually exclusive with
-                        `pvc`/`pvcSelector`. ADR §3.3.
+                      description: An inline NFS export to back up directly, mounted read-only. Mutually exclusive with `pvc`/`pvcSelector`.
                       nullable: true
                       properties:
                         path:
@@ -10993,25 +10892,21 @@ spec:
                       - server
                       type: object
                     pvc:
-                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`. ADR §3.3.
+                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`.
                       nullable: true
                       properties:
                         name:
-                          description: |-
-                            Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s
-                            namespace). ADR §3.3.
+                          description: Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s namespace).
                           type: string
                       required:
                       - name
                       type: object
                     pvcSelector:
-                      description: |-
-                        Label/namespace selector matching many PVCs (multi-PVC sources).
-                        Mutually exclusive with `pvc`/`nfs`. ADR §3.3/§5.4.
+                      description: Label/namespace selector matching many PVCs. Mutually exclusive with `pvc`/`nfs`.
                       nullable: true
                       properties:
                         labelSelector:
-                          description: Standard Kubernetes label selector matching the PVCs to include. ADR §3.3/§5.4.
+                          description: Standard Kubernetes label selector matching the PVCs to include.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -11042,28 +10937,18 @@ spec:
                               type: object
                           type: object
                         namespaceSelector:
-                          description: |-
-                            Restricts the search to specific namespaces; absent means the
-                            `SnapshotPolicy`'s own namespace. ADR §3.3/§5.4.
+                          description: Restricts the search to specific namespaces; absent means the policy's own namespace.
                           nullable: true
                           properties:
                             matchNames:
-                              description: |-
-                                Exact namespace names to search; empty means the `SnapshotPolicy`'s own
-                                namespace. ADR §3.3/§5.4.
+                              description: Exact namespace names to search; empty means the policy's own namespace.
                               items:
                                 type: string
                               type: array
                           type: object
                       type: object
                     sourcePathOverride:
-                      description: |-
-                        What kopia records as the source path (default `/pvc/<name>` for a PVC, or
-                        the NFS export `path` for an NFS source). ADR §3.3/§4.2.
-
-                        `maxLength` bounds the per-item cost of the exactly-one-of CEL rule on this
-                        struct (an unbounded string makes the apiserver assume a huge value and blow
-                        the rule's cost budget). A filesystem path is far shorter than 4096.
+                      description: What kopia records as the source path (default `/pvc/<name>`, or the NFS export `path`).
                       maxLength: 4096
                       nullable: true
                       type: string
@@ -11095,15 +10980,10 @@ spec:
                 maxItems: 100
                 type: array
               suspend:
-                description: |-
-                  Pause this recipe declaratively: a suspended `SnapshotPolicy` is skipped by
-                  schedules and by its own reconcile (no retention prune, no backup creation),
-                  surfaced via a condition/column. ADR-0005 §14(e).
+                description: Pause this recipe declaratively (schedules and reconcile skip a suspended policy).
                 type: boolean
               upload:
-                description: |-
-                  Upload parallelism (kopia's upload policy: `--max-parallel-snapshots`,
-                  `--max-parallel-file-reads`). ADR-0005 §13(f).
+                description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
                   maxParallelFileReads:
@@ -11118,88 +10998,57 @@ spec:
                     type: integer
                 type: object
               verification:
-                description: |-
-                  First-class backup verification (ADR-0005 §4). Opt-in: when absent, no
-                  verification runs (no behavior change). When set, the controller schedules
-                  periodic `kopia snapshot verify` (quick) and/or a scratch-restore test (deep),
-                  gated by an optional CEL `successExpr` predicate over the result, and surfaces
-                  `status.lastVerified`.
+                description: First-class backup verification; opt-in (absent ⇒ no verification runs).
                 nullable: true
                 properties:
                   deep:
-                    description: |-
-                      Schedule + knobs for the rarer scratch-restore restorability test. Absent ⇒
-                      no deep verification.
+                    description: Schedule + knobs for the rarer scratch-restore test; absent ⇒ no deep verification.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `10Gi`). When set, the operator
-                          mounts a fresh generic-ephemeral PVC of this size at the scratch path
-                          (auto-deleted with the Job) — size it to comfortably hold the restored
-                          snapshot. When absent, scratch falls back to a node-ephemeral `emptyDir`
-                          (zero-config, but bounded by node disk).
+                        description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set (an `emptyDir` has no StorageClass).
+                        description: StorageClass for the ephemeral scratch PVC; absent uses the cluster default (only with `capacity`).
                         nullable: true
                         type: string
                     required:
                     - schedule
                     type: object
                   quick:
-                    description: |-
-                      Schedule for the frequent blob-level `kopia snapshot verify`. Absent ⇒ no
-                      quick verification.
+                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
                     nullable: true
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   successExpr:
-                    description: |-
-                      A CEL pass/fail predicate over the verify result (ADR-0005 §15). Environment:
-                      `stats{files,bytes,errors}`, `snapshot`, and (deep only) `restored{files,
-                      checksumMatches}`. Returns a bool; when it evaluates `false` the verification
-                      run fails. Validated at admission (`validate_success_expr`). Applies to both
-                      tiers. Example: `"stats.files > 0 && stats.errors == 0"`.
+                    description: CEL pass/fail predicate over the verify result; applies to both tiers.
                     nullable: true
                     type: string
                   verifyFilesPercent:
-                    description: |-
-                      How many files `quick` verifies fully (`--verify-files-percent`); absent
-                      leaves kopia's default. Tuning knob for the quick tier.
+                    description: How many files `quick` verifies fully (`--verify-files-percent`); absent leaves kopia's default.
                     format: uint8
                     maximum: 255.0
                     minimum: 0.0
@@ -11207,22 +11056,18 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: |-
-                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.
-                  ADR §3.3.
+                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
                 nullable: true
                 type: string
             required:
             - repository
             type: object
           status:
-            description: Observed state of a [`SnapshotPolicy`]. ADR §3.3 status.
+            description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `RepositoryReachable`,
-                  `GroupSnapshotSupported`). ADR §3.3 status.
+                description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -11255,29 +11100,24 @@ spec:
                   type: object
                 type: array
               lastSuccessfulSnapshot:
-                description: |-
-                  RFC3339 timestamp of the most recent successful child `Snapshot` produced
-                  from this recipe. Backs the `LAST-SNAPSHOT` printer column and the
-                  `prometheusRule` staleness alert (ADR-0005 §3).
+                description: RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe.
                 nullable: true
                 type: string
               lastVerified:
-                description: |-
-                  RFC3339 timestamp of the most recent successful verification (any tier),
-                  ADR-0005 §4. Backs the `kopiur_snapshot_verified_timestamp_seconds` gauge.
+                description: RFC3339 timestamp of the most recent successful verification (any tier).
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.3 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
               resolved:
-                description: What would be passed to kopia — pinned at admission. ADR §3.3/§4.2.
+                description: What would be passed to kopia — pinned at admission.
                 nullable: true
                 properties:
                   identity:
-                    description: The resolved `username@hostname` identity. ADR §3.3/§4.2.
+                    description: The resolved `username@hostname` identity.
                     nullable: true
                     properties:
                       hostname:
@@ -11295,38 +11135,36 @@ spec:
                     - username
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths after selector expansion. ADR §3.3 status.
+                    description: The concrete PVCs + source paths after selector expansion.
                     items:
-                      description: One resolved source — a concrete PVC and the path kopia records for it. ADR §3.3 status.
+                      description: One resolved source — a concrete PVC and the path kopia records for it.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.3 status.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia records for this PVC. ADR §3.3/§4.2.
+                          description: The source path kopia records for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               retention:
-                description: |-
-                  Summary of GFS retention pruning against this config's `Snapshot` CRs.
-                  ADR §3.3 status/§4.4.
+                description: Summary of GFS retention pruning against this config's `Snapshot` CRs.
                 nullable: true
                 properties:
                   activeSnapshotCount:
-                    description: CRs currently inside the GFS window. ADR §3.3 status.
+                    description: CRs currently inside the GFS window.
                     format: int64
                     nullable: true
                     type: integer
                   lastPruneAt:
-                    description: RFC3339 timestamp of the last prune pass. ADR §3.3 status.
+                    description: RFC3339 timestamp of the last prune pass.
                     nullable: true
                     type: string
                   lastPruneDeleted:
-                    description: Number of `Snapshot` CRs deleted by the last prune pass. ADR §3.3 status/§4.4.
+                    description: Number of `Snapshot` CRs deleted by the last prune pass.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -34,22 +34,11 @@ spec:
         description: Auto-generated derived type for SnapshotSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A single kopia snapshot represented as a Kubernetes object. ADR §3.4.
-
-              For `scheduled`/`manual` backups the spec carries `policyRef` (+ optional
-              overrides). For `discovered` backups the spec is empty — every field is optional.
+            description: A single kopia snapshot represented as a Kubernetes object.
             properties:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -67,45 +56,30 @@ spec:
                 nullable: true
                 type: string
               failurePolicy:
-                description: Per-run failure controls passed to the mover `Job`. ADR §3.4 (G6).
+                description: Mover Job retry and deadline limits for this run.
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               pin:
-                description: |-
-                  Pin this snapshot to exempt it from GFS retention (ADR-0005 §13(c)). When
-                  `true` the reconciler applies a kopia snapshot pin and the GFS pruner never
-                  selects it for deletion — for pre-migration / compliance holds. Clearing it
-                  removes the pin. Default `false`.
+                description: Exempt this snapshot from GFS retention.
                 type: boolean
               policyRef:
-                description: The recipe to run. Absent for `discovered` backups. ADR §3.4.
+                description: The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
                 nullable: true
                 properties:
                   name:
@@ -121,7 +95,7 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). ADR §3.4.'
+                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
                 nullable: true
                 type: object
             type: object
@@ -130,9 +104,7 @@ spec:
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
-                  ADR §3.4 status.
+                description: Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -165,9 +137,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -196,11 +166,7 @@ spec:
                 - retryRecommended
                 type: object
               hooks:
-                description: |-
-                  Hook-execution bookkeeping (ADR §4.8): completion timestamps the
-                  reconciler stamps so each hook list runs exactly once per Snapshot across
-                  requeues and controller restarts (hooks have side effects — quiesce,
-                  resume — that must not repeat).
+                description: Hook-execution bookkeeping so each hook list runs exactly once per Snapshot.
                 nullable: true
                 properties:
                   postCompletedAt:
@@ -213,30 +179,25 @@ spec:
                     type: string
                 type: object
               job:
-                description: Present for scheduled/manual; absent for discovered. ADR §3.4.
+                description: The mover Job backing this run; absent for discovered.
                 nullable: true
                 properties:
                   attempts:
-                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`). ADR §3.4 status.
+                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`).
                     format: int32
                     nullable: true
                     type: integer
                   name:
-                    description: Name of the mover `Job`. ADR §3.4 status.
+                    description: Name of the mover `Job`.
                     nullable: true
                     type: string
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Snapshot created: <id>` line; failure: the
-                  actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
-                  ADR §3.4/§4.10.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.4 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
@@ -284,20 +245,15 @@ spec:
                 nullable: true
                 type: string
               pinned:
-                description: |-
-                  The observed kopia-side pin state (ADR-0005 §13(c)): `Some(true)` once the
-                  operator has applied the pin, `Some(false)` once it has removed it, `None`
-                  before any pin reconcile. The reconciler compares `spec.pin` against this to
-                  decide whether to issue a `kopia snapshot pin`/`unpin`, so a redundant op is
-                  never spawned.
+                description: 'The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile.'
                 nullable: true
                 type: boolean
               resolved:
-                description: Frozen recipe values at run time (scheduled/manual). ADR §3.4.
+                description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
                 properties:
                   repository:
-                    description: The repository this run targeted, frozen at run time. ADR §3.4 status.
+                    description: The repository this run targeted, frozen at run time.
                     nullable: true
                     properties:
                       kind:
@@ -318,27 +274,27 @@ spec:
                     - name
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths backed up this run. ADR §3.4 status.
+                    description: The concrete PVCs + source paths backed up this run.
                     items:
-                      description: One resolved source backed up by a run — a concrete PVC and its kopia path. ADR §3.4 status.
+                      description: One resolved source backed up by a run — a concrete PVC and its kopia path.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.4.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia recorded for this PVC. ADR §3.4/§4.2.
+                          description: The source path kopia recorded for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               snapshot:
-                description: The kopia artifact this CR represents. ADR §3.4.
+                description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
                   identity:
-                    description: The `username@hostname:path` identity recorded for this snapshot. ADR §3.4/§4.2.
+                    description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:
                       hostname:
                         description: The final `hostname` kopia records, fixed at admission.
@@ -355,23 +311,14 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      kopia's snapshot ID — the handle the finalizer uses to delete content.
-
-                      Renamed to match the ADR wire shape exactly (`kopiaSnapshotID`, capital `ID`);
-                      serde's `camelCase` would otherwise produce `kopiaSnapshotId`.
+                    description: kopia's snapshot ID — the handle the finalizer uses to delete content.
                     type: string
                 required:
                 - identity
                 - kopiaSnapshotID
                 type: object
               staged:
-                description: |-
-                  The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`
-                  (ADR §3.3). Pinned once when the stage is provisioned so the reconciler can
-                  (a) reuse the same VolumeSnapshot/PVC across mover-Job retries idempotently
-                  and (b) reap them on the terminal transition. Absent for `Direct` (and NFS),
-                  which mount the live source with no staging.
+                description: 'The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`.'
                 nullable: true
                 properties:
                   copyMethod:
@@ -379,79 +326,68 @@ spec:
                     nullable: true
                     type: string
                   pvcName:
-                    description: |-
-                      Name of the staged `PersistentVolumeClaim` the mover mounts in place of the
-                      live source PVC.
+                    description: Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC.
                     nullable: true
                     type: string
                   ready:
-                    description: |-
-                      `true` once the stage is ready for the mover (VolumeSnapshot `readyToUse` and
-                      the staged PVC applied). Before that the reconcile is still provisioning it.
+                    description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
                   volumeSnapshotName:
-                    description: |-
-                      Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot`
-                      only; absent for `Clone`, which stages directly from the source PVC).
+                    description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true
                     type: string
                 type: object
               stats:
-                description: Byte/file counts parsed from kopia's JSON output. ADR §3.4 status.
+                description: Byte/file counts parsed from kopia's JSON output.
                 nullable: true
                 properties:
                   bytesNew:
-                    description: Bytes newly uploaded this run (after dedup/compression). ADR §3.4 status.
+                    description: Bytes newly uploaded this run (after dedup/compression).
                     format: int64
                     nullable: true
                     type: integer
                   filesFailed:
-                    description: |-
-                      Count of source entries kopia could **not** read and therefore EXCLUDED from the
-                      snapshot (`rootEntry.summ.errors`), making it *incomplete*. Present (and `> 0`) only
-                      when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite
-                      unreadable files — the otherwise-silent partial-backup case. The controller surfaces
-                      it as a warning condition + Event. Usually a UID/GID mismatch with the workload.
+                    description: Count of source entries kopia could not read and excluded, making the snapshot incomplete.
                     format: int64
                     nullable: true
                     type: integer
                   filesModified:
-                    description: Count of files changed since the previous snapshot. ADR §3.4 status.
+                    description: Count of files changed since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesNew:
-                    description: Count of files new since the previous snapshot. ADR §3.4 status.
+                    description: Count of files new since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesUnchanged:
-                    description: Count of files unchanged since the previous snapshot. ADR §3.4 status.
+                    description: Count of files unchanged since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   sizeBytes:
-                    description: Total logical size of the snapshot in bytes. ADR §3.4 status.
+                    description: Total logical size of the snapshot in bytes.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               timing:
-                description: Start/end/duration of the snapshot run. ADR §3.4 status.
+                description: Start/end/duration of the snapshot run.
                 nullable: true
                 properties:
                   durationSeconds:
-                    description: Wall-clock duration in seconds. ADR §3.4 status.
+                    description: Wall-clock duration in seconds.
                     format: int64
                     nullable: true
                     type: integer
                   endTime:
-                    description: RFC3339 end time of the run. ADR §3.4 status.
+                    description: RFC3339 end time of the run.
                     nullable: true
                     type: string
                   startTime:
-                    description: RFC3339 start time of the run. ADR §3.4 status.
+                    description: RFC3339 start time of the run.
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/snapshotschedules.yaml
+++ b/deploy/crds/snapshotschedules.yaml
@@ -34,25 +34,16 @@ spec:
         description: Auto-generated derived type for SnapshotScheduleSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              Cron + `policyRef`. One source of `Snapshot` CRs; pausing it doesn't affect
-              in-flight or completed runs. ADR §3.5.
+            description: Cron schedule that fires `Snapshot` CRs from a `SnapshotPolicy`.
             properties:
               failedJobsHistoryLimit:
-                description: |-
-                  Bounds *failed* `Snapshot` CRs from this schedule. Successful retention is
-                  GFS-driven on `SnapshotPolicy.spec.retention` — there is deliberately NO
-                  `successfulJobsHistoryLimit` (ADR-0003 §4.4, ADR-0001 §4.4).
+                description: Maximum number of failed `Snapshot` CRs from this schedule to retain.
                 format: uint32
                 minimum: 0.0
                 nullable: true
                 type: integer
               policyRef:
-                description: |-
-                  The single `SnapshotPolicy` (recipe) this schedule invokes; resolved in the
-                  schedule's own namespace. ADR §3.5 separates recipe from schedule. **Mutually
-                  exclusive** with `policySelector` — exactly one is required (webhook-enforced,
-                  ADR-0005 §10). Optional at the type level so `policySelector` can be used instead.
+                description: The single `SnapshotPolicy` this schedule invokes; mutually exclusive with `policySelector`.
                 nullable: true
                 properties:
                   name:
@@ -66,11 +57,7 @@ spec:
                 - name
                 type: object
               policySelector:
-                description: |-
-                  Fan-out form (ADR-0005 §10): a label selector over `SnapshotPolicy` objects in
-                  the schedule's namespace. Each matching policy gets a `Snapshot` per firing
-                  ("back up everything tagged `tier=critical` nightly" in one object). **Mutually
-                  exclusive** with `policyRef`. Mirrors the `pvcSelector` pattern.
+                description: Label selector fanning out over `SnapshotPolicy` objects; mutually exclusive with `policyRef`.
                 nullable: true
                 properties:
                   matchExpressions:
@@ -101,50 +88,37 @@ spec:
                     type: object
                 type: object
               schedule:
-                description: Cron, jitter, timezone, and concurrency for the firing cadence. ADR §3.5.
+                description: Cron, jitter, timezone, and concurrency for the firing cadence.
                 properties:
                   concurrencyPolicy:
                     default: Forbid
-                    description: |-
-                      How to handle a firing while a prior run is still in flight. ADR §4.1.
-
-                      Carries a real OpenAPI `default: Forbid` (ADR-0005 §1) — unconditional, so it
-                      materializes into the stored object / `kubectl explain`.
+                    description: How to handle a firing while a prior run is still in flight (default `Forbid`).
                     enum:
                     - Forbid
                     - Allow
                     - Replace
                     type: string
                   cron:
-                    description: Cron expression with Jenkins-style `H` substitution. ADR §4.1 (G4).
+                    description: Cron expression with Jenkins-style `H` substitution.
                     type: string
                   jitter:
-                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`. ADR §4.1.
+                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`.
                     nullable: true
                     type: string
                   runOnCreate:
                     default: false
-                    description: |-
-                      GitOps-friendly default: do NOT fire immediately on create. ADR §4.1 (G3).
-
-                      Carries a real OpenAPI `default: false` (ADR-0005 §1) so it materializes into
-                      the stored object / `kubectl explain` and GitOps stops diff-thrashing. NOT
-                      `skip_serializing_if`-elided, so the materialized value round-trips.
+                    description: Whether to fire immediately on create (default `false`).
                     type: boolean
                   startingDeadlineSeconds:
-                    description: |-
-                      If a slot is missed by more than this many seconds (e.g. operator was
-                      down), skip it instead of firing late. ADR §4.1.
+                    description: If a slot is missed by more than this many seconds, skip it instead of firing late.
                     format: int64
                     nullable: true
                     type: integer
                   suspend:
-                    description: Skip future firings while true. ADR §5.9.
+                    description: Skip future firings while true.
                     type: boolean
                   timezone:
-                    description: |-
-                      IANA timezone the cron is evaluated in (e.g. `America/Los_Angeles`).
-                      Absent means the controller's configured default. ADR §4.1.
+                    description: IANA timezone the cron is evaluated in; absent uses the controller's default.
                     nullable: true
                     type: string
                 required:
@@ -157,11 +131,11 @@ spec:
             - message: exactly one of policyRef or policySelector
               rule: '[has(self.policyRef), has(self.policySelector)].filter(x, x).size() == 1'
           status:
-            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run. ADR §3.5.'
+            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing schedule health. ADR §5 status conventions.
+                description: Standard Kubernetes conditions surfacing schedule health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -194,19 +168,16 @@ spec:
                   type: object
                 type: array
               consecutiveFailures:
-                description: Count of back-to-back failed runs; resets on success. Drives alerting.
+                description: Count of back-to-back failed runs; resets on success.
                 format: int64
                 nullable: true
                 type: integer
               lastSchedule:
-                description: Most recent firing (cron + jitter, pinned). ADR §3.5.
+                description: Most recent firing (cron + jitter, pinned).
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -221,14 +192,11 @@ spec:
                     type: object
                 type: object
               lastSuccessfulSchedule:
-                description: The most recent firing whose `Snapshot` succeeded. ADR §3.5.
+                description: The most recent firing whose `Snapshot` succeeded.
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -247,10 +215,7 @@ spec:
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -41,15 +41,10 @@ spec:
         description: Auto-generated derived type for ClusterRepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A shared kopia repository referenceable from allow-listed namespaces. ADR §3.2.
-
-              Cluster-scoped: note the absence of `namespaced` in `#[kube(...)]`. Secret/config
-              references in `backend`/`encryption` therefore MUST carry an explicit `namespace`
-              (webhook-enforced — the type system cannot express that requirement here).
+            description: A cluster-scoped kopia repository referenceable from allow-listed namespaces.
             properties:
               allowedNamespaces:
-                description: Tenancy gate — webhook-enforced on every consumer CR. ADR §3.2.
+                description: Which namespaces are permitted to reference this repository.
                 oneOf:
                 - required:
                   - list
@@ -59,7 +54,7 @@ spec:
                   - all
                 properties:
                   all:
-                    description: Allow all namespaces (must be `true`; `false` is meaningless and rejected by webhook).
+                    description: Allow all namespaces (must be `true`).
                     type: boolean
                   list:
                     description: Explicit namespace names.
@@ -98,7 +93,7 @@ spec:
                     type: object
                 type: object
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -125,37 +120,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -179,24 +162,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -220,10 +197,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -265,37 +239,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -326,9 +288,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -346,41 +306,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -410,9 +358,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -425,16 +371,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -444,24 +384,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -493,24 +427,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -525,65 +453,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog. For a shared repo this also picks where to land discovered snapshots
-                  via `catalog.fallbackNamespace`. ADR §3.1/§3.2.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Same semantics as
-                  `Repository.spec.create`. ADR §3.1/§3.2.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -598,64 +500,45 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               credentialProjection:
-                description: |-
-                  Repository-owner gate for credential-Secret projection into a foreign consumer
-                  namespace. **Default off** (`allowed: false`): a consumer's
-                  `credentialProjection.enabled` is necessary but not sufficient — the
-                  `ClusterRepository` owner must also allow it. BREAKING (ADR-0005 §8). A
-                  namespaced `Repository` has no such gate (projection there is a same-namespace
-                  no-op).
+                description: Repository-owner gate for projecting credential Secrets into a foreign consumer namespace.
                 nullable: true
                 properties:
                   allowed:
                     default: false
-                    description: |-
-                      When `true`, the repository owner permits projecting this repository's
-                      credential Secret(s) into a foreign consumer namespace (still requires the
-                      consumer opt-in AND operator RBAC — fail-closed). Off by default.
+                    description: When `true`, the owner permits projecting this repository's credential Secret(s) into a consumer namespace.
                     type: boolean
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. As this CR is cluster-scoped,
-                  the ref MUST carry an explicit `namespace` (webhook-enforced). ADR §3.1/§3.2.
+                description: Repository password (a Secret reference that must carry an explicit `namespace`).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -665,90 +548,58 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13), shared with `Repository` — see
-                  [`RepositoryHealthSpec`]. Tunes the index-blob-count warning. Absent uses
-                  the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               identityDefaults:
-                description: |-
-                  Identity defaults (CEL `*Expr`) applied when consumers don't override.
-                  ADR §3.2 / ADR-0004 §5.
+                description: Identity defaults (CEL `*Expr`) applied when consumers don't override.
                 nullable: true
                 properties:
                   hostnameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *hostname* (e.g. `"namespace"`).
-                      Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity hostname (e.g. `"namespace"`).
                     nullable: true
                     type: string
                   usernameExpr:
-                    description: |-
-                      CEL expression for the kopia identity *username*
-                      (e.g. `"namespace + '-' + policyName"`). Returns a string. ADR-0004 §5.
+                    description: CEL expression for the kopia identity username (e.g. `"namespace + '-' + policyName"`).
                     nullable: true
                     type: string
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this cluster repository.
-                  As `Maintenance` is namespaced, `maintenance.namespace` selects where it
-                  lands (defaulting to the operator's namespace). ADR §3.2/§3.7.
+                description: Maintenance control; `maintenance.namespace` selects where the owned `Maintenance` CR lands.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -770,7 +621,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -782,11 +633,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -795,26 +642,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -855,12 +691,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -990,7 +821,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -1031,10 +862,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1139,65 +967,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1227,20 +1037,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  cluster repository serves restores only — backups and maintenance are refused.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults inherited by **every** mover this repository spawns — bootstrap,
-                  consumer backup/restore, and maintenance — overridable per-recipe and merged
-                  field-wise (ADR-0004 §1/§2). Absorbs the former `cacheDefaults`
-                  (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1746,7 +1549,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1764,7 +1567,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1782,9 +1585,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1951,31 +1752,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -2080,23 +1870,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2105,10 +1883,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2157,34 +1932,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history) or `Delete` (cascade). BREAKING
-                  default change in ADR-0005 §5. Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server. Cluster-scoped, so the target `namespace` is
-                  required (see [`ClusterServerSpec`]). Presence means enabled.
+                description: Optional kopia web-UI server (the target `namespace` is required).
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2195,9 +1960,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2205,10 +1968,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2237,15 +1997,7 @@ spec:
                     description: Target namespace for the server Deployment/Service (and generated Secret).
                     type: string
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2375,13 +2127,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2557,9 +2303,7 @@ spec:
                 - namespace
                 type: object
               suspend:
-                description: |-
-                  Pause this cluster repository declaratively (ADR-0005 §14(e)): skips
-                  connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this cluster repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - allowedNamespaces
@@ -2576,11 +2320,11 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: Mirrors `RepositoryStatus` (ADR §3.1) plus `allowedNamespaceCount`. ADR §3.2.
+            description: Observed state of a `ClusterRepository`; mirrors `RepositoryStatus` plus `allowedNamespaceCount`.
             nullable: true
             properties:
               allowedNamespaceCount:
-                description: Number of namespaces currently resolved by `spec.allowedNamespaces`. ADR §3.2.
+                description: Number of namespaces currently resolved by `spec.allowedNamespaces`.
                 format: int64
                 nullable: true
                 type: integer
@@ -2603,7 +2347,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.2.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2665,11 +2409,7 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
@@ -2692,24 +2432,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2718,12 +2452,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/helm/kopiur/files/crds/maintenances.yaml
+++ b/deploy/helm/kopiur/files/crds/maintenances.yaml
@@ -32,61 +32,41 @@ spec:
         properties:
           spec:
             description: |-
-              Maintenance schedule + ownership lease for one `Repository`/`ClusterRepository`. ADR §3.7.
+              Maintenance schedule and ownership lease for one `Repository`/`ClusterRepository`.
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this maintenance run's mover
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace this `Maintenance`
-                  runs in (a no-op when they already live there) — useful when maintaining a
-                  shared `ClusterRepository` from a namespace that lacks the Secret. ADR §4.11.
+                description: Opt-in projection of the repository's credential Secret(s) into this run's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: How a failed maintenance run is retried/bounded (backoff, deadline). ADR §3.7.
+                description: How a failed maintenance run is retried and bounded (backoff, deadline).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the maintenance run — resources, scheduling,
-                  etc. Object-store repositories typically tune this. ADR §3.7.
+                description: Mover (Job pod) overrides for the maintenance run.
                 nullable: true
                 properties:
                   cache:
@@ -108,7 +88,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -120,11 +100,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -133,26 +109,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -193,12 +158,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -328,7 +288,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -369,10 +329,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -477,28 +434,20 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               ownership:
-                description: |-
-                  Ownership-lease configuration; at most one `Maintenance` may own a
-                  repository at a time. ADR §3.7.
+                description: Maintenance ownership lease holder and takeover policy.
                 properties:
                   owner:
-                    description: |-
-                      Stable lease holder identity (e.g. `kopia-operator/nas-primary`). Two
-                      `Maintenance` CRs claiming the same repository compare this. ADR §3.7.
+                    description: Stable lease holder identity (e.g. `kopia-operator/nas-primary`).
                     type: string
                   takeoverPolicy:
                     default: Never
-                    description: What to do if the lease is already held by a different `owner`. ADR §3.7.
+                    description: What to do when the lease is already held by a different `owner`.
                     enum:
                     - Never
                     - PromptCondition
@@ -508,7 +457,7 @@ spec:
                 - owner
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Reference to the `Repository` or `ClusterRepository` to maintain.
                 properties:
                   kind:
                     default: Repository
@@ -528,46 +477,36 @@ spec:
                 - name
                 type: object
               schedule:
-                description: |-
-                  Quick + full cron schedules (with a shared timezone) for `kopia
-                  maintenance run`. ADR §3.7.
+                description: quick (cheap) and full (`--full`, reclamation) maintenance crons.
                 properties:
                   full:
-                    description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                    description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   quick:
-                    description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                    description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   timezone:
-                    description: IANA timezone both crons are evaluated in; absent means controller default.
+                    description: IANA timezone both crons are evaluated in; absent means the controller default.
                     nullable: true
                     type: string
                 required:
@@ -580,11 +519,11 @@ spec:
             - schedule
             type: object
           status:
-            description: 'Observed maintenance state: lease holder plus per-kind run results. ADR §3.7.'
+            description: 'Observed maintenance state: lease holder and per-kind run results.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing maintenance health. ADR §5.
+                description: Standard Kubernetes conditions surfacing maintenance health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -617,7 +556,7 @@ spec:
                   type: object
                 type: array
               full:
-                description: Last/next-run state for the full maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the full maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -626,24 +565,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:
@@ -656,9 +583,7 @@ spec:
                     type: string
                 type: object
               manualRun:
-                description: |-
-                  State of the most recent annotation-requested out-of-band run
-                  (`kopiur.home-operations.com/run-requested`); absent until one is requested.
+                description: State of the most recent annotation-requested out-of-band run; absent until one is requested.
                 nullable: true
                 properties:
                   completedAt:
@@ -702,7 +627,7 @@ spec:
                 nullable: true
                 type: integer
               ownership:
-                description: Current lease holder, if the lease has been claimed. ADR §3.7.
+                description: Current lease holder, if the lease has been claimed.
                 nullable: true
                 properties:
                   claimedAt:
@@ -715,7 +640,7 @@ spec:
                     type: string
                 type: object
               quick:
-                description: Last/next-run state for the quick maintenance schedule. ADR §3.7.
+                description: Last/next-run state for the quick maintenance schedule.
                 nullable: true
                 properties:
                   consecutiveFailures:
@@ -724,24 +649,12 @@ spec:
                     nullable: true
                     type: integer
                   lastContentReclaimedBytes:
-                    description: The ONLY place storage reclamation is surfaced (ADR §3.7/§4.5).
+                    description: Bytes of storage reclaimed by the most recent run of this kind.
                     format: int64
                     nullable: true
                     type: integer
                   lastHandledAt:
-                    description: |-
-                      RFC3339 instant the controller last observed one of this kind's per-slot
-                      Jobs reach terminal success — the mover either ran maintenance (which
-                      also advances `lastRunAt`) or deliberately *yielded* the lease (which
-                      does not). The scheduler measures the next slot from
-                      `max(lastRunAt, lastHandledAt)`, so a handled slot never re-fires after
-                      its Job self-reaps via `ttlSecondsAfterFinished`. Without this, a yielded
-                      slot's only record was the (self-reaping) Job itself, and the same slot
-                      respawned a yield Job every TTL period, forever. The stamp is the
-                      *observation instant*, not the (possibly year-old, first-ever) slot
-                      itself — anchoring at the slot would make a yield-only Maintenance march
-                      through the entire backlog of historic slots one Job at a time. Same
-                      catch-up-once semantics as the mover's `lastRunAt = now`.
+                    description: RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success.
                     nullable: true
                     type: string
                   lastRunAt:

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -38,13 +38,10 @@ spec:
         description: Auto-generated derived type for RepositorySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A kopia repository owned by one namespace: credentials, backend, encryption,
-              and optional catalog-materialization bounds. Many `SnapshotPolicy`s / `Restore`s
-              reference one. ADR §3.1.
+            description: A kopia repository owned by one namespace, referenced by `SnapshotPolicy`s and `Restore`s.
             properties:
               backend:
-                description: Exactly one backend, enforced at the type level by the `Backend` enum. ADR §3.1.
+                description: Exactly one storage backend.
                 oneOf:
                 - required:
                   - s3
@@ -71,37 +68,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -125,24 +110,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -166,10 +145,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -211,37 +187,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -272,9 +236,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -292,41 +254,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -356,9 +306,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -371,16 +319,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -390,24 +332,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -439,24 +375,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -471,65 +401,39 @@ spec:
                     type: object
                 type: object
               catalog:
-                description: |-
-                  Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
-                  catalog, keeping etcd footprint sane for large repositories. ADR §3.1.
+                description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
                   fallbackNamespace:
-                    description: |-
-                      Where to materialize discovered `Snapshot`s whose identity hostname does not
-                      map to an allowed namespace (ClusterRepository only; rejected on a namespaced
-                      `Repository`, which always materializes into its own namespace). ADR §3.2.
+                    description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
                   refreshInterval:
-                    description: |-
-                      How often to re-scan the repository for snapshots to materialize as (or
-                      expire from) `origin: discovered` `Snapshot` CRs. Go-style duration
-                      (`30s`, `5m`, `1h`); minimum `30s` (webhook-enforced), default `1h`.
+                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
                     nullable: true
                     type: string
                   retain:
-                    description: |-
-                      How many discovered `Snapshot` CRs to keep materialized; bounds etcd footprint
-                      for large repositories. Expiring a CR row never deletes the kopia snapshot
-                      behind it (discovered snapshots are always `deletionPolicy: Retain`).
-                      ADR §3.1/§4.5.
+                    description: How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
                     nullable: true
                     properties:
                       maxAgeDays:
-                        description: |-
-                          Don't materialize (and expire) discovered `Snapshot` CRs for snapshots whose
-                          end time is older than this many days. Minimum 1 (webhook-enforced). The
-                          kopia snapshots themselves are untouched.
+                        description: Expire discovered `Snapshot` CRs older than this many days (minimum 1); kopia snapshots untouched.
                         format: int64
                         nullable: true
                         type: integer
                       perIdentity:
-                        description: |-
-                          Keep the most-recent N discovered `Snapshot` CRs per `username@hostname:path`
-                          identity (snapshots this cluster produced don't count against N). `0` disables
-                          discovered-Snapshot materialization entirely; negative values are rejected by
-                          the webhook. Rows beyond N are expired (the CR is deleted; the kopia snapshot
-                          is untouched and stays restorable via `Restore.source.identity`).
+                        description: Keep the most-recent N discovered `Snapshot` CRs per identity; `0` disables materialization.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                 type: object
               create:
-                description: |-
-                  What to do when the repository does not yet exist. Absent/disabled means
-                  it must already exist; enabled means the operator creates it with the
-                  given encryption/splitter/hash algorithms. ADR §3.1.
+                description: What to do when the repository does not yet exist (absent means it must already exist).
                 nullable: true
                 properties:
                   ecc:
-                    description: |-
-                      Reed-Solomon ECC parity guarding repo blobs against backend bit-rot
-                      (`kopia repository create --ecc=... --ecc-overhead-percent=...`). Creation-time
-                      only and immutable post-create (ADR-0005 §13(a), gated by §7). ADR-0005 §13(a).
+                    description: Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
                     nullable: true
                     properties:
                       algorithm:
@@ -544,46 +448,36 @@ spec:
                     type: object
                   enabled:
                     default: false
-                    description: |-
-                      Create the repository if it does not exist yet. Off by default, so a typo'd
-                      backend can't silently spin up a brand-new empty repository.
+                    description: Create the repository if it does not exist yet; off by default.
                     type: boolean
                   encryption:
-                    description: |-
-                      kopia encryption algorithm for a freshly-created repository (e.g.
-                      `AES256-GCM-HMAC-SHA256`); only consulted at creation time.
+                    description: kopia encryption algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   hash:
-                    description: kopia content hash algorithm for a freshly-created repository; creation-time only.
+                    description: kopia content hash algorithm for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                   splitter:
-                    description: kopia object splitter for a freshly-created repository; creation-time only.
+                    description: kopia object splitter for a freshly-created repository (creation-time only).
                     nullable: true
                     type: string
                 type: object
               encryption:
-                description: |-
-                  Repository password, always a Secret reference. A sub-object so future
-                  rotation fields slot in without API breakage. ADR §3.1/§4.11.
+                description: Repository password (a Secret reference).
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -593,71 +487,45 @@ spec:
                 - passwordSecretRef
                 type: object
               health:
-                description: |-
-                  Repository health thresholds (ADR-0005 §13): tuning for the warnings the
-                  reconciler raises about a degrading-but-still-usable repository (currently
-                  the index-blob-count warning). A sub-object so future health knobs slot in
-                  without API breakage. Absent uses the built-in defaults.
+                description: Repository health thresholds (tunes the index-blob-count warning).
                 nullable: true
                 properties:
                   indexBlobWarnThreshold:
-                    description: |-
-                      Index-blob count above which the reconciler raises the `IndexBlobHealth`
-                      condition + a Warning event (maintenance isn't compacting fast enough).
-                      Absent uses [`DEFAULT_INDEX_BLOB_WARN_THRESHOLD`] (1000). `0` disables the
-                      warning entirely; negative is rejected by the admission webhook.
+                    description: Index-blob count above which the reconciler raises the `IndexBlobHealth` warning (`0` disables).
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               maintenance:
-                description: |-
-                  Maintenance control. Default-managed: when absent or `enabled: true`, the
-                  reconciler creates and owns a `Maintenance` CR for this repository in this
-                  namespace. ADR §3.1/§3.7.
+                description: Maintenance control; when absent or enabled the reconciler creates and owns a `Maintenance` CR.
                 nullable: true
                 properties:
                   enabled:
                     default: true
-                    description: |-
-                      Whether the operator manages a `Maintenance` CR for this repository.
-                      Defaults to `true` (default-on). When `false`, the operator does not
-                      create or manage one — but an externally-authored `Maintenance` is still
-                      honored.
+                    description: Whether the operator manages a `Maintenance` CR for this repository (default `true`).
                     type: boolean
                   failurePolicy:
                     description: Failure handling (backoff/deadline) for the managed `Maintenance` run.
                     nullable: true
                     properties:
                       activeDeadlineSeconds:
-                        description: |-
-                          Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                          after which a still-running run is killed.
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                         format: int64
                         nullable: true
                         type: integer
                       backoffLimit:
-                        description: |-
-                          Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                          run is retried before the Job is marked failed.
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                         format: int32
                         nullable: true
                         type: integer
                       podStartupDeadlineSeconds:
-                        description: |-
-                          How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                          `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                          `Unschedulable` — before the controller fails the run with an actionable reason,
-                          rather than waiting out `active_deadline_seconds` (which can be many hours and
-                          is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                          terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                          it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   mover:
-                    description: Mover overrides for the managed `Maintenance` (object-store repositories).
+                    description: Mover overrides for the managed `Maintenance`.
                     nullable: true
                     properties:
                       cache:
@@ -679,7 +547,7 @@ spec:
                             nullable: true
                             type: integer
                           mode:
-                            description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                            description: How a mover's kopia cache volume is provisioned.
                             enum:
                             - Ephemeral
                             - Persistent
@@ -691,11 +559,7 @@ spec:
                             type: string
                         type: object
                       inheritSecurityContextFrom:
-                        description: |-
-                          Opt-in: copy security context from a live workload pod instead of setting an
-                          explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                          Either name the workload by label (`workloadSelector`) or, on a **backup**
-                          source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                        description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                         nullable: true
                         oneOf:
                         - required:
@@ -704,26 +568,15 @@ spec:
                           - pvcConsumer
                         properties:
                           pvcConsumer:
-                            description: |-
-                              **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                              backs up: the operator finds the pod(s) mounting the source claim and inherits
-                              their securityContext, so the mover's UID/GID matches the workload *by
-                              construction* — no hand-written selector. Meaningless on a restore (the consuming
-                              pod may not exist yet, exactly like a populator), so restore must use
-                              `workloadSelector`.
+                            description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                             properties:
                               container:
-                                description: |-
-                                  Which container within the matched consumer pod to inherit from; absent uses the
-                                  first/only container (same semantics as [`PodSelector::container`]).
+                                description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
                             type: object
                           workloadSelector:
-                            description: |-
-                              Match the workload pod(s) by an explicit label selector and inherit the chosen
-                              container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                              both backup and restore (restore inherits from the pod that will *read* the data).
+                            description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                             properties:
                               container:
                                 description: Which container within the matched pod; absent uses the first/only container.
@@ -764,12 +617,7 @@ spec:
                             type: object
                         type: object
                       podSecurityContext:
-                        description: |-
-                          Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                          a freshly-provisioned volume group-writable so an unprivileged
-                          (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                          from the container-level [`MoverSpec::security_context`]; a pod-level
-                          `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                        description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                         nullable: true
                         properties:
                           appArmorProfile:
@@ -899,7 +747,7 @@ spec:
                             type: object
                         type: object
                       privilegedMode:
-                        description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                        description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                         nullable: true
                         type: boolean
                       resources:
@@ -940,10 +788,7 @@ spec:
                             type: object
                         type: object
                       securityContext:
-                        description: |-
-                          Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                          capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                          and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                        description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                         nullable: true
                         properties:
                           allowPrivilegeEscalation:
@@ -1048,65 +893,47 @@ spec:
                             type: object
                         type: object
                       ttlSecondsAfterFinished:
-                        description: |-
-                          Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                          `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                          backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                          is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                        description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                         format: int64
                         nullable: true
                         type: integer
                     type: object
                   namespace:
-                    description: |-
-                      **ClusterRepository only** — namespace the managed (namespaced)
-                      `Maintenance` CR is created in. Defaults to the operator's own namespace.
-                      Forbidden on a namespaced `Repository` (its `Maintenance` always lives in
-                      the repository's namespace), rejected by the admission webhook.
+                    description: 'ClusterRepository only: namespace the managed `Maintenance` CR is created in (default the operator''s namespace).'
                     nullable: true
                     type: string
                   schedule:
-                    description: |-
-                      Schedule override. When absent, the operator uses
-                      [`default_maintenance_schedule`] (quick 6h / full daily).
+                    description: Schedule override; absent uses the default quick-6h / full-daily schedule.
                     nullable: true
                     properties:
                       full:
-                        description: Cron + jitter for `kopia maintenance run --full` (content reclamation).
+                        description: Cron and jitter for `kopia maintenance run --full` (content reclamation).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       quick:
-                        description: Cron + jitter for `kopia maintenance run` (quick = cheap index/log work).
+                        description: Cron and jitter for `kopia maintenance run` (quick, cheap index/log work).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       timezone:
-                        description: IANA timezone both crons are evaluated in; absent means controller default.
+                        description: IANA timezone both crons are evaluated in; absent means the controller default.
                         nullable: true
                         type: string
                     required:
@@ -1136,22 +963,13 @@ spec:
                 type: object
               mode:
                 default: ReadWrite
-                description: |-
-                  Access mode (ADR-0005 §11): `ReadWrite` (default) or `ReadOnly`. A `ReadOnly`
-                  repository serves restores only — the reconciler refuses backup Jobs and skips
-                  maintenance projection — for decommissioning/migration without write risk.
-                  Carries a real OpenAPI `default: ReadWrite`.
+                description: 'Access mode: `ReadWrite` (default) or `ReadOnly` (serves restores only).'
                 enum:
                 - ReadWrite
                 - ReadOnly
                 type: string
               moverDefaults:
-                description: |-
-                  Mover defaults (security context, pod security context, resources, cache,
-                  nodeSelector/tolerations/affinity, Job TTL) inherited by **every** mover this
-                  repository spawns — bootstrap, backup, restore, maintenance — overridable
-                  per-recipe via `mover` and merged field-wise (ADR-0004 §1/§2). Absorbs the
-                  former `cacheDefaults` (now `moverDefaults.cache`).
+                description: Base mover configuration inherited by every mover this repository spawns.
                 nullable: true
                 properties:
                   affinity:
@@ -1657,7 +1475,7 @@ spec:
                         type: object
                     type: object
                   cache:
-                    description: kopia cache defaults (the former repository `cacheDefaults`).
+                    description: kopia cache defaults for every mover.
                     nullable: true
                     properties:
                       capacity:
@@ -1675,7 +1493,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -1693,9 +1511,7 @@ spec:
                     nullable: true
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod security-context base (notably `fsGroup`) for every mover, merged under the
-                      recipe's `mover.podSecurityContext`.
+                    description: Pod security-context base (notably `fsGroup`) for every mover.
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -1862,31 +1678,20 @@ spec:
                         type: object
                     type: object
                   scratch:
-                    description: |-
-                      Defaults for the deep-verification scratch (restore-test) volume, inherited by
-                      `SnapshotPolicy.spec.verification.deep` unless overridden there. Always
-                      ephemeral (no `mode`, unlike [`MoverDefaults::cache`]); `storageClassName`
-                      applies only when a `capacity` is set.
+                    description: Defaults for the deep-verification scratch (restore-test) volume.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `100Gi`) — size it to comfortably hold
-                          the restored snapshot. When absent (here and on `verification.deep`), scratch
-                          falls back to a node-ephemeral `emptyDir`.
+                        description: Size of the ephemeral scratch PVC (e.g. `100Gi`); absent falls back to an `emptyDir`.
                         nullable: true
                         type: string
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set.
+                        description: StorageClass for the ephemeral scratch PVC; only applies when `capacity` is set.
                         nullable: true
                         type: string
                     type: object
                   securityContext:
-                    description: |-
-                      Container security-context base for every mover, merged *under* the recipe's
-                      `mover.securityContext` and *over* the hardened default ([`hardened_security_context`]).
+                    description: Container security-context base for every mover.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -1991,23 +1796,11 @@ spec:
                         type: object
                     type: object
                   sourceColocation:
-                    description: |-
-                      How a mover co-locates with the node its RWO source/destination PVC is
-                      attached to, to avoid a Multi-Attach error. Defaults to
-                      [`SourceColocationMode::Auto`] when unset. ADR §3.7 / RWO multi-attach fix.
+                    description: How a mover co-locates with its RWO PVC's node; defaults to [`SourceColocationMode::Auto`].
                     nullable: true
                     properties:
                       mode:
-                        description: |-
-                          How the mover pod co-locates with the node a `ReadWriteOnce` source/destination
-                          PVC is attached to, to avoid a Kubernetes **Multi-Attach error**.
-
-                          A `ReadWriteOnce` (RWO) PVC can only be attached to one node at a time, but it
-                          *can* be mounted by multiple pods **on that same node**. When an app pod already
-                          holds an RWO PVC on node A and the mover lands on node B, the kubelet on B cannot
-                          attach the volume and the mover pod is stuck `Multi-Attach error`. The controller
-                          resolves the node the PVC is attached to (consuming pod → PV `nodeAffinity` →
-                          `VolumeAttachment`) and pins the mover there so it co-locates with the workload.
+                        description: How the mover co-locates with the node an RWO source/destination PVC is attached to.
                         enum:
                         - Auto
                         - Required
@@ -2016,10 +1809,7 @@ spec:
                         type: string
                     type: object
                   throttle:
-                    description: |-
-                      Repository throttle limits (`kopia repository throttle set`) applied by every
-                      mover after it connects, so a run doesn't saturate the link / hammer the
-                      object store. ADR-0005 §13(e).
+                    description: Repository throttle limits applied by every mover after it connects.
                     nullable: true
                     properties:
                       downloadBytesPerSecond:
@@ -2068,36 +1858,24 @@ spec:
                     nullable: true
                     type: array
                   ttlSecondsAfterFinished:
-                    description: |-
-                      `Job.spec.ttlSecondsAfterFinished` for every mover Job, so finished
-                      backup/restore/maintenance Jobs self-GC (ADR-0005 §12). A recipe's
-                      `mover` can override it.
+                    description: '`Job.spec.ttlSecondsAfterFinished` for every mover Job so finished Jobs self-GC.'
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               onNamespaceDelete:
                 default: Orphan
-                description: |-
-                  What happens to this repository's snapshots when a consuming **namespace** is
-                  deleted: `Orphan` (default — keep history, release ownership) or `Delete`
-                  (cascade per-`Snapshot` `deletionPolicy`). BREAKING default change in
-                  ADR-0005 §5 — `kubectl delete ns` no longer destroys snapshots by default.
-                  Carries a real OpenAPI `default: Orphan`.
+                description: What happens to this repository's snapshots when a consuming namespace is deleted.
                 enum:
                 - Orphan
                 - Delete
                 type: string
               server:
-                description: |-
-                  Optional kopia web-UI server, exposed via a `Service` in this Repository's
-                  own namespace. Presence means enabled. ADR §3.1 (server addendum).
+                description: Optional kopia web-UI server, exposed via a `Service` in this namespace.
                 nullable: true
                 properties:
                   auth:
-                    description: |-
-                      UI authentication mode. Omitted ⇒ [`ServerAuth::Generate`] (resolved at
-                      admission, pinned to `status.server.authMode`). **Never** defaults to no-auth.
+                    description: UI authentication mode; omitted ⇒ [`ServerAuth::Generate`] (never no-auth).
                     nullable: true
                     oneOf:
                     - required:
@@ -2108,9 +1886,7 @@ spec:
                       - insecure
                     properties:
                       generate:
-                        description: |-
-                          The operator mints random UI credentials into an owned `Secret` and pins the
-                          reference to `status.server.generatedSecretRef`. The safe default.
+                        description: The operator mints random UI credentials into an owned `Secret`; the safe default.
                         properties:
                           username:
                             description: UI username to provision (default `kopia`).
@@ -2118,10 +1894,7 @@ spec:
                             type: string
                         type: object
                       insecure:
-                        description: |-
-                          No UI authentication. Requires an explicit `acknowledgeInsecure: true`
-                          (webhook-rejected otherwise) because it exposes full read/write/delete of the
-                          repository with no login.
+                        description: 'No UI authentication; requires an explicit `acknowledgeInsecure: true`.'
                         properties:
                           acknowledgeInsecure:
                             default: false
@@ -2147,15 +1920,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Pod-level security context for the server pod. The hardened base
-                      (`fsGroup`) is applied first, then this is overlaid field-wise — the same
-                      resolution movers get (ADR-0004 §2). Notably carries `supplementalGroups`
-                      so the server can write a filesystem backend whose export is owned by a
-                      shared GID: **`fsGroup` is silently a no-op on NFS** (the kubelet does not
-                      recursively chown in-tree NFS mounts), so a group-writable export + a
-                      supplemental group is the way to grant the long-lived server write access.
-                      `PartialEq` only (embeds the k8s-openapi `PodSecurityContext`).
+                    description: Pod-level security context for the server pod (notably `supplementalGroups` for NFS exports).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -2285,13 +2050,7 @@ spec:
                         type: object
                     type: object
                   readOnly:
-                    description: |-
-                      Connect the server's repository **read-only** so the UI cannot create, delete, or
-                      alter backups (browse + restore-download only). Omitted ⇒ `false`. A `Repository`
-                      with `spec.mode: ReadOnly` forces this on regardless of the field; setting an
-                      explicit `readOnly: false` on a `ReadOnly` repository is rejected (contradictory).
-                      Read-only blocks *mutation*, not *reading*: the server still holds the decryption
-                      key. Orthogonal to [`ServerSpec::auth`] — no-auth still needs `acknowledgeInsecure`.
+                    description: Connect the server's repository read-only so the UI cannot mutate backups (browse + restore only).
                     nullable: true
                     type: boolean
                   resources:
@@ -2465,9 +2224,7 @@ spec:
                     type: object
                 type: object
               suspend:
-                description: |-
-                  Pause this repository declaratively (ADR-0005 §14(e)): a suspended repository
-                  skips connect/bootstrap and maintenance projection. Surfaced via a condition.
+                description: 'Pause this repository: skip connect/bootstrap and maintenance projection.'
                 type: boolean
             required:
             - backend
@@ -2483,9 +2240,7 @@ spec:
             - message: create.ecc is immutable after creation
               rule: '!has(self.create) || !has(oldSelf.create) || (has(self.create.ecc) == has(oldSelf.create.ecc) && (!has(self.create.ecc) || self.create.ecc == oldSelf.create.ecc))'
           status:
-            description: |-
-              Observed state of a [`Repository`]. Carries resolved values pinned by the
-              reconciler. ADR §3.1 status.
+            description: Observed state of a `Repository`, carrying resolved values pinned by the reconciler.
             nullable: true
             properties:
               backend:
@@ -2507,7 +2262,7 @@ spec:
                     type: string
                 type: object
               conditions:
-                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`). ADR §3.1.
+                description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -2569,15 +2324,11 @@ spec:
                 nullable: true
                 type: string
               resolvedCredentialVersion:
-                description: |-
-                  `resourceVersion` of the password Secret observed at the last connect attempt.
-                  The terminal-failure hard-stop reopens when this changes, so editing the
-                  Secret's *content* (which does NOT bump `metadata.generation`) re-triggers a
-                  connect instead of parking the repository as `Failed` forever.
+                description: '`resourceVersion` of the password Secret observed at the last connect attempt.'
                 nullable: true
                 type: string
               server:
-                description: Resolved kopia server endpoint/auth, pinned by the reconciler. ADR §3.1.
+                description: Resolved kopia server endpoint/auth, pinned by the reconciler.
                 nullable: true
                 properties:
                   authMode:
@@ -2596,24 +2347,18 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
                     - name
                     type: object
                   namespace:
-                    description: |-
-                      Namespace the server objects were last applied to. **Load-bearing**: lets the
-                      reconciler detect a `server.namespace` change and delete the stale objects.
+                    description: Namespace the server objects were last applied to.
                     nullable: true
                     type: string
                   readOnly:
-                    description: |-
-                      **Effective** read-only state of the served connection — `spec.mode: ReadOnly` OR
-                      `spec.server.readOnly: true`. When `true` the UI cannot mutate the repository.
+                    description: Effective read-only state of the served connection.
                     nullable: true
                     type: boolean
                 type: object
@@ -2622,12 +2367,7 @@ spec:
                 nullable: true
                 properties:
                   indexBlobCount:
-                    description: |-
-                      Number of content-index blobs (`kopia index list`) observed at the last
-                      bootstrap. kopia compacts these during maintenance; an unbounded climb
-                      means maintenance isn't keeping up. The reconciler raises the
-                      `IndexBlobHealth` condition + a Warning event when this crosses
-                      `spec.health.indexBlobWarnThreshold`. ADR-0005 §13.
+                    description: Number of content-index blobs (`kopia index list`) observed at the last bootstrap.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
@@ -38,16 +38,12 @@ spec:
         properties:
           spec:
             description: |-
-              Mirror a source repository's blobs to a destination backend on a schedule
-              (`kopia repository sync-to`), ADR-0005 §13(d).
+              Mirror a source repository's blobs to a destination backend on a schedule (`kopia repository sync-to`).
 
               Not `Eq`: `mover` transitively embeds k8s-openapi types.
             properties:
               destination:
-                description: |-
-                  The backend to mirror *to* (`kopia repository sync-to <destination>`).
-                  Exactly one backend by construction (the externally-tagged `Backend` enum,
-                  reused). Must differ from the source's backend (webhook-enforced).
+                description: The backend to mirror to; must differ from the source's backend (webhook-enforced).
                 oneOf:
                 - required:
                   - s3
@@ -74,37 +70,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -128,24 +112,18 @@ spec:
                     description: Backblaze B2.
                     properties:
                       auth:
-                        description: |-
-                          Access credentials (application key ID/key Secret). B2 has no cloud IAM
-                          federation, so this is Secret-only.
+                        description: Access credentials (application key ID/key Secret); Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -169,10 +147,7 @@ spec:
                         description: Mount path inside the mover pod where kopia writes the repository (e.g. `/repo`).
                         type: string
                       volume:
-                        description: |-
-                          What backs `path`. A PVC (`{ pvc: { name } }`) or an inline NFS export
-                          (`{ nfs: { server, path } }`). Absent for a path already present on the
-                          node/image (a `hostPath`/baked-in mount; mainly the e2e harness).
+                        description: 'What backs `path`: a PVC or an inline NFS export; absent for a path already on the node/image.'
                         nullable: true
                         oneOf:
                         - required:
@@ -214,37 +189,25 @@ spec:
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -275,9 +238,7 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: |-
-                              Namespace of the `Secret`. Absent = same namespace as the referrer;
-                              required for cluster-scoped CRs (ADR §3.2).
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
                             nullable: true
                             type: string
                         required:
@@ -295,41 +256,29 @@ spec:
                     description: Amazon S3 or any S3-compatible object store (MinIO, RustFS, Ceph RGW, …).
                     properties:
                       auth:
-                        description: Access credentials (Secret ref / workload identity). ADR §3.1.
+                        description: Access credentials (Secret ref / workload identity).
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials. The operator reads
-                              well-known keys (e.g. `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
-                              Mutually exclusive with `workloadIdentity`. ADR §3.1.
+                            description: Secret holding the backend's static access credentials (mutually exclusive with `workloadIdentity`).
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
                             - name
                             type: object
                           workloadIdentity:
-                            description: |-
-                              Cloud workload identity: the mover Job runs as the named `ServiceAccount`
-                              and authenticates via the cloud's federation (IRSA / EKS Pod Identity,
-                              AKS Workload Identity, GKE Workload Identity) — no static keys in the
-                              cluster. Mutually exclusive with `secretRef`. ADR §4.11.
+                            description: Use a cloud-federated ServiceAccount instead of static keys (mutually exclusive with `secretRef`).
                             nullable: true
                             properties:
                               serviceAccountName:
-                                description: |-
-                                  Name of the `ServiceAccount` the mover pod runs as, federated to the
-                                  cloud IAM role/identity that grants backend access. Resolved in the
-                                  mover Job's own namespace.
+                                description: Name of the `ServiceAccount` the mover pod runs as, resolved in the Job's own namespace.
                                 type: string
                             required:
                             - serviceAccountName
@@ -359,9 +308,7 @@ spec:
                         nullable: true
                         properties:
                           caBundleRef:
-                            description: |-
-                              CA bundle (PEM) used to verify the endpoint's certificate, sourced from a
-                              `ConfigMap`. Preferred over `insecureSkipVerify` for self-signed endpoints.
+                            description: CA bundle (PEM) used to verify the endpoint's certificate, sourced from a `ConfigMap`.
                             nullable: true
                             properties:
                               configMapName:
@@ -374,16 +321,10 @@ spec:
                                 type: string
                             type: object
                           disableTls:
-                            description: |-
-                              Disable TLS entirely and talk plain HTTP. Maps to kopia's `--disable-tls`.
-                              Needed for HTTP-only endpoints (e.g. an in-cluster MinIO/RustFS service);
-                              kopia's S3 path otherwise assumes HTTPS. Off by default.
+                            description: Disable TLS entirely and talk plain HTTP; maps to kopia's `--disable-tls`.
                             type: boolean
                           insecureSkipVerify:
-                            description: |-
-                              Skip TLS certificate verification (still uses TLS). Maps to kopia's
-                              `--disable-tls-verification`. For self-signed endpoints; prefer
-                              `caBundleRef` in production.
+                            description: Skip TLS certificate verification (still uses TLS); maps to kopia's `--disable-tls-verification`.
                             type: boolean
                         type: object
                     required:
@@ -393,24 +334,18 @@ spec:
                     description: SFTP server.
                     properties:
                       auth:
-                        description: |-
-                          Credentials (SSH private key / known-hosts) sourced from a Secret. SSH
-                          has no cloud IAM federation, so this is Secret-only.
+                        description: Credentials (SSH private key / known-hosts) sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -442,24 +377,18 @@ spec:
                     description: WebDAV endpoint.
                     properties:
                       auth:
-                        description: |-
-                          HTTP basic-auth credentials sourced from a Secret. WebDAV has no cloud
-                          IAM federation, so this is Secret-only.
+                        description: HTTP basic-auth credentials sourced from a Secret; Secret-only.
                         nullable: true
                         properties:
                           secretRef:
-                            description: |-
-                              Secret holding the backend's access credentials, read by well-known keys
-                              (e.g. `B2_KEY_ID`/`B2_KEY`, `KOPIA_SFTP_KEY_DATA`, `KOPIA_WEBDAV_USERNAME`).
+                            description: Secret holding the backend's access credentials, read by well-known keys.
                             nullable: true
                             properties:
                               name:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: |-
-                                  Namespace of the `Secret`. Absent = same namespace as the referrer;
-                                  required for cluster-scoped CRs (ADR §3.2).
+                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
                                 nullable: true
                                 type: string
                             required:
@@ -474,30 +403,21 @@ spec:
                     type: object
                 type: object
               destinationEncryption:
-                description: |-
-                  Encryption/password for the destination repository when it needs its own
-                  (e.g. a freshly-created mirror with a distinct password). Absent ⇒ the
-                  destination uses the **source** repository's password — the common case for a
-                  true mirror, where `sync-to` copies blobs verbatim and the format (including
-                  the encryption material) is identical. Document this in the example.
+                description: Encryption for the destination; omit to reuse the source repository password.
                 nullable: true
                 properties:
                   passwordSecretRef:
-                    description: Always a Secret ref; never inline. ADR §3.1.
+                    description: Repository password, always a Secret reference (never inline).
                     properties:
                       key:
-                        description: |-
-                          Which key inside the `Secret` to read. Defaults are documented per-field on
-                          the consuming struct.
+                        description: Which key inside the `Secret` to read.
                         nullable: true
                         type: string
                       name:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: |-
-                          Namespace of the `Secret`. Absent = same namespace as the referrer;
-                          required for cluster-scoped CRs which have no own namespace (ADR §3.2).
+                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
                         nullable: true
                         type: string
                     required:
@@ -507,10 +427,7 @@ spec:
                 - passwordSecretRef
                 type: object
               mover:
-                description: |-
-                  Mover (Job pod) overrides for the replication run — resources, scheduling,
-                  security context. Inherits the source repository's `moverDefaults` underneath
-                  (ADR-0004 §1/§2).
+                description: Mover (Job pod) overrides for the replication run.
                 nullable: true
                 properties:
                   cache:
@@ -532,7 +449,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -544,11 +461,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -557,26 +470,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -617,12 +519,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -752,7 +649,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -793,10 +690,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -901,38 +795,26 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               schedule:
-                description: |-
-                  Cron + deterministic jitter for the replication runs (ADR §3.7 scheduling
-                  kernel, shared with `Maintenance`).
+                description: Cron and deterministic jitter for the replication runs.
                 properties:
                   cron:
-                    description: |-
-                      The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                      deterministic per-schedule jitter (ADR §3.7).
+                    description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                     type: string
                   jitter:
-                    description: |-
-                      Optional deterministic jitter window as a Go-style duration string (e.g.
-                      `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                    description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
                 required:
                 - cron
                 type: object
               sourceRef:
-                description: |-
-                  The repository to mirror *from* — a `Repository` or `ClusterRepository`
-                  reference (ADR §3.2). Credentials/connect are resolved from it.
+                description: Reference to the `Repository` or `ClusterRepository` to mirror from.
                 properties:
                   kind:
                     default: Repository
@@ -952,10 +834,7 @@ spec:
                 - name
                 type: object
               suspend:
-                description: |-
-                  Pause this replication declaratively (ADR-0005 §14(e)): a suspended
-                  `RepositoryReplication` is skipped by its own reconcile (no sync runs),
-                  surfaced via a condition. Default `false`.
+                description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
             required:
             - destination
@@ -963,11 +842,11 @@ spec:
             - sourceRef
             type: object
           status:
-            description: Observed state of a [`RepositoryReplication`]. ADR-0005 §13(d).
+            description: Observed state of a `RepositoryReplication`.
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). ADR-0005 §2.
+                description: Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -1000,15 +879,11 @@ spec:
                   type: object
                 type: array
               destinationBackend:
-                description: |-
-                  The destination backend kind (mirror of `spec.destination` discriminant),
-                  for the `DESTINATION` print column.
+                description: The destination backend kind, for the `DESTINATION` print column.
                 nullable: true
                 type: string
               lastReplicated:
-                description: |-
-                  RFC3339 timestamp of the most recent successful replication run. Backs the
-                  `LAST` print column.
+                description: RFC3339 timestamp of the most recent successful replication run.
                 nullable: true
                 type: string
               lastReplicatedBlobs:

--- a/deploy/helm/kopiur/files/crds/restores.yaml
+++ b/deploy/helm/kopiur/files/crds/restores.yaml
@@ -32,69 +32,40 @@ spec:
         properties:
           spec:
             description: |-
-              A restore operation. `target` is **required** (ADR-0005 §9): explicit
-              `pvc`/`pvcRef`, or `populator: {}` for passive populator mode (consumed by a
-              PVC's `spec.dataSourceRef`). The empty-`target` form is removed. ADR §3.6/§4.7.
-              Desired state of a [`Restore`]: where to read from, where to write to, and how
-              to behave when the snapshot is missing. ADR §3.6/§4.6.
+              A restore operation from a snapshot/identity into a PVC, or a passive populator source.
+              Desired state of a Restore: where to read from, where to write to, and how to behave when the snapshot is missing.
             properties:
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this restore's mover (default off).
-                  When `enabled: true`, the operator copies the referenced repository's
-                  credential Secret(s) into the restore mover's namespace (a no-op when they
-                  already live there) — so restoring from a shared `ClusterRepository` into a
-                  fresh namespace need not pre-create the Secret there. ADR §4.11.
+                description: Opt-in copying of the repository's credential Secret(s) into the mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               failurePolicy:
-                description: |-
-                  Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`),
-                  mirroring `Snapshot.spec.failurePolicy`. Absent uses the ADR defaults.
+                description: Mover `Job` retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`).
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               mover:
-                description: |-
-                  Per-run mover overrides for this restore's Job — resource requests/limits,
-                  kopia cache sizing, container `securityContext` (UID/GID match), `privilegedMode`,
-                  and `inheritSecurityContextFrom`. The same surface `SnapshotPolicy.spec.mover`
-                  gives a backup. An elevated context is namespace-gated exactly like a backup's
-                  (ADR §4.11/§G16); `securityContext` and `inheritSecurityContextFrom` are
-                  mutually exclusive.
+                description: Per-run mover overrides for this restore's Job (resources, cache, `securityContext`).
                 nullable: true
                 properties:
                   cache:
@@ -116,7 +87,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -128,11 +99,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -141,26 +108,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -201,12 +157,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -336,7 +287,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -377,10 +328,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -485,35 +433,29 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               options:
-                description: kopia restore behavior (file deletion, permission/atomicity handling). ADR §4.6.
+                description: kopia restore behavior (file deletion, permission/atomicity handling).
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: |-
-                      Delete files in the target that are not present in the snapshot (make the
-                      target an exact mirror). Off by default — additive restore is the safe default.
+                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
                     type: boolean
                   ignorePermissionErrors:
-                    description: Default true; surfaces a condition if any errors occurred. ADR §4.6.
+                    description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
                   writeFilesAtomically:
-                    description: Default true. ADR §4.6.
+                    description: Write files atomically via a temp file + rename (default true).
                     nullable: true
                     type: boolean
                 type: object
               policy:
-                description: Missing-snapshot handling and wait timeout. ADR §4.6 (G7).
+                description: What to do when the referenced snapshot doesn't exist yet, and how long to wait.
                 nullable: true
                 properties:
                   onMissingSnapshot:
@@ -533,14 +475,12 @@ spec:
                     nullable: true
                     type: string
                   waitTimeout:
-                    description: |-
-                      How long to wait for the source snapshot to appear before giving up
-                      (Go-style duration string, e.g. `5m`).
+                    description: How long to wait for the source snapshot to appear before giving up (e.g. `5m`).
                     nullable: true
                     type: string
                 type: object
               repository:
-                description: Derived from `source` when omitted; REQUIRED only with `source.identity`. ADR §3.6/§4.6.
+                description: The repository to read from; derived from `source` when omitted, required only with `source.identity`.
                 nullable: true
                 properties:
                   kind:
@@ -561,7 +501,7 @@ spec:
                 - name
                 type: object
               source:
-                description: Exactly one source mode; webhook-enforced. ADR §3.6.
+                description: Where to read data from (snapshotRef, fromPolicy, or identity).
                 oneOf:
                 - required:
                   - snapshotRef
@@ -571,9 +511,7 @@ spec:
                   - identity
                 properties:
                   fromPolicy:
-                    description: |-
-                      A `SnapshotPolicy` CR — resolves via identity even with no `Snapshot` CR present
-                      (deploy-or-restore). Default `onMissingSnapshot: Continue`. ADR §4.6.
+                    description: A `SnapshotPolicy` CR, resolved via identity even with no `Snapshot` CR present (deploy-or-restore).
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -588,19 +526,14 @@ spec:
                         type: string
                       offset:
                         default: 0
-                        description: |-
-                          0 = latest, 1 = previous, ... ADR §3.6.
-
-                          Carries a real OpenAPI `default: 0` (ADR-0005 §1): unconditional, so it
-                          materializes into the stored object / `kubectl explain` and GitOps stops
-                          diff-thrashing. A bare `i64` (not `Option`) so the default is never dropped.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         type: integer
                     required:
                     - name
                     type: object
                   identity:
-                    description: A raw kopia identity (foreign writers / aged-out catalog). Requires `spec.repository`.
+                    description: A raw kopia identity (foreign writers / aged-out catalog); requires `spec.repository`.
                     properties:
                       asOf:
                         description: Restore the newest snapshot at or before this RFC3339 timestamp (point-in-time).
@@ -610,14 +543,12 @@ spec:
                         description: The kopia `hostname` to match.
                         type: string
                       offset:
-                        description: 0 = latest, 1 = previous, ... mutually exclusive with `snapshotID`/`asOf` in practice.
+                        description: 'Which snapshot to pick: 0 = latest, 1 = previous, and so on.'
                         format: int64
                         nullable: true
                         type: integer
                       snapshotID:
-                        description: |-
-                          Pin an exact kopia snapshot by ID. Renamed to match the ADR wire shape
-                          exactly (`snapshotID`, capital `ID`).
+                        description: Pin an exact kopia snapshot by ID.
                         nullable: true
                         type: string
                       sourcePath:
@@ -632,7 +563,7 @@ spec:
                     - username
                     type: object
                   snapshotRef:
-                    description: A `Snapshot` CR (scheduled, manual, or discovered — all the same kind). Default mode.
+                    description: A `Snapshot` CR (scheduled, manual, or discovered).
                     properties:
                       name:
                         description: Name of the referenced object.
@@ -646,11 +577,7 @@ spec:
                     type: object
                 type: object
               target:
-                description: |-
-                  Where to restore to — **required** (ADR-0005 §9): `pvc` (operator creates),
-                  `pvcRef` (existing PVC), or `populator: {}` (passive populator mode, claimed
-                  via a PVC's `spec.dataSourceRef`). The former empty-`target` form is removed;
-                  a `Restore` with no `target` is now invalid (deserialization fails).
+                description: Where to write the restored data (pvc, pvcRef, or populator).
                 oneOf:
                 - required:
                   - pvc
@@ -660,10 +587,7 @@ spec:
                   - populator
                 properties:
                   populator:
-                    description: |-
-                      Passive populator mode: no workload target at provision time — the restore is
-                      claimed by a PVC's `spec.dataSourceRef` (ADR-0005 §9). An (empty) sub-object so
-                      future populator knobs slot in without API breakage.
+                    description: 'Passive populator mode: the restore is claimed by a PVC''s `spec.dataSourceRef`.'
                     type: object
                   pvc:
                     description: Operator creates the PVC.
@@ -709,7 +633,7 @@ spec:
             - message: exactly one of target.pvc, target.pvcRef, target.populator
               rule: '[has(self.target.pvc), has(self.target.pvcRef), has(self.target.populator)].filter(x, x).size() == 1'
           status:
-            description: Observed state of a [`Restore`], written by the controller/mover. ADR §3.6 status.
+            description: Observed state of a Restore, written by the controller/mover.
             nullable: true
             properties:
               conditions:
@@ -746,9 +670,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -777,11 +699,7 @@ spec:
                 - retryRecommended
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Restore completed: snapshot <id>` line; failure:
-                  the actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
@@ -790,7 +708,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: Lifecycle phase of a restore. Closed enum. ADR §3.6 status.
+                description: Lifecycle phase of a restore.
                 enum:
                 - Pending
                 - Resolving
@@ -815,7 +733,7 @@ spec:
                     type: integer
                 type: object
               resolved:
-                description: Pinned at admission; never re-resolved. ADR §3.6/§4.6.
+                description: The source resolved and pinned at admission; never re-resolved.
                 nullable: true
                 properties:
                   identity:
@@ -837,11 +755,7 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      The exact kopia snapshot manifest id the source resolved to. Pinned once;
-                      subsequent reconciles restore THIS id even if newer snapshots appear, so a
-                      restore never silently retargets (ADR §4.6). Matches
-                      `Snapshot.status.snapshot.kopiaSnapshotID`.
+                    description: The exact kopia snapshot manifest id the source resolved to; pinned once.
                     nullable: true
                     type: string
                   pinnedAt:
@@ -870,15 +784,7 @@ spec:
                     - name
                     type: object
                   resolution:
-                    description: |-
-                      Which outcome the source resolution pinned. Closed enum so the decision is a
-                      single, exhaustively-matched value rather than an inferred combination of optional
-                      fields — `Snapshot` means a concrete snapshot was found (its details live in the
-                      sibling `kopiaSnapshotID`/`snapshotRef`/`identity` fields); `NoSnapshot` means the
-                      source matched nothing and `onMissingSnapshot: Continue` chose deploy-or-restore
-                      (the volume comes up empty). Pinned once and never re-resolved, exactly like a
-                      snapshot id, so a later-appearing snapshot can never silently retarget an
-                      already-provisioned volume (ADR §4.6).
+                    description: Which outcome the source resolution pinned, once and never re-resolved.
                     enum:
                     - Snapshot
                     - NoSnapshot
@@ -900,10 +806,7 @@ spec:
                     type: object
                 type: object
               sourceKind:
-                description: |-
-                  The pinned source kind (`RestoreSource::kind_str` — `SnapshotRef`/`FromPolicy`/
-                  `Identity`), set by the reconciler. Backs the `SOURCE` printer column so
-                  `kubectl get restores` shows where a restore reads from. ADR-0005 §3.
+                description: The pinned source kind (`SnapshotRef`/`FromPolicy`/`Identity`); backs the `SOURCE` printer column.
                 nullable: true
                 type: string
               target:
@@ -911,7 +814,7 @@ spec:
                 nullable: true
                 properties:
                   pvcPrime:
-                    description: Populator handshake (passive / pvc-create modes). ADR §3.6.
+                    description: Populator handshake (passive / pvc-create modes).
                     nullable: true
                     type: string
                   pvcRef:

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -37,70 +37,42 @@ spec:
         description: Auto-generated derived type for SnapshotPolicySpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              *What* to back up: sources, identity, retention, policy, hooks. ADR §3.3.
-
-              Not `Eq`: transitively embeds k8s-openapi types via `mover` and `hooks` (`JobSpec`).
+            description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
               compression:
-                description: Compression algorithm + per-extension opt-outs. ADR §3.3 (G12).
+                description: Compression algorithm + per-extension opt-outs.
                 nullable: true
                 properties:
                   compressor:
-                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default. ADR §3.3.
+                    description: kopia compressor name (e.g. `zstd`); absent leaves kopia's default.
                     nullable: true
                     type: string
                   neverCompress:
-                    description: Filename globs to leave uncompressed (e.g. already-compressed media). ADR §3.3.
+                    description: Filename globs to leave uncompressed (e.g. already-compressed media).
                     items:
                       type: string
                     type: array
                 type: object
               copyMethod:
                 default: Direct
-                description: |-
-                  How the source volume is captured before kopia reads it: `Direct` (read the live
-                  PVC, the **default** — works on any storage), `Snapshot` (point-in-time CSI
-                  snapshot, opt-in), or `Clone` (CSI clone, opt-in). ADR §3.3 / [Copy methods].
-
-                  Carries a real OpenAPI `default: Direct` so it materializes into the stored object
-                  and `kubectl explain`, and GitOps engines stop diff-thrashing on a controller-set
-                  value. A bare value (not `Option`) so the default is never dropped by
-                  `skip_serializing_if`.
-
-                  [Copy methods]: https://github.com/home-operations/kopiur/blob/main/docs/copy-methods.md
+                description: 'How the source volume is captured before kopia reads it: `Direct` (default), `Snapshot`, or `Clone`.'
                 enum:
                 - Snapshot
                 - Clone
                 - Direct
                 type: string
               credentialProjection:
-                description: |-
-                  Opt-in credential-Secret projection for this recipe's backup movers
-                  (default off). When `enabled: true`, the operator copies the referenced
-                  repository's credential Secret(s) into the namespace where each backup
-                  mover runs (a no-op when they already live there) — so a workload backing
-                  up to a shared `ClusterRepository` need not pre-create the Secret in its
-                  own namespace. Inherited by `Snapshot`s produced from this config. ADR §4.11.
+                description: Opt-in credential-Secret projection into each backup mover's namespace (default off).
                 nullable: true
                 properties:
                   enabled:
                     default: false
-                    description: |-
-                      When true, the operator copies the repository's credential Secret(s) into
-                      the namespace of each mover Job that uses this repository. Off by default.
+                    description: Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default.
                     type: boolean
                 type: object
               defaultDeletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -118,11 +90,7 @@ spec:
                 nullable: true
                 type: string
               errorHandling:
-                description: |-
-                  Backup-side error handling — the missing analog of restore's
-                  `ignorePermissionErrors`. Lets a snapshot complete-with-errors instead of
-                  failing outright (`--ignore-file-errors` / `--ignore-dir-errors` /
-                  `--ignore-unknown-types`). ADR-0005 §13(b).
+                description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
                   ignoreDirErrors:
@@ -136,24 +104,22 @@ spec:
                     type: boolean
                 type: object
               extraArgs:
-                description: Escape hatch for kopia flags not yet modeled. ADR §3.3 (G12).
+                description: Escape hatch for kopia flags not yet modeled.
                 items:
                   type: string
                 type: array
               files:
-                description: Paths/patterns kopia should skip while snapshotting. ADR §3.3 (G12).
+                description: Paths/patterns kopia should skip while snapshotting.
                 nullable: true
                 properties:
                   ignoreCacheDirs:
                     description: Honor `CACHEDIR.TAG`.
                     type: boolean
                   ignoreIdenticalSnapshots:
-                    description: 'fork issue #13.'
+                    description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: |-
-                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`,
-                      `*/cache/*`, `lost+found`). ADR §3.3.
+                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
                     items:
                       type: string
                     type: array
@@ -178,13 +144,11 @@ spec:
                 nullable: true
                 type: string
               hooks:
-                description: Pre/post snapshot hooks that run in the workload, not the mover. ADR §4.8 (G13).
+                description: Pre/post snapshot hooks that run in the workload, not the mover.
                 nullable: true
                 properties:
                   afterSnapshot:
-                    description: |-
-                      Hooks run (in order) after the snapshot completes — e.g. resuming the
-                      workload. ADR §4.8.
+                    description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -223,39 +187,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -5266,19 +5225,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -5287,7 +5244,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -5320,7 +5277,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -5329,9 +5286,7 @@ spec:
                       type: object
                     type: array
                   beforeSnapshot:
-                    description: |-
-                      Hooks run (in order) before the snapshot is taken — e.g. quiescing a
-                      database. ADR §4.8.
+                    description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
                         One of three hook forms. ADR §4.8.
@@ -5370,39 +5325,34 @@ spec:
                           description: Typed POST to a URL for cross-system orchestration.
                           properties:
                             body:
-                              description: Optional request body. ADR §4.8.
+                              description: Optional request body.
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed request does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed request does not abort the backup (default: abort).'
                               type: boolean
                             method:
-                              description: HTTP method (default `POST`). ADR §4.8.
+                              description: HTTP method (default `POST`).
                               nullable: true
                               type: string
                             timeout:
-                              description: Max time to wait for the response (Go duration string). ADR §4.8.
+                              description: Max time to wait for the response (Go duration string).
                               nullable: true
                               type: string
                             url:
-                              description: Target URL to call. ADR §4.8.
+                              description: Target URL to call.
                               type: string
                           required:
                           - url
                           type: object
                         runJob:
-                          description: |-
-                            Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
-
-                            Boxed: `RunJobHook` embeds a `JobSpec` (~2 KB), which would otherwise bloat
-                            every `Hook` (incl. the common `WorkloadExec`). `Box<T>` is transparent to
-                            serde, so the externally-tagged `{ runJob: {...} }` wire shape is unchanged.
+                          description: Full `JobSpec` run as a one-shot Job (k8up `PreBackupPod` analog).
                           properties:
                             continueOnFailure:
-                              description: 'If `true`, a failed Job does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed Job does not abort the backup (default: abort).'
                               type: boolean
                             jobSpec:
-                              description: The full Kubernetes `JobSpec` to run. ADR §4.8.
+                              description: The full Kubernetes `JobSpec` to run.
                               properties:
                                 activeDeadlineSeconds:
                                   description: Specifies the duration in seconds relative to the startTime that the job may be continuously active before the system tries to terminate it; value must be positive integer. If a Job is suspended (at creation or through an update), this timer will effectively be stopped and reset when the Job is resumed again.
@@ -10413,19 +10363,17 @@ spec:
                               - template
                               type: object
                             timeout:
-                              description: Max time to wait for the Job to complete (Go duration string). ADR §4.8.
+                              description: Max time to wait for the Job to complete (Go duration string).
                               nullable: true
                               type: string
                           required:
                           - jobSpec
                           type: object
                         workloadExec:
-                          description: |-
-                            `kubectl exec`-style into a matched workload pod/container (the default form,
-                            fork #22).
+                          description: '`kubectl exec`-style into a matched workload pod/container (the default form).'
                           properties:
                             command:
-                              description: Command + args to run inside the selected container. ADR §4.8.
+                              description: Command + args to run inside the selected container.
                               items:
                                 type: string
                               type: array
@@ -10434,7 +10382,7 @@ spec:
                               nullable: true
                               type: string
                             continueOnFailure:
-                              description: 'If `true`, a failed hook does not abort the backup (default: abort). ADR §4.8.'
+                              description: 'If `true`, a failed hook does not abort the backup (default: abort).'
                               type: boolean
                             podSelector:
                               description: Label selector matching the workload pod(s) to read context/hooks from.
@@ -10467,7 +10415,7 @@ spec:
                                   type: object
                               type: object
                             timeout:
-                              description: Max time to wait for the command (Go duration string, e.g. `2m`). ADR §4.8.
+                              description: Max time to wait for the command (Go duration string, e.g. `2m`).
                               nullable: true
                               type: string
                           required:
@@ -10477,26 +10425,20 @@ spec:
                     type: array
                 type: object
               identity:
-                description: Identity overrides — what kopia records as `username@hostname:path`. ADR §3.3/§4.2.
+                description: Identity overrides — what kopia records as `username@hostname:path`.
                 nullable: true
                 properties:
                   hostname:
-                    description: |-
-                      Override the `hostname` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      namespace). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `hostname` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                   username:
-                    description: |-
-                      Override the `username` portion of `username@hostname:path`; absent uses the
-                      resolved default (the repository's `identityDefaults` CEL expression, or the
-                      object name). Used verbatim and pinned at admission (ADR §4.2).
+                    description: Override the `username` portion of `username@hostname:path`; absent uses the resolved default.
                     nullable: true
                     type: string
                 type: object
               mover:
-                description: Per-recipe mover overrides (resources, cache, security context). ADR §3.3.
+                description: Per-recipe mover overrides (resources, cache, security context).
                 nullable: true
                 properties:
                   cache:
@@ -10518,7 +10460,7 @@ spec:
                         nullable: true
                         type: integer
                       mode:
-                        description: How a mover's kopia cache volume is provisioned. ADR §3.1.
+                        description: How a mover's kopia cache volume is provisioned.
                         enum:
                         - Ephemeral
                         - Persistent
@@ -10530,11 +10472,7 @@ spec:
                         type: string
                     type: object
                   inheritSecurityContextFrom:
-                    description: |-
-                      Opt-in: copy security context from a live workload pod instead of setting an
-                      explicit `securityContext`/`podSecurityContext` (mutually exclusive with both).
-                      Either name the workload by label (`workloadSelector`) or, on a **backup**
-                      source, auto-derive it from the PVC being backed up (`pvcConsumer`). ADR §4.11.
+                    description: Copy the UID/GID security context from a live workload instead of setting it explicitly.
                     nullable: true
                     oneOf:
                     - required:
@@ -10543,26 +10481,15 @@ spec:
                       - pvcConsumer
                     properties:
                       pvcConsumer:
-                        description: |-
-                          **Backup sources only.** Auto-derive the workload pod from the PVC this snapshot
-                          backs up: the operator finds the pod(s) mounting the source claim and inherits
-                          their securityContext, so the mover's UID/GID matches the workload *by
-                          construction* — no hand-written selector. Meaningless on a restore (the consuming
-                          pod may not exist yet, exactly like a populator), so restore must use
-                          `workloadSelector`.
+                        description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
                         properties:
                           container:
-                            description: |-
-                              Which container within the matched consumer pod to inherit from; absent uses the
-                              first/only container (same semantics as [`PodSelector::container`]).
+                            description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
                         type: object
                       workloadSelector:
-                        description: |-
-                          Match the workload pod(s) by an explicit label selector and inherit the chosen
-                          container's `securityContext` plus the pod's `spec.securityContext`. Works for
-                          both backup and restore (restore inherits from the pod that will *read* the data).
+                        description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
                         properties:
                           container:
                             description: Which container within the matched pod; absent uses the first/only container.
@@ -10603,12 +10530,7 @@ spec:
                         type: object
                     type: object
                   podSecurityContext:
-                    description: |-
-                      Security context applied to the mover **pod** — notably `fsGroup`, which makes
-                      a freshly-provisioned volume group-writable so an unprivileged
-                      (`runAsUser != 0`) mover can populate it on **restore** without root. Distinct
-                      from the container-level [`MoverSpec::security_context`]; a pod-level
-                      `runAsUser: 0` / `runAsNonRoot: false` here is still gated as privileged.
+                    description: Pod security context for the mover (notably `fsGroup` for group-writable restore volumes).
                     nullable: true
                     properties:
                       appArmorProfile:
@@ -10738,7 +10660,7 @@ spec:
                         type: object
                     type: object
                   privilegedMode:
-                    description: Opt-in, namespace-gated; preserves UID/GID on restore. ADR §4.11/§G16.
+                    description: Opt-in, namespace-gated privileged mode; preserves UID/GID on restore.
                     nullable: true
                     type: boolean
                   resources:
@@ -10779,10 +10701,7 @@ spec:
                         type: object
                     type: object
                   securityContext:
-                    description: |-
-                      Security context applied to the mover **container** (`runAsUser`/`runAsGroup`,
-                      capabilities, seccomp, …). Merged field-wise over `moverDefaults.securityContext`
-                      and the hardened base (ADR-0004 §2) — set only the fields you want to change.
+                    description: Container security context for the mover; merged field-wise over the defaults and hardened base.
                     nullable: true
                     properties:
                       allowPrivilegeEscalation:
@@ -10887,17 +10806,13 @@ spec:
                         type: object
                     type: object
                   ttlSecondsAfterFinished:
-                    description: |-
-                      Per-recipe override of `moverDefaults.ttlSecondsAfterFinished` — the
-                      `Job.spec.ttlSecondsAfterFinished` for this recipe's mover Jobs so finished
-                      backup/restore Jobs self-GC. Recipe wins over the repo default; when neither
-                      is set a built-in default applies ([`DEFAULT_JOB_TTL_SECONDS`]). ADR-0005 §12.
+                    description: Per-recipe override of `Job.spec.ttlSecondsAfterFinished` so finished Jobs self-GC.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               repository:
-                description: Discriminated reference to a `Repository` or `ClusterRepository`. ADR §3.2.
+                description: Discriminated reference to a `Repository` or `ClusterRepository`.
                 properties:
                   kind:
                     default: Repository
@@ -10917,7 +10832,7 @@ spec:
                 - name
                 type: object
               retention:
-                description: GFS retention — enforced by the operator pruning `Snapshot` CRs. ADR §4.4.
+                description: GFS retention, enforced by the operator pruning `Snapshot` CRs.
                 nullable: true
                 properties:
                   keepAnnual:
@@ -10958,28 +10873,12 @@ spec:
                     type: integer
                 type: object
               sources:
-                description: |-
-                  What to back up. At least one source; webhook-enforced. ADR §3.3.
-
-                  `maxItems` is set so the apiserver can bound the cost of the per-item
-                  `x-kubernetes-validations` exactly-one-of rule on [`Source`] (CEL rule cost is
-                  `rule_cost × maxItems`; without a bound the apiserver assumes a huge array and
-                  rejects the CRD as over budget). 100 sources per recipe is far past any real
-                  use.
+                description: What to back up (at least one source; webhook-enforced).
                 items:
-                  description: |-
-                    A single backup source. `pvc`, `pvcSelector`, and `nfs` are mutually exclusive
-                    (webhook-enforced — NOT an enum, because the forms share the sibling
-                    `sourcePath*` keys and YAML lists them as optional siblings). ADR §3.3.
-
-                    §15: an operator-authored `x-kubernetes-validations` rule enforces exactly-one-of
-                    in the apiserver + CI, complementing `validate_source`.
+                  description: A single backup source; exactly one of `pvc`, `pvcSelector`, `nfs` (webhook-enforced).
                   properties:
                     nfs:
-                      description: |-
-                        An inline NFS export to back up directly — no PVC. Mounted read-only at the
-                        source path (default: the export's `path`). Mutually exclusive with
-                        `pvc`/`pvcSelector`. ADR §3.3.
+                      description: An inline NFS export to back up directly, mounted read-only. Mutually exclusive with `pvc`/`pvcSelector`.
                       nullable: true
                       properties:
                         path:
@@ -10993,25 +10892,21 @@ spec:
                       - server
                       type: object
                     pvc:
-                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`. ADR §3.3.
+                      description: Single PVC by name. Mutually exclusive with `pvcSelector`/`nfs`.
                       nullable: true
                       properties:
                         name:
-                          description: |-
-                            Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s
-                            namespace). ADR §3.3.
+                          description: Name of the `PersistentVolumeClaim` to back up (in the `SnapshotPolicy`'s namespace).
                           type: string
                       required:
                       - name
                       type: object
                     pvcSelector:
-                      description: |-
-                        Label/namespace selector matching many PVCs (multi-PVC sources).
-                        Mutually exclusive with `pvc`/`nfs`. ADR §3.3/§5.4.
+                      description: Label/namespace selector matching many PVCs. Mutually exclusive with `pvc`/`nfs`.
                       nullable: true
                       properties:
                         labelSelector:
-                          description: Standard Kubernetes label selector matching the PVCs to include. ADR §3.3/§5.4.
+                          description: Standard Kubernetes label selector matching the PVCs to include.
                           nullable: true
                           properties:
                             matchExpressions:
@@ -11042,28 +10937,18 @@ spec:
                               type: object
                           type: object
                         namespaceSelector:
-                          description: |-
-                            Restricts the search to specific namespaces; absent means the
-                            `SnapshotPolicy`'s own namespace. ADR §3.3/§5.4.
+                          description: Restricts the search to specific namespaces; absent means the policy's own namespace.
                           nullable: true
                           properties:
                             matchNames:
-                              description: |-
-                                Exact namespace names to search; empty means the `SnapshotPolicy`'s own
-                                namespace. ADR §3.3/§5.4.
+                              description: Exact namespace names to search; empty means the policy's own namespace.
                               items:
                                 type: string
                               type: array
                           type: object
                       type: object
                     sourcePathOverride:
-                      description: |-
-                        What kopia records as the source path (default `/pvc/<name>` for a PVC, or
-                        the NFS export `path` for an NFS source). ADR §3.3/§4.2.
-
-                        `maxLength` bounds the per-item cost of the exactly-one-of CEL rule on this
-                        struct (an unbounded string makes the apiserver assume a huge value and blow
-                        the rule's cost budget). A filesystem path is far shorter than 4096.
+                      description: What kopia records as the source path (default `/pvc/<name>`, or the NFS export `path`).
                       maxLength: 4096
                       nullable: true
                       type: string
@@ -11095,15 +10980,10 @@ spec:
                 maxItems: 100
                 type: array
               suspend:
-                description: |-
-                  Pause this recipe declaratively: a suspended `SnapshotPolicy` is skipped by
-                  schedules and by its own reconcile (no retention prune, no backup creation),
-                  surfaced via a condition/column. ADR-0005 §14(e).
+                description: Pause this recipe declaratively (schedules and reconcile skip a suspended policy).
                 type: boolean
               upload:
-                description: |-
-                  Upload parallelism (kopia's upload policy: `--max-parallel-snapshots`,
-                  `--max-parallel-file-reads`). ADR-0005 §13(f).
+                description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
                   maxParallelFileReads:
@@ -11118,88 +10998,57 @@ spec:
                     type: integer
                 type: object
               verification:
-                description: |-
-                  First-class backup verification (ADR-0005 §4). Opt-in: when absent, no
-                  verification runs (no behavior change). When set, the controller schedules
-                  periodic `kopia snapshot verify` (quick) and/or a scratch-restore test (deep),
-                  gated by an optional CEL `successExpr` predicate over the result, and surfaces
-                  `status.lastVerified`.
+                description: First-class backup verification; opt-in (absent ⇒ no verification runs).
                 nullable: true
                 properties:
                   deep:
-                    description: |-
-                      Schedule + knobs for the rarer scratch-restore restorability test. Absent ⇒
-                      no deep verification.
+                    description: Schedule + knobs for the rarer scratch-restore test; absent ⇒ no deep verification.
                     nullable: true
                     properties:
                       capacity:
-                        description: |-
-                          Size of the ephemeral scratch PVC (e.g. `10Gi`). When set, the operator
-                          mounts a fresh generic-ephemeral PVC of this size at the scratch path
-                          (auto-deleted with the Job) — size it to comfortably hold the restored
-                          snapshot. When absent, scratch falls back to a node-ephemeral `emptyDir`
-                          (zero-config, but bounded by node disk).
+                        description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
                           cron:
-                            description: |-
-                              The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                              deterministic per-schedule jitter (ADR §3.7).
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                             type: string
                           jitter:
-                            description: |-
-                              Optional deterministic jitter window as a Go-style duration string (e.g.
-                              `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
                         required:
                         - cron
                         type: object
                       storageClassName:
-                        description: |-
-                          StorageClass for the ephemeral scratch PVC; absent uses the cluster default.
-                          Only applies when `capacity` is set (an `emptyDir` has no StorageClass).
+                        description: StorageClass for the ephemeral scratch PVC; absent uses the cluster default (only with `capacity`).
                         nullable: true
                         type: string
                     required:
                     - schedule
                     type: object
                   quick:
-                    description: |-
-                      Schedule for the frequent blob-level `kopia snapshot verify`. Absent ⇒ no
-                      quick verification.
+                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
                     nullable: true
                     properties:
                       cron:
-                        description: |-
-                          The cron expression, parsed by `croner`. May contain an `H` placeholder for
-                          deterministic per-schedule jitter (ADR §3.7).
+                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
                         type: string
                       jitter:
-                        description: |-
-                          Optional deterministic jitter window as a Go-style duration string (e.g.
-                          `30m`), derived from `(scheduleUID, slot)` so it is stable across restarts.
+                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
                     required:
                     - cron
                     type: object
                   successExpr:
-                    description: |-
-                      A CEL pass/fail predicate over the verify result (ADR-0005 §15). Environment:
-                      `stats{files,bytes,errors}`, `snapshot`, and (deep only) `restored{files,
-                      checksumMatches}`. Returns a bool; when it evaluates `false` the verification
-                      run fails. Validated at admission (`validate_success_expr`). Applies to both
-                      tiers. Example: `"stats.files > 0 && stats.errors == 0"`.
+                    description: CEL pass/fail predicate over the verify result; applies to both tiers.
                     nullable: true
                     type: string
                   verifyFilesPercent:
-                    description: |-
-                      How many files `quick` verifies fully (`--verify-files-percent`); absent
-                      leaves kopia's default. Tuning knob for the quick tier.
+                    description: How many files `quick` verifies fully (`--verify-files-percent`); absent leaves kopia's default.
                     format: uint8
                     maximum: 255.0
                     minimum: 0.0
@@ -11207,22 +11056,18 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: |-
-                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.
-                  ADR §3.3.
+                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
                 nullable: true
                 type: string
             required:
             - repository
             type: object
           status:
-            description: Observed state of a [`SnapshotPolicy`]. ADR §3.3 status.
+            description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `RepositoryReachable`,
-                  `GroupSnapshotSupported`). ADR §3.3 status.
+                description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -11255,29 +11100,24 @@ spec:
                   type: object
                 type: array
               lastSuccessfulSnapshot:
-                description: |-
-                  RFC3339 timestamp of the most recent successful child `Snapshot` produced
-                  from this recipe. Backs the `LAST-SNAPSHOT` printer column and the
-                  `prometheusRule` staleness alert (ADR-0005 §3).
+                description: RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe.
                 nullable: true
                 type: string
               lastVerified:
-                description: |-
-                  RFC3339 timestamp of the most recent successful verification (any tier),
-                  ADR-0005 §4. Backs the `kopiur_snapshot_verified_timestamp_seconds` gauge.
+                description: RFC3339 timestamp of the most recent successful verification (any tier).
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.3 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
               resolved:
-                description: What would be passed to kopia — pinned at admission. ADR §3.3/§4.2.
+                description: What would be passed to kopia — pinned at admission.
                 nullable: true
                 properties:
                   identity:
-                    description: The resolved `username@hostname` identity. ADR §3.3/§4.2.
+                    description: The resolved `username@hostname` identity.
                     nullable: true
                     properties:
                       hostname:
@@ -11295,38 +11135,36 @@ spec:
                     - username
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths after selector expansion. ADR §3.3 status.
+                    description: The concrete PVCs + source paths after selector expansion.
                     items:
-                      description: One resolved source — a concrete PVC and the path kopia records for it. ADR §3.3 status.
+                      description: One resolved source — a concrete PVC and the path kopia records for it.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.3 status.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia records for this PVC. ADR §3.3/§4.2.
+                          description: The source path kopia records for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               retention:
-                description: |-
-                  Summary of GFS retention pruning against this config's `Snapshot` CRs.
-                  ADR §3.3 status/§4.4.
+                description: Summary of GFS retention pruning against this config's `Snapshot` CRs.
                 nullable: true
                 properties:
                   activeSnapshotCount:
-                    description: CRs currently inside the GFS window. ADR §3.3 status.
+                    description: CRs currently inside the GFS window.
                     format: int64
                     nullable: true
                     type: integer
                   lastPruneAt:
-                    description: RFC3339 timestamp of the last prune pass. ADR §3.3 status.
+                    description: RFC3339 timestamp of the last prune pass.
                     nullable: true
                     type: string
                   lastPruneDeleted:
-                    description: Number of `Snapshot` CRs deleted by the last prune pass. ADR §3.3 status/§4.4.
+                    description: Number of `Snapshot` CRs deleted by the last prune pass.
                     format: int64
                     nullable: true
                     type: integer

--- a/deploy/helm/kopiur/files/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshots.yaml
@@ -34,22 +34,11 @@ spec:
         description: Auto-generated derived type for SnapshotSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              A single kopia snapshot represented as a Kubernetes object. ADR §3.4.
-
-              For `scheduled`/`manual` backups the spec carries `policyRef` (+ optional
-              overrides). For `discovered` backups the spec is empty — every field is optional.
+            description: A single kopia snapshot represented as a Kubernetes object.
             properties:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-                  Shared by `SnapshotPolicy.spec.defaultDeletionPolicy` and `Snapshot.spec.deletionPolicy`.
-                  ADR-0003 §4.5 / ADR-0001 §4.5.
-
-                  The reconciler distinguishes the three cases with an exhaustive `match` — Rust
-                  enforces that any new variant added later must be handled in every match site,
-                  preventing the class of bug where a new policy slips into production without a
-                  corresponding reconcile branch.
 
                   ```
                   use kopiur_api::common::DeletionPolicy;
@@ -67,45 +56,30 @@ spec:
                 nullable: true
                 type: string
               failurePolicy:
-                description: Per-run failure controls passed to the mover `Job`. ADR §3.4 (G6).
+                description: Mover Job retry and deadline limits for this run.
                 nullable: true
                 properties:
                   activeDeadlineSeconds:
-                    description: |-
-                      Passed through to the mover `Job.spec.activeDeadlineSeconds` — wall-clock cap
-                      after which a still-running run is killed.
+                    description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
                     format: int64
                     nullable: true
                     type: integer
                   backoffLimit:
-                    description: |-
-                      Passed through to the mover `Job.spec.backoffLimit` — how many times a failed
-                      run is retried before the Job is marked failed.
+                    description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
                     format: int32
                     nullable: true
                     type: integer
                   podStartupDeadlineSeconds:
-                    description: |-
-                      How long (seconds) a mover **pod** may sit in a non-starting state — a container
-                      `CreateContainerConfigError` / `ImagePullBackOff` / `InvalidImageName`, or
-                      `Unschedulable` — before the controller fails the run with an actionable reason,
-                      rather than waiting out `active_deadline_seconds` (which can be many hours and
-                      is meant for *long-running*, not *wedged*, work). A wedged pod never reaches a
-                      terminal phase, so `backoffLimit` never trips — this is the only thing that bounds
-                      it. Unset uses the built-in [`DEFAULT_POD_STARTUP_DEADLINE_SECONDS`].
+                    description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               pin:
-                description: |-
-                  Pin this snapshot to exempt it from GFS retention (ADR-0005 §13(c)). When
-                  `true` the reconciler applies a kopia snapshot pin and the GFS pruner never
-                  selects it for deletion — for pre-migration / compliance holds. Clearing it
-                  removes the pin. Default `false`.
+                description: Exempt this snapshot from GFS retention.
                 type: boolean
               policyRef:
-                description: The recipe to run. Absent for `discovered` backups. ADR §3.4.
+                description: The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
                 nullable: true
                 properties:
                   name:
@@ -121,7 +95,7 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). ADR §3.4.'
+                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
                 nullable: true
                 type: object
             type: object
@@ -130,9 +104,7 @@ spec:
             nullable: true
             properties:
               conditions:
-                description: |-
-                  Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
-                  ADR §3.4 status.
+                description: Standard Kubernetes conditions (e.g. `SourcesQuiesced`, `SnapshotCreated`).
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -165,9 +137,7 @@ spec:
                   type: object
                 type: array
               failure:
-                description: |-
-                  Structured terminal-failure detail (kopia error class, stderr tail, retry
-                  hint), written by the mover before it exits non-zero. ADR §4.10.
+                description: Structured terminal-failure detail (kopia error class, stderr tail, retry hint).
                 nullable: true
                 properties:
                   exitCode:
@@ -196,11 +166,7 @@ spec:
                 - retryRecommended
                 type: object
               hooks:
-                description: |-
-                  Hook-execution bookkeeping (ADR §4.8): completion timestamps the
-                  reconciler stamps so each hook list runs exactly once per Snapshot across
-                  requeues and controller restarts (hooks have side effects — quiesce,
-                  resume — that must not repeat).
+                description: Hook-execution bookkeeping so each hook list runs exactly once per Snapshot.
                 nullable: true
                 properties:
                   postCompletedAt:
@@ -213,30 +179,25 @@ spec:
                     type: string
                 type: object
               job:
-                description: Present for scheduled/manual; absent for discovered. ADR §3.4.
+                description: The mover Job backing this run; absent for discovered.
                 nullable: true
                 properties:
                   attempts:
-                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`). ADR §3.4 status.
+                    description: Number of attempts so far (bounded by `failurePolicy.backoffLimit`).
                     format: int32
                     nullable: true
                     type: integer
                   name:
-                    description: Name of the mover `Job`. ADR §3.4 status.
+                    description: Name of the mover `Job`.
                     nullable: true
                     type: string
                 type: object
               logTail:
-                description: |-
-                  The last lines of the run's output, written by the mover at the terminal
-                  transition (success: the `Snapshot created: <id>` line; failure: the
-                  actionable error + kopia stderr tail). Capped at
-                  [`crate::common::MAX_LOG_TAIL_BYTES`]; full logs live in the Job pod.
-                  ADR §3.4/§4.10.
+                description: The last lines of the run's output, written by the mover at the terminal transition.
                 nullable: true
                 type: string
               observedGeneration:
-                description: '`metadata.generation` last reconciled, for staleness detection. ADR §3.4 status.'
+                description: '`metadata.generation` last reconciled, for staleness detection.'
                 format: int64
                 nullable: true
                 type: integer
@@ -284,20 +245,15 @@ spec:
                 nullable: true
                 type: string
               pinned:
-                description: |-
-                  The observed kopia-side pin state (ADR-0005 §13(c)): `Some(true)` once the
-                  operator has applied the pin, `Some(false)` once it has removed it, `None`
-                  before any pin reconcile. The reconciler compares `spec.pin` against this to
-                  decide whether to issue a `kopia snapshot pin`/`unpin`, so a redundant op is
-                  never spawned.
+                description: 'The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile.'
                 nullable: true
                 type: boolean
               resolved:
-                description: Frozen recipe values at run time (scheduled/manual). ADR §3.4.
+                description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
                 properties:
                   repository:
-                    description: The repository this run targeted, frozen at run time. ADR §3.4 status.
+                    description: The repository this run targeted, frozen at run time.
                     nullable: true
                     properties:
                       kind:
@@ -318,27 +274,27 @@ spec:
                     - name
                     type: object
                   sources:
-                    description: The concrete PVCs + source paths backed up this run. ADR §3.4 status.
+                    description: The concrete PVCs + source paths backed up this run.
                     items:
-                      description: One resolved source backed up by a run — a concrete PVC and its kopia path. ADR §3.4 status.
+                      description: One resolved source backed up by a run — a concrete PVC and its kopia path.
                       properties:
                         pvc:
-                          description: '`namespace/name` of the PVC, as kopia sees it. ADR §3.4.'
+                          description: '`namespace/name` of the PVC, as kopia sees it.'
                           nullable: true
                           type: string
                         sourcePath:
-                          description: The source path kopia recorded for this PVC. ADR §3.4/§4.2.
+                          description: The source path kopia recorded for this PVC.
                           nullable: true
                           type: string
                       type: object
                     type: array
                 type: object
               snapshot:
-                description: The kopia artifact this CR represents. ADR §3.4.
+                description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
                   identity:
-                    description: The `username@hostname:path` identity recorded for this snapshot. ADR §3.4/§4.2.
+                    description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:
                       hostname:
                         description: The final `hostname` kopia records, fixed at admission.
@@ -355,23 +311,14 @@ spec:
                     - username
                     type: object
                   kopiaSnapshotID:
-                    description: |-
-                      kopia's snapshot ID — the handle the finalizer uses to delete content.
-
-                      Renamed to match the ADR wire shape exactly (`kopiaSnapshotID`, capital `ID`);
-                      serde's `camelCase` would otherwise produce `kopiaSnapshotId`.
+                    description: kopia's snapshot ID — the handle the finalizer uses to delete content.
                     type: string
                 required:
                 - identity
                 - kopiaSnapshotID
                 type: object
               staged:
-                description: |-
-                  The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`
-                  (ADR §3.3). Pinned once when the stage is provisioned so the reconciler can
-                  (a) reuse the same VolumeSnapshot/PVC across mover-Job retries idempotently
-                  and (b) reap them on the terminal transition. Absent for `Direct` (and NFS),
-                  which mount the live source with no staging.
+                description: 'The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`.'
                 nullable: true
                 properties:
                   copyMethod:
@@ -379,79 +326,68 @@ spec:
                     nullable: true
                     type: string
                   pvcName:
-                    description: |-
-                      Name of the staged `PersistentVolumeClaim` the mover mounts in place of the
-                      live source PVC.
+                    description: Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC.
                     nullable: true
                     type: string
                   ready:
-                    description: |-
-                      `true` once the stage is ready for the mover (VolumeSnapshot `readyToUse` and
-                      the staged PVC applied). Before that the reconcile is still provisioning it.
+                    description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
                   volumeSnapshotName:
-                    description: |-
-                      Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot`
-                      only; absent for `Clone`, which stages directly from the source PVC).
+                    description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true
                     type: string
                 type: object
               stats:
-                description: Byte/file counts parsed from kopia's JSON output. ADR §3.4 status.
+                description: Byte/file counts parsed from kopia's JSON output.
                 nullable: true
                 properties:
                   bytesNew:
-                    description: Bytes newly uploaded this run (after dedup/compression). ADR §3.4 status.
+                    description: Bytes newly uploaded this run (after dedup/compression).
                     format: int64
                     nullable: true
                     type: integer
                   filesFailed:
-                    description: |-
-                      Count of source entries kopia could **not** read and therefore EXCLUDED from the
-                      snapshot (`rootEntry.summ.errors`), making it *incomplete*. Present (and `> 0`) only
-                      when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite
-                      unreadable files — the otherwise-silent partial-backup case. The controller surfaces
-                      it as a warning condition + Event. Usually a UID/GID mismatch with the workload.
+                    description: Count of source entries kopia could not read and excluded, making the snapshot incomplete.
                     format: int64
                     nullable: true
                     type: integer
                   filesModified:
-                    description: Count of files changed since the previous snapshot. ADR §3.4 status.
+                    description: Count of files changed since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesNew:
-                    description: Count of files new since the previous snapshot. ADR §3.4 status.
+                    description: Count of files new since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   filesUnchanged:
-                    description: Count of files unchanged since the previous snapshot. ADR §3.4 status.
+                    description: Count of files unchanged since the previous snapshot.
                     format: int64
                     nullable: true
                     type: integer
                   sizeBytes:
-                    description: Total logical size of the snapshot in bytes. ADR §3.4 status.
+                    description: Total logical size of the snapshot in bytes.
                     format: int64
                     nullable: true
                     type: integer
                 type: object
               timing:
-                description: Start/end/duration of the snapshot run. ADR §3.4 status.
+                description: Start/end/duration of the snapshot run.
                 nullable: true
                 properties:
                   durationSeconds:
-                    description: Wall-clock duration in seconds. ADR §3.4 status.
+                    description: Wall-clock duration in seconds.
                     format: int64
                     nullable: true
                     type: integer
                   endTime:
-                    description: RFC3339 end time of the run. ADR §3.4 status.
+                    description: RFC3339 end time of the run.
                     nullable: true
                     type: string
                   startTime:
-                    description: RFC3339 start time of the run. ADR §3.4 status.
+                    description: RFC3339 start time of the run.
                     nullable: true
                     type: string
                 type: object

--- a/deploy/helm/kopiur/files/crds/snapshotschedules.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotschedules.yaml
@@ -34,25 +34,16 @@ spec:
         description: Auto-generated derived type for SnapshotScheduleSpec via `CustomResource`
         properties:
           spec:
-            description: |-
-              Cron + `policyRef`. One source of `Snapshot` CRs; pausing it doesn't affect
-              in-flight or completed runs. ADR §3.5.
+            description: Cron schedule that fires `Snapshot` CRs from a `SnapshotPolicy`.
             properties:
               failedJobsHistoryLimit:
-                description: |-
-                  Bounds *failed* `Snapshot` CRs from this schedule. Successful retention is
-                  GFS-driven on `SnapshotPolicy.spec.retention` — there is deliberately NO
-                  `successfulJobsHistoryLimit` (ADR-0003 §4.4, ADR-0001 §4.4).
+                description: Maximum number of failed `Snapshot` CRs from this schedule to retain.
                 format: uint32
                 minimum: 0.0
                 nullable: true
                 type: integer
               policyRef:
-                description: |-
-                  The single `SnapshotPolicy` (recipe) this schedule invokes; resolved in the
-                  schedule's own namespace. ADR §3.5 separates recipe from schedule. **Mutually
-                  exclusive** with `policySelector` — exactly one is required (webhook-enforced,
-                  ADR-0005 §10). Optional at the type level so `policySelector` can be used instead.
+                description: The single `SnapshotPolicy` this schedule invokes; mutually exclusive with `policySelector`.
                 nullable: true
                 properties:
                   name:
@@ -66,11 +57,7 @@ spec:
                 - name
                 type: object
               policySelector:
-                description: |-
-                  Fan-out form (ADR-0005 §10): a label selector over `SnapshotPolicy` objects in
-                  the schedule's namespace. Each matching policy gets a `Snapshot` per firing
-                  ("back up everything tagged `tier=critical` nightly" in one object). **Mutually
-                  exclusive** with `policyRef`. Mirrors the `pvcSelector` pattern.
+                description: Label selector fanning out over `SnapshotPolicy` objects; mutually exclusive with `policyRef`.
                 nullable: true
                 properties:
                   matchExpressions:
@@ -101,50 +88,37 @@ spec:
                     type: object
                 type: object
               schedule:
-                description: Cron, jitter, timezone, and concurrency for the firing cadence. ADR §3.5.
+                description: Cron, jitter, timezone, and concurrency for the firing cadence.
                 properties:
                   concurrencyPolicy:
                     default: Forbid
-                    description: |-
-                      How to handle a firing while a prior run is still in flight. ADR §4.1.
-
-                      Carries a real OpenAPI `default: Forbid` (ADR-0005 §1) — unconditional, so it
-                      materializes into the stored object / `kubectl explain`.
+                    description: How to handle a firing while a prior run is still in flight (default `Forbid`).
                     enum:
                     - Forbid
                     - Allow
                     - Replace
                     type: string
                   cron:
-                    description: Cron expression with Jenkins-style `H` substitution. ADR §4.1 (G4).
+                    description: Cron expression with Jenkins-style `H` substitution.
                     type: string
                   jitter:
-                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`. ADR §4.1.
+                    description: Deterministic jitter (Go-style duration), derived from `(scheduleUID, slot)`.
                     nullable: true
                     type: string
                   runOnCreate:
                     default: false
-                    description: |-
-                      GitOps-friendly default: do NOT fire immediately on create. ADR §4.1 (G3).
-
-                      Carries a real OpenAPI `default: false` (ADR-0005 §1) so it materializes into
-                      the stored object / `kubectl explain` and GitOps stops diff-thrashing. NOT
-                      `skip_serializing_if`-elided, so the materialized value round-trips.
+                    description: Whether to fire immediately on create (default `false`).
                     type: boolean
                   startingDeadlineSeconds:
-                    description: |-
-                      If a slot is missed by more than this many seconds (e.g. operator was
-                      down), skip it instead of firing late. ADR §4.1.
+                    description: If a slot is missed by more than this many seconds, skip it instead of firing late.
                     format: int64
                     nullable: true
                     type: integer
                   suspend:
-                    description: Skip future firings while true. ADR §5.9.
+                    description: Skip future firings while true.
                     type: boolean
                   timezone:
-                    description: |-
-                      IANA timezone the cron is evaluated in (e.g. `America/Los_Angeles`).
-                      Absent means the controller's configured default. ADR §4.1.
+                    description: IANA timezone the cron is evaluated in; absent uses the controller's default.
                     nullable: true
                     type: string
                 required:
@@ -157,11 +131,11 @@ spec:
             - message: exactly one of policyRef or policySelector
               rule: '[has(self.policyRef), has(self.policySelector)].filter(x, x).size() == 1'
           status:
-            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run. ADR §3.5.'
+            description: 'Observed state of a `SnapshotSchedule`: pinned firing slots and failure run.'
             nullable: true
             properties:
               conditions:
-                description: Standard Kubernetes conditions surfacing schedule health. ADR §5 status conventions.
+                description: Standard Kubernetes conditions surfacing schedule health.
                 items:
                   description: Condition contains details for one aspect of the current state of this API Resource.
                   properties:
@@ -194,19 +168,16 @@ spec:
                   type: object
                 type: array
               consecutiveFailures:
-                description: Count of back-to-back failed runs; resets on success. Drives alerting.
+                description: Count of back-to-back failed runs; resets on success.
                 format: int64
                 nullable: true
                 type: integer
               lastSchedule:
-                description: Most recent firing (cron + jitter, pinned). ADR §3.5.
+                description: Most recent firing (cron + jitter, pinned).
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -221,14 +192,11 @@ spec:
                     type: object
                 type: object
               lastSuccessfulSchedule:
-                description: The most recent firing whose `Snapshot` succeeded. ADR §3.5.
+                description: The most recent firing whose `Snapshot` succeeded.
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:
@@ -247,10 +215,7 @@ spec:
                 nullable: true
                 properties:
                   at:
-                    description: |-
-                      The RFC3339 instant this slot fired (or is scheduled to). Accepts the
-                      `scheduledAt` alias on the wire (see the struct docs) but always
-                      serializes back as `at`.
+                    description: The RFC3339 instant this slot fired (or is scheduled to); also accepts the `scheduledAt` alias.
                     nullable: true
                     type: string
                   snapshotRef:

--- a/docs/dev/design-rationale.md
+++ b/docs/dev/design-rationale.md
@@ -1,0 +1,242 @@
+# CRD design rationale
+
+Why the CRD fields are shaped the way they are. This is the *why* that used to live
+in the Rust doc comments (and therefore in the generated CRD `description` text). The
+descriptions themselves are now one-liners; the field-by-field user guidance lives in
+the [CRD reference](../reference/crds/index.md), and the cross-cutting design reasons
+live here for contributors.
+
+The code is the source of truth for current behavior — this page records intent. ADR
+section refs (e.g. `ADR-0005 §5`) point at [the ADRs](../adr/0003-kopiur-rust-operator.md)
+for the full decision record.
+
+## Recurring patterns
+
+### Sub-objects over leaf fields
+
+Every credential / policy / identity / schedule / health surface is a **struct, not a
+bare `bool`/`string`/`enum`**, so a future field slots in without an API break
+(ADR §4.11). Examples: `encryption` (room for rotation/`previousPasswords`),
+`credentialProjection` (key remapping, copy-name template, immutability),
+`sourceColocation` (custom hostname label key), `health` (future health knobs),
+`create.ecc`, `server.auth.generate` (username/rotation), `populator: {}` (an empty
+object whose mere presence selects the mode, leaving room for future populator knobs).
+
+### Externally-tagged enums (discriminated unions)
+
+`backend`, `source`, `target`, `allowedNamespaces`, `inheritSecurityContextFrom`,
+`server.auth`, hooks, and the cache/repo volume types are **externally-tagged** enums
+(`backend: { s3: {...} }`), never `#[serde(tag = "kind")]`. Internally-tagged enums
+break Kubernetes structural-schema generation — kube's rewriter hoists the `oneOf`
+branch properties and panics on the differing tag property. External tagging keeps full
+type-safety *and* generates a valid CRD: "exactly one of" is unrepresentable as two,
+and reconcilers `match` exhaustively so a new variant cannot compile until every handler
+accounts for it.
+
+### Not `Eq`, only `PartialEq`
+
+Several types are `PartialEq` but not `Eq` because they transitively embed `k8s-openapi`
+types that are `PartialEq`-only: `LabelSelector` (via `pvcSelector`, `policySelector`,
+`workloadSelector`, `AllowedNamespaces::Selector`), `JobSpec` (via `hooks`,
+`RunJobHook`), `ResourceRequirements`, `SecurityContext`, `PodSecurityContext`. Reuse
+these types; don't re-invent them, and don't add `Eq`.
+
+### Materialized defaults vs `skip_serializing_if`
+
+Fields like `copyMethod` (`Direct`), `mode` (`ReadWrite`), `onNamespaceDelete`
+(`Orphan`), `concurrencyPolicy` (`Forbid`), `runOnCreate` (`false`), and
+`fromPolicy.offset` (`0`) carry a **real OpenAPI `default:`** in the schema rather than
+being `Option` + `skip_serializing_if`. A named `default_*` fn backs **both**
+`#[serde(default = …)]` and `#[schemars(default = …)]` — that pairing is what makes
+schemars 1 emit a real `default:` in the generated CRD. The value then materializes into
+the stored object and `kubectl explain`, and GitOps engines stop diff-thrashing on a
+controller-set value (a bare value, not `Option`, so `skip_serializing_if` can never
+drop it).
+
+### CEL cost budgets (`maxItems` / `maxLength`)
+
+`SnapshotPolicy.spec.sources` carries `#[schemars(length(max = 100))]` and
+`source.sourcePathOverride` carries `length(max = 4096)` **so the apiserver can bound
+the cost of the per-item exactly-one-of `x-kubernetes-validations` rule** on `Source`.
+CEL rule cost is `rule_cost × maxItems`; without a bound the apiserver assumes a huge
+array/string and rejects the CRD as over budget. 100 sources / 4096-byte paths are far
+past any real use. The exactly-one-of rule is written as an integer **sum of
+`has()`-ternaries** rather than `filter().size()` precisely to stay inside that budget.
+
+### Immutability transition rules
+
+`Repository`/`ClusterRepository` `create.{splitter,hash,encryption,ecc}` carry CRD
+`x-kubernetes-validations` transition rules (apiserver + CI, §7/§15) complementing the
+webhook. Each leaf is **`has()`-guarded on both `self` and `oldSelf`**: a CEL field
+access on an absent optional key raises "no such key", which fails the *whole* rule →
+422 on *every* update, which would block the controller's own finalizer/status writes.
+The common `create: {enabled: true}` case (no algorithm fields) must reconcile, not
+wedge. The `encryption` password-Secret reference is deliberately **not** locked: kopia
+fixes only the resolved password *value* into the repo format, never the Secret
+name/key, so a rename with identical content must pass (locking it broke GitOps). See
+`validate::diff_immutable_repo_fields`.
+
+---
+
+## Per-CRD notes
+
+### Repository
+
+- **`encryption`** — password Secret ref is not locked by the immutability rules (see
+  above); only the resolved *value* is fixed in the kopia format.
+- **`moverDefaults`** — inherited by *every* mover (bootstrap/backup/restore/maintenance),
+  overridable per-recipe via `mover`, merged field-wise (ADR-0004 §1/§2). Absorbed the
+  former `cacheDefaults` (now `moverDefaults.cache`).
+- **`onNamespaceDelete`** — **breaking** default change (ADR-0005 §5): default `Orphan`
+  means `kubectl delete ns` no longer destroys snapshots. Materialized `default: Orphan`.
+- **`mode`** — ADR-0005 §11; materialized `default: ReadWrite`.
+- **`health.indexBlobWarnThreshold`** — absent ⇒ `DEFAULT_INDEX_BLOB_WARN_THRESHOLD`
+  (1000); `0` is the **disable sentinel** (not fall-back-to-default); negative rejected
+  by the webhook. The default/disable semantics live in the pure
+  `resolve_index_blob_warn_threshold` fn (shared by webhook/controller/tests).
+- **`status.resolvedCredentialVersion`** — the password Secret's `resourceVersion`; the
+  terminal-failure hard-stop reopens when it changes, so editing Secret *content* (which
+  doesn't bump `metadata.generation`) re-triggers a connect instead of parking the repo
+  `Failed` forever.
+- **`status.storageStats.indexBlobCount`** — observed at bootstrap; an unbounded climb
+  means maintenance isn't keeping up (raises `IndexBlobHealth`).
+
+### ClusterRepository
+
+- **Cluster scope** — every Secret/config ref (`backend`/`encryption`/`server`) MUST
+  carry an explicit `namespace` (webhook-enforced; the type system can't express it).
+- **`allowedNamespaces`** — externally-tagged (`list`/`selector`/`all`); `all` must be
+  `true` (`false` rejected). Not `Eq` (embeds `LabelSelector`).
+- **`identityDefaults`** — CEL `*Expr` (ADR-0004 §5), evaluated at admission against
+  `namespace`/`policyName`/`labels`/`annotations`; sandboxed, no I/O; a typo / out-of-scope
+  variable is rejected on apply.
+- **`maintenance.namespace`** — `Maintenance` is namespaced, so this selects where the
+  owned CR lands (defaults to the operator namespace).
+- **`credentialProjection`** — repository-**owner** gate (ADR-0005 §8), breaking,
+  default-off (`allowed: false`), fail-closed: consumer opt-in + this gate + operator
+  RBAC all required. A sub-object, distinct from the consumer-side
+  `credentialProjection.enabled`. A namespaced `Repository` has no such gate
+  (same-namespace projection is a no-op).
+
+### SnapshotPolicy
+
+- **`copyMethod` default `Direct`** — `Direct` (read the live PVC) is the default for
+  backward-compat and portability: it was the behavior in effect before `copyMethod` was
+  wired (the field was inert) and works on any storage with no CSI snapshot stack.
+  ADR-0005 §1 originally proposed `Snapshot` as the default, but defaulting to it would
+  silently break every existing policy / non-CSI source on upgrade. (The
+  backward-compat reasoning is preserved in full in the `default_copy_method` fn doc.)
+- **`groupBy`** — must be set explicitly; a silent per-PVC fallback would produce
+  inconsistent backups (a data-integrity hazard, ADR §4.9). Multi-PVC fan-out +
+  VolumeGroupSnapshot is **not yet wired** (single-PVC staging only today).
+- **`hooks.runJob`** — the `RunJobHook` is `Box`ed because it embeds a `JobSpec` (~2 KB);
+  `Box<T>` is transparent to serde.
+- **`verification`** — `successExpr` is a CEL bool predicate over
+  `stats{files,bytes,errors}` / `snapshot` / `restored{files,checksumMatches}`, validated
+  at admission (`validate_success_expr`).
+
+### Snapshot
+
+- **`deletionPolicy`** — origin-aware effective default: `Delete` for scheduled/manual,
+  forced `Retain` for discovered (a discovered `Snapshot` has an empty spec). ADR §4.5.
+- **`pin`** — exempts the snapshot from GFS retention; the reconciler reconciles kopia's
+  pin state against `spec.pin` and never spawns a redundant pin op.
+- **`status.stats.filesFailed`** — kopia's `rootEntry.summ.errors`: source entries kopia
+  **excluded** because it couldn't read them. Present and `> 0` only when an
+  `errorHandling.ignore*Errors` policy let the snapshot complete despite unreadable files
+  — i.e. the backup is **incomplete**. Backs the `SecurityContextCompatible` condition
+  (positive-only, never a heuristic guess).
+- **`status.hooks`** — each hook list runs exactly once per Snapshot, across requeues and
+  pod restarts (quiesce/resume has side effects).
+- **`status.staged`** — the CSI staging objects are recorded once, reused across retries,
+  reaped on the terminal transition, never double-created.
+
+### SnapshotSchedule
+
+- **`policyRef` XOR `policySelector`** — exactly one (webhook + CRD validation);
+  `policySelector` fans out to many policies in the namespace (mirrors `pvcSelector`).
+- **`failedJobsHistoryLimit`** — bounds *failed* child `Snapshot`s only. There is **no**
+  `successfulJobsHistoryLimit`: retention is GFS-only (ADR-0003 §4.4).
+- **`schedule.{runOnCreate,concurrencyPolicy}`** — materialized OpenAPI defaults (see the
+  pattern above); `Forbid` skips a firing rather than letting runs pile up.
+- **`status.lastSchedule.at`** — accepts the `scheduledAt` alias on the wire (serde
+  `alias`).
+
+### Restore
+
+- **`target` required** — ADR-0005 §9 removed the empty-`target` form; a `Restore` with
+  no `target` now fails deserialization. Exactly one of `pvc`/`pvcRef`/`populator`
+  (operator-authored CEL `x-kubernetes-validations` + webhook). `source` XOR is
+  webhook-enforced.
+- **`populator: {}`** — an empty sub-object whose presence selects passive-populator mode
+  (claimed via a PVC's `spec.dataSourceRef`); `inheritSecurityContextFrom` is rejected
+  with it (no workload pod exists at provision time).
+- **`fromPolicy.offset`** — materialized `default: 0` (see the defaults pattern).
+- **`status.resolved`** — `resolution` is a closed enum so the decision is one
+  exhaustively-matched value, **pinned once** at first resolution and never re-resolved:
+  a later-appearing snapshot can never silently retarget an already-provisioned volume
+  (ADR §4.6). A legacy pin written before `resolution` existed leaves it `None` with
+  `kopiaSnapshotID` set, read as `Snapshot` (stale-id self-heal).
+- **source/target semantics** — `repository` is derived from `source` unless
+  `source.identity` (which has no CR to derive it from, so `spec.repository` is required);
+  `onMissingSnapshot` defaults `Fail` for explicit sources, `Continue` for `fromPolicy`
+  (deploy-or-restore). `fsGroup` lives on the pod-level context so a fresh restore volume
+  is group-writable for an unprivileged mover.
+
+### Maintenance
+
+- **`ownership`** — at most one `Maintenance` may own a repository at a time (a lease).
+  `takeoverPolicy` (`Never`/`PromptCondition`/`Force`) governs what a second `Maintenance`
+  does when it finds a foreign owner. The lease identity can be a stale ephemeral
+  bootstrap-pod identity; a stuck owner is resolved with `takeoverPolicy: Force` once.
+- **`RepositoryMaintenanceSpec`** — default-managed: when absent or `enabled: true` the
+  reconciler creates and owns a `Maintenance` CR. An externally-authored `Maintenance`
+  is always honored (never duplicated), even with `enabled: false`. `namespace` is
+  ClusterRepository-only.
+- **`status.full.lastContentReclaimedBytes`** — the only place storage reclamation is
+  surfaced.
+- **`status.<kind>.lastHandledAt`** — records the most recent cron slot whose Job
+  finished, *including* a yield to a foreign lease holder (which deliberately does not
+  move `lastRunAt`), so a handled slot never re-fires after its Job self-reaps.
+
+### RepositoryReplication
+
+- **`destination`** — externally-tagged `Backend`, must **differ** from the source
+  backend (webhook-enforced).
+- **`destinationEncryption`** — `kopia repository sync-to` copies blobs verbatim, so the
+  destination must share the source's format; omit this to reuse the source password (a
+  true mirror).
+- **`mover`** — inherits the source repository's `moverDefaults`.
+
+## Shared types
+
+- **`BackendAuth.workloadIdentity`** — empty `--access-key=` flags engage kopia's ambient
+  credential chain; the user-created, cloud-federated ServiceAccount (IRSA / EKS Pod
+  Identity / AKS Workload Identity / GKE WI) must pre-exist with the right cloud
+  annotation — the operator preflights and binds the mover role to it, but **never
+  creates it**. Azure additionally requires `storageAccount`. A `RepositoryReplication`
+  whose source and destination are the same cloud kind must not mix static and
+  workload-identity auth (the replication pod's env would leak the static keys into the
+  ambient chain).
+- **`MoverSpec` / `MoverDefaults` merge** — `hardened ⊂ moverDefaults ⊂ recipe.mover`,
+  merged field-wise (ADR-0004 §2). A partial override can only **tighten** the hardened
+  baseline (it never drops `drop:[ALL]` / seccomp). This closes drift between the
+  maintenance/backup/restore movers and the bootstrap-mover gap.
+- **`inheritSecurityContextFrom`** — externally-tagged: `workloadSelector` (copy UID/GID
+  from a label-selected workload; valid on backup or restore) or `pvcConsumer`
+  (auto-derive from the pod mounting the source PVC; backup-source only — rejected on
+  `Restore`/`Maintenance`, which have no backup source).
+- **`server`** — the kopia web-UI server is read-write-delete and holds the repository
+  decryption key; read-only is enforced at the connection level (`spec.server.readOnly`).
+  On filesystem backends the repo PVC must be `ReadWriteMany`; `fsGroup` is a no-op on
+  NFS. `ServerStatus.namespace` is load-bearing (a cluster-scoped owner has no implicit
+  namespace).
+- **`FailurePolicy.podStartupDeadlineSeconds`** — fails a mover that can't *start*
+  (`CreateContainerConfigError`/`ImagePullBackOff`/`Unschedulable`); a wedged pod never
+  reaches a terminal phase and `backoffLimit` never trips, so this is the only backstop.
+
+## See also
+
+- [CRD reference](../reference/crds/index.md) — the per-field user documentation.
+- [API conventions](api-conventions.md) — the encoding rules these decisions follow.
+- [ADRs](../adr/0003-kopiur-rust-operator.md) — the full decision records.

--- a/docs/reference/crds/cluster-repository.md
+++ b/docs/reference/crds/cluster-repository.md
@@ -1,0 +1,81 @@
+# ClusterRepository
+
+A cluster-scoped, shared kopia repository operated by a platform team and
+referenceable from allow-listed namespaces. It has the same storage surface as a
+[Repository](repository.md) (backend, encryption, create, moverDefaults, catalog),
+plus a tenancy gate (`allowedNamespaces`) and per-namespace identity expressions
+(`identityDefaults`). For the terse type/default table see the
+[field reference](../../field-reference.md); for how-to guidance see
+[Repositories](../../repositories.md).
+
+!!! important "Every Secret reference needs an explicit namespace"
+    A `ClusterRepository` is cluster-scoped, so it has no namespace of its own to
+    resolve references against. Every Secret/config reference — in `backend`,
+    `encryption`, `server`, anywhere — **must carry an explicit `namespace`**. The
+    type system cannot express this, so it is webhook-enforced: a reference without
+    a namespace is rejected on apply.
+
+## `spec`
+
+Fields shared with `Repository` — `backend`, `create`, `moverDefaults`, `catalog`,
+`maintenance`, `onNamespaceDelete`, `mode`, `suspend`, `health` — behave exactly as
+on the [Repository](repository.md) page. The differences and additions:
+
+### `encryption`
+
+The repository password as a Secret reference. Because the CR is cluster-scoped, the
+reference **must** carry an explicit `namespace`.
+
+### `allowedNamespaces`
+
+The tenancy gate: which namespaces are permitted to reference this repository,
+webhook-enforced on every consumer CR. Exactly one of:
+
+- `list: [...]` — explicit namespace names.
+- `selector: {...}` — match namespaces by label (a `LabelSelector`).
+- `all: true` — allow all namespaces. Must be `true`; `false` is meaningless and
+  rejected by the webhook.
+
+The number of namespaces this currently resolves to is surfaced as
+`status.allowedNamespaceCount` and the `Namespaces` print column.
+
+### `identityDefaults`
+
+CEL expressions evaluated at admission to derive a consumer's kopia identity when a
+`SnapshotPolicy` doesn't override it. Each `*Expr` returns a string and is evaluated
+against `namespace`, `policyName`, `labels`, and `annotations` (the consuming
+`SnapshotPolicy`'s metadata). The expressions are sandboxed with no I/O and validated
+at admission, so a typo or out-of-scope variable is rejected on apply.
+
+- `hostnameExpr` — CEL expression for the kopia identity hostname (e.g. `"namespace"`).
+- `usernameExpr` — CEL expression for the kopia identity username
+  (e.g. `"namespace + '-' + policyName"`).
+
+### `server`
+
+Optional kopia web-UI server. Because the CR is cluster-scoped, the target
+`namespace` is required. Presence enables it. See [Server](../../server.md).
+
+### `maintenance`
+
+Default-managed like the namespaced kind, but since `Maintenance` is itself
+namespaced, `maintenance.namespace` selects where the owned `Maintenance` CR lands
+(defaulting to the operator's namespace). See [Maintenance](../../maintenance.md).
+
+### `credentialProjection`
+
+The repository-owner gate for projecting this repository's credential Secret(s) into
+a foreign consumer namespace. **Default off** (`credentialProjection.allowed:
+false`): a consumer's own `credentialProjection.enabled` is necessary but not
+sufficient — the `ClusterRepository` owner must also allow it, and operator RBAC must
+permit it (fail-closed). A namespaced `Repository` has no such gate, because
+projection there is a same-namespace no-op.
+
+## `status`
+
+Mirrors [Repository](repository.md) status (`phase`, `observedGeneration`,
+`resolvedCredentialVersion`, `uniqueId`, `backend`, `storageStats`, `catalog`,
+`server`, `conditions`) with one addition:
+
+- `allowedNamespaceCount` — number of namespaces currently resolved by
+  `spec.allowedNamespaces`; also the `Namespaces` print column.

--- a/docs/reference/crds/index.md
+++ b/docs/reference/crds/index.md
@@ -1,0 +1,33 @@
+# CRD reference
+
+Per-CRD, per-field reference for the eight CRDs in
+`kopiur.home-operations.com/v1alpha1`. Each page explains, field by field, what a
+field does, its default, the allowed values, and when you'd set it — the detail
+that used to live in the CRD `description` text.
+
+Three layers, by how much detail you want:
+
+- **[Field reference](../../field-reference.md)** — the terse, exhaustive table of
+  every field's type/default/immutability across all CRDs. Start here to look up a
+  single field fast.
+- **These pages** — the same fields with the fuller per-field explanation
+  (defaults, allowed values, gotchas, how a field maps to a kopia behavior).
+- **Task guides** ([Backups](../../backups.md), [Restores](../../restores.md),
+  [Repositories](../../repositories.md), …) — narrative how-to that ties fields
+  together for a goal.
+
+The design *rationale* behind why these fields are shaped the way they are
+(sub-objects, materialized defaults, CEL cost budgets, immutability rules) lives in
+[CRD design rationale](../../dev/design-rationale.md) for contributors.
+
+## The CRDs
+
+- [Repository](repository.md) — a namespaced kopia repository.
+- [ClusterRepository](cluster-repository.md) — a cluster-scoped, multi-tenant repository.
+- [SnapshotPolicy](snapshot-policy.md) — the backup recipe (what to back up).
+- [Snapshot](snapshot.md) — one backup invocation.
+- [SnapshotSchedule](snapshot-schedule.md) — the cron that fires snapshots.
+- [Restore](restore.md) — restore data from a repository.
+- [Maintenance](maintenance.md) — repository maintenance (quick/full).
+- [RepositoryReplication](repository-replication.md) — off-site mirror.
+- [Shared sub-objects](shared-types.md) — types reused across CRDs (Backend, MoverSpec, …).

--- a/docs/reference/crds/maintenance.md
+++ b/docs/reference/crds/maintenance.md
@@ -1,0 +1,96 @@
+# Maintenance
+
+Schedules `kopia maintenance run` (quick and full) for one repository and manages the ownership lease that keeps two operators from maintaining the same repository at once. For the terse type/default table see the [field reference](../../field-reference.md); for how-to guidance see [Maintenance](../../maintenance.md).
+
+Maintenance is **default-managed**: a [`Repository`](repository.md) or [`ClusterRepository`](cluster-repository.md) with `spec.maintenance` absent (or `enabled: true`) is projected by the repository reconciler into an *owned* `Maintenance` child CR, so kopia storage is reclaimed without you authoring a separate object. An externally-authored `Maintenance` that references the repository is always honored — even with `enabled: false`, which only tells the operator not to create its own; it never deletes, ignores, or warns about a user-managed one. At most one `Maintenance` may own a repository at a time.
+
+## `spec`
+
+### `repository`
+
+The `Repository` or `ClusterRepository` this maintenance run targets. Credentials and connect details are resolved from it.
+
+### `schedule`
+
+Two crons, evaluated in a shared `timezone` (IANA; absent uses the controller default):
+
+#### `schedule.quick`
+
+Cron and jitter for `kopia maintenance run` — the cheap pass that does index and log work. The managed default is every 6h with 30m jitter.
+
+#### `schedule.full`
+
+Cron and jitter for `kopia maintenance run --full` — the heavier pass that reclaims unreferenced content. The managed default is daily at 03:00 with 1h jitter.
+
+### `ownership`
+
+The maintenance lease. At most one `Maintenance` may own a repository at a time, so a run never collides with another operator's.
+
+#### `ownership.owner`
+
+A stable lease-holder identity (e.g. `kopia-operator/nas-primary`). Two `Maintenance` CRs claiming the same repository compare this string to decide who holds the lease. Keep it stable — the pod's own identity is ephemeral (a new hostname every run), so the operator stamps a stable kopia client identity derived from the lease.
+
+#### `ownership.takeoverPolicy`
+
+What to do when the lease is already held by a *different* owner. A free or already-owned lease is always (re)claimed regardless of policy. When another owner holds it:
+
+- **`Never`** (default, safest) — do not seize the lease; the run yields and a condition records `LeaseHeldByOther`.
+- **`PromptCondition`** — do not seize, but surface a `LeaseTakeoverPrompt` condition so an operator can decide whether to escalate to `Force`.
+- **`Force`** — forcibly claim the lease from the current holder.
+
+A yielded run completes cleanly (its Job succeeds) without running maintenance; check the `LeaseOwned` condition to tell a real run from a yield.
+
+### `mover`
+
+Mover (Job pod) overrides for the maintenance run — resources, scheduling, security context. Object-store repositories typically tune this.
+
+### `failurePolicy`
+
+How a failed maintenance run is retried and bounded (backoff limit, active deadline).
+
+### `credentialProjection`
+
+Opt-in (default off). When `enabled: true`, the operator copies the referenced repository's credential Secret(s) into the namespace this `Maintenance` runs in — a no-op when they already live there. Useful when maintaining a shared `ClusterRepository` from a namespace that lacks the Secret.
+
+## Inline form on a repository (`spec.maintenance`)
+
+A `Repository`/`ClusterRepository` carries `spec.maintenance` to control its default-managed `Maintenance`:
+
+- **`enabled`** — whether the operator manages a `Maintenance` CR for this repository (default `true`).
+- **`schedule`** — schedule override; absent uses the quick-6h / full-daily default.
+- **`mover`** / **`failurePolicy`** — overrides for the managed run.
+- **`takeoverPolicy`** — lease takeover policy for the managed run (default `Never`).
+- **`namespace`** — *ClusterRepository only* — the namespace the managed (namespaced) `Maintenance` CR is created in, defaulting to the operator's own namespace. Forbidden on a namespaced `Repository` (whose `Maintenance` always lives in the repository's namespace) and rejected by the admission webhook.
+
+## Out-of-band runs
+
+Annotating a `Maintenance` with `kopiur.home-operations.com/run-requested` (an RFC3339 timestamp) and optionally `…/run-mode` (`quick` or `full`, defaulting to `quick`) triggers a one-off run. The timestamp pins *which* request the status answers, so re-applying the same value is a no-op and a new timestamp starts a new run.
+
+## `status`
+
+### `ownership`
+
+The current lease holder (`owner`) and the RFC3339 instant it was `claimedAt`, present once the lease is claimed.
+
+### `quick` / `full`
+
+Per-kind run status:
+
+| Field | Meaning |
+| --- | --- |
+| `lastRunAt` | RFC3339 instant of the most recent run of this kind. |
+| `nextScheduledAt` | RFC3339 instant of the next scheduled run (cron + jitter, pinned). |
+| `lastHandledAt` | RFC3339 instant the controller last observed this kind's per-slot Job reach terminal success — set whether the run maintained or merely yielded the lease, so a yielded slot never re-fires endlessly. |
+| `consecutiveFailures` | Count of back-to-back failed runs of this kind; resets on success. |
+| `lastContentReclaimedBytes` | Bytes of storage reclaimed by the most recent run of this kind. |
+
+### `manualRun`
+
+State of the most recent annotation-requested run: the `requestedAt` value it answers, the `mode` performed, its `phase` (`Running` / `Succeeded` / `Failed`), and the `completedAt` instant it reached a terminal phase. Absent until a run is requested.
+
+### others
+
+| Field | Meaning |
+| --- | --- |
+| `observedGeneration` | The `metadata.generation` this status reflects, for staleness detection. |
+| `conditions` | Standard Kubernetes conditions surfacing maintenance health (including `LeaseOwned`). |

--- a/docs/reference/crds/repository-replication.md
+++ b/docs/reference/crds/repository-replication.md
@@ -1,0 +1,51 @@
+# RepositoryReplication
+
+Mirrors a repository's blobs to a second backend on a schedule (`kopia repository sync-to`) — the "2" in 3-2-1 backup. For the terse type/default table see the [field reference](../../field-reference.md); for how-to guidance see [Replication](../../replication.md).
+
+A `RepositoryReplication` is **namespaced**: it lives alongside its source repository (mirroring [`Maintenance`](maintenance.md)) and references either a namespaced [`Repository`](repository.md) or a cluster-scoped [`ClusterRepository`](cluster-repository.md). The controller schedules a per-slot mover Job (croner + deterministic jitter, single-flight, repo-ready gate) exactly like `Maintenance`.
+
+## `spec`
+
+### `sourceRef`
+
+The `Repository` or `ClusterRepository` to mirror *from*. Credentials and connect details are resolved from it.
+
+### `destination`
+
+The backend to mirror *to* — exactly one backend, expressed as the externally-tagged `Backend` enum (e.g. `destination: { s3: {…} }`), reused from the repository types. The destination **must differ from the source's backend**; the admission webhook rejects a same-backend mirror, since replicating a backend onto itself is meaningless.
+
+### `destinationEncryption`
+
+Encryption/password for the destination repository when it needs its own — for example a freshly-created mirror with a distinct password.
+
+**Omit this to mirror.** When absent, the destination uses the **source** repository's password. This is the common case for a true mirror: `sync-to` copies blobs verbatim, so the repository format (including the encryption material) is identical and a separate destination password would be wrong. Set it only when the destination is a distinct repository with its own credentials.
+
+### `schedule`
+
+Cron and deterministic jitter for the replication runs, using the same scheduling kernel as `Maintenance`.
+
+### `mover`
+
+Mover (Job pod) overrides for the replication run — resources, scheduling, security context. Inherits the source repository's `moverDefaults` underneath.
+
+### `suspend`
+
+Pause this replication declaratively (default `false`). A suspended `RepositoryReplication` is skipped by its own reconcile — no sync runs — and the state is surfaced via a condition.
+
+## `status`
+
+### `phase`
+
+Lifecycle phase: `Pending` (admitted, not yet run — the default), `Replicating` (a mover Job is in flight), `Succeeded` (last run completed, idle until the next slot), `Failed` (last run failed; see conditions), or `Suspended` (paused via `spec.suspend`).
+
+### others
+
+| Field | Meaning |
+| --- | --- |
+| `observedGeneration` | The `metadata.generation` last reconciled, for staleness detection / kstatus. |
+| `destinationBackend` | The destination backend kind (mirror of the `spec.destination` discriminant), backing the `DESTINATION` print column. |
+| `lastReplicated` | RFC3339 timestamp of the most recent successful replication run, backing the `LAST` print column. |
+| `nextScheduledAt` | RFC3339 timestamp of the next scheduled run (cron + jitter, pinned). |
+| `lastReplicatedBytes` | Bytes replicated by the last successful run (best-effort from kopia output). |
+| `lastReplicatedBlobs` | Blobs replicated by the last successful run (best-effort). |
+| `conditions` | Standard Kubernetes conditions (`Ready`, `Reconciling`, `Stalled`). |

--- a/docs/reference/crds/repository.md
+++ b/docs/reference/crds/repository.md
@@ -1,0 +1,124 @@
+# Repository
+
+A namespaced kopia repository — credentials, backend, encryption, and optional
+catalog-materialization bounds — owned by one namespace and referenced by many
+`SnapshotPolicy` and `Restore` resources. For the terse type/default table see the
+[field reference](../../field-reference.md); for how-to guidance see
+[Repositories](../../repositories.md).
+
+## `spec`
+
+### `backend`
+
+Exactly one storage backend. The wire shape is a single-key object
+(`backend: { s3: {...} }`), so an invalid "two backends at once" state is
+unrepresentable. See [Backends](../../backends/index.md) for the per-backend fields.
+
+### `encryption`
+
+The repository password, always given as a Secret reference. It is a sub-object
+(`encryption.passwordSecretRef`) rather than a bare field.
+
+### `create`
+
+What to do when the repository does not yet exist in the backing storage. When
+absent (or disabled) the repository must already exist and the operator only
+connects. When enabled, the operator creates it with the given
+encryption/splitter/hash/ECC algorithms. Those `create.*` algorithm choices are
+**immutable after creation** — the apiserver and webhook reject changing them on an
+existing repository, because kopia fixes them into the repository format. (The
+`encryption` password Secret reference itself is *not* locked: renaming the Secret
+with identical content is allowed.)
+
+### `moverDefaults`
+
+Base mover configuration — security context, pod security context, resources,
+cache, `nodeSelector`/`tolerations`/`affinity`, Job TTL — inherited by **every**
+mover this repository spawns (bootstrap, backup, restore, maintenance). Each recipe
+can override fields per-mover; the merge is field-wise. See [Movers](../../movers.md).
+
+### `catalog`
+
+Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia
+catalog, keeping the etcd footprint sane for large repositories.
+
+### `server`
+
+Optional kopia web-UI server, exposed via a `Service` in this Repository's own
+namespace. Presence of the block enables it. See [Server](../../server.md).
+
+### `maintenance`
+
+Maintenance control. Default-managed: when absent or `enabled: true`, the reconciler
+creates and owns a `Maintenance` CR for this repository in this namespace. An
+externally-authored `Maintenance` is always honored and never duplicated. See
+[Maintenance](../../maintenance.md).
+
+### `onNamespaceDelete`
+
+What happens to this repository's snapshots when a consuming namespace is deleted.
+`Orphan` (default) keeps the snapshot history and releases ownership; `Delete`
+cascades per-`Snapshot` `deletionPolicy`. The default means `kubectl delete ns` does
+not destroy snapshots.
+
+### `mode`
+
+Access mode: `ReadWrite` (default) or `ReadOnly`. A `ReadOnly` repository serves
+restores only — the reconciler refuses backup Jobs and skips maintenance projection
+— useful for decommissioning or migration without write risk. See
+[Access modes](../../access-modes.md).
+
+### `suspend`
+
+Pause this repository declaratively (default `false`). A suspended repository skips
+connect/bootstrap and maintenance projection, and surfaces the state via a condition.
+
+### `health`
+
+Repository health thresholds — tuning for the warnings the reconciler raises about a
+degrading-but-still-usable repository.
+
+- `health.indexBlobWarnThreshold` — the index-blob count above which the reconciler
+  raises the `IndexBlobHealth` condition plus a Warning event (maintenance isn't
+  compacting fast enough). Absent uses the built-in default (1000). `0` disables the
+  warning entirely; a negative value is rejected by the admission webhook.
+
+## `status`
+
+### `storageStats`
+
+Aggregate repository storage figures from the last catalog scan:
+
+- `snapshotCount` — total snapshots present in the repository (across all identities).
+- `totalSize` — human-readable total on-disk size (e.g. `412Gi`).
+- `lastObservedAt` — RFC 3339 timestamp these stats were last observed.
+- `indexBlobCount` — number of content-index blobs observed at the last bootstrap.
+  kopia compacts these during maintenance; an unbounded climb means maintenance
+  isn't keeping up, and crossing `spec.health.indexBlobWarnThreshold` raises the
+  `IndexBlobHealth` warning. Also surfaced as the `IndexBlobs` print column.
+
+### `catalog`
+
+Catalog-materialization status: `discoveredBackupCount` (how many `Snapshot` CRs
+were materialized from the scan) and `lastRefreshAt` (RFC 3339 timestamp of the last
+catalog refresh).
+
+### `server`
+
+Resolved kopia server endpoint/auth, pinned by the reconciler. See
+[Server](../../server.md).
+
+### Other status fields
+
+- `phase` — lifecycle phase: `Pending`, `Initializing`, `Ready`, `Degraded`
+  (reachable but a sub-operation is failing — see conditions), or `Failed`
+  (connect/create failed — see conditions for the actionable reason).
+- `observedGeneration` — `metadata.generation` of the `spec` last reconciled; drives
+  staleness detection.
+- `resolvedCredentialVersion` — `resourceVersion` of the password Secret observed at
+  the last connect attempt; editing the Secret's content re-triggers a connect
+  rather than parking the repository `Failed` forever.
+- `uniqueId` — the kopia repository's unique ID.
+- `backend` — mirror of `spec.backend`'s discriminant for the print column.
+- `conditions` — standard Kubernetes conditions (e.g. `Connected`,
+  `MaintenanceOwned`).

--- a/docs/reference/crds/restore.md
+++ b/docs/reference/crds/restore.md
@@ -1,0 +1,75 @@
+# Restore
+
+Restore data from a repository into a PVC. For the terse type/default table see the [field reference](../../field-reference.md); for how-to guidance see [Restores](../../restores.md).
+
+A `Restore` names three things: where to read data **from** (`source`), where to write it **to** (`target`), and how to behave when the source snapshot does not exist yet (`policy`). Exactly one `source` mode and exactly one `target` mode are present at a time. The source is resolved once at admission and pinned to status, so a restore never silently retargets a later-appearing snapshot.
+
+## `spec`
+
+### `source`
+
+Where to read data from — exactly one of three externally-tagged modes:
+
+- **`snapshotRef`** — a reference (`name`, optional `namespace`) to an existing `Snapshot` CR, whether scheduled, manual, or discovered (all the same kind). This is the explicit, point-at-a-specific-backup mode.
+- **`fromPolicy`** — name (and optional `namespace`) of a `SnapshotPolicy`; the restore resolves a snapshot through the policy's identity even when **no** `Snapshot` CR exists yet (deploy-or-restore). Pick the snapshot with `offset` (`0` = latest, `1` = previous, …; defaults to `0`) or restore the newest snapshot at or before a point in time with `asOf` (RFC3339).
+- **`identity`** — a raw kopia identity for foreign writers or snapshots that aged out of the catalog. Specify `username` and `hostname` (both required), optionally `sourcePath` (absent matches any path), and select the snapshot with `snapshotID` (an exact manifest id), `asOf`, or `offset`. The `identity` source **requires** `spec.repository` to be set, since there is no `Snapshot`/`SnapshotPolicy` to derive the repository from.
+
+### `target`
+
+Where to write the restored data — **required**, exactly one of three externally-tagged modes:
+
+- **`pvc`** — the operator creates the PVC from a template (`name` plus optional `storageClassName`, `capacity`, and `accessModes`).
+- **`pvcRef`** — write into an existing PVC by `name` (optional `namespace`).
+- **`populator`** — passive populator mode, written as an empty object `populator: {}`. No workload target exists at provision time; the restore is claimed by a separate PVC's `spec.dataSourceRef`. It is an empty sub-object today so future populator knobs can slot in without an API break.
+
+A `Restore` with no `target` is invalid and fails admission. `inheritSecurityContextFrom` (under `mover`) is meaningless with a `populator` target — there is no workload pod to copy a security context from — and is rejected by the validator.
+
+### `repository`
+
+The repository to read from. Derived from `source` when omitted; **required only** with `source.identity`, which has no CR to derive it from.
+
+### `options`
+
+kopia restore-behavior knobs: `enableFileDeletion` (delete files in the target absent from the snapshot, making the target an exact mirror — off by default, so restores are additive and safe), `ignorePermissionErrors` (continue past permission errors, default true), and `writeFilesAtomically` (temp-file + rename, default true).
+
+### `policy`
+
+How the restore reacts to a missing snapshot. `onMissingSnapshot` is `Fail` (fail-closed; the default for explicit `snapshotRef`/`identity` sources, so an explicit restore can never silently no-op) or `Continue` (proceed with an empty, deploy-or-restore volume; the default for `fromPolicy`). `waitTimeout` (e.g. `5m`) bounds how long the restore waits for the source snapshot to appear before giving up.
+
+### `mover`
+
+Per-run mover-Job overrides for this restore — resource requests/limits, kopia cache sizing, and the container/pod `securityContext` used to match the workload's UID/GID (and `fsGroup`, to make a fresh restore volume group-writable). This is the same surface a backup gets via `SnapshotPolicy.spec.mover`; an elevated context is namespace-gated exactly like a backup's, and `securityContext` and `inheritSecurityContextFrom` are mutually exclusive. See [Security context](../../security-context.md).
+
+### `credentialProjection`
+
+Opt-in (off by default). When `enabled: true`, the operator copies the referenced repository's credential Secret(s) into the restore mover's namespace (a no-op when they already live there) — so restoring from a shared `ClusterRepository` into a fresh namespace need not pre-create the Secret there.
+
+### `failurePolicy`
+
+Mover Job retry/deadline limits (`backoffLimit`, `activeDeadlineSeconds`), mirroring `Snapshot.spec.failurePolicy`. See [Movers](../../movers.md).
+
+## `status`
+
+### `resolved`
+
+The source resolved and **pinned at admission**, never re-resolved — this is what makes a restore deterministic. `resolution` records the pinned outcome: `Snapshot` (the source resolved to a concrete kopia snapshot) or `NoSnapshot` (the source matched nothing and `onMissingSnapshot: Continue` chose an empty deploy-or-restore volume). Because the outcome is pinned once, a snapshot that appears later can never silently retarget an already-provisioned volume. The block also carries `kopiaSnapshotID` (the exact manifest id; restored on every subsequent reconcile even if newer snapshots appear), `snapshotRef` (the concrete `Snapshot` CR, when applicable), `repository`, `pinnedAt` (RFC3339), and the resolved `identity` (`username@hostname:path`).
+
+### `target`
+
+Resolved target details: `pvcRef` (the PVC actually written to, created or pre-existing) and `pvcPrime` (the populator handshake for passive / pvc-create modes).
+
+### `failure`
+
+Structured terminal-failure detail (kopia error class, stderr tail, retry hint), written by the mover before it exits non-zero. Read this first when a `Restore` lands in `Failed`.
+
+### Other status fields
+
+| Field | Meaning |
+| --- | --- |
+| `phase` | Current lifecycle phase: `Pending`, `Resolving`, `Restoring`, `Completed`, or `Failed`. |
+| `sourceKind` | The pinned source kind (`SnapshotRef`/`FromPolicy`/`Identity`); backs the `SOURCE` printer column. |
+| `observedGeneration` | `metadata.generation` last reconciled, for staleness detection. |
+| `timing` | `startTime`/`endTime` (RFC3339) of the restore run. |
+| `progress` | Live `bytesRestored`/`filesRestored` counters, patched periodically by the mover. |
+| `conditions` | Standard Kubernetes conditions carrying the human-readable status/reason. |
+| `logTail` | The last lines of the run's output, written by the mover at the terminal transition; capped in size, with full logs in the Job pod. |

--- a/docs/reference/crds/shared-types.md
+++ b/docs/reference/crds/shared-types.md
@@ -1,0 +1,365 @@
+# Shared sub-objects
+
+Types reused across multiple CRDs. For the terse type/default table see the
+[field reference](../../field-reference.md).
+
+## Backend
+
+The storage backend for a kopia repository. Exactly one backend block is set —
+the wire shape is externally tagged, so you write `backend: { s3: {...} }`,
+`backend: { filesystem: {...} }`, and so on, and `kubectl` enforces "exactly one
+backend" at admission. See the [backend guides](../../backends/index.md) for
+provider-specific setup.
+
+Variants:
+
+- **`s3`** — Amazon S3 or any S3-compatible store (MinIO, RustFS, Ceph RGW, …).
+  `bucket` is required; `prefix` lets several repositories share one bucket
+  (e.g. `clusters/prod/`); `endpoint` is omitted for AWS and set for
+  S3-compatible stores; `region` is required by AWS and some providers; `tls`
+  carries TLS overrides; `auth` is a [BackendAuth](#backendauth).
+- **`azure`** — Azure Blob Storage. `container` is required; `storageAccount` is
+  set when it can't be inferred from credentials.
+- **`gcs`** — Google Cloud Storage. `bucket` is required.
+- **`b2`** — Backblaze B2. `bucket` is required; auth is Secret-only (B2 has no
+  cloud IAM federation).
+- **`filesystem`** — kopia writes the repository to a `path` inside the mover
+  pod, populated by a [RepoVolume](#repovolume). kopia has no NFS backend; NFS is
+  reached through the filesystem backend by mounting the export at `path`.
+- **`sftp`** — SFTP server (`host`, `path`, optional `port` defaulting to 22,
+  `username`); Secret-only auth (SSH key / known-hosts).
+- **`webdav`** — WebDAV endpoint (`url`); Secret-only HTTP basic-auth.
+- **`rclone`** — any rclone remote in `remote:path` form, with a Secret holding
+  the `rclone.conf`. kopia shells out to `rclone`, broadening reach to providers
+  without a native kopia backend.
+
+### RepoVolume
+
+What backs a filesystem repository's mount path. Externally tagged, exactly one
+of:
+
+- **`pvc`** — `volume: { pvc: { name: "repo-pvc" } }`: a `PersistentVolumeClaim`
+  mounted read-write at the repo path (in the mover's namespace).
+- **`nfs`** — `volume: { nfs: { server: "nas.lan", path: "/export/kopia" } }`: an
+  inline NFS export mounted directly, no PVC and no StorageClass.
+
+`volume` may be absent when the path is already present on the node/image (a
+baked-in mount, mainly the e2e harness).
+
+## BackendAuth
+
+Credentials for a cloud object-store backend that has an IAM plane (S3, Azure,
+GCS). Set **exactly one of**:
+
+- **`secretRef`** — a [SecretRef](#secretkeyref-and-secretref) to the Secret holding static access
+  credentials. The operator reads well-known keys (e.g.
+  `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` for S3).
+- **`workloadIdentity`** — a cloud-federated `ServiceAccount` instead of static
+  keys.
+
+An absent `auth` is also legal — the well-known keys may ride the
+encryption-password Secret.
+
+Backends without a cloud IAM plane (B2, SFTP, WebDAV, rclone) use a Secret-only
+auth surface instead, so a workload identity on them is structurally
+unrepresentable.
+
+### workloadIdentity
+
+A cloud workload-identity binding (AWS IRSA / EKS Pod Identity, AKS Workload
+Identity, GKE Workload Identity): the mover Job runs as a user-supplied
+Kubernetes `ServiceAccount` federated to the cloud IAM role that grants backend
+access, instead of reading static keys from a Secret.
+
+- **`serviceAccountName`** — the `ServiceAccount` the mover pod runs as, resolved
+  in the mover Job's own namespace.
+
+The `ServiceAccount` must already exist in each namespace mover Jobs run in (the
+operator never creates it) and carry the cloud-specific annotation
+(`eks.amazonaws.com/role-arn`, `azure.workload.identity/client-id`,
+`iam.gke.io/gcp-service-account`).
+
+## MoverDefaults
+
+Repository-wide mover defaults inherited by every mover the repository spawns —
+bootstrap, backup, restore, maintenance, verification, replication. Each field
+is overridable per-recipe via the recipe's [`mover`](#moverspec) block. This is
+the single place a repository defines mover identity, hardening, resources, and
+cache. See [movers](../../movers.md).
+
+- **`securityContext`** — container security-context base for every mover.
+- **`podSecurityContext`** — pod security-context base (notably `fsGroup`).
+- **`resources`** — resource requests/limits base for the mover container.
+- **`cache`** — kopia [CacheDefaults](#cachedefaults) for every mover.
+- **`scratch`** — [ScratchDefaults](#scratchdefaults) for the deep-verification
+  scratch volume.
+- **`nodeSelector`**, **`tolerations`**, **`affinity`** — pod scheduling for
+  every mover.
+- **`sourceColocation`** — RWO source-PVC node co-location (see below).
+- **`ttlSecondsAfterFinished`** — `Job.spec.ttlSecondsAfterFinished` for every
+  mover Job so finished Jobs self-GC. Defaults to 1h when neither the repo nor
+  the recipe sets one.
+- **`throttle`** — repository throttle limits (`kopia repository throttle set`)
+  applied by every mover after it connects, so a run doesn't saturate the link or
+  hammer the object store: `uploadBytesPerSecond`, `downloadBytesPerSecond`,
+  `readOpsPerSecond`, `writeOpsPerSecond` (each unset leaves kopia's current
+  limit).
+
+The `securityContext`/`podSecurityContext`/`resources`/`cache` fields resolve by
+field-wise merge: a repo-wide default composes with a partial per-recipe
+override, layered over a hardened base. See
+[security context](../../security-context.md) for the hardened defaults and how
+overrides only tighten them.
+
+### sourceColocation
+
+Controls how a mover co-locates with the node its `ReadWriteOnce` (RWO)
+source/destination PVC is attached to, to avoid a Kubernetes Multi-Attach error
+(an RWO PVC can only attach to one node at a time). The `mode` is one of:
+
+- **`Auto`** (default) — pin to the attached node when discoverable, otherwise
+  schedule freely (`ReadWriteMany`/`ReadOnlyMany` are never pinned). Fixes the
+  Multi-Attach error with no configuration.
+- **`Required`** — like `Auto`, but **fail** the run with an actionable error
+  when an RWO PVC's node cannot be determined.
+- **`Disabled`** — never compute a node pin; the mover uses only the explicit
+  `nodeSelector`/`affinity`/`tolerations`.
+
+## MoverSpec
+
+Per-recipe mover overrides on a recipe's `mover` field. Each field overlays the
+repository's [MoverDefaults](#moverdefaults) field-wise (recipe wins, the repo
+default fills, the hardened base underneath):
+
+- **`resources`** — resource requests/limits for the mover container.
+- **`cache`** — override the repository's [CacheDefaults](#cachedefaults).
+- **`securityContext`** — container security context; set only the fields you
+  want to change.
+- **`podSecurityContext`** — pod security context, notably `fsGroup`, which makes
+  a freshly-provisioned volume group-writable so an unprivileged mover can
+  populate it on restore without root.
+- **`privilegedMode`** — opt-in, namespace-gated; preserves UID/GID on restore.
+- **`inheritSecurityContextFrom`** — see below.
+- **`ttlSecondsAfterFinished`** — per-recipe override of the Job TTL.
+
+A pod-level `runAsUser: 0` / `runAsNonRoot: false` is still gated as privileged,
+exactly like the container-level setting.
+
+### inheritSecurityContextFrom
+
+Copies the UID/GID security context from a live workload instead of setting an
+explicit `securityContext`/`podSecurityContext` (mutually exclusive with both,
+webhook-enforced). Externally tagged, exactly one of:
+
+- **`workloadSelector`** — match the workload pod(s) by a label selector
+  (`podSelector` + optional `container`) and inherit the chosen container's
+  `securityContext` plus the pod's `spec.securityContext`. Works for both backup
+  and restore (restore inherits from the pod that will read the data).
+- **`pvcConsumer`** — **backup sources only.** Auto-derive the workload pod from
+  the PVC this snapshot backs up: the operator finds the pod(s) mounting the
+  source claim and inherits their security context, so the mover's UID/GID
+  matches the workload by construction — no hand-written selector. Meaningless on
+  a restore (the consuming pod may not exist yet), so restore must use
+  `workloadSelector`. `pvcConsumer` accepts an optional `container`.
+
+The resolved context still enters as the recipe layer, so the hardened base
+(`drop:[ALL]`, seccomp, `fsGroup`) still applies.
+
+## CacheDefaults
+
+How a mover's kopia cache volume is provisioned and sized.
+
+- **`capacity`** — size of the PVC backing the cache (e.g. `10Gi`).
+- **`storageClassName`** — StorageClass for the cache PVC; absent uses the
+  cluster default.
+- **`metadataCacheSizeMb`** — kopia metadata cache budget in MiB
+  (`--metadata-cache-size-mb`).
+- **`contentCacheSizeMb`** — kopia content cache budget in MiB
+  (`--content-cache-size-mb`).
+- **`mode`** — `Ephemeral` (default; the cache lives only for the run, fresh each
+  time) or `Persistent` (a warm cache reused across runs in a controller-owned
+  `ReadWriteOnce` PVC, which assumes non-overlapping runs for a given owner).
+
+## ScratchDefaults
+
+Defaults for the deep-verification **scratch** volume — the throwaway restore
+target a `deep` restore-test writes into and then discards. Inherited by a
+recipe's `verification.deep` unless overridden there.
+
+- **`storageClassName`** — StorageClass for the ephemeral scratch PVC; only
+  applies when `capacity` is set.
+- **`capacity`** — size of the ephemeral scratch PVC (e.g. `100Gi`); size it to
+  comfortably hold the restored snapshot. When absent, scratch falls back to a
+  node-ephemeral `emptyDir`.
+
+Unlike the cache, scratch is always ephemeral (auto-deleted with the verify
+Job), so it has no `mode`/persistent-PVC form.
+
+## CredentialProjection
+
+Opt-in projection of a repository's credential `Secret`(s) into the namespace
+where each mover Job runs (default off). When `enabled: true`, before each run
+the operator reads the source Secret(s) and writes a kopiur-managed copy into the
+Job's namespace, owned by the consuming CR (garbage-collected with it) and
+refreshed from source every run.
+
+Even when enabled, projection is a no-op where the source Secret already lives in
+the Job's namespace (the common namespaced-`Repository` layout) — there is
+nothing to copy. It only actually copies for the cross-namespace case (a shared
+`ClusterRepository` whose Secret is pinned to one namespace). Keeping it off by
+default preserves the namespace-as-trust-boundary posture.
+
+## CreateBehavior
+
+Behavior when the repository does not yet exist (a repository's `create` block).
+
+- **`enabled`** — create the repository if it does not exist yet (off by default,
+  so a typo'd backend can't silently spin up a brand-new empty repository).
+- **`encryption`** — kopia encryption algorithm for a freshly-created repository
+  (e.g. `AES256-GCM-HMAC-SHA256`).
+- **`splitter`** — kopia object splitter for a freshly-created repository.
+- **`hash`** — kopia content hash algorithm for a freshly-created repository.
+- **`ecc`** — Reed-Solomon error-correcting-code parity guarding repo blobs
+  against backend bit-rot: `algorithm` (e.g. `REED-SOLOMON-CRC32`) and
+  `overheadPercent`.
+
+All of these are consulted only at creation time and are immutable after the
+repository is created.
+
+## CatalogBounds
+
+Bounds on materialization of `origin: discovered` `Snapshot` CRs (a repository's
+`catalog` block). Expiring a CR row never deletes the kopia snapshot behind it —
+discovered snapshots are always `deletionPolicy: Retain`, and stay restorable via
+`Restore.source.identity`.
+
+- **`retain`** — how many discovered `Snapshot` CRs to keep materialized (bounds
+  etcd footprint for large repositories): `perIdentity` keeps the most-recent N
+  per `username@hostname:path` identity (snapshots this cluster produced don't
+  count; `0` disables discovered-Snapshot materialization entirely), and
+  `maxAgeDays` expires discovered CRs older than N days (minimum 1).
+- **`refreshInterval`** — how often to re-scan the repository (Go-style duration
+  like `30s`/`5m`/`1h`; minimum `30s`, default `1h`).
+- **`fallbackNamespace`** — where to materialize discovered `Snapshot`s whose
+  identity hostname doesn't map to an allowed namespace (ClusterRepository only;
+  rejected on a namespaced `Repository`, which always materializes into its own
+  namespace).
+
+## ServerSpec
+
+Optional kopia web-UI server configuration on a `Repository` /
+`ClusterRepository`. Presence of `spec.server` means **enabled** — there is no
+`enabled` bool. The operator runs `kopia server start` in a Deployment and
+exposes it via a Service; networking (Ingress/HTTPRoute) is left to the user. See
+[server](../../server.md).
+
+- **`auth`** — UI authentication mode (see below). Omitted defaults to
+  `generate` — **never** no-auth.
+- **`readOnly`** — connect the server's repository read-only so the UI cannot
+  create, delete, or alter backups (browse + restore-download only). A repository
+  with `spec.mode: ReadOnly` forces this on; setting an explicit `readOnly: false`
+  on a `ReadOnly` repository is rejected. Read-only blocks mutation, not reading —
+  the server still holds the decryption key, so anyone reaching the UI can read
+  and restore every backup.
+- **`service`** — how the server is exposed as a `Service`: `type`
+  (`ClusterIP` default, `NodePort`, `LoadBalancer`), `port` (default `51515`),
+  and `annotations` (the seam users wire their own Ingress/LoadBalancer onto).
+- **`resources`** — resource requests/limits for the server pod.
+- **`securityContext`** — override the hardened default container security
+  context.
+- **`podSecurityContext`** — pod-level security context. Notably carries
+  `supplementalGroups`, the way to grant the long-lived server write access to a
+  group-owned filesystem export — `fsGroup` is silently a no-op on NFS (the
+  kubelet does not recursively chown in-tree NFS mounts).
+
+On a `ClusterRepository` the server config additionally **requires** a
+`namespace` (a cluster-scoped server has no implicit namespace).
+
+By default the server holds a **read-write** repository connection. kopia's UI is
+full read-write-delete, and the server process holds the repository decryption
+key, so exposing it exposes full mutation of all backups — hence the
+`generate`-by-default and the mandatory `acknowledgeInsecure` on no-auth.
+
+### Server auth
+
+UI authentication mode, externally tagged, exactly one of:
+
+- **`generate`** — the operator mints random UI credentials into an owned
+  `Secret` and pins the reference to `status.server.generatedSecretRef`. The safe
+  default. Optional `username` (default `kopia`).
+- **`secretRef`** — the user supplies UI credentials via a `Secret`: `name`,
+  `usernameKey`, `passwordKey` (all required, so "keys are present" is a
+  structural guarantee).
+- **`insecure`** — no UI authentication. Requires an explicit
+  `acknowledgeInsecure: true` (webhook-rejected otherwise) because it exposes full
+  read/write/delete of the repository with no login.
+
+## Retention
+
+GFS (grandfather-father-son) retention — how many snapshots to keep per time
+bucket. The single successful-retention driver. All fields are optional counts:
+`keepLatest` (the N most-recent regardless of age), `keepHourly`, `keepDaily`,
+`keepWeekly`, `keepMonthly`, `keepAnnual` (one snapshot per bucket for the
+most-recent N of that bucket).
+
+## Identity
+
+What kopia records as `username@hostname:path` for a snapshot. Resolved at
+admission and pinned to status, never re-rendered.
+
+- **`username`** — override the `username` portion; absent uses the resolved
+  default (the repository's `identityDefaults` CEL expression, or the object
+  name).
+- **`hostname`** — override the `hostname` portion; absent uses the resolved
+  default (the `identityDefaults` expression, or the namespace).
+
+The fully-resolved values are pinned in status as `username`, `hostname`, and
+(where applicable) the `sourcePath`.
+
+## CronSpec
+
+A single cron entry with optional deterministic jitter, shared by `Maintenance`'s
+quick/full schedules.
+
+- **`cron`** — the cron expression, parsed by `croner`. May contain an `H`
+  placeholder for deterministic per-schedule jitter.
+- **`jitter`** — optional deterministic jitter window as a Go-style duration
+  string (e.g. `30m`), derived from `(scheduleUID, slot)` so it is stable across
+  restarts.
+
+## RepositoryRef
+
+A reference from a consumer CR (`SnapshotPolicy`, `Snapshot`, `Restore`,
+`Maintenance`) to a `Repository` or `ClusterRepository`. See
+[repositories](../../repositories.md).
+
+- **`kind`** — `Repository` (default, namespaced) or `ClusterRepository`
+  (cluster-scoped).
+- **`name`** — name of the referenced repository.
+- **`namespace`** — cross-namespace `Repository` reference. When
+  `kind: ClusterRepository`, `namespace` MUST be absent (webhook-enforced — a
+  cluster-scoped repository has no namespace).
+
+## SecretKeyRef and SecretRef
+
+`SecretKeyRef` references a single key within a `Secret` (`name`, optional
+`namespace`, optional `key`); a repository password (via `Encryption`) is always
+a `SecretKeyRef`, never inline. `SecretRef` references an entire `Secret` (the
+operator reads well-known keys from it; `name` + optional `namespace`). For both,
+an absent `namespace` means the same namespace as the referrer.
+
+## FailurePolicy
+
+Per-run failure controls passed through to the mover `Job` (on a recipe's
+`failurePolicy`):
+
+- **`backoffLimit`** — `Job.spec.backoffLimit`, retries before a failed run is
+  marked failed.
+- **`activeDeadlineSeconds`** — `Job.spec.activeDeadlineSeconds`, a wall-clock cap
+  after which a still-running run is killed (meant for long-running work).
+- **`podStartupDeadlineSeconds`** — how long a mover **pod** may sit in a
+  non-starting state (a container `CreateContainerConfigError` /
+  `ImagePullBackOff` / `InvalidImageName`, or `Unschedulable`) before the run is
+  failed with an actionable reason. A wedged pod never reaches a terminal phase,
+  so `backoffLimit` never trips — this is the only thing that bounds it.
+  Default 300s.

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -1,0 +1,199 @@
+# SnapshotPolicy
+
+The backup recipe — what to back up, identity, retention, policy, hooks. A
+`SnapshotPolicy` is idempotent and runs nothing on its own; a `Snapshot`
+invocation or a `SnapshotSchedule` drives it. For the terse type/default table see
+the [field reference](../../field-reference.md); for how-to guidance see
+[Backups & schedules](../../backups.md).
+
+## `spec`
+
+### `repository`
+
+Discriminated reference to the repository this recipe backs up to — either a
+namespaced `Repository` or a cluster-scoped `ClusterRepository`. The wire shape
+carries a `kind` so the referent kind is explicit.
+
+### `identity`
+
+Identity overrides — what kopia records as `username@hostname:path`. Resolved at
+admission and pinned to `status.resolved.identity`, never re-rendered afterward.
+Leave it unset to take the operator's defaults.
+
+### `sources`
+
+What to back up. At least one source is required (the webhook enforces it). Each
+entry is a single PVC by name, a label/namespace `pvcSelector` matching many PVCs,
+or an inline `nfs` export — exactly one of the three per source (also
+webhook-enforced). Both the `sourcePathOverride` and `sourcePathStrategy` siblings
+apply per source.
+
+Per-source fields:
+
+- `pvc` — a single `PersistentVolumeClaim` by name, in the policy's namespace.
+- `pvcSelector` — a Kubernetes `labelSelector` plus an optional `namespaceSelector`
+  (its `matchNames` restricts the search; absent means the policy's own namespace).
+- `nfs` — an inline NFS export backed up directly, with no PVC; mounted read-only.
+- `sourcePathOverride` — what kopia records as the source path. Defaults to
+  `/pvc/<name>` for a PVC, or the NFS export's `path` for an NFS source.
+- `sourcePathStrategy` — for `pvcSelector` sources only, how each matched PVC's
+  source path is derived: `PvcName` (default) uses the name alone;
+  `PvcNamespacedName` uses `<namespace>/<name>` to disambiguate same-named PVCs
+  across namespaces.
+
+### `copyMethod`
+
+How the source volume is captured before kopia reads it. `Direct` (the default)
+reads the live PVC with no intermediate snapshot or clone — it works on **any**
+storage, with no CSI snapshot stack required, but gives no point-in-time guarantee
+(the mover co-locates on the volume's node for RWO). `Snapshot` takes a
+point-in-time CSI volume snapshot; `Clone` takes a CSI volume clone, mounted
+read-only. Both `Snapshot` and `Clone` are opt-in: `Snapshot` needs the CSI
+snapshot stack and a `VolumeSnapshotClass` for the source's driver, and `Clone`
+needs a CSI driver that supports cloning. See [Copy methods](../../copy-methods.md).
+
+### `volumeSnapshotClassName`
+
+The `VolumeSnapshotClass` used when `copyMethod` is `Snapshot` or `Clone`.
+
+### `groupBy`
+
+Multi-PVC consistency grouping. `VolumeGroupSnapshot` (the default for multi-PVC
+sources) takes one consistent group snapshot across all PVCs; `None` opts into
+independent per-PVC snapshots. `None` must be set **explicitly** — there is no
+silent per-PVC fallback, because that would produce inconsistent backups.
+
+!!! note "Single-PVC today"
+    Group snapshotting is not yet fully wired; multi-PVC group consistency is a
+    work in progress. For the current single-PVC behavior this field has no
+    observable effect.
+
+### `retention`
+
+GFS (grandfather-father-son) retention, enforced by the operator pruning the
+`Snapshot` CRs produced from this recipe. See [Backups & schedules](../../backups.md).
+
+### `defaultDeletionPolicy`
+
+The default `deletionPolicy` stamped onto `Snapshot` CRs created against this
+recipe (`Delete`, `Retain`, or `Orphan`), controlling whether deleting the CR also
+deletes its kopia snapshot.
+
+### `compression`
+
+Compression policy. `compressor` names a kopia compressor (e.g. `zstd`); absent
+leaves kopia's default. `neverCompress` is a list of filename globs to leave
+uncompressed (e.g. already-compressed media).
+
+### `files`
+
+File-ignore policy. `ignoreRules` are filename/path globs to exclude from the
+snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`); `ignoreCacheDirs` honors
+`CACHEDIR.TAG`; `ignoreIdenticalSnapshots` skips taking a new snapshot when the
+source is identical to the previous one.
+
+### `extraArgs`
+
+An escape hatch for kopia flags not yet modeled as first-class fields.
+
+### `errorHandling`
+
+Backup-side error handling — lets a snapshot complete-with-errors instead of
+failing outright. Each flag defaults `false` (kopia's fail-on-error default):
+`ignoreFileErrors` (`--ignore-file-errors`) continues past unreadable files,
+`ignoreDirErrors` (`--ignore-dir-errors`) past unreadable directories, and
+`ignoreUnknownTypes` (`--ignore-unknown-types`) past entries of unknown type.
+
+### `upload`
+
+Upload parallelism (kopia's upload policy). `maxParallelSnapshots`
+(`--max-parallel-snapshots`) is how many sources snapshot concurrently;
+`maxParallelFileReads` (`--max-parallel-file-reads`) is file-read concurrency
+within a snapshot. Absent knobs leave kopia's default.
+
+### `verification`
+
+First-class backup verification that proves snapshots are **restorable**, not just
+that maintenance ran. Opt-in: when absent, no verification runs. Two tiers:
+
+- `quick` — a schedule for the frequent blob-level `kopia snapshot verify`; absent
+  means no quick verification. `verifyFilesPercent` (`--verify-files-percent`) tunes
+  how many files it verifies fully (absent leaves kopia's default).
+- `deep` — a schedule plus knobs for the rarer scratch-restore restorability test,
+  which restores the latest snapshot into an ephemeral volume, sanity-checks it,
+  then discards it. `deep.schedule` is its cron+jitter (e.g. weekly);
+  `deep.capacity` sizes the ephemeral scratch PVC (e.g. `10Gi`) — absent falls
+  back to a node-ephemeral `emptyDir`; `deep.storageClassName` picks the scratch
+  PVC's StorageClass (absent uses the cluster default, and only applies when
+  `capacity` is set).
+- `successExpr` — a CEL pass/fail predicate over the verify result, applied to both
+  tiers. The environment exposes `stats{files,bytes,errors}`, `snapshot`, and (deep
+  only) `restored{files,checksumMatches}`; returning `false` fails the run, killing
+  the silent "0 files" success. Example: `"stats.files > 0 && stats.errors == 0"`.
+
+### `suspend`
+
+Pause this recipe declaratively. A suspended `SnapshotPolicy` is skipped by
+schedules and by its own reconcile — no retention prune, no backup creation —
+and is surfaced via the `SUSPENDED` condition/column.
+
+### `hooks`
+
+Pre/post snapshot hooks that run in the workload, not the mover. `beforeSnapshot`
+hooks run in order before the snapshot is taken (e.g. quiescing a database);
+`afterSnapshot` hooks run in order after it completes (e.g. resuming the workload).
+Each hook is exactly one of three forms:
+
+- `workloadExec` — a `kubectl exec`-style command into a matched workload
+  pod/container (the default form). Carries the pod/container selector, `command`,
+  and `timeout`.
+- `runJob` — a full Kubernetes `JobSpec` run as a one-shot Job (the k8up
+  `PreBackupPod` analog).
+- `httpRequest` — a typed HTTP request for cross-system orchestration, with `url`,
+  `method` (default `POST`), optional `body`, and `timeout`.
+
+A hook failure aborts the backup by default; set `continueOnFailure: true` on any
+hook form to let the backup proceed past a failed hook. Timeouts are Go duration
+strings (e.g. `2m`).
+
+### `mover`
+
+Per-recipe mover overrides — resources, cache, security context — layered over the
+repository's `moverDefaults`. See [Movers](../../movers.md) and
+[Security context](../../security-context.md).
+
+### `credentialProjection`
+
+Opt-in credential-Secret projection for this recipe's backup movers (default off).
+When `enabled: true`, the operator copies the referenced repository's credential
+Secret(s) into the namespace where each backup mover runs (a no-op when they
+already live there) — so a workload backing up to a shared `ClusterRepository`
+need not pre-create the Secret in its own namespace. Inherited by `Snapshot`s
+produced from this recipe.
+
+## `status`
+
+### `resolved`
+
+The recipe as kopia would see it, pinned at admission and never re-rendered:
+`resolved.identity` is the resolved `username@hostname` identity, and
+`resolved.sources` is the concrete list of PVCs and source paths after selector
+expansion (each entry pairs a `namespace/name` `pvc` with the `sourcePath` kopia
+records for it).
+
+### `retention`
+
+Summary of the most recent GFS retention prune: `activeSnapshotCount` (CRs
+currently inside the GFS window), `lastPruneAt` (RFC3339 timestamp of the last
+prune pass), and `lastPruneDeleted` (number of `Snapshot` CRs deleted by it).
+
+### Other status fields
+
+- `observedGeneration` — `metadata.generation` last reconciled, for staleness
+  detection.
+- `lastSuccessfulSnapshot` — RFC3339 timestamp of the most recent successful child
+  `Snapshot` from this recipe (backs the `LAST-SNAPSHOT` column).
+- `lastVerified` — RFC3339 timestamp of the most recent successful verification of
+  any tier (backs the `LAST-VERIFIED` column).
+- `conditions` — standard Kubernetes conditions (e.g. `RepositoryReachable`,
+  `GroupSnapshotSupported`).

--- a/docs/reference/crds/snapshot-schedule.md
+++ b/docs/reference/crds/snapshot-schedule.md
@@ -1,0 +1,72 @@
+# SnapshotSchedule
+
+The cron schedule that fires [`Snapshot`](snapshot.md) CRs from a [`SnapshotPolicy`](snapshot-policy.md) — it decides *when* a backup runs, separate from the *what* (the policy) and the *one run* (the Snapshot). For the terse type/default table see the [field reference](../../field-reference.md); for how-to guidance see [Backups & schedules](../../backups.md).
+
+Each firing creates `Snapshot` CRs in the schedule's own namespace. Suspending or deleting a schedule does not affect in-flight or already-completed runs.
+
+## `spec`
+
+Exactly one of `policyRef` or `policySelector` is required (enforced by both the admission webhook and an apiserver CEL validation).
+
+### `policyRef`
+
+The single `SnapshotPolicy` recipe this schedule invokes, resolved in the schedule's own namespace. Mutually exclusive with `policySelector`.
+
+### `policySelector`
+
+The fan-out form: a label selector over `SnapshotPolicy` objects in the schedule's namespace. Each matching policy gets its own `Snapshot` per firing — "back up everything tagged `tier=critical` nightly" expressed as one object. Mutually exclusive with `policyRef`, and mirrors the `pvcSelector` pattern used elsewhere.
+
+### `schedule`
+
+The firing cadence. Its sub-fields:
+
+#### `schedule.cron`
+
+The cron expression, with Jenkins-style `H` substitution — `H` picks a deterministic per-object slot within the field's range so identical schedules don't stampede the same minute.
+
+#### `schedule.jitter`
+
+A deterministic offset (Go-style duration, e.g. `30m`) added to each firing, derived from `(scheduleUID, slot)` so it's stable across restarts rather than random.
+
+#### `schedule.timezone`
+
+The IANA timezone the cron is evaluated in (e.g. `America/Los_Angeles`). Absent uses the controller's configured default.
+
+#### `schedule.runOnCreate`
+
+Whether to fire immediately when the schedule is created. Defaults to `false` — the GitOps-friendly choice, so applying a manifest doesn't trigger an unexpected backup. This default materializes into the stored object and `kubectl explain`.
+
+#### `schedule.suspend`
+
+When `true`, skip future firings. In-flight and completed runs are untouched.
+
+#### `schedule.concurrencyPolicy`
+
+What to do when a slot fires while a prior run from this schedule is still in flight:
+
+- **`Forbid`** (default) — skip the new run and surface a condition, rather than let runs pile up.
+- **`Allow`** — start the new run alongside the in-flight one.
+- **`Replace`** — cancel the in-flight run and start the new one in its place.
+
+This default also materializes into the stored object and `kubectl explain`.
+
+#### `schedule.startingDeadlineSeconds`
+
+If a slot is missed by more than this many seconds (e.g. the operator was down), skip it instead of firing late.
+
+### `failedJobsHistoryLimit`
+
+The maximum number of *failed* `Snapshot` CRs from this schedule to retain. There is deliberately **no** `successfulJobsHistoryLimit`: retention of successful snapshots is GFS-driven on the [`SnapshotPolicy`](snapshot-policy.md)'s `retention` block, not a flat count.
+
+## `status`
+
+| Field | Meaning |
+| --- | --- |
+| `observedGeneration` | The `metadata.generation` this status reflects, for staleness detection. |
+| `lastSchedule` | The most recent firing (cron + jitter, pinned), and the `Snapshot` it produced. |
+| `nextSchedule` | The next firing slot the controller has computed. |
+| `lastSuccessfulSchedule` | The most recent firing whose `Snapshot` succeeded. |
+| `consecutiveFailures` | Count of back-to-back failed runs; resets on success. Drives alerting. |
+| `conditions` | Standard Kubernetes conditions surfacing schedule health. |
+
+Each schedule slot is recorded as an `at` (the RFC3339 instant it fired or is scheduled to) plus an optional `snapshotRef` naming the `Snapshot` CR that slot produced.

--- a/docs/reference/crds/snapshot.md
+++ b/docs/reference/crds/snapshot.md
@@ -1,0 +1,84 @@
+# Snapshot
+
+A single kopia snapshot represented as a Kubernetes object — one backup invocation. For the terse type/default table see the [field reference](../../field-reference.md); for how-to guidance see [Backups & schedules](../../backups.md).
+
+A `Snapshot` comes to exist in one of three ways, recorded in `status.origin`:
+
+- **`scheduled`** — created by a [`SnapshotSchedule`](snapshot-schedule.md); its spec carries `policyRef`.
+- **`manual`** — created by `kubectl create` or external automation; its spec carries `policyRef`.
+- **`discovered`** — materialized by the catalog scan for a kopia snapshot Kopiur did not produce. **A discovered Snapshot has an empty spec** — every spec field is optional and absent — and its data lives entirely in `status`.
+
+## `spec`
+
+For `scheduled`/`manual` backups the spec carries `policyRef` plus optional per-run overrides. For `discovered` backups the spec is empty.
+
+### `policyRef`
+
+The [`SnapshotPolicy`](snapshot-policy.md) recipe to run — what to back up. Absent for `discovered` snapshots, which Kopiur did not create.
+
+### `tags`
+
+Arbitrary key/value tags applied to the kopia snapshot (e.g. `reason: scheduled-nightly`). They flow through to kopia and are visible when listing snapshots.
+
+### `failurePolicy`
+
+Mover Job retry and deadline limits for this run — how many times the mover Job retries, and the deadlines that bound a single attempt and overall execution. See [Movers](../../movers.md).
+
+### `deletionPolicy`
+
+What happens to the underlying kopia snapshot when this CR is deleted. The default is origin-aware: scheduled/manual snapshots default to deleting the kopia content, while `discovered` snapshots are forced to retain it (Kopiur did not create that data, so it never reclaims it). Set `Orphan` to drop the CR without touching kopia. See [Backups & schedules](../../backups.md).
+
+### `pin`
+
+Exempt this snapshot from GFS retention. When `true` the reconciler applies a kopia snapshot pin and the GFS pruner never selects it for deletion — useful for pre-migration or compliance holds. Clearing it removes the pin. Defaults to `false`.
+
+## `status`
+
+The status is rich; `discovered` snapshots populate it without any spec.
+
+### `phase`
+
+Current lifecycle phase — one of `Pending` (admitted, not started), `Running` (mover Job in flight), `Succeeded`, `Failed` (retries exhausted), `Deleting` (finalizer reclaiming the kopia snapshot), or `Discovered` (catalog-materialized).
+
+### `origin`
+
+The canonical origin (`scheduled`, `manual`, or `discovered`), also mirrored to the `kopiur.home-operations.com/origin` label. Origin drives the `deletionPolicy` default.
+
+### `snapshot`
+
+Identifies the kopia snapshot this CR owns: `kopiaSnapshotID` (the handle the finalizer uses to delete content) and the resolved `username@hostname:path` `identity` recorded for it.
+
+### `stats`
+
+Byte and file counts parsed from kopia's JSON output: `sizeBytes`, `bytesNew` (uploaded after dedup/compression), `filesNew`, `filesModified`, `filesUnchanged`.
+
+#### `stats.filesFailed`
+
+The count of source entries kopia could **not** read and therefore **excluded** from the snapshot, making the backup *incomplete*. This is present (and `> 0`) only when an `ignoreFileErrors`/`ignoreDirErrors` policy let the snapshot complete despite unreadable files — the otherwise-silent partial-backup case. Kopiur surfaces it as a warning condition and Event. It usually means a UID/GID mismatch between the mover and the workload; see [Security context](../../security-context.md).
+
+### `conditions`
+
+Standard Kubernetes conditions surfacing run health (e.g. `SourcesQuiesced`, `SnapshotCreated`). Use these for kstatus-based readiness checks.
+
+### `logTail`
+
+The last lines of the run's output, written by the mover at the terminal transition — on success the `Snapshot created: <id>` line, on failure the actionable error plus a kopia stderr tail. It is capped in size; the full logs live in the mover Job's pod.
+
+### `failure`
+
+Structured terminal-failure detail (kopia error class, stderr tail, retry hint), written by the mover before it exits non-zero. Read this first when a `Snapshot` lands in `Failed`. See [Troubleshooting](../../troubleshooting.md).
+
+### `staged`
+
+The CSI staging objects the run created when the source was captured via `copyMethod: Snapshot`/`Clone` (the `VolumeSnapshot` and/or staged `PVC` the mover mounted in place of the live source, and whether the stage is `ready`). Absent for `Direct` and NFS, which mount the live source with no staging. See [Copy methods](../../copy-methods.md).
+
+### Other status fields
+
+| Field | Meaning |
+| --- | --- |
+| `observedGeneration` | `metadata.generation` last reconciled, for staleness detection. |
+| `timing` | `startTime`, `endTime`, `durationSeconds` of the run. |
+| `job` | The mover Job (`name`, `attempts`) backing a scheduled/manual run; absent for discovered. |
+| `resolved` | Frozen recipe values pinned at run time — the `repository` targeted and the concrete `sources` (PVCs + kopia paths) backed up. |
+| `pinned` | The observed kopia-side pin state: `true` if pinned, `false` if unpinned, absent before any pin reconcile. |
+| `hooks` | Completion timestamps so each hook list (`beforeSnapshot`/`afterSnapshot`) runs exactly once per Snapshot. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -212,6 +212,18 @@ nav:
       - Clone an app into another namespace: scenarios/clone-app-to-namespace.md
   - Reference:
       - Field reference (all CRDs): field-reference.md
+      # navigation.indexes: reference/crds/index.md is the section landing (first child).
+      - CRD reference:
+          - reference/crds/index.md
+          - Repository: reference/crds/repository.md
+          - ClusterRepository: reference/crds/cluster-repository.md
+          - SnapshotPolicy: reference/crds/snapshot-policy.md
+          - Snapshot: reference/crds/snapshot.md
+          - SnapshotSchedule: reference/crds/snapshot-schedule.md
+          - Restore: reference/crds/restore.md
+          - Maintenance: reference/crds/maintenance.md
+          - RepositoryReplication: reference/crds/repository-replication.md
+          - Shared sub-objects: reference/crds/shared-types.md
       - RBAC reference: rbac.md
       - API reference (rustdoc): api-reference.md
   # Top-level entry → its own top-level item in the left sidebar, so the Rust API
@@ -222,6 +234,7 @@ nav:
   - Rust API ↗: /rustdoc/index.html
   - Developer:
       - API conventions: dev/api-conventions.md
+      - CRD design rationale: dev/design-rationale.md
       - Observability: dev/observability.md
       - Watches & reconcile triggers: dev/watch-and-reconcile.md
   - Architecture Decision Records:


### PR DESCRIPTION
## What & why

Two changes that shrink the generated CRDs, prompted by reports that the Helm release is too big to install (Flux stores `HelmRelease` state in a gzipped Secret against a ~1 MiB limit, and large CRDs also blow client-side apply's 256 KB `last-applied-configuration` annotation limit).

**1. Trim verbose CRD descriptions to one sentence.** CRD `description` text is generated from Rust `///` doc comments via schemars and had grown to multi-paragraph prose (ADR refs, design rationale) that surfaced verbatim in `kubectl explain`. Each `///` is trimmed to a single concise sentence; the detail moves into the docs site, split by audience: user-facing field guidance → new per-CRD reference pages (`docs/reference/crds/`), developer rationale → a new `docs/dev/design-rationale.md`.

**2. Stop inlining embedded `core/v1` schemas (the big win).** schemars inlines the *entire* structural schema of embedded k8s-openapi types — `hooks.jobSpec` dragged in the full `PodSpec` (95% of the 1.2 MB `SnapshotPolicy` CRD), and `securityContext`/`podSecurityContext`/`resources`/`affinity` bloat every `moverDefaults`/`mover`/`server`. These fields now render as `x-kubernetes-preserve-unknown-fields` opaque objects via `#[schemars(schema_with = "crate::schema::preserve_unknown_object")]`. The Rust fields stay their concrete typed k8s-openapi types — kube still deserializes into them and the admission webhook still validates them — so only the apiserver's structural validation of the internals is relaxed (the standard pattern for embedded PodSpec/JobSpec).

## Size impact

| | raw | gzipped (Flux HelmRelease Secret) |
|---|---|---|
| `all-crds.yaml` before | 1.91 MB | 259 KB |
| after description trim only | 1.84 MB | 239 KB |
| **after preserve-unknown** | **277 KB** | **38 KB** |

Per-CRD: `snapshotpolicies` 1.26 MB → 47 KB (−96%), `repositories` 211 KB → 57 KB, `restores`/`maintenances` ~−55–63%. **Bundle −85%.**

## Notes / trade-off

- The Rust types are unchanged, so type-safety and webhook validation (resource bounds, the `securityContext` INV-1/INV-2 invariants, privileged-mover gating) are intact. A typo *inside* a `securityContext` now surfaces at the webhook / on deserialize rather than as an apiserver structural error. Rationale in `docs/dev/design-rationale.md`.
- Description trim is comment-only (zero code changes); the `schema_with` change adds 11 field attributes + a small helper module.

## Verification

- `mise run build`, `fmt-check`, `clippy`, `test` — pass (incl. preserved doctests)
- New regression test `embedded_core_v1_objects_render_as_preserve_unknown_not_inlined` (asserts preserve-unknown rendering + per-CRD size ceilings) — pass
- `mise run gen-check` — no drift; 3 insta snapshots reviewed (description-text + embedded-schema collapse only) and updated
- `mise run docs` — full pipeline passes `--strict`

https://claude.ai/code/session_01D3d39dmjfmPvYjAgpvxx7Q