### PR TITLE
feat(controller): gate Snapshot mover Jobs on repository readiness

### DIFF
--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -22,6 +22,11 @@ pub const REPOSITORY_WRITABLE_CONDITION: &str = "RepositoryWritable";
 /// repository (ADR-0005 §11).
 pub const REPOSITORY_READ_ONLY_REASON: &str = "RepositoryReadOnly";
 
+/// `reason` when a backup is held in `Pending` because its referenced repository
+/// is not `Ready` (backend unreachable). Mirrors the readiness gate Maintenance,
+/// `SnapshotPolicy`, and `RepositoryReplication` already apply.
+pub const REPOSITORY_NOT_READY_REASON: &str = "RepositoryNotReady";
+
 /// In-container mount path for an inline-NFS backup *source* whose server-side
 /// export is the NFSv4 pseudo-root (`/`). The export's server path and the
 /// container mount path are independent; reusing `/` as the mount path would

--- a/crates/controller/src/snapshot/build.rs
+++ b/crates/controller/src/snapshot/build.rs
@@ -244,6 +244,15 @@ pub(super) fn readonly_backup_message(repo_name: &str) -> String {
     )
 }
 
+/// Message for a backup held in `Pending` because its repository is not `Ready`
+/// (backend unreachable). Pure so the text is unit-asserted.
+pub(super) fn repository_not_ready_message(repo_name: &str) -> String {
+    format!(
+        "waiting for repository `{repo_name}` to become `Ready` before launching the backup \
+         (its backend is unreachable); the backup proceeds once the repository reconnects."
+    )
+}
+
 /// Snapshot tags from the config + run metadata.
 fn tags_for(config: &SnapshotPolicy) -> BTreeMap<String, String> {
     let mut tags = BTreeMap::new();

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -474,6 +474,27 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
         return Ok(Action::await_change());
     }
 
+    // Don't launch a mover Job against an unreachable repository (`phase != Ready`):
+    // the pod would only fail on `kopia repository connect`. Hold the Snapshot in
+    // `Pending` and requeue until the repository's own reconcile marks it `Ready`.
+    // Same gate Maintenance, `SnapshotPolicy`, and `RepositoryReplication` apply.
+    if !io::repository_ready(&ctx.client, &config.spec.repository, &namespace).await? {
+        let current = serde_json::to_value(&backup.status).ok();
+        io::patch_status_if_changed(
+            &api,
+            &name,
+            current.as_ref(),
+            snapshot_ready_status(
+                backup,
+                SnapshotPhase::Pending,
+                crate::consts::REPOSITORY_NOT_READY_REASON,
+                &repository_not_ready_message(&config.spec.repository.name),
+            ),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(15)));
+    }
+
     let (work_spec, mut source_volume, repo_volume, _) =
         build_backup_run(backup, &config, &repo, &namespace, &name)?;
 

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -24,6 +24,28 @@ fn readonly_repository_refuses_backup_writes() {
     assert!(msg.contains("ReadWrite"));
 }
 
+// --- Readiness gate: a not-Ready repository holds the backup in Pending ---
+
+#[test]
+fn not_ready_repository_holds_backup_pending() {
+    use crate::consts::REPOSITORY_NOT_READY_REASON;
+    use kopiur_api::common::PhaseLabel;
+    use kopiur_api::snapshot::SnapshotPhase;
+
+    // Pending is Reconciling (not Stalled), so the backup resumes on reconnect.
+    assert_eq!(
+        snapshot_ready_outcome(SnapshotPhase::Pending),
+        io::ReadyOutcome::Reconciling
+    );
+    assert_eq!(SnapshotPhase::Pending.label(), "Pending");
+    // The hold message names the repo; it's a wait, not a refusal.
+    let msg = repository_not_ready_message("nas");
+    assert!(msg.contains("nas"));
+    assert!(msg.contains("Ready"));
+    assert!(!msg.contains("refusing"));
+    assert_eq!(REPOSITORY_NOT_READY_REASON, "RepositoryNotReady");
+}
+
 // --- §13(c) pin decision (pure: spec.pin vs observed → pin/unpin/noop) ---
 
 #[test]


### PR DESCRIPTION
## What

The `Snapshot` reconciler now checks `repository_ready()` before building/launching the mover Job. If the referenced `Repository`/`ClusterRepository` is not `Ready` (its backend is unreachable), the `Snapshot` is held in `Pending` with a `RepositoryNotReady` reason and requeued, instead of spawning a pod that only fails on `kopia repository connect`.

This is the same readiness gate `Maintenance`, `SnapshotPolicy`, and `RepositoryReplication` already apply — `Snapshot` was the only write path that skipped it.

## Why

After a backend outage (e.g. a NAS that didn't come back after a power loss), every scheduled snapshot was spawning a doomed mover Job that failed on connect. The gate suppresses the Job storm once the repository is known-not-`Ready`; the backup resumes automatically (`Pending` → `Reconciling`) when the repository's own reconcile marks it `Ready` again.

## Notes / limitation

The gate keys off `Repository.status.phase`, which is re-probed on the catalog refresh cadence (default `1h`). So there is still a window after an outage where the repo reads `Ready` and Jobs spawn until the next re-probe flips it. Tightening that detection latency (fast-fail re-verify on backup failure, or a shorter connectivity probe) is a follow-up.

## Tests

- `not_ready_repository_holds_backup_pending` — asserts `Pending` maps to `Reconciling`, the hold message names the repo and reads as a wait (not a refusal), and the reason constant is `RepositoryNotReady`.
- Mirrors the existing `readonly_repository_refuses_backup_writes` pure-unit shape; full reconcile behavior remains e2e-tier.
- `cargo test`, `clippy -D warnings`, `fmt` all green.