### PR TITLE
feat(controller): re-probe repository on backup failure to fail-fast snapshots

### DIFF
--- a/crates/api/src/cluster_repository.rs
+++ b/crates/api/src/cluster_repository.rs
@@ -176,6 +176,10 @@ pub struct ClusterRepositoryStatus {
     /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
+    /// Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+    /// (RFC3339); the loop guard that keeps each request a one-shot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reverify_at: Option<String>,
     /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -192,6 +192,10 @@ pub struct RepositoryStatus {
     /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
+    /// Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+    /// (RFC3339); the loop guard that keeps each request a one-shot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reverify_at: Option<String>,
     /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -89,6 +89,33 @@ pub fn refresh_due(
     last.with_timezone(&Utc) + interval <= now
 }
 
+/// Whether a fresh reverify request should force a re-probe now, bypassing the
+/// refresh timer. Gated on the repo being `Ready` and the token differing from the
+/// last one honored (`status.lastReverifyAt`) — that comparison is the loop guard.
+pub fn reverify_due(token: Option<&str>, honored: Option<&str>, phase_ready: bool) -> bool {
+    phase_ready && token.is_some() && token != honored
+}
+
+/// Whether a `Snapshot` should (re)write the reverify-request annotation. Rate
+/// limited via the existing timestamp (shared across `Snapshot`s) so a wave of
+/// failures forces at most one re-probe per `min_interval`. Absent/unparseable ⇒ yes.
+pub fn should_request_reverify(
+    existing: Option<&str>,
+    now: DateTime<Utc>,
+    min_interval: std::time::Duration,
+) -> bool {
+    let Some(raw) = existing else {
+        return true;
+    };
+    let Ok(last) = DateTime::parse_from_rfc3339(raw) else {
+        return true;
+    };
+    let Ok(min_interval) = chrono::Duration::from_std(min_interval) else {
+        return true;
+    };
+    last.with_timezone(&Utc) + min_interval <= now
+}
+
 /// The steady-state requeue for a Ready repository: the usual 5 minutes, or the
 /// catalog refresh interval when the user asked for a faster re-scan cadence
 /// (otherwise a sub-5m `refreshInterval` would silently never fire on time).
@@ -824,6 +851,36 @@ mod tests {
         // Stale → due.
         let stale = (now - chrono::Duration::minutes(61)).to_rfc3339();
         assert!(refresh_due(Some(&stale), interval, now));
+    }
+
+    #[test]
+    fn reverify_due_honors_once_and_only_while_ready() {
+        // No request → never.
+        assert!(!reverify_due(None, None, true));
+        // Fresh request, Ready, never honored → force the re-probe.
+        assert!(reverify_due(Some("t1"), None, true));
+        // Already honored this exact token → no-op (the loop guard).
+        assert!(!reverify_due(Some("t1"), Some("t1"), true));
+        // A genuinely newer token re-fires.
+        assert!(reverify_due(Some("t2"), Some("t1"), true));
+        // Not Ready (already re-probing / Failed) → never force; the gate holds.
+        assert!(!reverify_due(Some("t2"), Some("t1"), false));
+    }
+
+    #[test]
+    fn should_request_reverify_rate_limits_on_the_existing_stamp() {
+        let now = Utc::now();
+        let min = std::time::Duration::from_secs(60);
+        // No prior request → request.
+        assert!(should_request_reverify(None, now, min));
+        // Unparseable → request (defensive).
+        assert!(should_request_reverify(Some("nope"), now, min));
+        // Within the window → skip (a wave of failures collapses to one re-probe).
+        let recent = (now - chrono::Duration::seconds(30)).to_rfc3339();
+        assert!(!should_request_reverify(Some(&recent), now, min));
+        // Past the window → request again.
+        let old = (now - chrono::Duration::seconds(61)).to_rfc3339();
+        assert!(should_request_reverify(Some(&old), now, min));
     }
 
     #[test]

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -601,6 +601,22 @@ async fn bootstrap_cluster_via_mover(
     let job_name = format!("{name}-bootstrap");
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &job_ns);
 
+    // Honor a `Snapshot`'s reverify nudge: force a re-probe (ORs into the
+    // recycle/create gates below), stamping the token at create time as the loop guard.
+    let reverify_token = repo
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+        .map(String::as_str);
+    let reverify = catalog::reverify_due(
+        reverify_token,
+        repo.status
+            .as_ref()
+            .and_then(|s| s.last_reverify_at.as_deref()),
+        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+    );
+
     if let Some(job) = job_api.get_opt(&job_name).await? {
         let already_ready =
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
@@ -625,14 +641,16 @@ async fn bootstrap_cluster_via_mover(
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
-                if catalog::bootstrap_recycle_due(
-                    already_ready,
-                    repo.metadata.generation,
-                    repo.status.as_ref().and_then(|s| s.observed_generation),
-                    cluster_last_refresh_at(repo),
-                    interval,
-                    chrono::Utc::now(),
-                ) {
+                if reverify
+                    || catalog::bootstrap_recycle_due(
+                        already_ready,
+                        repo.metadata.generation,
+                        repo.status.as_ref().and_then(|s| s.observed_generation),
+                        cluster_last_refresh_at(repo),
+                        interval,
+                        chrono::Utc::now(),
+                    )
+                {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
                     job_api
                         .delete(&job_name, &kube::api::DeleteParams::background())
@@ -661,14 +679,16 @@ async fn bootstrap_cluster_via_mover(
     // when a re-run is actually warranted (`bootstrap_create_due`: catalog refresh
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
-    if !catalog::bootstrap_create_due(
-        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
-        repo.metadata.generation,
-        repo.status.as_ref().and_then(|s| s.observed_generation),
-        cluster_last_refresh_at(repo),
-        CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
-        chrono::Utc::now(),
-    ) {
+    if !(reverify
+        || catalog::bootstrap_create_due(
+            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+            repo.metadata.generation,
+            repo.status.as_ref().and_then(|s| s.observed_generation),
+            cluster_last_refresh_at(repo),
+            CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            chrono::Utc::now(),
+        ))
+    {
         return Ok(Action::requeue(catalog::reconcile_interval(
             repo.spec.catalog.as_ref(),
         )));
@@ -767,12 +787,13 @@ async fn bootstrap_cluster_via_mover(
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
     io::apply_mover_objects(&ctx.client, &job_ns, &job_name, &cm, &job).await?;
-    io::patch_status(
-        api,
-        name,
-        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() }),
-    )
-    .await?;
+    // Stamp the reverify token (loop guard): this request is now honored.
+    let mut create_status =
+        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() });
+    if let Some(token) = reverify_token {
+        create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), namespace = %job_ns, "launched ClusterRepository bootstrap Job");
     Ok(Action::requeue(Duration::from_secs(15)))
 }

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -64,6 +64,11 @@ pub const REPLICATION_INSTANCE_LABEL: &str = "kopiur.home-operations.com/replica
 /// Annotation on a replication Job recording the scheduled slot it runs (RFC3339).
 pub const REPLICATION_SLOT_ANNOTATION: &str = "kopiur.home-operations.com/replication-slot";
 
+/// Annotation a `Snapshot` stamps (RFC3339) on its repository when a backup fails,
+/// requesting an immediate connectivity re-probe. Honored once via
+/// `status.lastReverifyAt`; rate-limited so a wave of failures forces one re-probe.
+pub const REVERIFY_REQUESTED_ANNOTATION: &str = "kopiur.home-operations.com/reverify-requested-at";
+
 /// Condition reason when a `Maintenance` (managed or external) covers the repo.
 pub const MAINTENANCE_CONFIGURED_REASON: &str = "MaintenanceConfigured";
 /// `action` for the maintenance-configuration check Event.

--- a/crates/controller/src/io/repo.rs
+++ b/crates/controller/src/io/repo.rs
@@ -1,5 +1,6 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::Api;
+use kube::api::{Patch, PatchParams};
 
 use kopiur_api::backend::Backend;
 use kopiur_api::cluster_repository::IdentityDefaults;
@@ -234,6 +235,66 @@ pub async fn repository_ready(
             Ok(repo.status.and_then(|s| s.phase) == ready)
         }
     }
+}
+
+/// Stamp the reverify annotation (`now`, RFC3339) to request an immediate
+/// connectivity re-probe. Best-effort: skips a non-`Ready` repo (the gate already
+/// holds) and a request within the rate-limit window; a missing repo is a no-op.
+pub async fn request_repository_reverify(
+    client: &kube::Client,
+    repo_ref: &RepositoryRef,
+    default_ns: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    /// At most one forced re-probe per repository per this window.
+    const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+    let ready = Some(kopiur_api::RepositoryPhase::Ready);
+    let key = crate::consts::REVERIFY_REQUESTED_ANNOTATION;
+    let body = |ts: &str| {
+        Patch::Merge(serde_json::json!({
+            "metadata": { "annotations": { key: ts } }
+        }))
+    };
+    let pp = PatchParams::apply(super::apply::FIELD_MANAGER);
+    let stamp = now.to_rfc3339();
+
+    match repo_lookup(repo_ref, default_ns) {
+        RepoLookup::Namespaced { namespace, name } => {
+            let api: Api<Repository> = Api::namespaced(client.clone(), &namespace);
+            let Some(repo) = api.get_opt(&name).await? else {
+                return Ok(());
+            };
+            if repo.status.as_ref().and_then(|s| s.phase) != ready {
+                return Ok(());
+            }
+            let existing = repo.metadata.annotations.as_ref().and_then(|a| a.get(key));
+            if crate::catalog::should_request_reverify(
+                existing.map(String::as_str),
+                now,
+                MIN_INTERVAL,
+            ) {
+                api.patch(&name, &pp, &body(&stamp)).await?;
+            }
+        }
+        RepoLookup::Cluster { name } => {
+            let api: Api<ClusterRepository> = Api::all(client.clone());
+            let Some(repo) = api.get_opt(&name).await? else {
+                return Ok(());
+            };
+            if repo.status.as_ref().and_then(|s| s.phase) != ready {
+                return Ok(());
+            }
+            let existing = repo.metadata.annotations.as_ref().and_then(|a| a.get(key));
+            if crate::catalog::should_request_reverify(
+                existing.map(String::as_str),
+                now,
+                MIN_INTERVAL,
+            ) {
+                api.patch(&name, &pp, &body(&stamp)).await?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Whether the named `Namespace` is being torn down — its `deletionTimestamp` is

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -530,6 +530,22 @@ async fn bootstrap_via_mover(
     let job_name = format!("{name}-bootstrap");
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
 
+    // Honor a `Snapshot`'s reverify nudge: force a re-probe (ORs into the
+    // recycle/create gates below), stamping the token at create time as the loop guard.
+    let reverify_token = repo
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+        .map(String::as_str);
+    let reverify = catalog::reverify_due(
+        reverify_token,
+        repo.status
+            .as_ref()
+            .and_then(|s| s.last_reverify_at.as_deref()),
+        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+    );
+
     if let Some(job) = job_api.get_opt(&job_name).await? {
         let already_ready =
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
@@ -555,14 +571,16 @@ async fn bootstrap_via_mover(
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
-                if catalog::bootstrap_recycle_due(
-                    already_ready,
-                    repo.metadata.generation,
-                    repo.status.as_ref().and_then(|s| s.observed_generation),
-                    last_refresh_at(repo),
-                    interval,
-                    chrono::Utc::now(),
-                ) {
+                if reverify
+                    || catalog::bootstrap_recycle_due(
+                        already_ready,
+                        repo.metadata.generation,
+                        repo.status.as_ref().and_then(|s| s.observed_generation),
+                        last_refresh_at(repo),
+                        interval,
+                        chrono::Utc::now(),
+                    )
+                {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
                     job_api
                         .delete(&job_name, &DeleteParams::background())
@@ -588,14 +606,16 @@ async fn bootstrap_via_mover(
     // when a re-run is actually warranted (`bootstrap_create_due`: catalog refresh
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
-    if !catalog::bootstrap_create_due(
-        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
-        repo.metadata.generation,
-        repo.status.as_ref().and_then(|s| s.observed_generation),
-        last_refresh_at(repo),
-        CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
-        chrono::Utc::now(),
-    ) {
+    if !(reverify
+        || catalog::bootstrap_create_due(
+            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+            repo.metadata.generation,
+            repo.status.as_ref().and_then(|s| s.observed_generation),
+            last_refresh_at(repo),
+            CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            chrono::Utc::now(),
+        ))
+    {
         return Ok(Action::requeue(catalog::reconcile_interval(
             repo.spec.catalog.as_ref(),
         )));
@@ -731,12 +751,13 @@ async fn bootstrap_via_mover(
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
     io::apply_mover_objects(&ctx.client, namespace, &job_name, &cm, &job).await?;
-    io::patch_status(
-        api,
-        name,
-        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() }),
-    )
-    .await?;
+    // Stamp the reverify token (loop guard): this request is now honored.
+    let mut create_status =
+        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() });
+    if let Some(token) = reverify_token {
+        create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), "launched repository bootstrap Job");
     Ok(Action::requeue(Duration::from_secs(15)))
 }

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -349,6 +349,24 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         ),
                     )
                     .await?;
+                    // A failed backup may mean the backend went away: nudge the repository
+                    // to re-probe now so the gate engages without waiting for the catalog
+                    // refresh. Best-effort — a nudge error must not mask the failure above.
+                    if let Some(repo_ref) = backup
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.resolved.as_ref())
+                        .and_then(|r| r.repository.as_ref())
+                        && let Err(e) = io::request_repository_reverify(
+                            &ctx.client,
+                            repo_ref,
+                            &namespace,
+                            chrono::Utc::now(),
+                        )
+                        .await
+                    {
+                        tracing::debug!(backup = %name, error = %e, "repository reverify nudge failed (ignored)");
+                    }
                 }
                 // The run is terminal (the Job exhausted its retries) — reap any CSI
                 // staging objects. No-op for Direct.

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
-assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2298,6 +2297,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -2294,6 +2294,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64
@@ -4779,6 +4785,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -2379,6 +2379,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -2294,6 +2294,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -2379,6 +2379,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -2294,6 +2294,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64


### PR DESCRIPTION
Stacked on #147 (the readiness gate). Closes the detection-latency window that PR left open.

## Problem

The gate in #147 keys off `Repository.status.phase`, which is only re-probed on the catalog refresh cadence (**default 1h**). So after a backend outage there is still an up-to-1h window where the repo reads `Ready` and every scheduled snapshot spawns a doomed mover Job.

## What

When a backup mover Job fails, the `Snapshot` reconciler stamps a `reverify-requested-at` annotation on its `Repository`/`ClusterRepository`, asking it to re-probe connectivity **now** instead of waiting for the refresh. The repository honors a token newer than `status.lastReverifyAt` exactly once, re-runs its bootstrap connect, and flips to `Failed` if the backend is gone — at which point the gate suppresses all further snapshot Jobs.

Net effect: one doomed Job at outage onset instead of one per schedule tick; automatic resume when the backend returns.

## Design

- **Event-driven, not polling** — no new standing Jobs; the re-probe is the repository's existing bootstrap path, triggered on demand.
- **Loop-safe** — honoring is gated on `phase == Ready` AND `token != status.lastReverifyAt`; the token is stamped at re-probe *create* time, so a fresh re-probe is never itself recycled.
- **Rate-limited** — the annotation timestamp is shared across all Snapshots, so a wave of failing backups forces at most one re-probe per 60s.
- **Ownership preserved** — the Snapshot only writes the repository's *metadata* (annotation); the repository remains the sole writer of its own status. The honoring logic is additive (ORs a `reverify` flag into the existing recycle/create gates; `catalog.rs` gate functions are untouched).
- **No mover changes** — deliberately does not depend on backup error-class plumbing (that was the rejected "clean nudge" option); any backup failure nudges, and a false alarm costs one rate-limited re-probe that simply re-confirms `Ready`.

## Changes

- `RepositoryStatus` / `ClusterRepositoryStatus`: new `lastReverifyAt` (CRDs regenerated).
- `catalog::reverify_due` / `catalog::should_request_reverify`: pure decision + rate-limit, unit-tested for loop-safety.
- `io::request_repository_reverify`: best-effort annotation nudge (both kinds, phase-guarded, rate-limited).
- `Repository` / `ClusterRepository` reconcilers: honor the token, stamp the loop guard at create.
- Controller already has `patch` on both repository kinds — no RBAC change.

## Tests

- `reverify_due_honors_once_and_only_while_ready`, `should_request_reverify_rate_limits_on_the_existing_stamp` — pure loop-safety + rate-limit.
- `cargo test` (63 groups), `clippy -D warnings`, `gen-check` all green; CRD insta snapshot updated.