### PR TITLE
feat: repository health fail-fast, cron timezones, and verification successExpr fixes

### DIFF
--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -377,17 +377,6 @@ provenance = "github-attestations"
 version = "22.23.0"
 backend = "core:node"
 
-[tools.node.options]
-compile = "true"
-
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:535eeb608ca1e0b71d49a0e36991d449d5f935fbb04eca61677519b010cd673a"
-url = "https://nodejs.org/dist/v22.23.0/node-v22.23.0-linux-x64.tar.gz"
-
-[[tools.node]]
-version = "22.23.0"
-backend = "core:node"
-
 [tools.node."platforms.linux-arm64"]
 checksum = "sha256:0c96aa074abd109e0b5da8d10202a9bbcea9bcf9ddb587b20944f71b8f21f8c8"
 url = "https://nodejs.org/dist/v22.23.0/node-v22.23.0-linux-arm64.tar.gz"
@@ -395,6 +384,10 @@ url = "https://nodejs.org/dist/v22.23.0/node-v22.23.0-linux-arm64.tar.gz"
 [tools.node."platforms.linux-arm64-musl"]
 checksum = "sha256:b554e3fd26b450bdc0d3a279f7de436018bd215ea17a323268c81749aa25cc71"
 url = "https://unofficial-builds.nodejs.org/download/release/v22.23.0/node-v22.23.0-linux-arm64-musl.tar.gz"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:535eeb608ca1e0b71d49a0e36991d449d5f935fbb04eca61677519b010cd673a"
+url = "https://nodejs.org/dist/v22.23.0/node-v22.23.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
 checksum = "sha256:43b3a26b712ab2d7226acffbda47c65caa570e83bc7fbc8c59087f5515730997"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf",
+]
+
+[[package]]
 name = "clap"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1502,7 @@ dependencies = [
  "assert-json-diff",
  "cel",
  "chrono",
+ "chrono-tz",
  "croner",
  "k8s-openapi",
  "kube",
@@ -1533,6 +1544,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "chrono-tz",
  "croner",
  "futures",
  "http",
@@ -2180,6 +2192,24 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3037,6 +3067,12 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,6 +84,10 @@ clap = { version = "4", features = ["derive", "wrap_help"] }
 
 # Scheduling / expressions
 croner = "2"
+# IANA timezone database for evaluating cron schedules in a user-specified zone
+# (CronSpec.timezone / ScheduleSpec.timezone / MaintenanceSchedule.timezone). Pure,
+# tokio-free, so it is safe in the api crate alongside chrono.
+chrono-tz = "0.10"
 # CEL (Common Expression Language) for identity *Expr fields (ADR-0004 §5) and the
 # broader *Expr convention (ADR-0005 §15). Sync + tokio-free, so it is safe in the
 # api crate (ADR §5.1). Replaces the former Jinja2/tera identity templating.

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -16,6 +16,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 croner = { workspace = true }
 cel = { workspace = true }
 kube_quantity = "0.9.0"

--- a/crates/api/src/cluster_repository.rs
+++ b/crates/api/src/cluster_repository.rs
@@ -176,6 +176,10 @@ pub struct ClusterRepositoryStatus {
     /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
+    /// Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+    /// (RFC3339); the loop guard that keeps each request a one-shot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reverify_at: Option<String>,
     /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/crates/api/src/common/cache.rs
+++ b/crates/api/src/common/cache.rs
@@ -108,7 +108,16 @@ pub struct CatalogBounds {
     /// How many discovered `Snapshot` CRs to keep materialized (bounds etcd footprint).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retain: Option<CatalogRetain>,
-    /// How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+    /// Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+    /// current (re-list snapshots; for object-store / volume-backed repos this recycles
+    /// the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+    /// still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+    /// failure, but does not re-run on a timer. Enable it if you rely on discovered
+    /// snapshots reflecting changes made outside this operator.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub periodic_refresh: bool,
+    /// How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+    /// `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub refresh_interval: Option<String>,
     /// Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
@@ -117,10 +126,17 @@ pub struct CatalogBounds {
 }
 
 impl CatalogBounds {
-    /// The effective catalog re-scan cadence: `refreshInterval` when set and
-    /// parseable, else [`crate::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`].
-    /// (The webhook rejects an unparseable value, so the fallback only covers
-    /// objects admitted before the validator existed.)
+    /// Whether periodic re-scan is opted in (`catalog.periodicRefresh`). Off by
+    /// default, so a repository does not re-run its bootstrap Job on a timer.
+    pub fn periodic_refresh_enabled(catalog: Option<&Self>) -> bool {
+        catalog.is_some_and(|c| c.periodic_refresh)
+    }
+
+    /// The effective catalog re-scan cadence used **when `periodicRefresh` is on**:
+    /// `refreshInterval` when set and parseable, else
+    /// [`crate::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`]. (The webhook rejects an
+    /// unparseable value, so the fallback only covers objects admitted before the
+    /// validator existed.)
     pub fn effective_refresh_interval(catalog: Option<&Self>) -> std::time::Duration {
         catalog
             .and_then(|c| c.refresh_interval.as_deref())

--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -398,6 +398,19 @@ pub struct CronSpec {
     /// Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub jitter: Option<String>,
+    /// IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+    /// the enclosing schedule's timezone, else the controller default (UTC).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<String>,
+}
+
+/// Resolve an optional IANA timezone name to a concrete zone, defaulting to UTC.
+/// An unparseable name falls back to UTC defensively — the admission webhook rejects
+/// bad names up front via `validate::validate_timezone`, so reconcile-time resolution
+/// should never see one.
+pub fn resolve_tz(name: Option<&str>) -> chrono_tz::Tz {
+    name.and_then(|s| s.parse::<chrono_tz::Tz>().ok())
+        .unwrap_or(chrono_tz::Tz::UTC)
 }
 
 impl RepositoryRef {

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -111,6 +111,15 @@ pub enum ValidationError {
         reason: String,
     },
 
+    /// A schedule's `timezone` is not a recognized IANA timezone name (e.g. a typo
+    /// like `America/Chicgo`), rejected at apply time rather than silently falling
+    /// back to UTC at reconcile.
+    #[error("invalid timezone {name:?}: not a recognized IANA timezone name")]
+    InvalidTimezone {
+        /// The timezone string that failed to parse.
+        name: String,
+    },
+
     /// Two fields that may not both be set were both set (e.g. a `Source` with
     /// both `pvc` and `pvcSelector`).
     #[error("fields {a:?} and {b:?} are mutually exclusive but both were set ({context})")]

--- a/crates/api/src/maintenance.rs
+++ b/crates/api/src/maintenance.rs
@@ -28,10 +28,12 @@ pub fn default_maintenance_schedule() -> MaintenanceSchedule {
         quick: CronSpec {
             cron: "0 */6 * * *".to_string(),
             jitter: Some("30m".to_string()),
+            timezone: None,
         },
         full: CronSpec {
             cron: "0 3 * * *".to_string(),
             jitter: Some("1h".to_string()),
+            timezone: None,
         },
         timezone: None,
     }

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -192,6 +192,10 @@ pub struct RepositoryStatus {
     /// Resolved kopia server endpoint/auth, pinned by the reconciler.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub server: Option<ServerStatus>,
+    /// Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+    /// (RFC3339); the loop guard that keeps each request a one-shot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_reverify_at: Option<String>,
     /// Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub conditions: Vec<Condition>,

--- a/crates/api/src/success_expr.rs
+++ b/crates/api/src/success_expr.rs
@@ -21,6 +21,8 @@
 //! - `restored` — a map `{files, checksumMatches}` for the *deep* (scratch-restore)
 //!   tier. Present (possibly empty) so an expression that only references it under a
 //!   guard validates; a quick verify leaves it empty.
+//! - `tier` — the string `"quick"` or `"deep"`, so a single predicate can branch on
+//!   the tier (e.g. `tier == 'deep' ? restored.checksumMatches : stats.files > 0`).
 //!
 //! Each value is supplied by the mover from the real verify result and evaluated
 //! there; admission validation ([`validate_success_expr`]) trial-evaluates against a
@@ -66,6 +68,8 @@ pub struct SuccessExprInputs<'a> {
     pub snapshot: BTreeMap<String, String>,
     /// `restored.{files,checksumMatches}` for the deep tier; `None` for quick.
     pub restored: Option<RestoredStats>,
+    /// `tier`: `"quick"` or `"deep"`, so a predicate can branch on the verify tier.
+    pub tier: String,
     /// Lifetime tie so the struct can borrow string slices in future without churn.
     pub _marker: std::marker::PhantomData<&'a ()>,
 }
@@ -100,6 +104,7 @@ fn context<'a>(inputs: &SuccessExprInputs<'_>) -> Context<'a> {
     ]);
     let _ = ctx.add_variable("stats", &stats);
     let _ = ctx.add_variable("snapshot", &inputs.snapshot);
+    let _ = ctx.add_variable("tier", &inputs.tier);
     // `restored` is always present (possibly empty) so a guarded reference validates;
     // a quick verify leaves it empty rather than absent.
     match inputs.restored {
@@ -160,6 +165,7 @@ pub fn validate_success_expr(expr: &str) -> ValidationResult {
             files: 1,
             checksum_matches: true,
         }),
+        tier: "deep".to_string(),
         _marker: std::marker::PhantomData,
     };
     let ctx = context(&inputs);
@@ -194,6 +200,7 @@ mod tests {
             },
             snapshot: BTreeMap::from([("id".to_string(), "k1".to_string())]),
             restored: None,
+            tier: "quick".to_string(),
             _marker: std::marker::PhantomData,
         }
     }
@@ -230,6 +237,28 @@ mod tests {
     }
 
     #[test]
+    fn tier_is_available_for_branching() {
+        // `inputs` is the quick tier; a tier-aware predicate must see it.
+        let i = inputs(5, 0);
+        assert_eq!(i.tier, "quick");
+        let expr = "tier == 'deep' ? restored.checksumMatches : stats.files > 0";
+        assert!(eval_success_expr(expr, &i).unwrap());
+        // The deep branch reads `restored` (empty for quick) only when tier=='deep'.
+        let mut d = inputs(5, 0);
+        d.tier = "deep".to_string();
+        d.restored = Some(RestoredStats {
+            files: 5,
+            checksum_matches: true,
+        });
+        assert!(eval_success_expr(expr, &d).unwrap());
+        d.restored = Some(RestoredStats {
+            files: 5,
+            checksum_matches: false,
+        });
+        assert!(!eval_success_expr(expr, &d).unwrap());
+    }
+
+    #[test]
     fn non_bool_result_is_an_error() {
         let err = eval_success_expr("stats.files", &inputs(1, 0)).unwrap_err();
         assert!(matches!(err, ValidationError::SuccessExprType { .. }));
@@ -248,6 +277,11 @@ mod tests {
         assert!(validate_success_expr("stats.files > 0 && stats.errors == 0").is_ok());
         assert!(validate_success_expr("restored.checksumMatches").is_ok());
         assert!(validate_success_expr("snapshot.id != ''").is_ok());
+        // A tier-aware predicate validates against the trial environment.
+        assert!(
+            validate_success_expr("tier == 'deep' ? restored.checksumMatches : stats.files > 0")
+                .is_ok()
+        );
         // Data-dependent map index on snapshot is tolerated.
         assert!(validate_success_expr("snapshot.id != '' && stats.errors == 0").is_ok());
     }

--- a/crates/api/src/validate/mod.rs
+++ b/crates/api/src/validate/mod.rs
@@ -228,6 +228,29 @@ pub fn validate_cron(expr: &str) -> ValidationResult {
     }
 }
 
+/// Validate an optional IANA timezone name against the same `chrono-tz` database the
+/// controller uses at scheduling time, so a typo (e.g. `America/Chicgo`) is rejected at
+/// apply time rather than silently resolving to UTC at the next reconcile. `None` (use
+/// the controller default) is always valid.
+///
+/// ```
+/// use kopiur_api::validate::validate_timezone;
+///
+/// assert!(validate_timezone(None).is_ok());
+/// assert!(validate_timezone(Some("America/Chicago")).is_ok());
+/// assert!(validate_timezone(Some("UTC")).is_ok());
+/// assert!(validate_timezone(Some("America/Chicgo")).is_err());
+/// ```
+pub fn validate_timezone(name: Option<&str>) -> ValidationResult {
+    match name {
+        None => Ok(()),
+        Some(tz) if tz.parse::<chrono_tz::Tz>().is_ok() => Ok(()),
+        Some(tz) => Err(ValidationError::InvalidTimezone {
+            name: tz.to_string(),
+        }),
+    }
+}
+
 /// The shared `spec.server` rules the type system can't express (server addendum):
 ///   * `auth.insecure` requires `acknowledgeInsecure: true` — a no-auth server exposes
 ///     full read/read of the repository, so it must be explicit.

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -203,6 +203,15 @@ pub fn validate_repository_maintenance(
         if let Err(e) = validate_cron(&schedule.full.cron) {
             errs.push(e);
         }
+        for tz in [
+            schedule.timezone.as_deref(),
+            schedule.quick.timezone.as_deref(),
+            schedule.full.timezone.as_deref(),
+        ] {
+            if let Err(e) = validate_timezone(tz) {
+                errs.push(e);
+            }
+        }
     }
     if !cluster_scoped && let Some(ns) = &maintenance.namespace {
         errs.push(ValidationError::MaintenanceNamespaceOnNamespacedRepo {
@@ -473,6 +482,9 @@ pub fn validate_repository_replication(spec: &RepositoryReplicationSpec) -> Vec<
     if let Err(e) = validate_cron(&spec.schedule.cron) {
         errs.push(e);
     }
+    if let Err(e) = validate_timezone(spec.schedule.timezone.as_deref()) {
+        errs.push(e);
+    }
     if let Err(e) = validate_backend(&spec.destination) {
         errs.push(e);
     }
@@ -543,6 +555,15 @@ pub fn validate_maintenance(spec: &MaintenanceSpec) -> Vec<ValidationError> {
     }
     if let Err(e) = validate_cron(&spec.schedule.full.cron) {
         errs.push(e);
+    }
+    for tz in [
+        spec.schedule.timezone.as_deref(),
+        spec.schedule.quick.timezone.as_deref(),
+        spec.schedule.full.timezone.as_deref(),
+    ] {
+        if let Err(e) = validate_timezone(tz) {
+            errs.push(e);
+        }
     }
     if let Some(m) = &spec.mover {
         if let Err(e) = forbid_pvc_consumer(

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -83,15 +83,21 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
     // `successExpr` (ADR-0005 §15) must compile + trial-evaluate to a bool with no
     // out-of-scope variable — rejected at admission rather than at first verify run.
     if let Some(v) = &spec.verification {
-        if let Some(q) = &v.quick
-            && let Err(e) = validate_cron(&q.cron)
-        {
-            errs.push(e);
+        if let Some(q) = &v.quick {
+            if let Err(e) = validate_cron(&q.cron) {
+                errs.push(e);
+            }
+            if let Err(e) = validate_timezone(q.timezone.as_deref()) {
+                errs.push(e);
+            }
         }
-        if let Some(d) = &v.deep
-            && let Err(e) = validate_cron(&d.schedule.cron)
-        {
-            errs.push(e);
+        if let Some(d) = &v.deep {
+            if let Err(e) = validate_cron(&d.schedule.cron) {
+                errs.push(e);
+            }
+            if let Err(e) = validate_timezone(d.schedule.timezone.as_deref()) {
+                errs.push(e);
+            }
         }
         if let Some(expr) = &v.success_expr
             && let Err(e) = crate::success_expr::validate_success_expr(expr)
@@ -217,6 +223,9 @@ pub fn validate_backup_schedule(spec: &SnapshotScheduleSpec) -> Vec<ValidationEr
         errs.push(e);
     }
     if let Err(e) = validate_cron(&spec.schedule.cron) {
+        errs.push(e);
+    }
+    if let Err(e) = validate_timezone(spec.schedule.timezone.as_deref()) {
         errs.push(e);
     }
     errs

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -1133,6 +1133,35 @@ fn backup_schedule_aggregate_rejects_bad_cron() {
     );
 }
 
+#[test]
+fn backup_schedule_aggregate_rejects_bad_timezone() {
+    use crate::common::PolicyRef;
+    use crate::snapshot_schedule::ScheduleSpec;
+    let spec = SnapshotScheduleSpec {
+        policy_ref: Some(PolicyRef {
+            name: "c".into(),
+            namespace: None,
+        }),
+        policy_selector: None,
+        schedule: ScheduleSpec {
+            cron: "0 2 * * *".into(),
+            jitter: None,
+            timezone: Some("America/Chicgo".into()), // typo'd IANA name
+            run_on_create: false,
+            suspend: false,
+            concurrency_policy: Default::default(),
+            starting_deadline_seconds: None,
+        },
+        failed_jobs_history_limit: None,
+    };
+    let errs = validate_backup_schedule(&spec);
+    assert!(
+        errs.iter()
+            .any(|e| matches!(e, ValidationError::InvalidTimezone { .. })),
+        "a typo'd timezone must be rejected at admission: {errs:?}"
+    );
+}
+
 // --- §10 policyRef XOR policySelector ---
 
 #[test]
@@ -1279,10 +1308,12 @@ fn repository_maintenance_bad_override_cron_is_rejected() {
             quick: CronSpec {
                 cron: "totally bad".into(),
                 jitter: None,
+                timezone: None,
             },
             full: CronSpec {
                 cron: "0 3 * * *".into(),
                 jitter: None,
+                timezone: None,
             },
             timezone: None,
         }),
@@ -1664,6 +1695,7 @@ fn replication_spec(
         schedule: CronSpec {
             cron: cron.into(),
             jitter: None,
+            timezone: None,
         },
         mover: None,
         suspend: false,

--- a/crates/controller/Cargo.toml
+++ b/crates/controller/Cargo.toml
@@ -32,6 +32,7 @@ opentelemetry = { workspace = true }
 axum = { workspace = true }
 croner = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 thiserror = { workspace = true }
 anyhow = { workspace = true }
 libc = { workspace = true }

--- a/crates/controller/src/cache.rs
+++ b/crates/controller/src/cache.rs
@@ -207,6 +207,7 @@ mod tests {
             schedule: kopiur_api::common::CronSpec {
                 cron: "0 5 * * 0".into(),
                 jitter: None,
+                timezone: None,
             },
             storage_class_name: storage_class.map(str::to_string),
             capacity: capacity.map(str::to_string),

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -89,6 +89,33 @@ pub fn refresh_due(
     last.with_timezone(&Utc) + interval <= now
 }
 
+/// Whether a fresh reverify request should force a re-probe now, bypassing the
+/// refresh timer. Gated on the repo being `Ready` and the token differing from the
+/// last one honored (`status.lastReverifyAt`) — that comparison is the loop guard.
+pub fn reverify_due(token: Option<&str>, honored: Option<&str>, phase_ready: bool) -> bool {
+    phase_ready && token.is_some() && token != honored
+}
+
+/// Whether a `Snapshot` should (re)write the reverify-request annotation. Rate
+/// limited via the existing timestamp (shared across `Snapshot`s) so a wave of
+/// failures forces at most one re-probe per `min_interval`. Absent/unparseable ⇒ yes.
+pub fn should_request_reverify(
+    existing: Option<&str>,
+    now: DateTime<Utc>,
+    min_interval: std::time::Duration,
+) -> bool {
+    let Some(raw) = existing else {
+        return true;
+    };
+    let Ok(last) = DateTime::parse_from_rfc3339(raw) else {
+        return true;
+    };
+    let Ok(min_interval) = chrono::Duration::from_std(min_interval) else {
+        return true;
+    };
+    last.with_timezone(&Utc) + min_interval <= now
+}
+
 /// The steady-state requeue for a Ready repository: the usual 5 minutes, or the
 /// catalog refresh interval when the user asked for a faster re-scan cadence
 /// (otherwise a sub-5m `refreshInterval` would silently never fire on time).
@@ -824,6 +851,36 @@ mod tests {
         // Stale → due.
         let stale = (now - chrono::Duration::minutes(61)).to_rfc3339();
         assert!(refresh_due(Some(&stale), interval, now));
+    }
+
+    #[test]
+    fn reverify_due_honors_once_and_only_while_ready() {
+        // No request → never.
+        assert!(!reverify_due(None, None, true));
+        // Fresh request, Ready, never honored → force the re-probe.
+        assert!(reverify_due(Some("t1"), None, true));
+        // Already honored this exact token → no-op (the loop guard).
+        assert!(!reverify_due(Some("t1"), Some("t1"), true));
+        // A genuinely newer token re-fires.
+        assert!(reverify_due(Some("t2"), Some("t1"), true));
+        // Not Ready (already re-probing / Failed) → never force; the gate holds.
+        assert!(!reverify_due(Some("t2"), Some("t1"), false));
+    }
+
+    #[test]
+    fn should_request_reverify_rate_limits_on_the_existing_stamp() {
+        let now = Utc::now();
+        let min = std::time::Duration::from_secs(60);
+        // No prior request → request.
+        assert!(should_request_reverify(None, now, min));
+        // Unparseable → request (defensive).
+        assert!(should_request_reverify(Some("nope"), now, min));
+        // Within the window → skip (a wave of failures collapses to one re-probe).
+        let recent = (now - chrono::Duration::seconds(30)).to_rfc3339();
+        assert!(!should_request_reverify(Some(&recent), now, min));
+        // Past the window → request again.
+        let old = (now - chrono::Duration::seconds(61)).to_rfc3339();
+        assert!(should_request_reverify(Some(&old), now, min));
     }
 
     #[test]

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -30,14 +30,18 @@
 //!
 //! ## Refresh cadence
 //!
-//! Scans run when `status.catalog.lastRefreshAt` is older than the effective
+//! An **initial** scan always runs — on first bootstrap and again on any spec
+//! change (the `generation != observedGeneration` arm of [`scan_due`] /
+//! [`bootstrap_recycle_due`]). **Repeated, timed** re-scans are **opt-in** via
+//! `spec.catalog.periodicRefresh` (off by default): when enabled, a scan runs once
+//! `status.catalog.lastRefreshAt` is older than the effective
 //! `spec.catalog.refreshInterval` (default
-//! [`kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`]) — see
-//! [`refresh_due`]. Gating the scan also gates the `lastRefreshAt` status write,
-//! so a Ready repository's status is byte-stable between refreshes (the
-//! status-churn rule). Object-store repositories re-list by recycling their
-//! finished bootstrap Job ([`bootstrap_recycle_due`]); bare-path filesystem
-//! repositories re-list in-process.
+//! [`kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`]) — see [`refresh_due`].
+//! With it off, a succeeded repository bootstraps once and is never recycled on a
+//! timer. Gating the scan also gates the `lastRefreshAt` status write, so a Ready
+//! repository's status is byte-stable between refreshes (the status-churn rule).
+//! Object-store repositories re-list by recycling their finished bootstrap Job
+//! ([`bootstrap_recycle_due`]); bare-path filesystem repositories re-list in-process.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -116,11 +120,18 @@ pub fn should_request_reverify(
     last.with_timezone(&Utc) + min_interval <= now
 }
 
-/// The steady-state requeue for a Ready repository: the usual 5 minutes, or the
-/// catalog refresh interval when the user asked for a faster re-scan cadence
-/// (otherwise a sub-5m `refreshInterval` would silently never fire on time).
+/// The steady-state requeue for a Ready repository: the usual 5 minutes, or — only
+/// when `periodicRefresh` is on — the catalog refresh interval when the user asked
+/// for a faster re-scan cadence (otherwise a sub-5m `refreshInterval` would silently
+/// never fire on time). With periodic refresh off, the interval is inert, so we stay
+/// at the 5-minute liveness cadence.
 pub fn reconcile_interval(catalog: Option<&CatalogBounds>) -> std::time::Duration {
-    std::time::Duration::from_secs(300).min(CatalogBounds::effective_refresh_interval(catalog))
+    let base = std::time::Duration::from_secs(300);
+    if CatalogBounds::periodic_refresh_enabled(catalog) {
+        base.min(CatalogBounds::effective_refresh_interval(catalog))
+    } else {
+        base
+    }
 }
 
 /// `true` when a *finished* bootstrap Job should be deleted so the next
@@ -134,6 +145,7 @@ pub fn bootstrap_recycle_due(
     observed_generation: Option<i64>,
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
+    periodic_enabled: bool,
     now: DateTime<Utc>,
 ) -> bool {
     if !phase_is_ready {
@@ -142,7 +154,9 @@ pub fn bootstrap_recycle_due(
     if generation != observed_generation {
         return true;
     }
-    refresh_due(last_refresh_at, interval, now)
+    // The timed refresh arm only fires when periodic refresh is opted in; otherwise a
+    // succeeded bootstrap is never recycled on a timer (one-time bootstrap semantics).
+    periodic_enabled && refresh_due(last_refresh_at, interval, now)
 }
 
 /// `true` when a fresh repository listing should actually be SCANNED into the
@@ -160,12 +174,15 @@ pub fn scan_due(
     observed_generation: Option<i64>,
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
+    periodic_enabled: bool,
     now: DateTime<Utc>,
 ) -> bool {
     if generation != observed_generation {
         return true;
     }
-    refresh_due(last_refresh_at, interval, now)
+    // The initial scan runs on the generation arm above (first reconcile, spec change);
+    // the timed re-scan only fires when periodic refresh is opted in.
+    periodic_enabled && refresh_due(last_refresh_at, interval, now)
 }
 
 /// `true` when the *no-Job* path may (re-)create the bootstrap Job. The finished
@@ -189,6 +206,7 @@ pub fn bootstrap_create_due(
     observed_generation: Option<i64>,
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
+    periodic_enabled: bool,
     now: DateTime<Utc>,
 ) -> bool {
     if !phase_is_ready {
@@ -200,6 +218,7 @@ pub fn bootstrap_create_due(
         observed_generation,
         last_refresh_at,
         interval,
+        periodic_enabled,
         now,
     )
 }
@@ -896,15 +915,18 @@ mod tests {
             Some(1),
             None,
             interval,
+            true,
             now
         ));
-        // Ready + spec changed → recycle even when fresh.
+        // Ready + spec changed → recycle even when fresh — independent of the
+        // periodic-refresh flag (a re-pointed backend must always re-bootstrap).
         assert!(bootstrap_recycle_due(
             true,
             Some(2),
             Some(1),
             Some(&fresh),
             interval,
+            false,
             now
         ));
         // Ready + same generation + fresh → keep the finished Job.
@@ -914,15 +936,28 @@ mod tests {
             Some(2),
             Some(&fresh),
             interval,
+            true,
             now
         ));
-        // Ready + same generation + stale → recycle for a fresh listing.
+        // Ready + same generation + stale + periodic ON → recycle for a fresh listing.
         assert!(bootstrap_recycle_due(
             true,
             Some(2),
             Some(2),
             Some(&stale),
             interval,
+            true,
+            now
+        ));
+        // Ready + same generation + stale + periodic OFF (default) → do NOT recycle
+        // on the timer: one-time bootstrap semantics.
+        assert!(!bootstrap_recycle_due(
+            true,
+            Some(2),
+            Some(2),
+            Some(&stale),
+            interval,
+            false,
             now
         ));
     }
@@ -937,16 +972,48 @@ mod tests {
         let now = Utc::now();
         let interval = std::time::Duration::from_secs(3600);
         let fresh = (now - chrono::Duration::minutes(5)).to_rfc3339();
-        // Spec changed (gen != observed) + fresh stamp → scan NOW.
-        assert!(scan_due(Some(3), Some(2), Some(&fresh), interval, now));
+        // Spec changed (gen != observed) + fresh stamp → scan NOW, regardless of the
+        // periodic-refresh flag (the initial/spec-change scan is always honored).
+        assert!(scan_due(
+            Some(3),
+            Some(2),
+            Some(&fresh),
+            interval,
+            false,
+            now
+        ));
         // Settled generation + fresh stamp → byte-stable, no scan (the
         // status-churn rule).
-        assert!(!scan_due(Some(3), Some(3), Some(&fresh), interval, now));
-        // Settled generation + stale stamp → the timed refresh still fires.
+        assert!(!scan_due(
+            Some(3),
+            Some(3),
+            Some(&fresh),
+            interval,
+            true,
+            now
+        ));
+        // Settled generation + stale stamp + periodic ON → the timed refresh fires.
         let stale = (now - chrono::Duration::minutes(61)).to_rfc3339();
-        assert!(scan_due(Some(3), Some(3), Some(&stale), interval, now));
-        // Never scanned → due regardless.
-        assert!(scan_due(Some(1), Some(1), None, interval, now));
+        assert!(scan_due(
+            Some(3),
+            Some(3),
+            Some(&stale),
+            interval,
+            true,
+            now
+        ));
+        // Settled generation + stale stamp + periodic OFF (default) → no timed re-scan.
+        assert!(!scan_due(
+            Some(3),
+            Some(3),
+            Some(&stale),
+            interval,
+            false,
+            now
+        ));
+        // Never scanned + periodic OFF → still no timed scan (the initial scan runs on
+        // the generation arm, not this timer).
+        assert!(!scan_due(Some(1), Some(1), None, interval, false, now));
     }
 
     // Regression guard for the TTL-reap loop: when the kube TTL controller
@@ -959,13 +1026,15 @@ mod tests {
         let interval = std::time::Duration::from_secs(3600);
         let fresh = (now - chrono::Duration::minutes(5)).to_rfc3339();
         let stale = (now - chrono::Duration::minutes(61)).to_rfc3339();
-        // Not Ready → always proceed (first bootstrap / failure retry).
+        // Not Ready → always proceed (first bootstrap / failure retry), regardless
+        // of the periodic flag.
         assert!(bootstrap_create_due(
             false,
             Some(1),
             None,
             None,
             interval,
+            false,
             now
         ));
         // Ready + same generation + fresh scan → HOLD: the reaped Job must not
@@ -976,33 +1045,47 @@ mod tests {
             Some(2),
             Some(&fresh),
             interval,
+            true,
             now
         ));
-        // Ready + refresh due → re-create for a fresh listing.
+        // Ready + refresh due + periodic ON → re-create for a fresh listing.
         assert!(bootstrap_create_due(
             true,
             Some(2),
             Some(2),
             Some(&stale),
             interval,
+            true,
             now
         ));
-        // Ready + spec changed → re-create even when fresh.
+        // Ready + refresh due + periodic OFF (default) → HOLD: no timed re-create.
+        assert!(!bootstrap_create_due(
+            true,
+            Some(2),
+            Some(2),
+            Some(&stale),
+            interval,
+            false,
+            now
+        ));
+        // Ready + spec changed → re-create even when fresh (independent of the flag).
         assert!(bootstrap_create_due(
             true,
             Some(3),
             Some(2),
             Some(&fresh),
             interval,
+            false,
             now
         ));
-        // Ready but never stamped (e.g. pre-catalog status) → defensive re-run.
+        // Ready but never stamped + periodic ON → defensive re-run.
         assert!(bootstrap_create_due(
             true,
             Some(2),
             Some(2),
             None,
             interval,
+            true,
             now
         ));
     }
@@ -1150,18 +1233,30 @@ mod tests {
             reconcile_interval(None),
             std::time::Duration::from_secs(300)
         );
-        let slow: CatalogBounds =
-            serde_json::from_value(serde_json::json!({ "refreshInterval": "2h" })).unwrap();
+        let slow: CatalogBounds = serde_json::from_value(
+            serde_json::json!({ "periodicRefresh": true, "refreshInterval": "2h" }),
+        )
+        .unwrap();
         assert_eq!(
             reconcile_interval(Some(&slow)),
             std::time::Duration::from_secs(300)
         );
-        // A faster refresh shortens the requeue so the cadence actually fires.
-        let fast: CatalogBounds =
-            serde_json::from_value(serde_json::json!({ "refreshInterval": "30s" })).unwrap();
+        // A faster refresh (with periodic ON) shortens the requeue so the cadence fires.
+        let fast: CatalogBounds = serde_json::from_value(
+            serde_json::json!({ "periodicRefresh": true, "refreshInterval": "30s" }),
+        )
+        .unwrap();
         assert_eq!(
             reconcile_interval(Some(&fast)),
             std::time::Duration::from_secs(30)
+        );
+        // Periodic refresh OFF (default): the interval is inert — stay at 5 minutes
+        // even with a fast `refreshInterval` set.
+        let fast_off: CatalogBounds =
+            serde_json::from_value(serde_json::json!({ "refreshInterval": "30s" })).unwrap();
+        assert_eq!(
+            reconcile_interval(Some(&fast_off)),
+            std::time::Duration::from_secs(300)
         );
     }
 

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -358,6 +358,7 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
                 repo.status.as_ref().and_then(|s| s.observed_generation),
                 cluster_last_refresh_at(repo),
                 interval,
+                CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -663,6 +664,7 @@ async fn bootstrap_cluster_via_mover(
                         repo.status.as_ref().and_then(|s| s.observed_generation),
                         cluster_last_refresh_at(repo),
                         interval,
+                        CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                         chrono::Utc::now(),
                     )
                 {
@@ -701,6 +703,7 @@ async fn bootstrap_cluster_via_mover(
             repo.status.as_ref().and_then(|s| s.observed_generation),
             cluster_last_refresh_at(repo),
             CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
             chrono::Utc::now(),
         ))
     {
@@ -992,6 +995,7 @@ async fn finalize_cluster_bootstrap(
         repo.status.as_ref().and_then(|s| s.observed_generation),
         cluster_last_refresh_at(repo),
         interval,
+        CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
         chrono::Utc::now(),
     ) {
         run_cluster_catalog_scan(

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -315,21 +315,36 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
             }
             let status = client.repository_status().await?;
             let allowed_count = allowed_namespace_count(&repo.spec.allowed_namespaces);
+            let mut status_patch = serde_json::json!({
+                "phase": "Ready",
+                "backend": "Filesystem",
+                "uniqueId": status.unique_id_hex,
+                "allowedNamespaceCount": allowed_count,
+                "observedGeneration": repo.metadata.generation,
+                "resolvedCredentialVersion": cred_version,
+            });
+            // Record a `Snapshot`'s reverify nudge as honored. This in-process arm
+            // re-probes on every reconcile (the connect above) and the annotation patch
+            // already retriggered us, so the re-probe is implicit — we only stamp
+            // `lastReverifyAt` so the once-honored token is observable in status and
+            // consistent with the mover bootstrap path.
+            let reverify_token = repo
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+                .map(String::as_str);
+            if let Some(token) = reverify_token
+                && repo
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.last_reverify_at.as_deref())
+                    != Some(token)
+            {
+                status_patch["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+            }
             let current = serde_json::to_value(&repo.status).ok();
-            io::patch_status_if_changed(
-                &api,
-                &name,
-                current.as_ref(),
-                serde_json::json!({
-                    "phase": "Ready",
-                    "backend": "Filesystem",
-                    "uniqueId": status.unique_id_hex,
-                    "allowedNamespaceCount": allowed_count,
-                    "observedGeneration": repo.metadata.generation,
-                    "resolvedCredentialVersion": cred_version,
-                }),
-            )
-            .await?;
+            io::patch_status_if_changed(&api, &name, current.as_ref(), status_patch).await?;
 
             // Catalog scan on the `catalog.refreshInterval` cadence: a bare-path
             // filesystem repo re-lists in-process. Each discovered snapshot is
@@ -601,6 +616,22 @@ async fn bootstrap_cluster_via_mover(
     let job_name = format!("{name}-bootstrap");
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &job_ns);
 
+    // Honor a `Snapshot`'s reverify nudge: force a re-probe (ORs into the
+    // recycle/create gates below), stamping the token at create time as the loop guard.
+    let reverify_token = repo
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+        .map(String::as_str);
+    let reverify = catalog::reverify_due(
+        reverify_token,
+        repo.status
+            .as_ref()
+            .and_then(|s| s.last_reverify_at.as_deref()),
+        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+    );
+
     if let Some(job) = job_api.get_opt(&job_name).await? {
         let already_ready =
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
@@ -625,14 +656,16 @@ async fn bootstrap_cluster_via_mover(
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
-                if catalog::bootstrap_recycle_due(
-                    already_ready,
-                    repo.metadata.generation,
-                    repo.status.as_ref().and_then(|s| s.observed_generation),
-                    cluster_last_refresh_at(repo),
-                    interval,
-                    chrono::Utc::now(),
-                ) {
+                if reverify
+                    || catalog::bootstrap_recycle_due(
+                        already_ready,
+                        repo.metadata.generation,
+                        repo.status.as_ref().and_then(|s| s.observed_generation),
+                        cluster_last_refresh_at(repo),
+                        interval,
+                        chrono::Utc::now(),
+                    )
+                {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
                     job_api
                         .delete(&job_name, &kube::api::DeleteParams::background())
@@ -661,14 +694,16 @@ async fn bootstrap_cluster_via_mover(
     // when a re-run is actually warranted (`bootstrap_create_due`: catalog refresh
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
-    if !catalog::bootstrap_create_due(
-        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
-        repo.metadata.generation,
-        repo.status.as_ref().and_then(|s| s.observed_generation),
-        cluster_last_refresh_at(repo),
-        CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
-        chrono::Utc::now(),
-    ) {
+    if !(reverify
+        || catalog::bootstrap_create_due(
+            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+            repo.metadata.generation,
+            repo.status.as_ref().and_then(|s| s.observed_generation),
+            cluster_last_refresh_at(repo),
+            CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            chrono::Utc::now(),
+        ))
+    {
         return Ok(Action::requeue(catalog::reconcile_interval(
             repo.spec.catalog.as_ref(),
         )));
@@ -767,12 +802,13 @@ async fn bootstrap_cluster_via_mover(
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
     io::apply_mover_objects(&ctx.client, &job_ns, &job_name, &cm, &job).await?;
-    io::patch_status(
-        api,
-        name,
-        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() }),
-    )
-    .await?;
+    // Stamp the reverify token (loop guard): this request is now honored.
+    let mut create_status =
+        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() });
+    if let Some(token) = reverify_token {
+        create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), namespace = %job_ns, "launched ClusterRepository bootstrap Job");
     Ok(Action::requeue(Duration::from_secs(15)))
 }

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -22,6 +22,11 @@ pub const REPOSITORY_WRITABLE_CONDITION: &str = "RepositoryWritable";
 /// repository (ADR-0005 §11).
 pub const REPOSITORY_READ_ONLY_REASON: &str = "RepositoryReadOnly";
 
+/// `reason` when a backup is held in `Pending` because its referenced repository
+/// is not `Ready` (backend unreachable). Mirrors the readiness gate Maintenance,
+/// `SnapshotPolicy`, and `RepositoryReplication` already apply.
+pub const REPOSITORY_NOT_READY_REASON: &str = "RepositoryNotReady";
+
 /// In-container mount path for an inline-NFS backup *source* whose server-side
 /// export is the NFSv4 pseudo-root (`/`). The export's server path and the
 /// container mount path are independent; reusing `/` as the mount path would
@@ -58,6 +63,11 @@ pub const REPLICATION_COMPONENT: &str = "replication";
 pub const REPLICATION_INSTANCE_LABEL: &str = "kopiur.home-operations.com/replication";
 /// Annotation on a replication Job recording the scheduled slot it runs (RFC3339).
 pub const REPLICATION_SLOT_ANNOTATION: &str = "kopiur.home-operations.com/replication-slot";
+
+/// Annotation a `Snapshot` stamps (RFC3339) on its repository when a backup fails,
+/// requesting an immediate connectivity re-probe. Honored once via
+/// `status.lastReverifyAt`; rate-limited so a wave of failures forces one re-probe.
+pub const REVERIFY_REQUESTED_ANNOTATION: &str = "kopiur.home-operations.com/reverify-requested-at";
 
 /// Condition reason when a `Maintenance` (managed or external) covers the repo.
 pub const MAINTENANCE_CONFIGURED_REASON: &str = "MaintenanceConfigured";

--- a/crates/controller/src/io/repo.rs
+++ b/crates/controller/src/io/repo.rs
@@ -1,5 +1,6 @@
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
 use kube::Api;
+use kube::api::{Patch, PatchParams};
 
 use kopiur_api::backend::Backend;
 use kopiur_api::cluster_repository::IdentityDefaults;
@@ -234,6 +235,66 @@ pub async fn repository_ready(
             Ok(repo.status.and_then(|s| s.phase) == ready)
         }
     }
+}
+
+/// Stamp the reverify annotation (`now`, RFC3339) to request an immediate
+/// connectivity re-probe. Best-effort: skips a non-`Ready` repo (the gate already
+/// holds) and a request within the rate-limit window; a missing repo is a no-op.
+pub async fn request_repository_reverify(
+    client: &kube::Client,
+    repo_ref: &RepositoryRef,
+    default_ns: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<()> {
+    /// At most one forced re-probe per repository per this window.
+    const MIN_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
+    let ready = Some(kopiur_api::RepositoryPhase::Ready);
+    let key = crate::consts::REVERIFY_REQUESTED_ANNOTATION;
+    let body = |ts: &str| {
+        Patch::Merge(serde_json::json!({
+            "metadata": { "annotations": { key: ts } }
+        }))
+    };
+    let pp = PatchParams::apply(super::apply::FIELD_MANAGER);
+    let stamp = now.to_rfc3339();
+
+    match repo_lookup(repo_ref, default_ns) {
+        RepoLookup::Namespaced { namespace, name } => {
+            let api: Api<Repository> = Api::namespaced(client.clone(), &namespace);
+            let Some(repo) = api.get_opt(&name).await? else {
+                return Ok(());
+            };
+            if repo.status.as_ref().and_then(|s| s.phase) != ready {
+                return Ok(());
+            }
+            let existing = repo.metadata.annotations.as_ref().and_then(|a| a.get(key));
+            if crate::catalog::should_request_reverify(
+                existing.map(String::as_str),
+                now,
+                MIN_INTERVAL,
+            ) {
+                api.patch(&name, &pp, &body(&stamp)).await?;
+            }
+        }
+        RepoLookup::Cluster { name } => {
+            let api: Api<ClusterRepository> = Api::all(client.clone());
+            let Some(repo) = api.get_opt(&name).await? else {
+                return Ok(());
+            };
+            if repo.status.as_ref().and_then(|s| s.phase) != ready {
+                return Ok(());
+            }
+            let existing = repo.metadata.annotations.as_ref().and_then(|a| a.get(key));
+            if crate::catalog::should_request_reverify(
+                existing.map(String::as_str),
+                now,
+                MIN_INTERVAL,
+            ) {
+                api.patch(&name, &pp, &body(&stamp)).await?;
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Whether the named `Namespace` is being torn down — its `deletionTimestamp` is

--- a/crates/controller/src/io/tests.rs
+++ b/crates/controller/src/io/tests.rs
@@ -824,10 +824,12 @@ fn build_managed_maintenance_for_cluster_repository_uses_overrides() {
             quick: CronSpec {
                 cron: "0 */2 * * *".into(),
                 jitter: None,
+                timezone: None,
             },
             full: CronSpec {
                 cron: "0 1 * * *".into(),
                 jitter: None,
+                timezone: None,
             },
             timezone: Some("UTC".into()),
         }),

--- a/crates/controller/src/maintenance/mod.rs
+++ b/crates/controller/src/maintenance/mod.rs
@@ -720,7 +720,13 @@ fn slot_for(
         MaintenanceMode::Full => &maint.spec.schedule.full,
     };
     let jitter = spec.jitter.as_deref().and_then(parse_go_duration);
-    next_fire(&spec.cron, jitter, &seed, after)
+    // Per-cron `timezone` wins; else the schedule-level shared timezone; else UTC.
+    let tz = kopiur_api::common::resolve_tz(
+        spec.timezone
+            .as_deref()
+            .or(maint.spec.schedule.timezone.as_deref()),
+    );
+    next_fire(&spec.cron, jitter, &seed, after, tz)
 }
 
 /// Parse `status.<mode>.lastRunAt` (RFC3339) into a `DateTime<Utc>`.

--- a/crates/controller/src/maintenance/tests.rs
+++ b/crates/controller/src/maintenance/tests.rs
@@ -16,10 +16,12 @@ fn maint_with(quick_cron: &str, full_cron: &str, status: Option<MaintenanceStatu
                 quick: CronSpec {
                     cron: quick_cron.into(),
                     jitter: None,
+                    timezone: None,
                 },
                 full: CronSpec {
                     cron: full_cron.into(),
                     jitter: None,
+                    timezone: None,
                 },
                 timezone: None,
             },

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -426,6 +426,7 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
                 repo.status.as_ref().and_then(|s| s.observed_generation),
                 last_refresh_at(repo),
                 interval,
+                CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -598,6 +599,7 @@ async fn bootstrap_via_mover(
                         repo.status.as_ref().and_then(|s| s.observed_generation),
                         last_refresh_at(repo),
                         interval,
+                        CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                         chrono::Utc::now(),
                     )
                 {
@@ -633,6 +635,7 @@ async fn bootstrap_via_mover(
             repo.status.as_ref().and_then(|s| s.observed_generation),
             last_refresh_at(repo),
             CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
             chrono::Utc::now(),
         ))
     {
@@ -986,6 +989,7 @@ async fn finalize_bootstrap(
         repo.status.as_ref().and_then(|s| s.observed_generation),
         last_refresh_at(repo),
         interval,
+        CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
         chrono::Utc::now(),
     ) {
         run_catalog_scan(

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -386,6 +386,26 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
                 status_patch["conditions"] = serde_json::to_value(&conditions).unwrap_or_default();
                 status_patch["storageStats"] = serde_json::json!({ "indexBlobCount": count });
             }
+            // Record a `Snapshot`'s reverify nudge as honored. Unlike the mover
+            // bootstrap path, this in-process arm re-probes on every reconcile (the
+            // connect above) and the annotation patch already retriggered us — so the
+            // re-probe is implicit. We only stamp `lastReverifyAt` so the once-honored
+            // token is observable in status and consistent with the mover path.
+            let reverify_token = repo
+                .metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+                .map(String::as_str);
+            if let Some(token) = reverify_token
+                && repo
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.last_reverify_at.as_deref())
+                    != Some(token)
+            {
+                status_patch["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+            }
             let current = serde_json::to_value(&repo.status).ok();
             io::patch_status_if_changed(&api, &name, current.as_ref(), status_patch).await?;
             if let Some(w) = index_blob_event {
@@ -530,6 +550,22 @@ async fn bootstrap_via_mover(
     let job_name = format!("{name}-bootstrap");
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
 
+    // Honor a `Snapshot`'s reverify nudge: force a re-probe (ORs into the
+    // recycle/create gates below), stamping the token at create time as the loop guard.
+    let reverify_token = repo
+        .metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::REVERIFY_REQUESTED_ANNOTATION))
+        .map(String::as_str);
+    let reverify = catalog::reverify_due(
+        reverify_token,
+        repo.status
+            .as_ref()
+            .and_then(|s| s.last_reverify_at.as_deref()),
+        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+    );
+
     if let Some(job) = job_api.get_opt(&job_name).await? {
         let already_ready =
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
@@ -555,14 +591,16 @@ async fn bootstrap_via_mover(
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
-                if catalog::bootstrap_recycle_due(
-                    already_ready,
-                    repo.metadata.generation,
-                    repo.status.as_ref().and_then(|s| s.observed_generation),
-                    last_refresh_at(repo),
-                    interval,
-                    chrono::Utc::now(),
-                ) {
+                if reverify
+                    || catalog::bootstrap_recycle_due(
+                        already_ready,
+                        repo.metadata.generation,
+                        repo.status.as_ref().and_then(|s| s.observed_generation),
+                        last_refresh_at(repo),
+                        interval,
+                        chrono::Utc::now(),
+                    )
+                {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
                     job_api
                         .delete(&job_name, &DeleteParams::background())
@@ -588,14 +626,16 @@ async fn bootstrap_via_mover(
     // when a re-run is actually warranted (`bootstrap_create_due`: catalog refresh
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
-    if !catalog::bootstrap_create_due(
-        repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
-        repo.metadata.generation,
-        repo.status.as_ref().and_then(|s| s.observed_generation),
-        last_refresh_at(repo),
-        CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
-        chrono::Utc::now(),
-    ) {
+    if !(reverify
+        || catalog::bootstrap_create_due(
+            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
+            repo.metadata.generation,
+            repo.status.as_ref().and_then(|s| s.observed_generation),
+            last_refresh_at(repo),
+            CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
+            chrono::Utc::now(),
+        ))
+    {
         return Ok(Action::requeue(catalog::reconcile_interval(
             repo.spec.catalog.as_ref(),
         )));
@@ -731,12 +771,13 @@ async fn bootstrap_via_mover(
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
     io::apply_mover_objects(&ctx.client, namespace, &job_name, &cm, &job).await?;
-    io::patch_status(
-        api,
-        name,
-        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() }),
-    )
-    .await?;
+    // Stamp the reverify token (loop guard): this request is now honored.
+    let mut create_status =
+        serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() });
+    if let Some(token) = reverify_token {
+        create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), "launched repository bootstrap Job");
     Ok(Action::requeue(Duration::from_secs(15)))
 }

--- a/crates/controller/src/repository_replication.rs
+++ b/crates/controller/src/repository_replication.rs
@@ -351,7 +351,8 @@ fn slot_for(repl: &RepositoryReplication, after: DateTime<Utc>) -> Result<DateTi
         .jitter
         .as_deref()
         .and_then(parse_go_duration);
-    next_fire(&repl.spec.schedule.cron, jitter, &seed, after)
+    let tz = kopiur_api::common::resolve_tz(repl.spec.schedule.timezone.as_deref());
+    next_fire(&repl.spec.schedule.cron, jitter, &seed, after, tz)
 }
 
 /// Parse `status.lastReplicated` (RFC3339) into a `DateTime<Utc>`.
@@ -504,6 +505,7 @@ mod tests {
                 schedule: CronSpec {
                     cron: cron.into(),
                     jitter: None,
+                    timezone: None,
                 },
                 mover: None,
                 suspend: false,

--- a/crates/controller/src/snapshot/build.rs
+++ b/crates/controller/src/snapshot/build.rs
@@ -244,6 +244,15 @@ pub(super) fn readonly_backup_message(repo_name: &str) -> String {
     )
 }
 
+/// Message for a backup held in `Pending` because its repository is not `Ready`
+/// (backend unreachable). Pure so the text is unit-asserted.
+pub(super) fn repository_not_ready_message(repo_name: &str) -> String {
+    format!(
+        "waiting for repository `{repo_name}` to become `Ready` before launching the backup \
+         (its backend is unreachable); the backup proceeds once the repository reconnects."
+    )
+}
+
 /// Snapshot tags from the config + run metadata.
 fn tags_for(config: &SnapshotPolicy) -> BTreeMap<String, String> {
     let mut tags = BTreeMap::new();

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -349,6 +349,24 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         ),
                     )
                     .await?;
+                    // A failed backup may mean the backend went away: nudge the repository
+                    // to re-probe now so the gate engages without waiting for the catalog
+                    // refresh. Best-effort — a nudge error must not mask the failure above.
+                    if let Some(repo_ref) = backup
+                        .status
+                        .as_ref()
+                        .and_then(|s| s.resolved.as_ref())
+                        .and_then(|r| r.repository.as_ref())
+                        && let Err(e) = io::request_repository_reverify(
+                            &ctx.client,
+                            repo_ref,
+                            &namespace,
+                            chrono::Utc::now(),
+                        )
+                        .await
+                    {
+                        tracing::debug!(backup = %name, error = %e, "repository reverify nudge failed (ignored)");
+                    }
                 }
                 // The run is terminal (the Job exhausted its retries) — reap any CSI
                 // staging objects. No-op for Direct.
@@ -472,6 +490,27 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             tracing::warn!(backup = %name, repository = %config.spec.repository.name, "refusing backup: repository is ReadOnly");
         }
         return Ok(Action::await_change());
+    }
+
+    // Don't launch a mover Job against an unreachable repository (`phase != Ready`):
+    // the pod would only fail on `kopia repository connect`. Hold the Snapshot in
+    // `Pending` and requeue until the repository's own reconcile marks it `Ready`.
+    // Same gate Maintenance, `SnapshotPolicy`, and `RepositoryReplication` apply.
+    if !io::repository_ready(&ctx.client, &config.spec.repository, &namespace).await? {
+        let current = serde_json::to_value(&backup.status).ok();
+        io::patch_status_if_changed(
+            &api,
+            &name,
+            current.as_ref(),
+            snapshot_ready_status(
+                backup,
+                SnapshotPhase::Pending,
+                crate::consts::REPOSITORY_NOT_READY_REASON,
+                &repository_not_ready_message(&config.spec.repository.name),
+            ),
+        )
+        .await?;
+        return Ok(Action::requeue(Duration::from_secs(15)));
     }
 
     let (work_spec, mut source_volume, repo_volume, _) =

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -24,6 +24,28 @@ fn readonly_repository_refuses_backup_writes() {
     assert!(msg.contains("ReadWrite"));
 }
 
+// --- Readiness gate: a not-Ready repository holds the backup in Pending ---
+
+#[test]
+fn not_ready_repository_holds_backup_pending() {
+    use crate::consts::REPOSITORY_NOT_READY_REASON;
+    use kopiur_api::common::PhaseLabel;
+    use kopiur_api::snapshot::SnapshotPhase;
+
+    // Pending is Reconciling (not Stalled), so the backup resumes on reconnect.
+    assert_eq!(
+        snapshot_ready_outcome(SnapshotPhase::Pending),
+        io::ReadyOutcome::Reconciling
+    );
+    assert_eq!(SnapshotPhase::Pending.label(), "Pending");
+    // The hold message names the repo; it's a wait, not a refusal.
+    let msg = repository_not_ready_message("nas");
+    assert!(msg.contains("nas"));
+    assert!(msg.contains("Ready"));
+    assert!(!msg.contains("refusing"));
+    assert_eq!(REPOSITORY_NOT_READY_REASON, "RepositoryNotReady");
+}
+
 // --- §13(c) pin decision (pure: spec.pin vs observed → pin/unpin/noop) ---
 
 #[test]

--- a/crates/controller/src/snapshot_schedule.rs
+++ b/crates/controller/src/snapshot_schedule.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use std::time::Duration as StdDuration;
 
 use chrono::{DateTime, Utc};
+use chrono_tz::Tz;
 use kube::api::ListParams;
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
@@ -55,19 +56,26 @@ pub fn next_fire(
     jitter_window: Option<StdDuration>,
     seed: &str,
     after: DateTime<Utc>,
+    tz: Tz,
 ) -> Result<DateTime<Utc>> {
     let resolved = jitter::substitute_h(cron_expr, seed);
     let cron = croner::Cron::new(&resolved)
         .parse()
         .map_err(|e| Error::InvalidSchedule(format!("{resolved}: {e}")))?;
+    // Evaluate the cron in the target zone so a wall-clock field like `0 2 * * *`
+    // means 02:00 *there* (DST-correct), then convert the chosen instant back to UTC
+    // for storage/requeue. Jitter is a tz-independent offset on the resolved instant.
+    let after_local = after.with_timezone(&tz);
     let slot = cron
-        .find_next_occurrence(&after, false)
+        .find_next_occurrence(&after_local, false)
         .map_err(|e| Error::InvalidSchedule(format!("no next occurrence for {resolved}: {e}")))?;
     let offset = match jitter_window {
         Some(w) => jitter::offset(seed, slot.timestamp(), w),
         None => StdDuration::ZERO,
     };
-    Ok(slot + chrono::Duration::from_std(offset).unwrap_or_else(|_| chrono::Duration::zero()))
+    let slot =
+        slot + chrono::Duration::from_std(offset).unwrap_or_else(|_| chrono::Duration::zero());
+    Ok(slot.with_timezone(&Utc))
 }
 
 /// Whether a slot is due to fire at `now` (i.e. the scheduled time has arrived).
@@ -228,6 +236,7 @@ async fn reconcile_inner(schedule: &SnapshotSchedule, ctx: &Context) -> Result<A
         .jitter
         .as_deref()
         .and_then(parse_go_duration);
+    let tz = kopiur_api::common::resolve_tz(schedule.spec.schedule.timezone.as_deref());
 
     // The previously-pinned slot (status.nextSchedule) is the one that may now be
     // due. If absent (first reconcile), compute the upcoming slot from now and
@@ -253,7 +262,7 @@ async fn reconcile_inner(schedule: &SnapshotSchedule, ctx: &Context) -> Result<A
                 .policy_ref
                 .as_ref()
                 .map(|_| scheduled_backup_name(&sched_name, slot));
-            let next = next_fire(&schedule.spec.schedule.cron, jitter_window, &seed, now)?;
+            let next = next_fire(&schedule.spec.schedule.cron, jitter_window, &seed, now, tz)?;
             let (conditions, generation) = schedule_ready_status(schedule);
             io::patch_status(
                 &api,
@@ -276,7 +285,7 @@ async fn reconcile_inner(schedule: &SnapshotSchedule, ctx: &Context) -> Result<A
     }
 
     // First reconcile (nextSchedule not yet pinned). Compute the upcoming slot.
-    let next = next_fire(&schedule.spec.schedule.cron, jitter_window, &seed, now)?;
+    let next = next_fire(&schedule.spec.schedule.cron, jitter_window, &seed, now, tz)?;
 
     // Honor `runOnCreate`: fire one backup immediately instead of waiting for the
     // first cron slot. The run is anchored to the schedule's creation time (not
@@ -509,8 +518,8 @@ mod tests {
         // 02:00 daily, no jitter. From 2026-05-24T03:00 the next slot is the
         // following day's 02:00.
         let after = at(2026, 5, 24, 3, 0);
-        let a = next_fire("0 2 * * *", None, "uid-1", after).unwrap();
-        let b = next_fire("0 2 * * *", None, "uid-1", after).unwrap();
+        let a = next_fire("0 2 * * *", None, "uid-1", after, Tz::UTC).unwrap();
+        let b = next_fire("0 2 * * *", None, "uid-1", after, Tz::UTC).unwrap();
         assert_eq!(a, b);
         assert_eq!(a, at(2026, 5, 25, 2, 0));
     }
@@ -519,7 +528,7 @@ mod tests {
     fn next_fire_applies_deterministic_jitter_within_window() {
         let after = at(2026, 5, 24, 3, 0);
         let window = StdDuration::from_secs(1800); // 30m
-        let fired = next_fire("0 2 * * *", Some(window), "uid-1", after).unwrap();
+        let fired = next_fire("0 2 * * *", Some(window), "uid-1", after, Tz::UTC).unwrap();
         let base = at(2026, 5, 25, 2, 0);
         let delta = (fired - base).num_seconds();
         assert!(
@@ -527,7 +536,7 @@ mod tests {
             "jittered fire {fired} must be within [base, base+30m); delta={delta}"
         );
         // Deterministic: same inputs reproduce the exact same fire time.
-        let again = next_fire("0 2 * * *", Some(window), "uid-1", after).unwrap();
+        let again = next_fire("0 2 * * *", Some(window), "uid-1", after, Tz::UTC).unwrap();
         assert_eq!(fired, again);
     }
 
@@ -536,15 +545,38 @@ mod tests {
         // `H 2 * * *` must parse (H resolved deterministically) and land at
         // some minute past 02:00.
         let after = at(2026, 5, 24, 3, 0);
-        let fired = next_fire("H 2 * * *", None, "uid-x", after).unwrap();
+        let fired = next_fire("H 2 * * *", None, "uid-x", after, Tz::UTC).unwrap();
         assert_eq!(fired.format("%H").to_string(), "02");
     }
 
     #[test]
     fn next_fire_rejects_bad_cron() {
         let after = at(2026, 5, 24, 3, 0);
-        let err = next_fire("totally bad", None, "uid", after).unwrap_err();
+        let err = next_fire("totally bad", None, "uid", after, Tz::UTC).unwrap_err();
         assert!(matches!(err, Error::InvalidSchedule(_)));
+    }
+
+    #[test]
+    fn next_fire_evaluates_cron_in_the_given_timezone() {
+        // `0 2 * * *` is "2am wall-clock". In America/Chicago during CDT (UTC-5,
+        // summer) the next 2am after 2026-05-24T03:00Z (= 2026-05-23 22:00 CDT) is
+        // 2026-05-24 02:00 CDT = 2026-05-24T07:00Z. UTC would have given 05-25 02:00Z.
+        let after = at(2026, 5, 24, 3, 0);
+        let chicago = next_fire("0 2 * * *", None, "uid-1", after, Tz::America__Chicago).unwrap();
+        assert_eq!(chicago, at(2026, 5, 24, 7, 0));
+        let utc = next_fire("0 2 * * *", None, "uid-1", after, Tz::UTC).unwrap();
+        assert_eq!(utc, at(2026, 5, 25, 2, 0));
+        assert_ne!(chicago, utc);
+    }
+
+    #[test]
+    fn next_fire_is_dst_correct_across_the_spring_forward() {
+        // US DST 2026 begins 2026-03-08 (clocks jump 02:00→03:00, CST→CDT). A 2am
+        // daily cron after 2026-03-07T12:00Z must land on a real instant: the
+        // 03-08 02:00 CST slot (= 08:00Z), not a skipped wall-clock time.
+        let after = at(2026, 3, 7, 12, 0);
+        let fired = next_fire("0 2 * * *", None, "uid-dst", after, Tz::America__Chicago).unwrap();
+        assert_eq!(fired, at(2026, 3, 8, 8, 0));
     }
 
     #[test]

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -24,7 +24,7 @@ use k8s_openapi::api::batch::v1::Job;
 use kube::api::ListParams;
 use kube::{Api, ResourceExt};
 
-use kopiur_api::common::ScratchDefaults;
+use kopiur_api::common::{CronSpec, ScratchDefaults};
 use kopiur_api::{SnapshotPolicy, Verification};
 use kopiur_mover::workspec::{
     DeepVerify, MoverOptions, MoverWorkSpec, Operation, QuickVerify, ResolvedIdentity, TargetRef,
@@ -81,16 +81,13 @@ fn tier_after(last_verified: Option<DateTime<Utc>>) -> DateTime<Utc> {
     last_verified.unwrap_or_else(|| Utc::now() - chrono::Duration::days(365))
 }
 
-/// The next cron slot for a verification `cron`/`jitter` strictly after `after`,
-/// seeded by the policy UID for a stable per-replica spread.
-fn slot_for(
-    seed: &str,
-    cron: &str,
-    jitter: Option<&str>,
-    after: DateTime<Utc>,
-) -> Result<DateTime<Utc>> {
-    let jitter = jitter.and_then(parse_go_duration);
-    next_fire(cron, jitter, seed, after)
+/// The next cron slot for a verification `CronSpec` strictly after `after`, seeded by
+/// the policy UID for a stable per-replica spread and evaluated in the cron's own
+/// `timezone` (absent ⇒ UTC).
+fn slot_for(seed: &str, spec: &CronSpec, after: DateTime<Utc>) -> Result<DateTime<Utc>> {
+    let jitter = spec.jitter.as_deref().and_then(parse_go_duration);
+    let tz = kopiur_api::common::resolve_tz(spec.timezone.as_deref());
+    next_fire(&spec.cron, jitter, seed, after, tz)
 }
 
 /// Decide which verification tier is due now, preferring deep (it subsumes quick).
@@ -104,13 +101,13 @@ pub fn due_tier(
 ) -> Option<(VerifyTierKind, DateTime<Utc>)> {
     let after = tier_after(last_verified);
     if let Some(d) = &verification.deep
-        && let Ok(slot) = slot_for(seed, &d.schedule.cron, d.schedule.jitter.as_deref(), after)
+        && let Ok(slot) = slot_for(seed, &d.schedule, after)
         && now >= slot
     {
         return Some((VerifyTierKind::Deep, slot));
     }
     if let Some(q) = &verification.quick
-        && let Ok(slot) = slot_for(seed, &q.cron, q.jitter.as_deref(), after)
+        && let Ok(slot) = slot_for(seed, q, after)
         && now >= slot
     {
         return Some((VerifyTierKind::Quick, slot));
@@ -135,7 +132,7 @@ pub fn next_verify_wakeup(
     .into_iter()
     .flatten()
     {
-        if let Ok(slot) = slot_for(seed, &spec.cron, spec.jitter.as_deref(), after) {
+        if let Ok(slot) = slot_for(seed, spec, after) {
             earliest = Some(earliest.map_or(slot, |e| e.min(slot)));
         }
     }
@@ -562,11 +559,13 @@ mod tests {
             quick: quick.map(|c| CronSpec {
                 cron: c.into(),
                 jitter: None,
+                timezone: None,
             }),
             deep: deep.map(|c| DeepVerification {
                 schedule: CronSpec {
                     cron: c.into(),
                     jitter: None,
+                    timezone: None,
                 },
                 storage_class_name: None,
                 capacity: None,
@@ -806,6 +805,7 @@ mod tests {
                 schedule: CronSpec {
                     cron: "0 5 * * 0".into(),
                     jitter: None,
+                    timezone: None,
                 },
                 storage_class_name: storage_class.map(Into::into),
                 capacity: capacity.map(Into::into),

--- a/crates/e2e/tests/import.rs
+++ b/crates/e2e/tests/import.rs
@@ -587,7 +587,7 @@ async fn catalog_refresh_discovers_out_of_band_snapshots_and_never_duplicates_pr
                 "e2e-import-refresh",
                 "kopiur-import-refresh",
                 true,
-                Some(serde_json::json!({ "refreshInterval": "30s" })),
+                Some(serde_json::json!({ "periodicRefresh": true, "refreshInterval": "30s" })),
             )),
         )
         .await

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -1059,7 +1059,7 @@ async fn run_verify_flow(
 
     // Run the tier and collect the result environment for successExpr. A kopia
     // failure is terminal; a clean run yields the stats the predicate inspects.
-    let (stats, restored) = match &op.tier {
+    let (stats, restored, snapshot_id) = match &op.tier {
         VerifyTier::Quick(q) => {
             if let Err(e) = client.snapshot_verify(&q.to_kopia()).await {
                 patch_verify_status(&spec.target_ref, &verify_failed_body(&e.to_string())).await;
@@ -1070,18 +1070,32 @@ async fn run_verify_flow(
                 });
             }
             // kopia `snapshot verify` reports no machine-readable file/byte counts on
-            // stdout, so we conservatively report 0/0/0 for the predicate environment
-            // and rely on the exit code for the integrity verdict. (A future kopia
-            // JSON surface can populate real counts.)
-            (kopiur_api::VerifyStats::default(), None)
+            // its own, so derive the predicate environment from the snapshot manifest:
+            // a healthy quick verify of a non-empty snapshot then satisfies the common
+            // `stats.files > 0` predicate instead of always failing on a hardcoded 0.
+            // `errors` is 0 — a passing verify found no integrity errors. Best-effort:
+            // if the manifest can't be listed we fall back to 0/0/0 and the exit code
+            // remains the integrity verdict.
+            match resolve_latest_snapshot(client, spec).await {
+                Ok(Some(entry)) => (
+                    kopiur_api::VerifyStats {
+                        files: i64::try_from(entry.stats.file_count).unwrap_or(i64::MAX),
+                        bytes: i64::try_from(entry.stats.total_size).unwrap_or(i64::MAX),
+                        errors: 0,
+                    },
+                    None,
+                    Some(entry.id),
+                ),
+                _ => (kopiur_api::VerifyStats::default(), None, None),
+            }
         }
         VerifyTier::Deep(d) => {
             // Resolve the snapshot id to restore: the controller's choice, else the
             // newest snapshot for this identity.
             let id = match &d.snapshot_id {
                 Some(id) => id.clone(),
-                None => match resolve_latest_snapshot_id(client, spec).await {
-                    Ok(Some(id)) => id,
+                None => match resolve_latest_snapshot(client, spec).await {
+                    Ok(Some(entry)) => entry.id,
                     Ok(None) => {
                         let err = MoverError::VerifyNoSnapshot {
                             source_path: spec.identity.source_path.clone(),
@@ -1140,6 +1154,7 @@ async fn run_verify_flow(
                     files,
                     checksum_matches: true,
                 }),
+                Some(id),
             )
         }
     };
@@ -1147,11 +1162,15 @@ async fn run_verify_flow(
     // Evaluate the optional CEL successExpr over the result — killing the silent
     // "0 files" success when the user opted in.
     if let Some(expr) = &op.success_expr {
-        let snapshot = std::collections::BTreeMap::new();
+        let mut snapshot = std::collections::BTreeMap::new();
+        if let Some(id) = &snapshot_id {
+            snapshot.insert("id".to_string(), id.clone());
+        }
         let inputs = kopiur_api::SuccessExprInputs {
             stats,
             snapshot,
             restored,
+            tier: op.tier.kind_str().to_string(),
             _marker: std::marker::PhantomData,
         };
         match kopiur_api::eval_success_expr(expr, &inputs) {
@@ -1180,19 +1199,18 @@ async fn run_verify_flow(
     Ok(())
 }
 
-/// The newest snapshot id for this run's identity, by source path (the kopia
-/// catalog records the path authoritatively; the pod's user/host differ).
-async fn resolve_latest_snapshot_id(
+/// The newest snapshot for this run's identity, by source path (the kopia catalog
+/// records the path authoritatively; the pod's user/host differ). The full manifest
+/// entry is returned so callers can read both its id (deep-verify restore target) and
+/// its `stats` (quick-verify predicate environment).
+async fn resolve_latest_snapshot(
     client: &KopiaClient,
     spec: &MoverWorkSpec,
-) -> Result<Option<String>, KopiaError> {
+) -> Result<Option<kopiur_kopia::SnapshotListEntry>, KopiaError> {
     let mut list = client.snapshot_list(None).await?;
     list.sort_by_key(|e| std::cmp::Reverse(e.end_time));
     let path = &spec.identity.source_path;
-    Ok(list
-        .into_iter()
-        .find(|e| e.source.path == *path)
-        .map(|e| e.id))
+    Ok(list.into_iter().find(|e| e.source.path == *path))
 }
 
 /// Best-effort recursive file count under `dir` for the deep-verify result

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -411,8 +411,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
-assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -920,6 +919,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -931,6 +936,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2298,6 +2309,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
-assertion_line: 38
 expression: "body(&artifacts, \"repositoryreplications\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -812,6 +811,12 @@ spec:
                     type: string
                   jitter:
                     description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                    nullable: true
+                    type: string
+                  timezone:
+                    description: |-
+                      IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                      the enclosing schedule's timezone, else the controller default (UTC).
                     nullable: true
                     type: string
                 required:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -408,8 +408,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:
@@ -2878,8 +2889,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -916,6 +916,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -927,6 +933,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2294,6 +2306,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64
@@ -3390,6 +3408,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -3401,6 +3425,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -4779,6 +4809,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64
@@ -5890,6 +5926,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -5909,6 +5951,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:
@@ -8043,6 +8091,12 @@ spec:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
+                        nullable: true
+                        type: string
                     required:
                     - cron
                     type: object
@@ -8054,6 +8108,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:
@@ -9039,6 +9099,12 @@ spec:
                     type: string
                   jitter:
                     description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                    nullable: true
+                    type: string
+                  timezone:
+                    description: |-
+                      IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                      the enclosing schedule's timezone, else the controller default (UTC).
                     nullable: true
                     type: string
                 required:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -460,8 +460,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -990,6 +990,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -1001,6 +1007,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2379,6 +2391,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/crds/maintenances.yaml
+++ b/deploy/crds/maintenances.yaml
@@ -489,6 +489,12 @@ spec:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
+                        nullable: true
+                        type: string
                     required:
                     - cron
                     type: object
@@ -500,6 +506,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -408,8 +408,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -916,6 +916,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -927,6 +933,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2294,6 +2306,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -810,6 +810,12 @@ spec:
                     description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
+                  timezone:
+                    description: |-
+                      IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                      the enclosing schedule's timezone, else the controller default (UTC).
+                    nullable: true
+                    type: string
                 required:
                 - cron
                 type: object

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -1005,6 +1005,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -1024,6 +1030,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:

--- a/deploy/examples/scenarios/05-adopt-existing-repo.yaml
+++ b/deploy/examples/scenarios/05-adopt-existing-repo.yaml
@@ -56,13 +56,14 @@ spec:
       key: KOPIA_PASSWORD
   create:
     enabled: false # adopt: the repo already exists, never re-initialize it
-  # Discovery knobs (all optional — these are the defaults made explicit, except
-  # retain, which is unbounded by default). The catalog re-scans the repository on
-  # this cadence, so snapshots the OLD tooling keeps writing during the migration
-  # window appear too; retain bounds the discovered Snapshot CR ROWS for very
-  # large histories (expiring a row never deletes the kopia snapshot behind it).
+  # Discovery knobs (all optional). An initial scan always runs on connect; here we
+  # opt in to PERIODIC re-scans so snapshots the OLD tooling keeps writing during the
+  # migration window keep appearing (off by default — each re-scan re-runs the
+  # bootstrap Job). retain bounds the discovered Snapshot CR ROWS for very large
+  # histories (expiring a row never deletes the kopia snapshot behind it).
   catalog:
-    refreshInterval: 1h # default 1h, minimum 30s
+    periodicRefresh: true # opt in to repeated re-scans (default false = scan once)
+    refreshInterval: 1h # cadence when periodicRefresh is on (default 1h, minimum 30s)
     retain:
       perIdentity: 100 # newest N rows per username@hostname:path
       maxAgeDays: 90 # no rows for snapshots older than this

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -460,8 +460,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -990,6 +990,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -1001,6 +1007,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2379,6 +2391,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/helm/kopiur/files/crds/maintenances.yaml
+++ b/deploy/helm/kopiur/files/crds/maintenances.yaml
@@ -489,6 +489,12 @@ spec:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                         nullable: true
                         type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
+                        nullable: true
+                        type: string
                     required:
                     - cron
                     type: object
@@ -500,6 +506,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -408,8 +408,19 @@ spec:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
                     type: string
+                  periodicRefresh:
+                    description: |-
+                      Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs
+                      current (re-list snapshots; for object-store / volume-backed repos this recycles
+                      the bootstrap Job every `refreshInterval`). **Off by default** — the repository
+                      still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup
+                      failure, but does not re-run on a timer. Enable it if you rely on discovered
+                      snapshots reflecting changes made outside this operator.
+                    type: boolean
                   refreshInterval:
-                    description: How often to re-scan the repository (Go-style duration; minimum `30s`, default `1h`).
+                    description: |-
+                      How often to re-scan when `periodicRefresh: true` (Go-style duration; minimum
+                      `30s`, default `1h`). Inert unless `periodicRefresh` is enabled.
                     nullable: true
                     type: string
                   retain:

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -916,6 +916,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -927,6 +933,12 @@ spec:
                             type: string
                           jitter:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
                             nullable: true
                             type: string
                         required:
@@ -2294,6 +2306,12 @@ spec:
                   - type
                   type: object
                 type: array
+              lastReverifyAt:
+                description: |-
+                  Last reverify-request token honored from a `Snapshot`'s re-probe nudge
+                  (RFC3339); the loop guard that keeps each request a one-shot.
+                nullable: true
+                type: string
               observedGeneration:
                 description: '`metadata.generation` of the `spec` last reconciled; drives staleness detection.'
                 format: int64

--- a/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
@@ -810,6 +810,12 @@ spec:
                     description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                     nullable: true
                     type: string
+                  timezone:
+                    description: |-
+                      IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                      the enclosing schedule's timezone, else the controller default (UTC).
+                    nullable: true
+                    type: string
                 required:
                 - cron
                 type: object

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -1005,6 +1005,12 @@ spec:
                             description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
                             nullable: true
                             type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
                         required:
                         - cron
                         type: object
@@ -1024,6 +1030,12 @@ spec:
                         type: string
                       jitter:
                         description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                        nullable: true
+                        type: string
+                      timezone:
+                        description: |-
+                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                          the enclosing schedule's timezone, else the controller default (UTC).
                         nullable: true
                         type: string
                     required:

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -283,7 +283,17 @@ Deep verify restores into a throwaway scratch volume, then discards it. `capacit
 
 You can set the scratch size/class **once** at the repository level via [`moverDefaults.scratch`](repositories.md#moverdefaults--one-place-to-configure-every-mover) instead of repeating it on every policy; the `verification.deep` fields here override that repo default field-wise.
 
-`successExpr` is a CEL predicate (returns `bool`) over the verify result — environment `stats{files,bytes,errors}`, `snapshot`, and (deep only) `restored{files,checksumMatches}`. It is validated at admission, so a typo is rejected on `kubectl apply`. See the [verification-drill scenario](scenarios/verification-drills.md).
+`successExpr` is a CEL predicate (returns `bool`) over the verify result. The environment is:
+
+- `stats{files,bytes,errors}` — for **both** tiers. `quick` has no machine-readable counts of its own, so the operator fills `stats.files`/`stats.bytes` from the verified snapshot's manifest and reports `errors: 0` on a passing run — so `stats.files > 0 && stats.errors == 0` works on `quick`, not just `deep`.
+- `snapshot` — snapshot metadata; `snapshot.id` is the verified snapshot's id.
+- `restored{files,checksumMatches}` — the scratch-restore result, **deep only** (empty for `quick`, so guard a deep-only reference with `tier`).
+- `tier` — `"quick"` or `"deep"`, so one predicate can branch per tier, e.g. `tier == 'deep' ? restored.checksumMatches : stats.files > 0`.
+
+It is validated at admission, so a typo or out-of-scope variable is rejected on `kubectl apply`. See the [verification-drill scenario](scenarios/verification-drills.md).
+
+!!! tip "A timezone for the verify crons"
+    Each verification cron is a `CronSpec`, so it takes the same `timezone` as a backup schedule: `quick: { cron: "0 4 * * *", jitter: 30m, timezone: America/Chicago }` evaluates `0 4 * * *` as 4 a.m. **Chicago time** (DST-correct), not UTC. Set it per cron (`quick`, `deep.schedule`); absent ⇒ UTC.
 
 ### suspend — pause a recipe
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -402,9 +402,13 @@ no-op, surfaced as the `ScratchStorageClassIgnored` condition + a Warning Event 
 
 ### CatalogBounds
 
-`{ retain?: { perIdentity?, maxAgeDays? }, refreshInterval?, fallbackNamespace? }` —
-bounds materialized `discovered` `Snapshot`s. `refreshInterval` is the re-scan
-cadence (Go-style duration; default **`1h`**, minimum `30s`, webhook-enforced).
+`{ retain?: { perIdentity?, maxAgeDays? }, periodicRefresh?, refreshInterval?,
+fallbackNamespace? }` — bounds materialized `discovered` `Snapshot`s. An initial scan
+always runs (first bootstrap + on spec change); **`periodicRefresh`** (bool, default
+`false`) opts in to repeated re-scans so out-of-band snapshots keep appearing — off by
+default because each re-scan re-runs the bootstrap Job for object-store/volume-backed
+repos. `refreshInterval` is the re-scan cadence **when `periodicRefresh` is on** (Go-style
+duration; default **`1h`**, minimum `30s`, webhook-enforced; inert when off).
 `retain.perIdentity` keeps the newest N rows per `username@hostname:path` (`0`
 disables materialization; negative rejected); `retain.maxAgeDays` (≥ 1) drops
 rows for snapshots older than N days. Bounds expire **CR rows only — never kopia

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -465,8 +465,10 @@ Externally tagged — `workloadExec` / `runJob` / `httpRequest`. Each carries
 
 `{ quick?: CronSpec, deep?: { schedule, storageClassName?, capacity? }, successExpr?,
 verifyFilesPercent? }` — `successExpr` is a CEL bool predicate over
-`stats{files,bytes,errors}`/`snapshot`/`restored{files,checksumMatches}`, validated
-at admission. §4
+`stats{files,bytes,errors}`/`snapshot`/`restored{files,checksumMatches}`/`tier`
+(`"quick"`|`"deep"`), validated at admission. For `quick`, `stats.files`/`stats.bytes`
+are filled from the verified snapshot's manifest (so `stats.files > 0` is meaningful);
+`restored` is deep-only. §4
 
 ### RestoreSource
 
@@ -503,8 +505,10 @@ alias on the wire). `snapshotRef` is `{ name }`.
 
 ### CronSpec
 
-`{ cron, jitter? }` — used by `Maintenance` quick/full, `Verification`, and
-`RepositoryReplication`.
+`{ cron, jitter?, timezone? }` — used by `Maintenance` quick/full, `Verification`, and
+`RepositoryReplication`. `timezone` is an IANA name (e.g. `America/Chicago`) the cron is
+evaluated in; absent uses the enclosing schedule's timezone, else UTC. Validated at
+admission.
 
 ### RunStatus
 

--- a/docs/reference/crds/shared-types.md
+++ b/docs/reference/crds/shared-types.md
@@ -238,8 +238,12 @@ discovered snapshots are always `deletionPolicy: Retain`, and stay restorable vi
   per `username@hostname:path` identity (snapshots this cluster produced don't
   count; `0` disables discovered-Snapshot materialization entirely), and
   `maxAgeDays` expires discovered CRs older than N days (minimum 1).
-- **`refreshInterval`** — how often to re-scan the repository (Go-style duration
-  like `30s`/`5m`/`1h`; minimum `30s`, default `1h`).
+- **`periodicRefresh`** — opt in to repeated re-scans (bool, default `false`). An
+  initial scan always runs (first bootstrap + on any spec change); set this to keep
+  re-scanning so out-of-band snapshots keep appearing. Off by default because each
+  re-scan re-runs the bootstrap Job for object-store / volume-backed repos.
+- **`refreshInterval`** — how often to re-scan **when `periodicRefresh` is on**
+  (Go-style duration like `30s`/`5m`/`1h`; minimum `30s`, default `1h`; inert when off).
 - **`fallbackNamespace`** — where to materialize discovered `Snapshot`s whose
   identity hostname doesn't map to an allowed namespace (ClusterRepository only;
   rejected on a namespaced `Repository`, which always materializes into its own

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -166,7 +166,8 @@ How it behaves (all of this is automatic — there is nothing to install):
 
 - **Discovered means "not produced through this Repository CR".** Snapshots Kopiur itself takes via your `SnapshotPolicy`s already have their own `Snapshot` CRs and are never duplicated as discovered rows.
 - **Discovered rows are forced `deletionPolicy: Retain`.** Deleting a discovered `Snapshot` CR deletes only the CR — Kopiur **never** deletes a kopia snapshot it didn't create. (And because the row mirrors repository state, it reappears on the next refresh; to keep rows away permanently, bound them with `catalog.retain` below.)
-- **The scan repeats** every `catalog.refreshInterval` (default **1h**, minimum `30s`), so snapshots written out-of-band *after* adoption keep appearing — and rows whose snapshot was pruned repository-side are expired (the CR is removed). The interval is the *only* thing that drives re-scans: object-store repositories re-list by re-running their (self-cleaning) bootstrap Job, and a Job removed early by its `ttlSecondsAfterFinished` does **not** trigger an extra scan — set `refreshInterval: 24h` and you get one scan a day, regardless of the Job TTL.
+- **An initial scan always runs** (on first bootstrap and again on any spec change), so adopting a repository surfaces its existing history immediately.
+- **Repeated re-scanning is opt-in.** Set `catalog.periodicRefresh: true` to keep re-scanning every `catalog.refreshInterval` (default **1h**, minimum `30s`) so snapshots written out-of-band *after* adoption keep appearing — and rows whose snapshot was pruned repository-side are expired. **Off by default**, because for object-store / volume-backed repos each re-scan re-runs the (self-cleaning) bootstrap Job; leaving it off means the repository bootstraps once and isn't re-run on a timer. When on, the interval is the *only* thing that drives re-scans — a Job removed early by its `ttlSecondsAfterFinished` does **not** trigger an extra scan, so `refreshInterval: 24h` gives one scan a day regardless of the Job TTL.
 - **The row carries the real data**: the kopia snapshot ID, the foreign `username@hostname:path` identity, the snapshot's timing and logical size.
 
 The knobs, all under `spec.catalog`:
@@ -174,7 +175,8 @@ The knobs, all under `spec.catalog`:
 ```yaml
 spec:
     catalog:
-        refreshInterval: 1h # how often to re-scan (default 1h, min 30s)
+        periodicRefresh: true # opt in to repeated re-scans (default false = scan once)
+        refreshInterval: 1h # how often to re-scan when periodicRefresh is on (default 1h, min 30s)
         retain:
             perIdentity: 100 # keep the newest N rows per username@hostname:path (0 = no rows)
             maxAgeDays: 90 # no rows for snapshots older than this

--- a/docs/repository-health.md
+++ b/docs/repository-health.md
@@ -47,9 +47,11 @@ already applied — `Snapshot` was the only write path that skipped it.
   **in-process on every reconcile** — steady-state every 5 minutes, or immediately when a
   re-probe is requested. Detection here is prompt.
 - **Object-store and volume-backed filesystem** repos connect in a **short bootstrap
-  Job** (the controller can't reach the backend or mount the volume in-process). Their
-  `phase` is only refreshed when that Job is recycled on the **catalog refresh cadence
-  (`catalog.refreshInterval`, default `1h`)** — *or* on demand via the re-probe nudge below.
+  Job** (the controller can't reach the backend or mount the volume in-process). By
+  default they bootstrap **once** and are **not** re-probed on a timer — `phase` then
+  changes only on a spec change or via the re-probe nudge below. Opting in to
+  `catalog.periodicRefresh: true` recycles the bootstrap Job every
+  `catalog.refreshInterval` (default `1h`), which also re-probes connectivity proactively.
 
 ### Reactive re-probe (closing most of the latency window)
 
@@ -60,14 +62,15 @@ once (loop-guarded on `status.lastReverifyAt`) and flips to `Failed` if the back
 gone — at which point the gate suppresses all further Jobs.
 
 !!! warning "Known limitation: a one-Job detection window"
-    For object-store / volume-backed repositories, the gate reads `status.phase`, which
-    is only refreshed on the `catalog.refreshInterval` cadence (default `1h`). So at the
-    **onset** of an outage, **one** scheduled backup can still launch a doomed Job before
-    anything flips the phase. The reactive re-probe then engages within ~60s of that
-    first failure, so you get **one** doomed Job per outage instead of one per schedule
-    tick — not zero. Bare-path filesystem repos don't have this window (they re-probe
-    every reconcile). To tighten it for object stores, lower `catalog.refreshInterval`,
-    or see the active probe below.
+    For object-store / volume-backed repositories, the gate reads `status.phase`. By
+    default (`periodicRefresh` off) the phase isn't re-probed on a timer, so an outage
+    that begins between backups is detected when the **next** backup fails: that failure
+    fires the reactive re-probe, the phase flips to `Failed` within ~60s, and the gate
+    then suppresses every subsequent Job — **one** doomed Job per outage instead of one
+    per schedule tick, not zero. Bare-path filesystem repos don't have this window (they
+    re-probe every reconcile). To get proactive timed detection for object stores, enable
+    `catalog.periodicRefresh` (and tune `refreshInterval`) — at the cost of re-running
+    the bootstrap Job on that cadence — or see the active probe below.
 
 ## Not yet implemented — the stronger preflight
 

--- a/docs/repository-health.md
+++ b/docs/repository-health.md
@@ -1,0 +1,123 @@
+# Repository health & preflight checks
+
+This page enumerates **every health/preflight check Kopiur runs today** — what each
+one does, where it surfaces, and what it gates — plus the **known limitation** of the
+current fail-fast design and the **planned** stronger preflight that is not yet built.
+
+The mental model: Kopiur separates the **repository** (a first-class resource whose
+reconcile owns connectivity) from the **work** (`Snapshot`/`Restore`/`Maintenance`/…
+that runs in a short-lived mover Job). Most "preflight" is therefore **the work
+refusing to start until the repository is known healthy**, rather than each Job
+re-testing the backend itself.
+
+## What runs today
+
+| Check | Where it runs | Surfaced as | Gates |
+|---|---|---|---|
+| **Connectivity probe** (`kopia repository connect`) | Repository reconcile | `status.phase` (`Pending`→`Initializing`→`Ready`/`Degraded`/`Failed`) + `Ready`/`Stalled` conditions | Everything downstream keys off `phase == Ready` |
+| **Readiness gate** (`repository_ready`) | `Snapshot`, `Maintenance`, `SnapshotPolicy`, `RepositoryReplication` reconcilers | `RepositoryNotReady` / `WaitingForRepository` reason, held in `Pending`/`Reconciling` | Building & launching the mover Job |
+| **Reactive re-probe on failure** | `Snapshot` reconciler → repository | `reverify-requested-at` annotation → `status.lastReverifyAt` | Forces a fresh connectivity probe within ~60s of a failed backup |
+| **Credentials available** | Mover preflight | `CredentialsAvailable=False` + Warning Event | The mover starting (the credential Secret must exist in the workload namespace) |
+| **Mover permitted** | Admission / reconcile | `MoverPermitted=False` | A privileged mover that wasn't opted in |
+| **Security-context compatibility** | Admission (advisory) + post-run | admission Warning + `SecurityContextCompatible=False` | Advisory — warns the mover UID likely can't read the source |
+| **Index-blob health** | Repository reconcile (post-`Ready`) | `IndexBlobHealth` condition + Warning Event | Advisory — flags maintenance falling behind; non-blocking |
+| **Scratch writability** (`/scratch`) | Mover, **deep verify only** | `ScratchNotWritable` error | The restore-test, before kopia runs — turns a cryptic `mkdir` failure into an actionable one |
+| **Terminal gate** | Repository reconcile | stays `Failed`, long heartbeat | Stops hammering the backend after a non-retryable failure until an input (spec/Secret) changes |
+
+### The fail-fast gate (the headline behavior)
+
+A `Snapshot` will **not** spawn a mover Job while its repository is not `Ready`. Instead
+of a storm of pods that each only fail on `kopia repository connect` (the classic
+"volsync spins up jobs that can't do anything" after a NAS doesn't come back from a
+power loss), the backup holds in `Pending` with reason `RepositoryNotReady` and
+resumes automatically once the repository reconnects.
+
+```console
+$ kubectl get snapshot <name> -n <ns> \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+# → "waiting for repository `nas` to become `Ready` before launching the backup…"
+```
+
+This is the same gate `Maintenance`, `SnapshotPolicy`, and `RepositoryReplication`
+already applied — `Snapshot` was the only write path that skipped it.
+
+### How the repository's `phase` is kept current
+
+- **Bare-path filesystem** repos (reachable from the controller's own filesystem) connect
+  **in-process on every reconcile** — steady-state every 5 minutes, or immediately when a
+  re-probe is requested. Detection here is prompt.
+- **Object-store and volume-backed filesystem** repos connect in a **short bootstrap
+  Job** (the controller can't reach the backend or mount the volume in-process). Their
+  `phase` is only refreshed when that Job is recycled on the **catalog refresh cadence
+  (`catalog.refreshInterval`, default `1h`)** — *or* on demand via the re-probe nudge below.
+
+### Reactive re-probe (closing most of the latency window)
+
+When a backup mover Job fails, the `Snapshot` stamps a rate-limited
+`reverify-requested-at` annotation on its repository, asking it to re-probe connectivity
+**now** rather than waiting for the next refresh. The repository honors a fresh token
+once (loop-guarded on `status.lastReverifyAt`) and flips to `Failed` if the backend is
+gone — at which point the gate suppresses all further Jobs.
+
+!!! warning "Known limitation: a one-Job detection window"
+    For object-store / volume-backed repositories, the gate reads `status.phase`, which
+    is only refreshed on the `catalog.refreshInterval` cadence (default `1h`). So at the
+    **onset** of an outage, **one** scheduled backup can still launch a doomed Job before
+    anything flips the phase. The reactive re-probe then engages within ~60s of that
+    first failure, so you get **one** doomed Job per outage instead of one per schedule
+    tick — not zero. Bare-path filesystem repos don't have this window (they re-probe
+    every reconcile). To tighten it for object stores, lower `catalog.refreshInterval`,
+    or see the active probe below.
+
+## Not yet implemented — the stronger preflight
+
+The current design is **reactive fail-fast**, deliberately scoped (it adds no standing
+Jobs and re-uses the repository's existing connectivity probe). Two stronger forms were
+discussed and intentionally deferred; this section is the design intent, not current
+behavior.
+
+!!! note "Status: design only"
+    Nothing in this section ships yet. It records *how* we'd build a proactive preflight
+    so the choice is deliberate when we do.
+
+### 1. Active periodic connectivity probe
+
+Have the controller proactively run a lightweight `kopia repository connect` (it already
+ships the kopia binary) on a short cadence for object-store backends — which need only
+network + credentials, no volume mount — and flip `phase` *before* the next scheduled
+Job. This converts "one doomed Job per outage" into "zero" for those backends.
+
+Implementation sketch:
+
+- A short idempotent connect probe in the repository reconcile (ADR §5.4 already permits
+  short idempotent ops in the controller), gated to object-store backends and bounded by
+  a dedicated `health.probeInterval` (default off / conservative) so it doesn't hammer
+  metered object stores.
+- Keep the result on the existing `phase` machine — no new condition vocabulary.
+- Volume-backed filesystem repos still can't be probed in-process (no mount); they keep
+  the reactive path.
+
+### 2. CEL-configurable enumerated preflight (tuppr-style)
+
+Let a user declare arbitrary preconditions a backup must satisfy — expressed as CEL,
+the same engine `successExpr` and the identity `*Expr` fields use — evaluated before the
+Job is created (e.g. "the repository's last successful maintenance is < 7d old", "free
+space > X"). This generalizes the hard-coded gate into a user-extensible preflight.
+
+Implementation sketch:
+
+- A `preflightExpr` (or list) on `SnapshotPolicy`, validated at admission exactly like
+  `successExpr` (compile + trial-evaluate + bool result; see
+  [verification](backups.md#verification--prove-the-snapshots-are-restorable)).
+- An environment exposing repository status (`phase`, `lastReverifyAt`, storage stats,
+  maintenance recency) and recent run history.
+- A failed predicate holds the `Snapshot` in `Pending` with a `PreflightFailed` reason,
+  symmetric with the existing readiness gate.
+
+If you want either of these, open an issue (or ask) — they're additive to what's here.
+
+## See also
+
+- [Backups & schedules → verification](backups.md#verification--prove-the-snapshots-are-restorable)
+- [Troubleshooting → stuck in `Pending` with no Job](troubleshooting.md#backup-or-restore-stuck-in-pending-with-no-job)
+- [Repositories & backends](repositories.md)

--- a/docs/scenarios/adopt-existing-repo.md
+++ b/docs/scenarios/adopt-existing-repo.md
@@ -21,8 +21,10 @@ flowchart TB
 Once the `Repository` connects, Kopiur materializes snapshots it didn't create as
 `Snapshot` CRs with `origin=discovered`, in the repository's namespace. Discovered
 backups are **forced to `deletionPolicy: Retain`** — Kopiur never deletes data it
-didn't create. The scan repeats every `catalog.refreshInterval` (default 1h), so
-snapshots the old tooling keeps writing during the migration window show up too;
+didn't create. The initial scan runs as soon as it connects; set
+`catalog.periodicRefresh: true` (off by default) to keep re-scanning every
+`catalog.refreshInterval` (default 1h) so snapshots the old tooling keeps writing
+during the migration window show up too;
 bound the rows with `catalog.retain` for very large histories (see
 [The catalog](../repositories.md#the-catalog--discovered-snapshots)). List them:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,7 +51,20 @@ $ kubectl describe repository primary -n <ns>   # the condition message names th
 
 ## Backup (or Restore) stuck in `Pending` with no Job
 
-The mover is blocked on a precondition. The two common ones, both surfaced as conditions and `Warning` Events:
+The mover is blocked on a precondition. The common ones, all surfaced as conditions and `Warning` Events:
+
+### `RepositoryNotReady` — the repository backend is unreachable
+
+A `Snapshot` won't spawn a mover Job while its referenced `Repository`/`ClusterRepository` is not `Ready` (its backend is unreachable — e.g. a NAS that didn't come back after a power loss). Instead of a storm of pods that each only fail on `kopia repository connect`, the backup is held in `Pending` with reason `RepositoryNotReady` and resumes automatically once the repository reconnects.
+
+```console
+$ kubectl get snapshots <name> -n <ns> \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}'
+# → "waiting for repository `nas` to become `Ready` before launching the backup…"
+$ kubectl get repository <repo> -n <ns>   # fix the backend; watch PHASE return to Ready
+```
+
+When a backup *does* fail because the backend went away mid-run, the operator nudges the repository to re-probe connectivity immediately (rather than waiting for the next catalog refresh), so the gate engages within ~60s instead of up to an hour.
 
 ### `CredentialsAvailable=False` — Secret missing in the workload namespace
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -194,6 +194,7 @@ nav:
       - Permissions, UID & GID: permissions.md
       - Security context: security-context.md
       - Maintenance: maintenance.md
+      - Repository health & preflight: repository-health.md
       - Web UI (kopia server): server.md
       - Troubleshooting: troubleshooting.md
   # Scenarios = end-to-end, problem-driven walkthroughs (one apply-ready bundle


### PR DESCRIPTION
## What

Operability fixes raised in user reports + two contributor PRs, plus a preflight-docs page and an opt-in for the periodic bootstrap re-run.

### 1. Repository health fail-fast (integrates #147 + #148)
- **Readiness gate** (#147): `Snapshot` now checks `repository_ready()` before building a mover Job — a not-`Ready` repo holds the backup `Pending`/`RepositoryNotReady` instead of spawning pods that only fail on `kopia repository connect`. Resumes automatically on reconnect. Same gate `Maintenance`/`SnapshotPolicy`/`RepositoryReplication` already used.
- **Reactive re-probe** (#148): a failed backup stamps a rate-limited `reverify-requested-at` annotation so the repo re-probes within ~60s instead of waiting for the refresh cadence. Loop-guarded on `status.lastReverifyAt`.
- **Gap fixed beyond the PRs:** the nudge was only honored in the mover-Job bootstrap path; **bare-path filesystem** repos connect in-process and never recorded the token. Both `Repository` and `ClusterRepository` in-process arms now stamp `lastReverifyAt`.

### 2. Cron timezones (`CronSpec.timezone`)
`next_fire()` was UTC-only and `CronSpec` (verification + replication) had no timezone field. Adds `chrono-tz`, a `timezone` on `CronSpec`, DST-correct evaluation, and threads the zone through all four schedulers. Precedence: `CronSpec.timezone` > enclosing schedule timezone > UTC. Non-IANA names rejected at admission.

### 3. Verification `successExpr` on the quick tier
Quick verify hardcoded `stats = {0,0,0}`, so `stats.files > 0` could never pass. Quick now fills `stats.files`/`stats.bytes` from the snapshot manifest, exposes a `tier` (`"quick"`/`"deep"`) CEL variable, and populates `snapshot.id` for both tiers.

### 4. Preflight documentation
New `docs/repository-health.md` (linked in nav) enumerating **every** health/preflight check that runs today (connectivity probe, readiness gate, reactive re-probe, credentials/mover-permission/security-context, index-blob health, deep-verify scratch probe, terminal gate), the known detection-latency window, and a clearly-marked **design-only** section for the stronger preflight (active periodic probe + CEL-configurable enumerated preflight) that is intentionally not yet built.

### 5. Periodic repository re-scan is now opt-in (off by default)
The bootstrap Job was recycled every `catalog.refreshInterval` (default 1h) by default — object-store / volume-backed repos re-ran a Job on a timer forever. New `catalog.periodicRefresh` (bool, default **false**) gates the timed re-scan. The **initial** scan (first bootstrap) and the **spec-change** re-bootstrap still always run; only the timer is opt-in. `reconcile_interval` stays at the 5-minute liveness cadence when off.

## Credit
The fail-fast gate and re-probe nudge are based on @eleboucher's #147 and #148 (co-authored on the relevant commit). This PR supersedes both and adds the in-process honoring fix.

## Tests
`mise run test` (63 groups), `clippy -D warnings`, `fmt-check`, `gen-check`, and `mkdocs build --strict` all green. New unit tests: readiness-gate hold, reverify loop-safety + rate-limit, DST-correct `next_fire`, timezone admission rejection, `successExpr` `tier`/`snapshot.id`, and on/off coverage for every catalog-refresh gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
