### PR TITLE
feat(restore): resolve "latest" for object-store backends in the mover Job

### DIFF
--- a/crates/api/src/validate/restore.rs
+++ b/crates/api/src/validate/restore.rs
@@ -48,17 +48,43 @@ pub fn validate_restore(spec: &RestoreSpec) -> ValidationResult {
             }
         }
     }
-    if let Some(wt) = spec.policy.as_ref().and_then(|p| p.wait_timeout.as_deref())
-        && crate::duration::parse_go_duration(wt).is_none()
-    {
-        return Err(ValidationError::InvalidFieldValue {
-            field: "restore.policy.waitTimeout".to_string(),
-            reason: format!(
-                "{wt:?} is not a valid Go-style duration; use a positive number with an \
-                 s/m/h suffix (e.g. 90s, 5m, 1h) — how long the restore waits for the \
-                 source snapshot to appear before applying onMissingSnapshot"
-            ),
-        });
+    if let Some(wt) = spec.policy.as_ref().and_then(|p| p.wait_timeout.as_deref()) {
+        let Some(wait) = crate::duration::parse_go_duration(wt) else {
+            return Err(ValidationError::InvalidFieldValue {
+                field: "restore.policy.waitTimeout".to_string(),
+                reason: format!(
+                    "{wt:?} is not a valid Go-style duration; use a positive number with an \
+                     s/m/h suffix (e.g. 90s, 5m, 1h) — how long the restore waits for the \
+                     source snapshot to appear before applying onMissingSnapshot"
+                ),
+            });
+        };
+        // For an object-store `fromPolicy`/`identity` restore the wait is polled
+        // INSIDE the mover Job, so it must fit within an explicit
+        // `activeDeadlineSeconds` (else the Job is killed mid-wait, before
+        // onMissingSnapshot applies). When the deadline is unset the controller's
+        // generous default (hours) always dwarfs a sane waitTimeout, so this only
+        // guards an explicit, too-small deadline. `snapshotRef` waits in the
+        // controller, but the same bound is harmless and keeps the rule simple.
+        if let Some(deadline) = spec
+            .failure_policy
+            .as_ref()
+            .and_then(|f| f.active_deadline_seconds)
+            && deadline > 0
+            && wait.as_secs() as i64 >= deadline
+        {
+            return Err(ValidationError::InvalidFieldValue {
+                field: "restore.policy.waitTimeout".to_string(),
+                reason: format!(
+                    "{wt:?} ({}s) must be shorter than failurePolicy.activeDeadlineSeconds \
+                     ({deadline}s): the wait for the source snapshot is polled inside the \
+                     restore Job, so a waitTimeout at or beyond the deadline would let the \
+                     Job be killed before onMissingSnapshot applies. Lower waitTimeout or \
+                     raise activeDeadlineSeconds.",
+                    wait.as_secs()
+                ),
+            });
+        }
     }
     match &spec.target {
         RestoreTarget::Pvc(t) if t.name.trim().is_empty() => {

--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -69,44 +69,6 @@ pub enum Error {
     #[error("invariant violated: {0}")]
     Invariant(String),
 
-    /// A `Restore` source needs an in-process kopia snapshot listing
-    /// (`fromPolicy` / `identity` without a pinned `snapshotID`) against a
-    /// backend the controller cannot list in-process. Structural: the spec must
-    /// change to a supported source form.
-    #[error(
-        "cannot resolve the restore source by identity: in-process snapshot listing is only \
-         implemented for filesystem-backed repositories (this repository's backend is \
-         '{backend}'). Use source.snapshotRef to pick a Snapshot CR, or pin the exact \
-         snapshot with source.identity.snapshotID"
-    )]
-    UnsupportedSourceResolution {
-        /// The repository backend kind the listing was attempted against.
-        backend: &'static str,
-    },
-
-    /// A `Restore` source needs an in-process kopia snapshot listing
-    /// (`fromPolicy` / `identity` without a pinned `snapshotID`) against a
-    /// FILESYSTEM repository whose path is not mounted into the controller pod.
-    /// Resolving "latest / offset / asOf" lists snapshots in-process, which
-    /// requires the controller to be able to read the repository — but the repo
-    /// volume is normally mounted only into the mover Jobs. Structural: the
-    /// deployment must mount the repo into the controller, or the spec must pin
-    /// the snapshot explicitly. Surfaced instead of letting the raw kopia
-    /// `stat <path>: no such file or directory` leak (actionable-error-messages).
-    #[error(
-        "cannot resolve the restore source by identity: the filesystem repository path \
-         '{path}' is not accessible to the controller. fromPolicy/identity resolution lists \
-         snapshots in-process, so the repository must be mounted into the CONTROLLER pod at \
-         '{path}' and the controller must run as a UID that can read it (controller.extraVolumes \
-         + extraVolumeMounts + podSecurityContext). Alternatively, restore by source.snapshotRef \
-         or pin source.identity.snapshotID, which need no controller mount"
-    )]
-    FilesystemResolutionUnmounted {
-        /// The repository's `backend.filesystem.path` (where the controller must
-        /// have the repo mounted to list in-process).
-        path: String,
-    },
-
     /// Self-managed webhook TLS setup failed on the **cluster IO** side: reading/
     /// writing the serving Secret or injecting `caBundle` into a webhook
     /// configuration ([`crate::webhook_tls`]). Transient — the webhook config or
@@ -193,9 +155,7 @@ impl Error {
             | Error::BlockedOnGrant(_)
             | Error::Serialization(_)
             | Error::InvalidSchedule(_)
-            | Error::Invariant(_)
-            | Error::UnsupportedSourceResolution { .. }
-            | Error::FilesystemResolutionUnmounted { .. } => ErrorClass::Structural,
+            | Error::Invariant(_) => ErrorClass::Structural,
         }
     }
 }
@@ -332,20 +292,6 @@ mod tests {
             Error::Invariant("no name".into()).class(),
             ErrorClass::Structural
         );
-    }
-
-    #[test]
-    fn unsupported_source_resolution_is_structural_and_message_names_the_fix() {
-        let err = Error::UnsupportedSourceResolution { backend: "s3" };
-        // Structural: only a spec change (snapshotRef / pinned snapshotID) fixes it,
-        // so it must not retry on the transient 30 s cadence.
-        assert_eq!(err.class(), ErrorClass::Structural);
-        // The message a human acts on: what failed, why, and both fixes.
-        let msg = err.to_string();
-        assert!(msg.contains("'s3'"), "{msg}");
-        assert!(msg.contains("filesystem-backed"), "{msg}");
-        assert!(msg.contains("source.snapshotRef"), "{msg}");
-        assert!(msg.contains("source.identity.snapshotID"), "{msg}");
     }
 
     #[test]

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -296,12 +296,6 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
                  webhook configurations."
             ),
         ),
-        // The error message itself carries the full what/why/fix (use snapshotRef
-        // or pin snapshotID) — the spec must change, same remediation as a
-        // validation failure.
-        Error::UnsupportedSourceResolution { .. } | Error::FilesystemResolutionUnmounted { .. } => {
-            (INVALID_SPEC_REASON, FIX_SPEC_ACTION, err.to_string())
-        }
     };
     FailureEvent {
         reason,

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -487,11 +487,18 @@ async fn drive_populator_restore(
             // stamps the empty message. A restore stamps `RestoreSucceeded`;
             // deploy-or-restore (no snapshot) stamps `NoSnapshotContinue` + a
             // `Resolved=True` domain condition so the empty outcome is self-describing.
-            let restored = restore
-                .status
-                .as_ref()
-                .and_then(|s| s.resolved.as_ref())
-                .and_then(|r| r.resolution)
+            // Re-read status.resolved fresh: for a deferred restore the mover pins it in
+            // its own terminal PATCH, which the cached `restore` (watch cache) may not yet
+            // reflect when a PVC/PV bind event triggers this finalize reconcile — the
+            // direct path guards the same race. Fall back to the cached value for the
+            // controller-pinned paths (which pin before dispatch).
+            let resolved = api
+                .get_opt(name)
+                .await?
+                .and_then(|r| r.status)
+                .and_then(|s| s.resolved)
+                .or_else(|| restore.status.as_ref().and_then(|s| s.resolved.clone()));
+            let restored = resolved.and_then(|r| r.resolution)
                 == Some(kopiur_api::ResolutionOutcome::Snapshot);
             let status = if restored {
                 restore_ready_status(

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -158,14 +158,18 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
             // logTail/failure/progress and the pinned resolution). Self-gated by
             // `kstatus_settled_for`, so a healed Restore never re-patches.
             if !kstatus_settled_for(restore, phase) {
-                let (reason, message) = if phase == RestorePhase::Completed {
-                    (
-                        "RestoreSucceeded",
-                        "the restore mover completed; the snapshot data was written \
-                         into the target",
+                let status = if phase == RestorePhase::Completed {
+                    // The mover wrote `phase: Completed` + `status.resolved` in one
+                    // PATCH, so `resolved` is observed here — distinguish a real
+                    // restore from a deploy-or-restore that came up empty.
+                    restore_success_status(
+                        restore,
+                        restore.status.as_ref().and_then(|s| s.resolved.as_ref()),
                     )
                 } else {
-                    (
+                    restore_ready_status(
+                        restore,
+                        phase,
                         "MoverJobFailed",
                         "the restore mover reported a terminal failure; see \
                          status.failure / status.logTail for the cause, fix it, and \
@@ -173,12 +177,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                          never retries",
                     )
                 };
-                io::patch_status(
-                    &api,
-                    &name,
-                    restore_ready_status(restore, phase, reason, message),
-                )
-                .await?;
+                io::patch_status(&api, &name, status).await?;
             }
             return Ok(Action::requeue(std::time::Duration::from_secs(600)));
         }
@@ -938,6 +937,47 @@ async fn finalize_populator(
     Ok(())
 }
 
+/// Terminal-success status for a DIRECT restore, distinguishing a real restore
+/// from a deploy-or-restore that resolved to no snapshot. The mover pins
+/// `resolution: NoSnapshot` for a deferred `Continue` that found nothing (it left
+/// the target empty), so reading it here lets the controller stamp the
+/// self-describing `Resolved=True NoSnapshotContinue` condition + an accurate
+/// message instead of falsely claiming data was written. Mirrors the populator
+/// finalize and the controller-side empty (`selection: None`) branch.
+fn restore_success_status(
+    restore: &Restore,
+    resolved: Option<&kopiur_api::restore::ResolvedRestore>,
+) -> serde_json::Value {
+    let empty =
+        resolved.and_then(|r| r.resolution) == Some(kopiur_api::ResolutionOutcome::NoSnapshot);
+    if empty {
+        let msg = "no snapshot matched the source; provisioned an empty target volume \
+                   (deploy-or-restore)";
+        let conditions = io::upsert_condition(
+            &existing_conditions(restore),
+            "Resolved",
+            true,
+            "NoSnapshotContinue",
+            msg,
+            restore.metadata.generation,
+        );
+        restore_ready_status_on(
+            restore,
+            &conditions,
+            RestorePhase::Completed,
+            "NoSnapshotContinue",
+            msg,
+        )
+    } else {
+        restore_ready_status(
+            restore,
+            RestorePhase::Completed,
+            "RestoreSucceeded",
+            "the restore mover completed; the snapshot data was written into the target",
+        )
+    }
+}
+
 /// Drive a restore-with-explicit-target: create the restore mover Job (writing
 /// into the target PVC), then track it to terminal.
 ///
@@ -1018,16 +1058,20 @@ async fn drive_direct_restore(
                 ctx.metrics.set_restore_duration(namespace, name, secs);
             }
             if phase != Some(RestorePhase::Completed) {
+                // A deferred (object-store/identity) resolution may have come up
+                // empty under `Continue`. The mover pins the outcome to
+                // status.resolved before its Job goes terminal, so a fresh read
+                // tells a real restore from a deploy-or-restore-empty — without it
+                // the success message would falsely claim "data was written".
+                let resolved = api
+                    .get_opt(name)
+                    .await?
+                    .and_then(|r| r.status)
+                    .and_then(|s| s.resolved);
                 io::patch_status(
                     api,
                     name,
-                    restore_ready_status(
-                        restore,
-                        RestorePhase::Completed,
-                        "RestoreSucceeded",
-                        "the restore mover Job completed; the snapshot data was \
-                         written into the target",
-                    ),
+                    restore_success_status(restore, resolved.as_ref()),
                 )
                 .await?;
             }

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -24,7 +24,7 @@ use kopiur_api::{
 };
 use kopiur_mover::workspec::{
     MoverOptions, MoverWorkSpec, Operation, RepositoryConnect, ResolvedIdentity as MoverIdentity,
-    RestoreOp, SnapshotAnchor, TargetRef,
+    RestoreOp, RestoreSelection, RestoreSelector, SnapshotAnchor, TargetRef,
 };
 
 use crate::config;
@@ -45,14 +45,20 @@ pub use plan::*;
 
 #[cfg(test)]
 mod tests;
-/// The pinned source-resolution decision the reconcile loop acts on: a concrete
-/// snapshot id, or a deliberate "no snapshot, come up empty" (deploy-or-restore).
+/// The source-resolution decision the reconcile loop acts on: a concrete snapshot
+/// id (controller-resolved/pinned), a deliberate "no snapshot, come up empty"
+/// (deploy-or-restore), or a selector the MOVER resolves in-Job (object stores,
+/// where the controller can't list the backend in-process).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Resolution {
     /// The source resolved to (or was pinned to) this kopia snapshot id.
     Snapshot(String),
     /// `onMissingSnapshot: Continue` with no matching snapshot — provision an empty volume.
     Empty,
+    /// `fromPolicy`/`identity`-without-id on a backend the controller can't list
+    /// in-process: dispatch the restore Job with this selector and let the mover
+    /// resolve "latest"/offset/asOf (and pin `status.resolved` itself).
+    Deferred(RestoreSelector),
 }
 
 /// The already-pinned resolution decision, or `None` when the source still has to be
@@ -216,7 +222,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     let decision = match pinned_decision(resolved, phase, state) {
         Some(d) => d,
         None => match resolve_snapshot(ctx, restore, &namespace).await? {
-            Some(res) => {
+            Some(ResolveOutcome::Pinned(res)) => {
                 // Pin the FULL resolution (outcome + id + provenance + timestamp) exactly
                 // once; the no-pin check above makes this a single write, so it cannot
                 // churn status.
@@ -242,6 +248,14 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                 io::patch_status(&api, &name, status).await?;
                 Resolution::Snapshot(res.kopia_snapshot_id)
             }
+            // Object stores can't be listed in-process, so the controller resolves
+            // only the identity and defers snapshot selection to the mover Job. Do
+            // NOT pin here — the mover pins `status.resolved` once it resolves
+            // "latest"/offset/asOf (or NoSnapshot under Continue). The driver's
+            // job-exists guard makes re-dispatch across requeues idempotent while
+            // unpinned, so the pin-once invariant holds (a one-shot Restore is
+            // terminal after the Job, and never re-resolves).
+            Some(ResolveOutcome::Deferred(sel)) => Resolution::Deferred(sel),
             None => {
                 // No snapshot matched. While the `waitTimeout` window (anchored at
                 // the Restore's creation) is open, keep waiting instead of giving
@@ -349,17 +363,21 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
         io::patch_status(&api, &name, serde_json::json!({ "resolved": pin })).await?;
     }
 
-    let snapshot_id = match &decision {
-        Resolution::Snapshot(id) => Some(id.as_str()),
+    // The mover work the decision dispatches: a concrete id, an in-Job selector, or
+    // nothing (deploy-or-restore empty volume). `None` is the only case that skips
+    // the mover entirely. Exhaustive so a new `Resolution` variant must be handled.
+    let selection = match &decision {
+        Resolution::Snapshot(id) => Some(RestoreSelection::Snapshot(id.clone())),
+        Resolution::Deferred(sel) => Some(RestoreSelection::Resolve(sel.clone())),
         Resolution::Empty => None,
     };
 
     match state {
         PopulatorState::DirectTarget => {
-            drive_direct_restore(ctx, restore, &api, &namespace, &name, snapshot_id).await
+            drive_direct_restore(ctx, restore, &api, &namespace, &name, selection.as_ref()).await
         }
         PopulatorState::AwaitingClaim => {
-            drive_populator_restore(ctx, restore, &api, &namespace, &name, snapshot_id).await
+            drive_populator_restore(ctx, restore, &api, &namespace, &name, selection.as_ref()).await
         }
     }
 }
@@ -394,16 +412,18 @@ async fn park_awaiting_claim(
 /// are idempotent; the prime PV is set `Retain` before its PVC is deleted so the
 /// volume survives the swap.
 ///
-/// `snapshot_id` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
+/// `selection` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
 /// matching snapshot): the empty, freshly-provisioned prime PVC IS the result, so the
-/// mover is skipped and the empty prime is rebound straight to the claiming PVC.
+/// mover is skipped and the empty prime is rebound straight to the claiming PVC. A
+/// `Some` selection runs the mover into the prime (a deferred selector resolves in-Job,
+/// and may itself find no snapshot under `Continue` — then the prime stays empty).
 async fn drive_populator_restore(
     ctx: &Context,
     restore: &Restore,
     api: &Api<Restore>,
     namespace: &str,
     name: &str,
-    snapshot_id: Option<&str>,
+    selection: Option<&RestoreSelection>,
 ) -> Result<Action> {
     use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 
@@ -461,10 +481,20 @@ async fn drive_populator_restore(
                 == Some(pv_name.as_str())
         {
             finalize_populator(ctx, namespace, &populate_job, &prime_name, Some(&pv_name)).await?;
-            // Branch the completion on whether there was a snapshot: a restore stamps
-            // `RestoreSucceeded`; deploy-or-restore (no snapshot) stamps `NoSnapshotContinue`
-            // + a `Resolved=True` domain condition so the empty outcome is self-describing.
-            let status = if snapshot_id.is_some() {
+            // Branch the completion on whether a snapshot was actually restored. Read the
+            // pinned outcome (the controller pins it for a concrete id; the mover pins it
+            // for a deferred selector, which may itself have found nothing under
+            // `Continue`) rather than `selection.is_some()`, so a deferred no-match also
+            // stamps the empty message. A restore stamps `RestoreSucceeded`;
+            // deploy-or-restore (no snapshot) stamps `NoSnapshotContinue` + a
+            // `Resolved=True` domain condition so the empty outcome is self-describing.
+            let restored = restore
+                .status
+                .as_ref()
+                .and_then(|s| s.resolved.as_ref())
+                .and_then(|r| r.resolution)
+                == Some(kopiur_api::ResolutionOutcome::Snapshot);
+            let status = if restored {
                 restore_ready_status(
                     restore,
                     RestorePhase::Completed,
@@ -530,7 +560,7 @@ async fn drive_populator_restore(
     )
     .await?;
 
-    if let Some(snapshot_id) = snapshot_id {
+    if let Some(selection) = selection {
         match run_restore_mover(
             ctx,
             restore,
@@ -538,7 +568,7 @@ async fn drive_populator_restore(
             namespace,
             &populate_job,
             &prime_name,
-            snapshot_id,
+            selection,
         )
         .await?
         {
@@ -911,17 +941,18 @@ async fn finalize_populator(
 /// Drive a restore-with-explicit-target: create the restore mover Job (writing
 /// into the target PVC), then track it to terminal.
 ///
-/// `snapshot_id` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
+/// `selection` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
 /// matching snapshot): the target PVC is still ensured (so `target.pvc` is provisioned
 /// empty rather than left missing), but the mover is skipped and the restore completes
-/// cleanly with a fresh, empty volume.
+/// cleanly with a fresh, empty volume. A `Some` selection is either a concrete id or an
+/// in-Job selector the mover resolves.
 async fn drive_direct_restore(
     ctx: &Context,
     restore: &Restore,
     api: &Api<Restore>,
     namespace: &str,
     name: &str,
-    snapshot_id: Option<&str>,
+    selection: Option<&RestoreSelection>,
 ) -> Result<Action> {
     // Resolve the target PVC for the restore Job. DirectTarget is only reached for
     // an explicit PVC target (populator routes to AwaitingClaim in the reconcile
@@ -952,7 +983,7 @@ async fn drive_direct_restore(
     // a terminal `Completed` via `restore_ready_status_on` (Ready=True) so the entry-guard
     // heal does NOT clobber this message with "the snapshot data was written" — there is no
     // mover here, so the controller is the sole writer (no two-writer race).
-    let Some(snapshot_id) = snapshot_id else {
+    let Some(selection) = selection else {
         if phase != Some(RestorePhase::Completed) {
             let msg = "no snapshot found; provisioned an empty target volume (deploy-or-restore)";
             let conditions = io::upsert_condition(
@@ -981,7 +1012,7 @@ async fn drive_direct_restore(
 
     // The Job is named after the Restore and writes into the explicit target PVC;
     // the helper creates/tracks it, the phase writes stay here.
-    match run_restore_mover(ctx, restore, api, namespace, name, &target_pvc, snapshot_id).await? {
+    match run_restore_mover(ctx, restore, api, namespace, name, &target_pvc, selection).await? {
         MoverOutcome::Succeeded { duration_secs } => {
             if let Some(secs) = duration_secs {
                 ctx.metrics.set_restore_duration(namespace, name, secs);
@@ -1074,10 +1105,11 @@ enum MoverOutcome {
     Wedged { message: String },
 }
 
-/// Build + apply the restore mover Job named `job_name` (writing `snapshot_id` into
+/// Build + apply the restore mover Job named `job_name` (writing `selection` into
 /// `target_pvc`, mounted read-write at `/restore`) and report its [`MoverOutcome`].
 /// Idempotent: an existing Job is tracked to terminal, never re-applied. The caller
-/// owns the status/phase writes.
+/// owns the status/phase writes. `selection` is a concrete id (anchor-healed) or an
+/// in-Job selector the mover resolves.
 async fn run_restore_mover(
     ctx: &Context,
     restore: &Restore,
@@ -1085,7 +1117,7 @@ async fn run_restore_mover(
     namespace: &str,
     job_name: &str,
     target_pvc: &str,
-    snapshot_id: &str,
+    selection: &RestoreSelection,
 ) -> Result<MoverOutcome> {
     use k8s_openapi::api::batch::v1::Job;
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
@@ -1390,12 +1422,16 @@ async fn run_restore_mover(
     );
     let cache = crate::cache::cache_tuning(effective_cache.as_ref());
     // Stable anchors so the mover can heal a stale pinned id (kopia rewrites the
-    // manifest id on pin). Read once here, where we still have the source ref.
-    let anchor = restore_source_anchor(ctx, restore, namespace).await;
+    // manifest id on pin). Only meaningful for a concrete id; a Resolve selector
+    // lists fresh in-Job, so it carries no anchor.
+    let anchor = match selection {
+        RestoreSelection::Snapshot(_) => restore_source_anchor(ctx, restore, namespace).await,
+        RestoreSelection::Resolve(_) => SnapshotAnchor::default(),
+    };
     let work_spec = MoverWorkSpec {
-        version: 1,
+        version: 2,
         operation: Operation::Restore(RestoreOp {
-            snapshot_id: snapshot_id.to_string(),
+            source: selection.clone(),
             target_path: target_path.clone(),
             anchor,
             ignore_permission_errors,
@@ -1492,7 +1528,13 @@ async fn run_restore_mover(
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
     io::apply_mover_objects(&ctx.client, namespace, job_name, &cm, &job).await?;
-    tracing::info!(restore = %name, job = %job_name, %snapshot_id, "created restore mover Job");
+    let source_label = match selection {
+        RestoreSelection::Snapshot(id) => format!("snapshot {id}"),
+        RestoreSelection::Resolve(sel) => {
+            format!("resolve {}@{}", sel.username, sel.hostname)
+        }
+    };
+    tracing::info!(restore = %name, job = %job_name, source = %source_label, "created restore mover Job");
     // The Job is new; the CALLER writes the matching status (direct: MoverJobCreated;
     // populator: PopulatingPrimePvc) so each path keeps its own phase discipline.
     Ok(MoverOutcome::Running { created: true })
@@ -1506,6 +1548,19 @@ struct ResolvedSource {
     kopia_snapshot_id: String,
     snapshot_ref: Option<kopiur_api::common::ObjectRef>,
     identity: Option<kopiur_api::common::ResolvedIdentity>,
+}
+
+/// The outcome of resolving a restore source in the controller (ADR §4.6): a
+/// concrete snapshot the controller can pin now (`snapshotRef` / explicit id), or
+/// a selector handed to the mover Job because the backend can't be listed
+/// in-process (`fromPolicy` / `identity`-without-id). Exactly one — externally
+/// modeled as an enum so the reconcile core must handle both.
+#[derive(Debug, Clone)]
+enum ResolveOutcome {
+    /// Resolved here; pin `status.resolved` and dispatch with a concrete id.
+    Pinned(ResolvedSource),
+    /// Deferred to the mover; dispatch with this selector and let the mover pin.
+    Deferred(RestoreSelector),
 }
 
 /// Stable identity anchors for the restore's snapshot, so the mover can
@@ -1686,14 +1741,38 @@ async fn ensure_restore_target_pvc(
     }
 }
 
-/// Resolve the restore's source to a concrete kopia snapshot. Returns `None`
-/// when no snapshot matches (caller applies `waitTimeout` + `onMissingSnapshot`).
+/// Resolve the restore's source (ADR §4.6). `snapshotRef`/`identity.snapshotID`
+/// resolve to a concrete id the controller pins ([`ResolveOutcome::Pinned`]);
+/// `fromPolicy`/`identity`-without-id defer the by-identity snapshot listing to
+/// the mover Job ([`ResolveOutcome::Deferred`]) because in-process listing only
+/// works for filesystem repos, and the mover reaches every backend. Returns
+/// `None` ONLY for a `snapshotRef` whose `Snapshot` CR has no resolved snapshot
+/// yet (the caller applies `waitTimeout` + `onMissingSnapshot`); deferred sources
+/// never return `None` — the mover applies `onMissingSnapshot` in-Job.
 async fn resolve_snapshot(
     ctx: &Context,
     restore: &Restore,
     namespace: &str,
-) -> Result<Option<ResolvedSource>> {
+) -> Result<Option<ResolveOutcome>> {
     use kopiur_api::common::{ObjectRef, ResolvedIdentity};
+    // Selector policy is the same for both deferred arms: the per-mode default
+    // onMissing unless the spec overrides it, and the waitTimeout window in
+    // seconds (polled inside the mover Job).
+    let on_missing = effective_on_missing(
+        restore
+            .spec
+            .policy
+            .as_ref()
+            .and_then(|p| p.on_missing_snapshot),
+        &restore.spec.source,
+    );
+    let wait_timeout_secs = restore
+        .spec
+        .policy
+        .as_ref()
+        .and_then(|p| p.wait_timeout.as_deref())
+        .and_then(crate::snapshot_schedule::parse_go_duration)
+        .and_then(|d| i64::try_from(d.as_secs()).ok());
     match &restore.spec.source {
         RestoreSource::SnapshotRef(r) => {
             let ns = r.namespace.as_deref().unwrap_or(namespace);
@@ -1702,52 +1781,45 @@ async fn resolve_snapshot(
             Ok(backup
                 .and_then(|b| b.status)
                 .and_then(|s| s.snapshot)
-                .map(|s| ResolvedSource {
-                    kopia_snapshot_id: s.kopia_snapshot_id,
-                    snapshot_ref: Some(ObjectRef {
-                        name: r.name.clone(),
-                        namespace: Some(ns.to_string()),
-                    }),
-                    // Record the referenced snapshot's identity (provenance, and
-                    // the source-path anchor used to self-heal a stale id).
-                    identity: Some(s.identity),
+                .map(|s| {
+                    ResolveOutcome::Pinned(ResolvedSource {
+                        kopia_snapshot_id: s.kopia_snapshot_id,
+                        snapshot_ref: Some(ObjectRef {
+                            name: r.name.clone(),
+                            namespace: Some(ns.to_string()),
+                        }),
+                        // Record the referenced snapshot's identity (provenance, and
+                        // the source-path anchor used to self-heal a stale id).
+                        identity: Some(s.identity),
+                    })
                 }))
         }
         RestoreSource::Identity(id) => {
-            let identity = ResolvedIdentity {
+            // An explicit snapshot id wins — pin it directly. Otherwise defer the
+            // listing to the mover (works on every backend).
+            if let Some(sid) = &id.snapshot_id {
+                return Ok(Some(ResolveOutcome::Pinned(ResolvedSource {
+                    kopia_snapshot_id: sid.clone(),
+                    snapshot_ref: None,
+                    identity: Some(ResolvedIdentity {
+                        username: id.username.clone(),
+                        hostname: id.hostname.clone(),
+                        source_path: id.source_path.clone(),
+                    }),
+                })));
+            }
+            Ok(Some(ResolveOutcome::Deferred(RestoreSelector {
                 username: id.username.clone(),
                 hostname: id.hostname.clone(),
                 source_path: id.source_path.clone(),
-            };
-            // An explicit snapshot id wins; otherwise resolve via snapshot list.
-            if let Some(sid) = &id.snapshot_id {
-                return Ok(Some(ResolvedSource {
-                    kopia_snapshot_id: sid.clone(),
-                    snapshot_ref: None,
-                    identity: Some(identity),
-                }));
-            }
-            let repo = resolve_restore_repository(ctx, restore, namespace).await?;
-            let snapshots = list_for_identity(
-                ctx,
-                &repo,
-                namespace,
-                &id.username,
-                &id.hostname,
-                id.source_path.as_deref(),
-            )
-            .await?;
-            let snapshots = filter_as_of(snapshots, id.as_of.as_deref())?;
-            Ok(
-                pick_offset(snapshots, id.offset.unwrap_or(0)).map(|sid| ResolvedSource {
-                    kopia_snapshot_id: sid,
-                    snapshot_ref: None,
-                    identity: Some(identity),
-                }),
-            )
+                as_of: id.as_of.clone(),
+                offset: id.offset.unwrap_or(0),
+                on_missing,
+                wait_timeout_secs,
+            })))
         }
         RestoreSource::FromPolicy(c) => {
-            // Resolve identity from the SnapshotPolicy, then list newest/offset.
+            // Resolve the identity from the SnapshotPolicy, then defer the listing.
             use kopiur_api::SnapshotPolicy;
             let cfg_ns = c.namespace.as_deref().unwrap_or(namespace);
             let cfg_api: Api<SnapshotPolicy> = Api::namespaced(ctx.client.clone(), cfg_ns);
@@ -1760,82 +1832,16 @@ async fn resolve_snapshot(
                 cfg_ns,
                 repo.identity_defaults.as_ref(),
             )?;
-            let snapshots = list_for_identity(
-                ctx,
-                &repo,
-                namespace,
-                &identity.username,
-                &identity.hostname,
-                identity.source_path.as_deref(),
-            )
-            .await?;
-            let snapshots = filter_as_of(snapshots, c.as_of.as_deref())?;
-            Ok(pick_offset(snapshots, c.offset).map(|sid| ResolvedSource {
-                kopia_snapshot_id: sid,
-                snapshot_ref: None,
-                identity: Some(identity),
-            }))
+            Ok(Some(ResolveOutcome::Deferred(RestoreSelector {
+                username: identity.username,
+                hostname: identity.hostname,
+                source_path: identity.source_path,
+                as_of: c.as_of.clone(),
+                offset: c.offset,
+                on_missing,
+                wait_timeout_secs,
+            })))
         }
-    }
-}
-
-/// kopia snapshot list filtered to one identity (filesystem in-process path),
-/// newest-first.
-async fn list_for_identity(
-    ctx: &Context,
-    repo: &ResolvedRepository,
-    namespace: &str,
-    username: &str,
-    hostname: &str,
-    source_path: Option<&str>,
-) -> Result<Vec<kopiur_kopia::SnapshotListEntry>> {
-    use kopiur_api::backend::Backend;
-    let creds = io::repo_credentials(&repo.encryption);
-    match &repo.backend {
-        Backend::Filesystem(fs) => {
-            // Pre-flight the repo path: in-process listing connects kopia to
-            // `fs.path`, which only works if the repo volume is mounted into the
-            // CONTROLLER (it is normally mounted only into mover Jobs). Catch the
-            // missing mount here with an actionable error instead of letting the
-            // raw kopia `stat <path>: no such file or directory` leak (#137).
-            if !std::path::Path::new(&fs.path).is_dir() {
-                return Err(Error::FilesystemResolutionUnmounted {
-                    path: fs.path.clone(),
-                });
-            }
-            let password = io::read_repo_password(&ctx.client, namespace, &creds).await?;
-            let client = ctx.kopia.build([("KOPIA_PASSWORD".to_string(), password)]);
-            client
-                .repository_connect(
-                    &kopiur_kopia::ConnectSpec::Filesystem {
-                        path: fs.path.clone().into(),
-                    },
-                    kopiur_kopia::CacheTuning::default(),
-                )
-                .await?;
-            let filter = kopiur_kopia::SnapshotSource {
-                host: hostname.to_string(),
-                user_name: username.to_string(),
-                path: source_path.unwrap_or("").to_string(),
-            };
-            let mut list = client.snapshot_list(Some(&filter)).await?;
-            list.sort_by_key(|e| std::cmp::Reverse(e.end_time));
-            Ok(list)
-        }
-        // In-process snapshot listing needs a locally mounted repo; object-store
-        // backends cannot be listed here. Fail LOUDLY with the fix (snapshotRef or
-        // a pinned snapshotID) instead of returning an empty list that would read
-        // as "no snapshots" and silently Continue/Fail. Exhaustive so a new
-        // backend must decide its resolution story before it compiles.
-        b @ (Backend::S3(_)
-        | Backend::Azure(_)
-        | Backend::Gcs(_)
-        | Backend::B2(_)
-        | Backend::Sftp(_)
-        | Backend::WebDav(_)
-        | Backend::Rclone(_)) => Err(Error::UnsupportedSourceResolution {
-            backend: b.kind_str(),
-        }),
     }
 }
 

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -944,44 +944,52 @@ async fn finalize_populator(
     Ok(())
 }
 
-/// Terminal-success status for a DIRECT restore, distinguishing a real restore
-/// from a deploy-or-restore that resolved to no snapshot. The mover pins
-/// `resolution: NoSnapshot` for a deferred `Continue` that found nothing (it left
-/// the target empty), so reading it here lets the controller stamp the
-/// self-describing `Resolved=True NoSnapshotContinue` condition + an accurate
-/// message instead of falsely claiming data was written. Mirrors the populator
-/// finalize and the controller-side empty (`selection: None`) branch.
+/// Terminal-success status for a DIRECT restore, branching on the pinned
+/// `resolution`. The mover pins `Snapshot` (real restore) or `NoSnapshot` (a
+/// deferred `Continue` that found nothing and left the target empty) BEFORE the
+/// Job goes terminal, so the controller can stamp an accurate message:
+/// - `Snapshot` → `RestoreSucceeded`, "data was written";
+/// - `NoSnapshot` → self-describing `Resolved=True NoSnapshotContinue` + empty-volume message;
+/// - unknown (best-effort pin AND terminal PATCH both lost) → a NEUTRAL message
+///   that never falsely claims data was written. Mirrors the populator finalize.
 fn restore_success_status(
     restore: &Restore,
     resolved: Option<&kopiur_api::restore::ResolvedRestore>,
 ) -> serde_json::Value {
-    let empty =
-        resolved.and_then(|r| r.resolution) == Some(kopiur_api::ResolutionOutcome::NoSnapshot);
-    if empty {
-        let msg = "no snapshot matched the source; provisioned an empty target volume \
-                   (deploy-or-restore)";
-        let conditions = io::upsert_condition(
-            &existing_conditions(restore),
-            "Resolved",
-            true,
-            "NoSnapshotContinue",
-            msg,
-            restore.metadata.generation,
-        );
-        restore_ready_status_on(
-            restore,
-            &conditions,
-            RestorePhase::Completed,
-            "NoSnapshotContinue",
-            msg,
-        )
-    } else {
-        restore_ready_status(
+    match resolved.and_then(|r| r.resolution) {
+        Some(kopiur_api::ResolutionOutcome::NoSnapshot) => {
+            let msg = "no snapshot matched the source; provisioned an empty target volume \
+                       (deploy-or-restore)";
+            let conditions = io::upsert_condition(
+                &existing_conditions(restore),
+                "Resolved",
+                true,
+                "NoSnapshotContinue",
+                msg,
+                restore.metadata.generation,
+            );
+            restore_ready_status_on(
+                restore,
+                &conditions,
+                RestorePhase::Completed,
+                "NoSnapshotContinue",
+                msg,
+            )
+        }
+        Some(kopiur_api::ResolutionOutcome::Snapshot) => restore_ready_status(
             restore,
             RestorePhase::Completed,
             "RestoreSucceeded",
             "the restore mover completed; the snapshot data was written into the target",
-        )
+        ),
+        // Outcome unknown (the mover's best-effort status PATCHes were both lost):
+        // report completion truthfully without claiming data was written.
+        None => restore_ready_status(
+            restore,
+            RestorePhase::Completed,
+            "RestoreSucceeded",
+            "the restore mover Job completed; see status.logTail for what was restored",
+        ),
     }
 }
 
@@ -1807,8 +1815,10 @@ async fn resolve_snapshot(
 ) -> Result<Option<ResolveOutcome>> {
     use kopiur_api::common::{ObjectRef, ResolvedIdentity};
     // Selector policy is the same for both deferred arms: the per-mode default
-    // onMissing unless the spec overrides it, and the waitTimeout window in
-    // seconds (polled inside the mover Job).
+    // onMissing unless the spec overrides it, and the waitTimeout window as an
+    // ABSOLUTE deadline anchored at the Restore's creation (so the in-Job wait
+    // matches the snapshotRef path and is stable across pod retries), polled by
+    // the mover until that wall-clock instant.
     let on_missing = effective_on_missing(
         restore
             .spec
@@ -1817,13 +1827,17 @@ async fn resolve_snapshot(
             .and_then(|p| p.on_missing_snapshot),
         &restore.spec.source,
     );
-    let wait_timeout_secs = restore
+    let wait_deadline = restore
         .spec
         .policy
         .as_ref()
         .and_then(|p| p.wait_timeout.as_deref())
         .and_then(crate::snapshot_schedule::parse_go_duration)
-        .and_then(|d| i64::try_from(d.as_secs()).ok());
+        .and_then(|d| {
+            let created = restore.metadata.creation_timestamp.as_ref()?.0.as_second();
+            let secs = i64::try_from(d.as_secs()).ok()?;
+            chrono::DateTime::from_timestamp(created.checked_add(secs)?, 0).map(|t| t.to_rfc3339())
+        });
     match &restore.spec.source {
         RestoreSource::SnapshotRef(r) => {
             let ns = r.namespace.as_deref().unwrap_or(namespace);
@@ -1866,7 +1880,7 @@ async fn resolve_snapshot(
                 as_of: id.as_of.clone(),
                 offset: id.offset.unwrap_or(0),
                 on_missing,
-                wait_timeout_secs,
+                wait_deadline: wait_deadline.clone(),
             })))
         }
         RestoreSource::FromPolicy(c) => {
@@ -1890,7 +1904,7 @@ async fn resolve_snapshot(
                 as_of: c.as_of.clone(),
                 offset: c.offset,
                 on_missing,
-                wait_timeout_secs,
+                wait_deadline: wait_deadline.clone(),
             })))
         }
     }

--- a/crates/controller/src/restore/plan.rs
+++ b/crates/controller/src/restore/plan.rs
@@ -9,7 +9,6 @@ use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 
 use kopiur_api::{OnMissingSnapshot, Restore, RestorePhase, RestoreSource, RestoreTarget};
 
-use crate::error::{Error, Result};
 use crate::io;
 
 /// Which source mode a restore uses, as a stable string (mirrors
@@ -186,30 +185,6 @@ pub(super) fn existing_conditions(restore: &Restore) -> Vec<Condition> {
         .map(|s| s.conditions.clone())
         .unwrap_or_default()
 }
-/// Keep only snapshots taken at or before `asOf` (point-in-time selection,
-/// applied BEFORE `offset` so the two compose: "the previous one as of last
-/// Tuesday"). `None` keeps the full list. The webhook validates the format at
-/// admission; re-parsing here is defensive (one validator, two callers).
-pub(super) fn filter_as_of(
-    mut snapshots: Vec<kopiur_kopia::SnapshotListEntry>,
-    as_of: Option<&str>,
-) -> Result<Vec<kopiur_kopia::SnapshotListEntry>> {
-    let Some(s) = as_of else {
-        return Ok(snapshots);
-    };
-    let cutoff = chrono::DateTime::parse_from_rfc3339(s)
-        .map_err(|e| {
-            Error::Validation(format!(
-                "source asOf {s:?} is not an RFC3339 timestamp; use e.g. \
-                 2026-05-01T00:00:00Z (the newest snapshot at or before this instant \
-                 is restored): {e}"
-            ))
-        })?
-        .with_timezone(&chrono::Utc);
-    snapshots.retain(|e| e.end_time <= cutoff);
-    Ok(snapshots)
-}
-
 /// Seconds left in the `waitTimeout` window that started at the Restore's
 /// creation, or `None` when no (parseable) window is configured or it has
 /// elapsed. Pure, clock-free — unit-tested without a cluster.
@@ -221,12 +196,4 @@ pub fn wait_remaining_secs(
     let timeout = crate::snapshot_schedule::parse_go_duration(wait_timeout?)?;
     let deadline = created_epoch.saturating_add(timeout.as_secs().try_into().ok()?);
     (now_epoch < deadline).then(|| (deadline - now_epoch) as u64)
-}
-/// Pick the snapshot at `offset` (0 = newest) from a newest-first list.
-pub(super) fn pick_offset(
-    snapshots: Vec<kopiur_kopia::SnapshotListEntry>,
-    offset: i64,
-) -> Option<String> {
-    let idx = offset.max(0) as usize;
-    snapshots.into_iter().nth(idx).map(|e| e.id)
 }

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -88,69 +88,9 @@ fn source_mode_strings_match_each_variant() {
     assert_eq!(source_mode(&identity()), "Identity");
 }
 
-fn list_entry(id: &str, end_time: &str) -> kopiur_kopia::SnapshotListEntry {
-    serde_json::from_value(serde_json::json!({
-        "id": id,
-        "source": { "host": "h", "userName": "u", "path": "/data" },
-        "startTime": end_time,
-        "endTime": end_time,
-    }))
-    .expect("valid SnapshotListEntry")
-}
-
-/// Three snapshots, newest-first (the order `list_for_identity` returns).
-fn three_snapshots() -> Vec<kopiur_kopia::SnapshotListEntry> {
-    vec![
-        list_entry("k3", "2026-06-03T00:00:00Z"),
-        list_entry("k2", "2026-06-02T00:00:00Z"),
-        list_entry("k1", "2026-06-01T00:00:00Z"),
-    ]
-}
-
-#[test]
-fn filter_as_of_keeps_snapshots_at_or_before_the_instant() {
-    // A cutoff between k2 and k3 drops k3 (newer than the instant); k2/k1 remain.
-    let kept = filter_as_of(three_snapshots(), Some("2026-06-02T12:00:00Z")).unwrap();
-    assert_eq!(
-        kept.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
-        ["k2", "k1"]
-    );
-    // Exactly AT a snapshot's endTime keeps it ("at or before").
-    let kept = filter_as_of(three_snapshots(), Some("2026-06-02T00:00:00Z")).unwrap();
-    assert_eq!(kept.first().map(|e| e.id.as_str()), Some("k2"));
-    // Before everything → empty (caller applies onMissingSnapshot).
-    let kept = filter_as_of(three_snapshots(), Some("2026-05-01T00:00:00Z")).unwrap();
-    assert!(kept.is_empty());
-    // No asOf → untouched.
-    let kept = filter_as_of(three_snapshots(), None).unwrap();
-    assert_eq!(kept.len(), 3);
-}
-
-#[test]
-fn filter_as_of_rejects_non_rfc3339_with_actionable_message() {
-    let err = filter_as_of(three_snapshots(), Some("yesterday")).unwrap_err();
-    let msg = err.to_string();
-    assert!(msg.contains("yesterday"), "{msg}");
-    assert!(msg.contains("RFC3339"), "{msg}");
-    assert!(msg.contains("2026-05-01T00:00:00Z"), "{msg}");
-}
-
-#[test]
-fn as_of_composes_with_offset() {
-    // "the previous one as of just after k2": asOf drops k3, offset 1 then
-    // steps past k2 to k1.
-    let kept = filter_as_of(three_snapshots(), Some("2026-06-02T12:00:00Z")).unwrap();
-    assert_eq!(pick_offset(kept, 1), Some("k1".to_string()));
-}
-
-#[test]
-fn pick_offset_zero_is_newest_and_out_of_range_is_none() {
-    assert_eq!(pick_offset(three_snapshots(), 0), Some("k3".to_string()));
-    assert_eq!(pick_offset(three_snapshots(), 2), Some("k1".to_string()));
-    assert_eq!(pick_offset(three_snapshots(), 3), None);
-    // A negative offset clamps to newest rather than panicking.
-    assert_eq!(pick_offset(three_snapshots(), -1), Some("k3".to_string()));
-}
+// `filter_as_of` / `pick_offset` (snapshot selection) moved to
+// `kopiur_kopia::selection` with their unit tests — both binaries share them and
+// only the mover resolves by-identity now.
 
 #[test]
 fn wait_remaining_counts_down_from_creation_and_closes() {

--- a/crates/e2e/tests/cli.rs
+++ b/crates/e2e/tests/cli.rs
@@ -575,13 +575,14 @@ async fn cli_snapshot_now_wait_logs_and_failure() {
     );
 }
 
-/// M3: the restore one-liner end-to-end, against what each backend supports:
+/// M3: the restore one-liner end-to-end, against every backend:
 /// - S3 repo + `--from-snapshot --create-pvc --wait`: real data round-trips
 ///   (reader pod proves the seeded bytes);
-/// - filesystem repo + `--from-policy`: identity-based resolution (the
-///   operator only implements in-process snapshot listing for filesystem
-///   backends — pairing fromPolicy with S3 leaves the Restore Pending with an
-///   InvalidSpec warning, which is how this test's first draft failed);
+/// - S3 repo + `--from-policy` (no snapshot id): identity-based resolution now
+///   works for object stores — the mover lists/picks "latest" in-Job — and the
+///   seeded bytes round-trip (the reported user scenario);
+/// - filesystem repo + `--from-policy`: identity-based resolution via the same
+///   in-Job mover path;
 /// - a missing `--from-snapshot` fails closed → exit 1.
 #[tokio::test]
 #[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + MinIO + built images + helm install"]
@@ -610,9 +611,12 @@ async fn cli_restore_from_policy_into_created_pvc() {
     delete_and_wait_gone(&restores, "e2e-cli-restore").await;
     delete_and_wait_gone(&restores, "e2e-cli-restore-fs").await;
     delete_and_wait_gone(&restores, "e2e-cli-restore-miss").await;
+    delete_and_wait_gone(&restores, "e2e-cli-restore-s3pol").await;
     delete_and_wait_gone(&pods, "e2e-cli-restored-reader").await;
+    delete_and_wait_gone(&pods, "e2e-cli-restored-s3pol-reader").await;
     delete_and_wait_gone(&pvcs, "e2e-cli-restored").await;
     delete_and_wait_gone(&pvcs, "e2e-cli-restored-fs").await;
+    delete_and_wait_gone(&pvcs, "e2e-cli-restored-s3pol").await;
 
     // A fresh snapshot of e2e-src (seeded with known bytes by node-seed).
     let out = run_cli(&[
@@ -757,6 +761,55 @@ async fn cli_restore_from_policy_into_created_pvc() {
         "fromPolicy completion summary: {}",
         out.stdout
     );
+
+    // --- fromPolicy against the S3 repo (the reported user scenario): no snapshot
+    // id given, so the mover resolves "latest" by identity in-Job — which only
+    // worked for filesystem before. `POLICY` (S3) already produced
+    // `e2e-cli-restore-src` above, so this resolves to it and the seeded bytes
+    // round-trip through a freshly created PVC.
+    let out = run_cli(&[
+        "-n",
+        E2E_NAMESPACE,
+        "restore",
+        "--from-policy",
+        POLICY,
+        "--create-pvc",
+        "e2e-cli-restored-s3pol",
+        "--size",
+        "1Gi",
+        "--name",
+        "e2e-cli-restore-s3pol",
+        "--wait",
+        "--timeout",
+        "5m",
+    ]);
+    assert!(
+        out.success,
+        "restore --from-policy (S3) failed: stdout={} stderr={}",
+        out.stdout, out.stderr
+    );
+    assert!(
+        out.stdout
+            .contains("restore e2e-cli-restore-s3pol completed: kopia id "),
+        "S3 fromPolicy completion summary: {}",
+        out.stdout
+    );
+    let reader = builders::one_shot_pod(
+        E2E_NAMESPACE,
+        "e2e-cli-restored-s3pol-reader",
+        &[
+            "sh",
+            "-c",
+            "grep -q 'hello kopiur e2e' /restore/a.txt && grep -q 'nested data' /restore/sub/b.txt",
+        ],
+        &[("e2e-cli-restored-s3pol", "/restore")],
+    );
+    pods.create(&PostParams::default(), &reader)
+        .await
+        .expect("create S3 fromPolicy reader pod");
+    kopiur_e2e::wait::pod_succeeded(&client, E2E_NAMESPACE, "e2e-cli-restored-s3pol-reader")
+        .await
+        .expect("S3 fromPolicy-restored PVC must contain the seeded bytes");
 
     // Restore error path: a snapshotRef that doesn't exist fails closed
     // (onMissingSnapshot defaults to Fail for explicit sources) → exit 1.

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -5,6 +5,7 @@ pub mod client;
 pub mod env;
 pub mod error;
 pub mod model;
+pub mod selection;
 pub mod session;
 
 pub use client::{
@@ -18,4 +19,5 @@ pub use model::{
     IndexBlobEntry, MaintenanceCadence, MaintenanceInfo, MaintenanceSchedule, RepositoryStatus,
     RootEntry, SnapshotCreateResult, SnapshotListEntry, SnapshotSource, SnapshotStats, StorageInfo,
 };
+pub use selection::{filter_as_of, pick_offset};
 pub use session::SessionCmd;

--- a/crates/kopia/src/selection.rs
+++ b/crates/kopia/src/selection.rs
@@ -1,0 +1,108 @@
+//! Pure snapshot-selection helpers shared by the controller and the mover.
+//!
+//! Restore resolution picks a snapshot from a `kopia snapshot list` by an
+//! optional point-in-time cutoff (`asOf`) and a zero-based `offset` (0 = newest).
+//! These two operations are pure functions over an already-fetched, newest-first
+//! list, so they live here (next to [`crate::SnapshotListEntry`]) rather than in
+//! either binary — the mover resolves object-store restores in-Job and the
+//! controller's tests exercise the same logic. The RFC3339 parse of the `asOf`
+//! string is the caller's concern (the admission webhook validates it; callers
+//! re-parse defensively) so these stay infallible.
+
+use chrono::{DateTime, Utc};
+
+use crate::SnapshotListEntry;
+
+/// Keep only snapshots taken at or before `cutoff` (point-in-time selection),
+/// preserving order so it composes with [`pick_offset`]: filter first, then
+/// offset ("the previous one as of last Tuesday"). `None` keeps the full list.
+pub fn filter_as_of(
+    mut snapshots: Vec<SnapshotListEntry>,
+    cutoff: Option<DateTime<Utc>>,
+) -> Vec<SnapshotListEntry> {
+    if let Some(cutoff) = cutoff {
+        snapshots.retain(|e| e.end_time <= cutoff);
+    }
+    snapshots
+}
+
+/// Pick the snapshot at `offset` (0 = newest) from a newest-first list. A
+/// negative offset clamps to the newest rather than panicking; an out-of-range
+/// offset returns `None` (the caller applies `onMissingSnapshot`).
+pub fn pick_offset(snapshots: Vec<SnapshotListEntry>, offset: i64) -> Option<SnapshotListEntry> {
+    let idx = offset.max(0) as usize;
+    snapshots.into_iter().nth(idx)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list_entry(id: &str, end_time: &str) -> SnapshotListEntry {
+        serde_json::from_value(serde_json::json!({
+            "id": id,
+            "source": { "host": "h", "userName": "u", "path": "/data" },
+            "startTime": end_time,
+            "endTime": end_time,
+        }))
+        .expect("valid SnapshotListEntry")
+    }
+
+    /// Three snapshots, newest-first (the order the list is sorted into).
+    fn three_snapshots() -> Vec<SnapshotListEntry> {
+        vec![
+            list_entry("k3", "2026-06-03T00:00:00Z"),
+            list_entry("k2", "2026-06-02T00:00:00Z"),
+            list_entry("k1", "2026-06-01T00:00:00Z"),
+        ]
+    }
+
+    fn cutoff(s: &str) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(s).unwrap().with_timezone(&Utc)
+    }
+
+    #[test]
+    fn filter_as_of_keeps_snapshots_at_or_before_the_instant() {
+        // A cutoff between k2 and k3 drops k3 (newer than the instant); k2/k1 remain.
+        let kept = filter_as_of(three_snapshots(), Some(cutoff("2026-06-02T12:00:00Z")));
+        assert_eq!(
+            kept.iter().map(|e| e.id.as_str()).collect::<Vec<_>>(),
+            ["k2", "k1"]
+        );
+        // Exactly AT a snapshot's endTime keeps it ("at or before").
+        let kept = filter_as_of(three_snapshots(), Some(cutoff("2026-06-02T00:00:00Z")));
+        assert_eq!(kept.first().map(|e| e.id.as_str()), Some("k2"));
+        // Before everything → empty (caller applies onMissingSnapshot).
+        let kept = filter_as_of(three_snapshots(), Some(cutoff("2026-05-01T00:00:00Z")));
+        assert!(kept.is_empty());
+        // No cutoff → untouched.
+        let kept = filter_as_of(three_snapshots(), None);
+        assert_eq!(kept.len(), 3);
+    }
+
+    #[test]
+    fn as_of_composes_with_offset() {
+        // "the previous one as of just after k2": asOf drops k3, offset 1 then
+        // steps past k2 to k1.
+        let kept = filter_as_of(three_snapshots(), Some(cutoff("2026-06-02T12:00:00Z")));
+        assert_eq!(pick_offset(kept, 1).map(|e| e.id), Some("k1".to_string()));
+    }
+
+    #[test]
+    fn pick_offset_zero_is_newest_and_out_of_range_is_none() {
+        assert_eq!(
+            pick_offset(three_snapshots(), 0).map(|e| e.id),
+            Some("k3".to_string())
+        );
+        assert_eq!(
+            pick_offset(three_snapshots(), 2).map(|e| e.id),
+            Some("k1".to_string())
+        );
+        assert_eq!(pick_offset(three_snapshots(), 3).map(|e| e.id), None);
+        // A negative offset clamps to newest rather than panicking.
+        assert_eq!(
+            pick_offset(three_snapshots(), -1).map(|e| e.id),
+            Some("k3".to_string())
+        );
+    }
+}

--- a/crates/mover/src/error.rs
+++ b/crates/mover/src/error.rs
@@ -44,6 +44,9 @@ pub enum KopiaOp {
     VerifyConnect,
     /// `snapshot verify` (quick tier).
     SnapshotVerify,
+    /// `snapshot list` while resolving an object-store restore source (the in-Job
+    /// `fromPolicy`/`identity` listing path).
+    RestoreSnapshotList,
     /// `snapshot list` while resolving the deep-verify restore candidate.
     DeepVerifySnapshotList,
     /// The deep-verify scratch restore.
@@ -74,6 +77,7 @@ impl KopiaOp {
             KopiaOp::MaintenanceRun => "maintenance run",
             KopiaOp::VerifyConnect => "verify connect",
             KopiaOp::SnapshotVerify => "snapshot verify",
+            KopiaOp::RestoreSnapshotList => "restore snapshot list",
             KopiaOp::DeepVerifySnapshotList => "deep verify snapshot list",
             KopiaOp::DeepVerifyRestore => "deep verify restore",
             KopiaOp::ReplicateConnect => "replication connect",
@@ -238,6 +242,29 @@ pub enum MoverError {
         source_path: String,
     },
 
+    /// An object-store restore selector matched NO snapshot once the wait window
+    /// closed and `onMissingSnapshot: Fail` was in effect. Terminal (a Failed
+    /// Restore never retries); the fix is to create the snapshot, widen
+    /// `source.asOf`/`offset`, or choose `Continue` to come up empty.
+    #[error(
+        "no snapshot matched the restore source ({identity}) within the wait window; create the \
+         snapshot, widen source.asOf/offset, or set onMissingSnapshot: Continue to come up empty"
+    )]
+    RestoreNoSnapshot {
+        /// The kopia identity the listing keyed on (`user@host:path`).
+        identity: String,
+    },
+
+    /// A restore selector's `asOf` was not a valid RFC3339 timestamp. The webhook
+    /// validates this at admission, so this is the defensive in-Job path.
+    #[error("restore source asOf {as_of:?} is not an RFC3339 timestamp: {message}")]
+    RestoreAsOfInvalid {
+        /// The offending value.
+        as_of: String,
+        /// The parse error text.
+        message: String,
+    },
+
     /// The deep-verify scratch path is not writable by the mover, so the
     /// scratch-restore would fail with a cryptic kopia `mkdir` error. Caught by a
     /// preflight probe before kopia runs (the non-root mover cannot create a dir
@@ -355,6 +382,8 @@ impl MoverError {
             | MoverError::CredentialWrite { .. }
             | MoverError::ReadyMarkerWrite { .. }
             | MoverError::VerifyNoSnapshot { .. }
+            | MoverError::RestoreNoSnapshot { .. }
+            | MoverError::RestoreAsOfInvalid { .. }
             | MoverError::ScratchNotWritable { .. }
             | MoverError::SuccessExprFalse { .. }
             | MoverError::SuccessExprEval { .. }
@@ -398,6 +427,7 @@ mod tests {
             KopiaOp::MaintenanceRun,
             KopiaOp::VerifyConnect,
             KopiaOp::SnapshotVerify,
+            KopiaOp::RestoreSnapshotList,
             KopiaOp::DeepVerifySnapshotList,
             KopiaOp::DeepVerifyRestore,
             KopiaOp::ReplicateConnect,

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -20,7 +20,10 @@ use std::time::Duration;
 use kopiur_api::common::ResolvedIdentity;
 use kopiur_api::snapshot::SnapshotInfo;
 use kopiur_api::{LeaseAction, lease_action};
-use kopiur_kopia::{ConnectSpec, KopiaClient, KopiaError, KopiaErrorClass};
+use kopiur_kopia::{
+    ConnectSpec, KopiaClient, KopiaError, KopiaErrorClass, SnapshotSource, filter_as_of,
+    pick_offset,
+};
 use tracing::{error, info, warn};
 
 use kopiur_mover::bootstrap::{
@@ -38,7 +41,8 @@ use kopiur_mover::status::{
 };
 use kopiur_mover::workspec::{
     self, BootstrapRepositoryOp, BrowseSessionOp, KOPIUR_PIN_NAME, MaintenanceOp, MoverWorkSpec,
-    Operation, ReplicateOp, RestoreOp, SnapshotAnchor, SnapshotPinOp, VerifyOp, VerifyTier,
+    Operation, ReplicateOp, RestoreOp, RestoreSelection, RestoreSelector, SnapshotAnchor,
+    SnapshotPinOp, VerifyOp, VerifyTier,
 };
 
 fn main() -> std::process::ExitCode {
@@ -403,17 +407,28 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
             Ok(StatusUpdate::succeeded_backup(&result, chrono::Utc::now()))
         }
         Operation::Restore(op) => {
-            // The recorded id can be STALE — kopia rewrites a snapshot's manifest
-            // id on pin (`UpdateSnapshot`), so a snapshotRef/identity restore of a
-            // pinned snapshot created before this fix points at a deleted manifest.
-            // On a not-found, self-heal by re-resolving the live id from the
-            // snapshot's stable identity (source path + start time).
-            let restored_id = restore_with_heal(client, op)
-                .await
-                .map_err(kopia(KopiaOp::SnapshotRestore))?;
-            // Restore's terminal success phase is `Completed`, not `Succeeded`
-            // (the Snapshot phase) — the Restore CRD enum rejects `Succeeded`.
-            Ok(StatusUpdate::completed(&restored_id, chrono::Utc::now()))
+            // Exactly one source kind (externally tagged): a controller-resolved id,
+            // or an in-Job selector to resolve here. Exhaustive — a new variant
+            // can't compile until handled.
+            match &op.source {
+                RestoreSelection::Snapshot(id) => {
+                    // The recorded id can be STALE — kopia rewrites a snapshot's
+                    // manifest id on pin (`UpdateSnapshot`), so a snapshotRef/identity
+                    // restore of a snapshot pinned before this fix points at a deleted
+                    // manifest. On a not-found, self-heal by re-resolving the live id
+                    // from the snapshot's stable identity (source path + start time).
+                    let restored_id = restore_with_heal(client, op, id)
+                        .await
+                        .map_err(kopia(KopiaOp::SnapshotRestore))?;
+                    // Restore's terminal success phase is `Completed`, not `Succeeded`
+                    // (the Snapshot phase) — the Restore CRD enum rejects `Succeeded`.
+                    Ok(StatusUpdate::completed(&restored_id, chrono::Utc::now()))
+                }
+                // Object-store `fromPolicy`/`identity`-without-id: the controller
+                // can't list the backend in-process, so resolve "latest" (offset/asOf)
+                // here, where the mover reaches every backend.
+                RestoreSelection::Resolve(sel) => resolve_and_restore(client, op, sel).await,
+            }
         }
         Operation::SnapshotDelete(op) => {
             // Delete the recorded snapshot. Space reclamation (maintenance) is a
@@ -507,28 +522,30 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
     }
 }
 
-/// Restore `op.snapshot_id`, self-healing a stale id. kopia rewrites a
-/// snapshot's manifest id on pin (`UpdateSnapshot`), so a snapshotRef/identity
-/// restore of a snapshot pinned before this fix can name a deleted manifest. On
-/// a `NotFound`, re-resolve the live id from the snapshot's stable anchors and
-/// retry once. Returns the id actually restored (for `status.logTail`).
+/// Restore `snapshot_id`, self-healing a stale id. kopia rewrites a snapshot's
+/// manifest id on pin (`UpdateSnapshot`), so a snapshotRef/identity restore of a
+/// pinned snapshot created before this fix can name a deleted manifest. On a
+/// `NotFound`, re-resolve the live id from the snapshot's stable anchors
+/// ([`RestoreOp::anchor`]) and retry once. Returns the id actually restored (for
+/// `status.logTail`).
 async fn restore_with_heal(
     client: &KopiaClient,
     op: &RestoreOp,
+    snapshot_id: &str,
 ) -> std::result::Result<String, KopiaError> {
     match client
-        .snapshot_restore_with(&op.snapshot_id, &op.target_path, &op.restore_options())
+        .snapshot_restore_with(snapshot_id, &op.target_path, &op.restore_options())
         .await
     {
-        Ok(()) => Ok(op.snapshot_id.clone()),
+        Ok(()) => Ok(snapshot_id.to_string()),
         Err(e) if e.class() == KopiaErrorClass::NotFound => {
             // Only heal when we have anchors AND they resolve to a DIFFERENT live
             // id; otherwise the original not-found is the truthful error.
             if let Some(live) = resolve_live_id(client, &op.anchor).await
-                && live != op.snapshot_id
+                && live != snapshot_id
             {
                 warn!(
-                    stale = %op.snapshot_id,
+                    stale = %snapshot_id,
                     live = %live,
                     "restore snapshot id not found; healing to the live manifest \
                      re-resolved from the snapshot's identity (kopia rewrites the id on pin)",
@@ -541,6 +558,106 @@ async fn restore_with_heal(
             Err(e)
         }
         Err(e) => Err(e),
+    }
+}
+
+/// Resolve an object-store restore source in-Job and restore it. The controller
+/// can only list filesystem repos in-process, so `fromPolicy`/`identity`-without-id
+/// defer the listing here, where the mover reaches every backend: list the
+/// repository for `sel`'s identity, pick newest/`offset`/`asOf`, and restore. When
+/// nothing matches yet, keep re-listing until the `waitTimeout` window closes (the
+/// "wait for the snapshot to appear" semantic, now inside the Job), then apply
+/// `onMissingSnapshot` — `Continue` leaves the target empty (deploy-or-restore),
+/// `Fail` errors. On success the resolved snapshot is pinned to `status.resolved`.
+async fn resolve_and_restore(
+    client: &KopiaClient,
+    op: &RestoreOp,
+    sel: &RestoreSelector,
+) -> Result<StatusUpdate> {
+    let filter = SnapshotSource {
+        host: sel.hostname.clone(),
+        user_name: sel.username.clone(),
+        path: sel.source_path.clone().unwrap_or_default(),
+    };
+    // The webhook validates `asOf` at admission; re-parse defensively here.
+    let cutoff = match sel.as_of.as_deref() {
+        Some(s) => Some(
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map_err(|e| MoverError::RestoreAsOfInvalid {
+                    as_of: s.to_string(),
+                    message: e.to_string(),
+                })?
+                .with_timezone(&chrono::Utc),
+        ),
+        None => None,
+    };
+    let deadline = sel
+        .wait_timeout_secs
+        .filter(|s| *s > 0)
+        .map(|s| std::time::Instant::now() + Duration::from_secs(s as u64));
+    const POLL: Duration = Duration::from_secs(10);
+
+    loop {
+        let mut list = client
+            .snapshot_list(Some(&filter))
+            .await
+            .map_err(|source| MoverError::Kopia {
+                op: KopiaOp::RestoreSnapshotList,
+                source,
+            })?;
+        // Newest-first, then point-in-time filter, then offset (0 = latest).
+        list.sort_by_key(|e| std::cmp::Reverse(e.end_time));
+        let candidates = filter_as_of(list, cutoff);
+        if let Some(entry) = pick_offset(candidates, sel.offset) {
+            info!(
+                snapshot = %entry.id,
+                identity = %filter.identity(),
+                offset = sel.offset,
+                "resolved restore source to a snapshot; restoring",
+            );
+            let restored_id = restore_with_heal(client, op, &entry.id)
+                .await
+                .map_err(|source| MoverError::Kopia {
+                    op: KopiaOp::SnapshotRestore,
+                    source,
+                })?;
+            let identity = ResolvedIdentity {
+                username: entry.source.user_name.clone(),
+                hostname: entry.source.host.clone(),
+                source_path: Some(entry.source.path.clone()),
+            };
+            return Ok(StatusUpdate::completed_resolved(
+                &restored_id,
+                identity,
+                chrono::Utc::now(),
+            ));
+        }
+        // No match yet: keep waiting while the window stays open (and the next
+        // poll fits inside it). A poll that would overshoot the deadline breaks.
+        match deadline {
+            Some(d) if std::time::Instant::now() + POLL < d => {
+                info!(
+                    identity = %filter.identity(),
+                    "no snapshot matched the restore source yet; re-listing after a short wait",
+                );
+                tokio::time::sleep(POLL).await;
+            }
+            _ => break,
+        }
+    }
+    // Window closed (or no wait configured): honor onMissingSnapshot exhaustively.
+    match sel.on_missing {
+        kopiur_api::restore::OnMissingSnapshot::Continue => {
+            info!(
+                identity = %filter.identity(),
+                "no snapshot matched the restore source; onMissingSnapshot=Continue — \
+                 leaving the target empty (deploy-or-restore)",
+            );
+            Ok(StatusUpdate::completed_empty(chrono::Utc::now()))
+        }
+        kopiur_api::restore::OnMissingSnapshot::Fail => Err(MoverError::RestoreNoSnapshot {
+            identity: filter.identity(),
+        }),
     }
 }
 

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -633,16 +633,23 @@ async fn resolve_and_restore(
             ));
         }
         // No match yet: keep waiting while the window stays open (and the next
-        // poll fits inside it). A poll that would overshoot the deadline breaks.
+        // until the deadline truly passes). Sleep the lesser of POLL and the time
+        // left, so a sub-POLL waitTimeout still waits (not zero) and a longer one
+        // isn't cut short by up to POLL.
         match deadline {
-            Some(d) if std::time::Instant::now() + POLL < d => {
+            Some(d) => {
+                let now = std::time::Instant::now();
+                if now >= d {
+                    break;
+                }
+                let remaining = d - now;
                 info!(
                     identity = %filter.identity(),
                     "no snapshot matched the restore source yet; re-listing after a short wait",
                 );
-                tokio::time::sleep(POLL).await;
+                tokio::time::sleep(remaining.min(POLL)).await;
             }
-            _ => break,
+            None => break,
         }
     }
     // Window closed (or no wait configured): honor onMissingSnapshot exhaustively.

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -324,7 +324,7 @@ async fn execute(
     let interval = Duration::from_secs(spec.options.progress_interval_secs.max(1));
 
     // Spawn the operation as a future and tick progress alongside it.
-    let op = run_operation(client, spec);
+    let op = run_operation(client, spec, reporter);
     tokio::pin!(op);
 
     let mut ticker = tokio::time::interval(interval);
@@ -343,7 +343,11 @@ async fn execute(
 
 /// Dispatch on the operation kind. Exhaustive `match` — a new [`Operation`]
 /// variant fails to compile until handled (the project's type-safety thesis).
-async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<StatusUpdate> {
+async fn run_operation(
+    client: &KopiaClient,
+    spec: &MoverWorkSpec,
+    reporter: &StatusReporter,
+) -> Result<StatusUpdate> {
     // Each kopia call is wrapped with the `KopiaOp` naming it, so a failure's
     // message/log always says *which* invocation failed.
     let kopia = |op: KopiaOp| move |source: KopiaError| MoverError::Kopia { op, source };
@@ -427,7 +431,9 @@ async fn run_operation(client: &KopiaClient, spec: &MoverWorkSpec) -> Result<Sta
                 // Object-store `fromPolicy`/`identity`-without-id: the controller
                 // can't list the backend in-process, so resolve "latest" (offset/asOf)
                 // here, where the mover reaches every backend.
-                RestoreSelection::Resolve(sel) => resolve_and_restore(client, op, sel).await,
+                RestoreSelection::Resolve(sel) => {
+                    resolve_and_restore(client, op, sel, reporter).await
+                }
             }
         }
         Operation::SnapshotDelete(op) => {
@@ -563,22 +569,61 @@ async fn restore_with_heal(
 
 /// Resolve an object-store restore source in-Job and restore it. The controller
 /// can only list filesystem repos in-process, so `fromPolicy`/`identity`-without-id
-/// defer the listing here, where the mover reaches every backend: list the
-/// repository for `sel`'s identity, pick newest/`offset`/`asOf`, and restore. When
-/// nothing matches yet, keep re-listing until the `waitTimeout` window closes (the
-/// "wait for the snapshot to appear" semantic, now inside the Job), then apply
-/// `onMissingSnapshot` — `Continue` leaves the target empty (deploy-or-restore),
-/// `Fail` errors. On success the resolved snapshot is pinned to `status.resolved`.
+/// defer the listing here, where the mover reaches every backend.
+///
+/// Determinism + durability: a snapshot a PRIOR pod attempt already pinned to
+/// `status.resolved` is reused verbatim (so a Job retry never re-resolves to a
+/// different "latest"); a fresh resolution is pinned BEFORE the restore runs (so
+/// the choice survives a later terminal-PATCH failure and the controller adopts
+/// it as the pin-once record). When nothing matches yet, re-list until the
+/// `waitTimeout` deadline (an absolute instant the controller anchored at the
+/// Restore's creation) passes, then apply `onMissingSnapshot` — `Continue` leaves
+/// the target empty (deploy-or-restore), `Fail` errors.
 async fn resolve_and_restore(
     client: &KopiaClient,
     op: &RestoreOp,
     sel: &RestoreSelector,
+    reporter: &StatusReporter,
 ) -> Result<StatusUpdate> {
+    use kopiur_api::restore::{ResolutionOutcome, ResolvedRestore};
+
     let filter = SnapshotSource {
         host: sel.hostname.clone(),
         user_name: sel.username.clone(),
         path: sel.source_path.clone().unwrap_or_default(),
     };
+
+    // Reuse a snapshot a prior attempt of THIS Job already pinned, so a pod retry
+    // restores the same id rather than re-resolving "latest" to a snapshot that
+    // appeared since (the controller never pins the deferred path, so a non-empty
+    // resolved here can only be the mover's own pre-restore pin).
+    if let Some(prior) = reporter.resolved().await
+        && let Some(id) = prior.kopia_snapshot_id.as_deref()
+    {
+        info!(
+            snapshot = %id,
+            identity = %filter.identity(),
+            "reusing the snapshot pinned by a prior attempt; restoring",
+        );
+        let restored_id =
+            restore_with_heal(client, op, id)
+                .await
+                .map_err(|source| MoverError::Kopia {
+                    op: KopiaOp::SnapshotRestore,
+                    source,
+                })?;
+        let identity = prior.identity.unwrap_or_else(|| ResolvedIdentity {
+            username: sel.username.clone(),
+            hostname: sel.hostname.clone(),
+            source_path: sel.source_path.clone(),
+        });
+        return Ok(StatusUpdate::completed_resolved(
+            &restored_id,
+            identity,
+            chrono::Utc::now(),
+        ));
+    }
+
     // The webhook validates `asOf` at admission; re-parse defensively here.
     let cutoff = match sel.as_of.as_deref() {
         Some(s) => Some(
@@ -591,10 +636,14 @@ async fn resolve_and_restore(
         ),
         None => None,
     };
+    // Absolute wall-clock deadline (anchored at the Restore's creation by the
+    // controller), so the wait matches the snapshotRef path and is stable across
+    // pod restarts. Defensive parse; unparseable ⇒ resolve once, no wait.
     let deadline = sel
-        .wait_timeout_secs
-        .filter(|s| *s > 0)
-        .map(|s| std::time::Instant::now() + Duration::from_secs(s as u64));
+        .wait_deadline
+        .as_deref()
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|t| t.with_timezone(&chrono::Utc));
     const POLL: Duration = Duration::from_secs(10);
 
     loop {
@@ -615,39 +664,50 @@ async fn resolve_and_restore(
                 offset = sel.offset,
                 "resolved restore source to a snapshot; restoring",
             );
+            let identity = ResolvedIdentity {
+                username: entry.source.user_name.clone(),
+                hostname: entry.source.host.clone(),
+                source_path: Some(entry.source.path.clone()),
+            };
+            // Pin the choice BEFORE restoring: a retry reuses it (above), the
+            // controller adopts it as pin-once, and it survives a failed terminal
+            // PATCH (best-effort; logged on failure).
+            reporter
+                .pin_resolved(&ResolvedRestore {
+                    resolution: Some(ResolutionOutcome::Snapshot),
+                    kopia_snapshot_id: Some(entry.id.clone()),
+                    identity: Some(identity.clone()),
+                    pinned_at: Some(chrono::Utc::now().to_rfc3339()),
+                    ..Default::default()
+                })
+                .await;
             let restored_id = restore_with_heal(client, op, &entry.id)
                 .await
                 .map_err(|source| MoverError::Kopia {
                     op: KopiaOp::SnapshotRestore,
                     source,
                 })?;
-            let identity = ResolvedIdentity {
-                username: entry.source.user_name.clone(),
-                hostname: entry.source.host.clone(),
-                source_path: Some(entry.source.path.clone()),
-            };
             return Ok(StatusUpdate::completed_resolved(
                 &restored_id,
                 identity,
                 chrono::Utc::now(),
             ));
         }
-        // No match yet: keep waiting while the window stays open (and the next
-        // until the deadline truly passes). Sleep the lesser of POLL and the time
-        // left, so a sub-POLL waitTimeout still waits (not zero) and a longer one
-        // isn't cut short by up to POLL.
+        // No match yet: keep waiting until the deadline truly passes. Sleep the
+        // lesser of POLL and the time left, so a sub-POLL window still waits (not
+        // zero) and a longer one isn't cut short by up to POLL.
         match deadline {
             Some(d) => {
-                let now = std::time::Instant::now();
+                let now = chrono::Utc::now();
                 if now >= d {
                     break;
                 }
-                let remaining = d - now;
+                let remaining = (d - now).to_std().unwrap_or(POLL).min(POLL);
                 info!(
                     identity = %filter.identity(),
                     "no snapshot matched the restore source yet; re-listing after a short wait",
                 );
-                tokio::time::sleep(remaining.min(POLL)).await;
+                tokio::time::sleep(remaining).await;
             }
             None => break,
         }
@@ -660,6 +720,15 @@ async fn resolve_and_restore(
                 "no snapshot matched the restore source; onMissingSnapshot=Continue — \
                  leaving the target empty (deploy-or-restore)",
             );
+            // Pin the empty outcome before completing, for the same durability/
+            // adoption reasons as the snapshot case.
+            reporter
+                .pin_resolved(&ResolvedRestore {
+                    resolution: Some(ResolutionOutcome::NoSnapshot),
+                    pinned_at: Some(chrono::Utc::now().to_rfc3339()),
+                    ..Default::default()
+                })
+                .await;
             Ok(StatusUpdate::completed_empty(chrono::Utc::now()))
         }
         kopiur_api::restore::OnMissingSnapshot::Fail => Err(MoverError::RestoreNoSnapshot {

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -662,6 +662,43 @@ impl StatusReporter {
             }
         }
     }
+
+    /// Read the target's currently-pinned `status.resolved`, if any. Used by the
+    /// in-Job restore resolver to reuse a snapshot a PRIOR pod attempt already
+    /// pinned (deterministic across Job retries) instead of re-resolving "latest".
+    /// Best-effort: returns `None` when there's no client or the read fails.
+    pub async fn resolved(&self) -> Option<ResolvedRestore> {
+        let r = self.inner.as_ref()?;
+        let guard = r.lock().await;
+        match guard.read_resolved().await {
+            Ok(v) => v,
+            Err(e) => {
+                warn!(error = %e, target = %self.target.name, "status.resolved read failed");
+                None
+            }
+        }
+    }
+
+    /// Pin `resolved` to the target's `status.resolved` via a resolved-only merge
+    /// PATCH (no `phase`, so it never trips the Restore phase enum). The in-Job
+    /// resolver calls this BEFORE restoring so the chosen snapshot is durably
+    /// recorded — a retry reuses it, the controller adopts it (pin-once), and the
+    /// outcome survives a later failure of the terminal status PATCH. Best-effort.
+    pub async fn pin_resolved(&self, resolved: &ResolvedRestore) {
+        match &self.inner {
+            Some(r) => {
+                let mut guard = r.lock().await;
+                if let Err(e) = guard.pin_resolved(resolved).await {
+                    warn!(error = %e, target = %self.target.name, "status.resolved pin failed");
+                }
+            }
+            None => info!(
+                target = %self.target.name,
+                "status.resolved pin (no cluster): {}",
+                serde_json::to_string(resolved).unwrap_or_default()
+            ),
+        }
+    }
 }
 
 /// The real kube PATCH path. Uses a dynamic API so the mover does not need to
@@ -702,6 +739,44 @@ impl KubeStatusReporter {
     pub async fn patch(&mut self, update: &StatusUpdate) -> Result<()> {
         use kube::api::{Patch, PatchParams};
         let body = update.as_patch_body();
+        self.api
+            .patch_status(&self.name, &PatchParams::default(), &Patch::Merge(&body))
+            .await
+            .map_err(|source| MoverError::StatusPatch {
+                kind: self.kind.clone(),
+                namespace: self.namespace.clone(),
+                name: self.name.clone(),
+                source: Box::new(source),
+            })?;
+        Ok(())
+    }
+
+    /// GET the target and deserialize its `status.resolved`, if present.
+    async fn read_resolved(&self) -> Result<Option<ResolvedRestore>> {
+        let obj = self
+            .api
+            .get_opt(&self.name)
+            .await
+            .map_err(|source| MoverError::StatusPatch {
+                kind: self.kind.clone(),
+                namespace: self.namespace.clone(),
+                name: self.name.clone(),
+                source: Box::new(source),
+            })?;
+        Ok(obj
+            .and_then(|o| {
+                o.data
+                    .get("status")
+                    .and_then(|s| s.get("resolved"))
+                    .cloned()
+            })
+            .and_then(|v| serde_json::from_value(v).ok()))
+    }
+
+    /// Resolved-only `.status` merge PATCH (no `phase`), pinning `status.resolved`.
+    async fn pin_resolved(&mut self, resolved: &ResolvedRestore) -> Result<()> {
+        use kube::api::{Patch, PatchParams};
+        let body = serde_json::json!({ "status": { "resolved": resolved } });
         self.api
             .patch_status(&self.name, &PatchParams::default(), &Patch::Merge(&body))
             .await

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
 use kopiur_api::common::ResolvedIdentity;
-use kopiur_api::restore::RestorePhase;
+use kopiur_api::restore::{ResolutionOutcome, ResolvedRestore, RestorePhase};
 use kopiur_api::snapshot::SnapshotInfo;
 use kopiur_api::{PhaseLabel, SnapshotStats, SnapshotTiming};
 use kopiur_kopia::{KopiaError, MaintenanceMode, SnapshotCreateResult};
@@ -148,6 +148,8 @@ impl From<&crate::error::MoverError> for FailureBlock {
             | MoverError::CredentialWrite { .. }
             | MoverError::ReadyMarkerWrite { .. }
             | MoverError::VerifyNoSnapshot { .. }
+            | MoverError::RestoreNoSnapshot { .. }
+            | MoverError::RestoreAsOfInvalid { .. }
             | MoverError::ScratchNotWritable { .. }
             | MoverError::SuccessExprFalse { .. }
             | MoverError::SuccessExprEval { .. }
@@ -274,6 +276,14 @@ pub struct StatusUpdate {
     /// [`kopiur_api::common::MAX_LOG_TAIL_BYTES`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub log_tail: Option<String>,
+    /// The pinned restore resolution (CRD `status.resolved`), set ONLY when the
+    /// mover RESOLVED the source itself (object-store `fromPolicy`/`identity` — the
+    /// in-Job listing path). The controller never pins these (it can't list the
+    /// backend in-process), so the mover writes the outcome here for provenance.
+    /// Disjoint from the controller-written phase/conditions subtree, so the merge
+    /// PATCH never collides. Absent for controller-resolved restores.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resolved: Option<ResolvedRestore>,
 }
 
 impl StatusUpdate {
@@ -287,6 +297,7 @@ impl StatusUpdate {
             stats: None,
             failure: None,
             log_tail: None,
+            resolved: None,
         }
     }
 
@@ -301,6 +312,7 @@ impl StatusUpdate {
             stats: Some(stats_from_result(result)),
             failure: None,
             log_tail: Some(format!("Snapshot created: {}", result.id)),
+            resolved: None,
         }
     }
 
@@ -315,6 +327,7 @@ impl StatusUpdate {
             stats: None,
             failure: None,
             log_tail: None,
+            resolved: None,
         }
     }
 
@@ -339,6 +352,7 @@ impl StatusUpdate {
             stats: None,
             failure: None,
             log_tail: Some(format!("Snapshot pin reconciled: {id}")),
+            resolved: None,
         }
     }
 
@@ -357,6 +371,59 @@ impl StatusUpdate {
             stats: None,
             failure: None,
             log_tail: Some(format!("Restore completed: snapshot {snapshot_id}")),
+            resolved: None,
+        }
+    }
+
+    /// A successful restore the MOVER resolved (object-store `fromPolicy`/`identity`
+    /// in-Job path): same terminal `Completed` as [`StatusUpdate::completed`], but
+    /// it also pins `status.resolved` with the snapshot the selector resolved to,
+    /// since the controller couldn't list the backend in-process to pin it.
+    pub fn completed_resolved(
+        snapshot_id: &str,
+        identity: ResolvedIdentity,
+        observed_at: DateTime<Utc>,
+    ) -> Self {
+        StatusUpdate {
+            phase: RestorePhase::Completed.label().to_string(),
+            observed_at,
+            snapshot: None,
+            timing: None,
+            stats: None,
+            failure: None,
+            log_tail: Some(format!("Restore completed: snapshot {snapshot_id}")),
+            resolved: Some(ResolvedRestore {
+                resolution: Some(ResolutionOutcome::Snapshot),
+                kopia_snapshot_id: Some(snapshot_id.to_string()),
+                identity: Some(identity),
+                pinned_at: Some(observed_at.to_rfc3339()),
+                ..Default::default()
+            }),
+        }
+    }
+
+    /// A successful deploy-or-restore where the selector matched NO snapshot and
+    /// `onMissingSnapshot: Continue` was in effect: the target is left empty and
+    /// `status.resolved` pins the `NoSnapshot` outcome so a later-appearing
+    /// snapshot can never silently retarget this Restore.
+    pub fn completed_empty(observed_at: DateTime<Utc>) -> Self {
+        StatusUpdate {
+            phase: RestorePhase::Completed.label().to_string(),
+            observed_at,
+            snapshot: None,
+            timing: None,
+            stats: None,
+            failure: None,
+            log_tail: Some(
+                "Restore completed: no snapshot matched the source; left the target \
+                 empty (deploy-or-restore)"
+                    .to_string(),
+            ),
+            resolved: Some(ResolvedRestore {
+                resolution: Some(ResolutionOutcome::NoSnapshot),
+                pinned_at: Some(observed_at.to_rfc3339()),
+                ..Default::default()
+            }),
         }
     }
 
@@ -373,6 +440,7 @@ impl StatusUpdate {
             stats: None,
             log_tail: Some(failure_log_tail(&failure)),
             failure: Some(failure),
+            resolved: None,
         }
     }
 
@@ -389,6 +457,7 @@ impl StatusUpdate {
             stats: None,
             log_tail: Some(failure_log_tail(&failure)),
             failure: Some(failure),
+            resolved: None,
         }
     }
 
@@ -901,6 +970,46 @@ mod tests {
         assert_eq!(
             body["status"]["logTail"],
             "Restore completed: snapshot k1f1ec0a8"
+        );
+    }
+
+    #[test]
+    fn completed_resolved_pins_status_resolved_for_in_job_resolution() {
+        // The object-store in-Job path: the mover resolved the snapshot itself, so
+        // it must pin status.resolved (the controller couldn't list the backend).
+        let identity = ResolvedIdentity {
+            username: "restore".into(),
+            hostname: "prod".into(),
+            source_path: Some("/pvc/db".into()),
+        };
+        let u = StatusUpdate::completed_resolved("k9", identity, ts());
+        assert_eq!(u.phase, "Completed");
+        let body = u.as_patch_body();
+        // The exact CRD `status.resolved` field names, or the API server prunes them.
+        assert_eq!(body["status"]["resolved"]["resolution"], "Snapshot");
+        assert_eq!(body["status"]["resolved"]["kopiaSnapshotID"], "k9");
+        assert_eq!(
+            body["status"]["resolved"]["identity"]["sourcePath"],
+            "/pvc/db"
+        );
+        assert!(body["status"]["resolved"]["pinnedAt"].is_string());
+        assert_eq!(body["status"]["logTail"], "Restore completed: snapshot k9");
+    }
+
+    #[test]
+    fn completed_empty_pins_no_snapshot_outcome() {
+        // Deploy-or-restore with no match under Continue: pin NoSnapshot so a
+        // later-appearing snapshot can never silently retarget the Restore.
+        let u = StatusUpdate::completed_empty(ts());
+        assert_eq!(u.phase, "Completed");
+        let body = u.as_patch_body();
+        assert_eq!(body["status"]["resolved"]["resolution"], "NoSnapshot");
+        assert!(body["status"]["resolved"].get("kopiaSnapshotID").is_none());
+        assert!(
+            body["status"]["logTail"]
+                .as_str()
+                .unwrap()
+                .contains("deploy-or-restore")
         );
     }
 

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -291,19 +291,67 @@ impl SnapshotAnchor {
     }
 }
 
+/// Which snapshot a restore run targets. Externally tagged (exactly one variant)
+/// so a restore is either pre-resolved by the controller or resolved in-Job —
+/// never both, and a new variant can't compile until every `match` handles it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum RestoreSelection {
+    /// A concrete kopia snapshot manifest id the controller already resolved
+    /// (from a `snapshotRef` Snapshot CR, or an explicit `identity.snapshotID`).
+    /// Self-heals a stale id via [`RestoreOp::anchor`].
+    Snapshot(String),
+    /// Resolve the snapshot in-Job by listing the repository for an identity and
+    /// picking newest/offset/asOf. This is what makes "restore the latest" work
+    /// for object stores: in-process listing only works for filesystem repos, so
+    /// `fromPolicy`/`identity`-without-id defer the listing to the mover, which
+    /// reaches every backend.
+    Resolve(RestoreSelector),
+}
+
+/// An unresolved restore source: list the repository for this kopia identity and
+/// pick a snapshot by `asOf` (point-in-time) then `offset` (0 = latest). Mirrors
+/// the `Restore` CRD's `fromPolicy`/`identity` selection so the mover resolves it
+/// exactly as the controller's filesystem path used to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RestoreSelector {
+    /// The kopia `username` to match.
+    pub username: String,
+    /// The kopia `hostname` to match.
+    pub hostname: String,
+    /// The kopia source path to match; absent matches any path for the identity.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_path: Option<String>,
+    /// Restore the newest snapshot at or before this RFC3339 instant (validated at
+    /// admission; the mover re-parses defensively).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub as_of: Option<String>,
+    /// Which snapshot to pick: 0 = latest, 1 = previous, and so on.
+    #[serde(default)]
+    pub offset: i64,
+    /// What to do when no snapshot matches once the wait window closes: `Fail`
+    /// (exit non-zero) or `Continue` (leave the target empty — deploy-or-restore).
+    pub on_missing: kopiur_api::restore::OnMissingSnapshot,
+    /// Seconds to keep re-listing for a matching snapshot before applying
+    /// `on_missing` (the `waitTimeout` window, now polled inside the Job). Bounded
+    /// by the Job's `activeDeadlineSeconds`. `None` ⇒ resolve once, no wait.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub wait_timeout_secs: Option<i64>,
+}
+
 /// Payload for a restore run.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreOp {
-    /// The snapshot manifest id to restore from. Resolved by the controller
-    /// (browse-and-reference, not a timestamp).
-    pub snapshot_id: String,
+    /// Which snapshot to restore: a controller-resolved id, or an in-Job selector.
+    pub source: RestoreSelection,
     /// Absolute path inside the mover pod to restore into (e.g. `/data`).
     pub target_path: String,
     /// Stable identity anchors for the referenced snapshot, used to self-heal a
-    /// stale `snapshot_id` (kopia rewrites the manifest id on pin) when the
-    /// restore reports the id not found. Empty ⇒ no fallback (a raw
-    /// user-supplied id stays a hard failure).
+    /// stale id (kopia rewrites the manifest id on pin) when a
+    /// [`RestoreSelection::Snapshot`] restore reports the id not found. Empty ⇒ no
+    /// fallback; never set for [`RestoreSelection::Resolve`] (it lists fresh).
     #[serde(default, skip_serializing_if = "SnapshotAnchor::is_empty")]
     pub anchor: SnapshotAnchor,
     /// `--[no-]ignore-permission-errors` (Restore CRD `options`; kopia default
@@ -320,10 +368,10 @@ impl RestoreOp {
     /// Translate the carried restore flags into the kopia client's options.
     ///
     /// ```
-    /// use kopiur_mover::workspec::RestoreOp;
+    /// use kopiur_mover::workspec::{RestoreOp, RestoreSelection};
     ///
     /// let op = RestoreOp {
-    ///     snapshot_id: "k1".into(),
+    ///     source: RestoreSelection::Snapshot("k1".into()),
     ///     target_path: "/data".into(),
     ///     anchor: Default::default(),
     ///     ignore_permission_errors: Some(false),
@@ -1004,7 +1052,11 @@ impl ThrottleSpec {
 }
 
 fn default_spec_version() -> u32 {
-    1
+    // v2: RestoreOp carries `source: RestoreSelection` (was a bare `snapshot_id`)
+    // so object-store restores resolve "latest" in-Job. A work spec is written and
+    // read by a single controller+mover image pair per Job, so v1 and v2 never mix
+    // within one run — no cross-version deserializer is needed.
+    2
 }
 
 #[cfg(test)]

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -333,11 +333,12 @@ pub struct RestoreSelector {
     /// What to do when no snapshot matches once the wait window closes: `Fail`
     /// (exit non-zero) or `Continue` (leave the target empty — deploy-or-restore).
     pub on_missing: kopiur_api::restore::OnMissingSnapshot,
-    /// Seconds to keep re-listing for a matching snapshot before applying
-    /// `on_missing` (the `waitTimeout` window, now polled inside the Job). Bounded
-    /// by the Job's `activeDeadlineSeconds`. `None` ⇒ resolve once, no wait.
+    /// Absolute RFC3339 instant to keep re-listing until before applying
+    /// `on_missing` — the `waitTimeout` window, anchored by the controller at the
+    /// Restore's creation (NOT at Job start), so it matches the `snapshotRef` path
+    /// and is stable across pod retries. `None` ⇒ resolve once, no wait.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub wait_timeout_secs: Option<i64>,
+    pub wait_deadline: Option<String>,
 }
 
 /// Payload for a restore run.

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -53,9 +53,9 @@ fn backup_roundtrip() {
 #[test]
 fn restore_roundtrip() {
     let spec = MoverWorkSpec {
-        version: 1,
+        version: 2,
         operation: Operation::Restore(RestoreOp {
-            snapshot_id: "abc123".into(),
+            source: RestoreSelection::Snapshot("abc123".into()),
             target_path: "/data".into(),
             anchor: SnapshotAnchor {
                 source_path: "/pvc/db".into(),
@@ -88,6 +88,57 @@ fn restore_roundtrip() {
     };
     assert_eq!(roundtrip(&spec), spec);
     assert_eq!(spec.operation.kind_str(), "Restore");
+    // The externally-tagged source serializes under its own camelCase key.
+    let v = serde_json::to_value(&spec).unwrap();
+    assert_eq!(v["operation"]["restore"]["source"]["snapshot"], "abc123");
+}
+
+#[test]
+fn restore_resolve_source_roundtrips_and_wire_shape() {
+    // The in-Job (object-store) path: an unresolved selector instead of an id.
+    let spec = MoverWorkSpec {
+        version: 2,
+        operation: Operation::Restore(RestoreOp {
+            source: RestoreSelection::Resolve(RestoreSelector {
+                username: "restore".into(),
+                hostname: "prod".into(),
+                source_path: Some("/pvc/db".into()),
+                as_of: Some("2026-06-19T05:54:19Z".into()),
+                offset: 0,
+                on_missing: kopiur_api::restore::OnMissingSnapshot::Continue,
+                wait_timeout_secs: Some(300),
+            }),
+            target_path: "/data".into(),
+            anchor: SnapshotAnchor::default(),
+            ignore_permission_errors: None,
+            write_files_atomically: None,
+        }),
+        identity: sample_identity(),
+        repository: RepositoryConnect::S3 {
+            bucket: "backups".into(),
+            endpoint: None,
+            prefix: None,
+            region: None,
+            disable_tls: false,
+            disable_tls_verification: false,
+            ambient_credentials: false,
+        },
+        target_ref: TargetRef {
+            kind: "Restore".into(),
+            ..sample_target()
+        },
+        hook_plan: HookPlanSummary::default(),
+        options: MoverOptions::default(),
+        cache: Default::default(),
+        throttle: Default::default(),
+    };
+    assert_eq!(roundtrip(&spec), spec);
+    let v = serde_json::to_value(&spec).unwrap();
+    let sel = &v["operation"]["restore"]["source"]["resolve"];
+    assert_eq!(sel["username"], "restore");
+    assert_eq!(sel["offset"], 0);
+    assert_eq!(sel["onMissing"], "Continue");
+    assert_eq!(sel["waitTimeoutSecs"], 300);
 }
 
 #[test]
@@ -268,7 +319,7 @@ fn defaults_fill_in_when_absent() {
         "targetRef": {"apiVersion": "kopiur.home-operations.com/v1alpha1", "kind": "Snapshot", "name": "n", "namespace": "ns"}
     }"#;
     let spec: MoverWorkSpec = serde_json::from_str(json).unwrap();
-    assert_eq!(spec.version, 1);
+    assert_eq!(spec.version, 2);
     assert_eq!(spec.options.progress_interval_secs, 5);
     assert_eq!(spec.options.operation_timeout_secs, None);
     assert!(spec.hook_plan.pre.is_empty());
@@ -396,7 +447,7 @@ fn object_store_backends_convert_and_roundtrip() {
 fn restore_op_maps_options_and_defaults_absent() {
     // Options present → mapped onto the kopia client options.
     let op = RestoreOp {
-        snapshot_id: "s".into(),
+        source: RestoreSelection::Snapshot("s".into()),
         target_path: "/data".into(),
         anchor: SnapshotAnchor::default(),
         ignore_permission_errors: Some(false),
@@ -406,9 +457,9 @@ fn restore_op_maps_options_and_defaults_absent() {
     assert_eq!(opts.ignore_permission_errors, Some(false));
     assert_eq!(opts.write_files_atomically, Some(true));
 
-    // Older wire payload without the option/anchor fields still deserializes
-    // (forward/backward compatible), mapping to kopia defaults (None/empty).
-    let json = r#"{"snapshotId":"s","targetPath":"/data"}"#;
+    // A wire payload with just the source + path still deserializes (option/anchor
+    // fields default), mapping to kopia defaults (None/empty).
+    let json = r#"{"source":{"snapshot":"s"},"targetPath":"/data"}"#;
     let parsed: RestoreOp = serde_json::from_str(json).unwrap();
     assert_eq!(parsed.ignore_permission_errors, None);
     assert_eq!(parsed.restore_options().write_files_atomically, None);

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -106,7 +106,7 @@ fn restore_resolve_source_roundtrips_and_wire_shape() {
                 as_of: Some("2026-06-19T05:54:19Z".into()),
                 offset: 0,
                 on_missing: kopiur_api::restore::OnMissingSnapshot::Continue,
-                wait_timeout_secs: Some(300),
+                wait_deadline: Some("2026-06-19T06:00:00Z".into()),
             }),
             target_path: "/data".into(),
             anchor: SnapshotAnchor::default(),
@@ -138,7 +138,7 @@ fn restore_resolve_source_roundtrips_and_wire_shape() {
     assert_eq!(sel["username"], "restore");
     assert_eq!(sel["offset"], 0);
     assert_eq!(sel["onMissing"], "Continue");
-    assert_eq!(sel["waitTimeoutSecs"], 300);
+    assert_eq!(sel["waitDeadline"], "2026-06-19T06:00:00Z");
 }
 
 #[test]

--- a/docs/cli/backup-restore.md
+++ b/docs/cli/backup-restore.md
@@ -79,13 +79,13 @@ Only `--from-policy` defaults to `continue`, for deploy-or-restore.
 
 ///
 
-/// warning | Identity-based sources need a filesystem backend (today)
+/// note | Identity-based sources work on every backend
 The operator resolves `--from-policy` and un-pinned `--identity` sources by
-listing the repository's snapshots in-process, which is currently implemented
-only for **filesystem-backed** repositories. Against an object-store backend
-(S3/GCS/Azure/B2) the Restore stays `Pending` with an `InvalidSpec` warning
-event. Use `--from-snapshot` (any backend), or pin the exact snapshot with
-`--identity … --snapshot-id <ID>`.
+listing the repository's snapshots **inside the restore Job**, so picking
+"latest" (or `--as-of`/`--offset`) works the same on S3/GCS/Azure/B2/SFTP/
+WebDAV/rclone as on a filesystem repo — no controller-side repo mount needed.
+`--from-snapshot` and a pinned `--identity … --snapshot-id <ID>` still skip the
+listing entirely.
 
 ///
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -235,7 +235,7 @@ CRD validation).
 | `target` | {`pvcPrime`,`pvcRef`} | Resolved target. |
 | `timing` | {`startTime`,`endTime`} | — |
 | `progress` | {`bytesRestored`,`filesRestored`} | Live mover progress. |
-| `conditions` | []Condition | `Ready`/`Reconciling`/`Stalled`, reason text; `Resolved=False reason=WaitingForSnapshot` while a `policy.waitTimeout` window is open; `CredentialsAvailable`, `MoverPermitted`, `RestoreSecurityContextCompatible` (positive-only — `True` when the future consumer can read what the mover writes; advisory negatives are admission warnings). |
+| `conditions` | []Condition | `Ready`/`Reconciling`/`Stalled`, reason text; `Resolved=False reason=WaitingForSnapshot` while a `snapshotRef` `policy.waitTimeout` window is open (a `fromPolicy`/`identity` source waits inside the restore Job instead, shown as `Restoring`); `Resolved=True reason=NoSnapshotContinue` when a deploy-or-restore came up empty; `CredentialsAvailable`, `MoverPermitted`, `RestoreSecurityContextCompatible` (positive-only — `True` when the future consumer can read what the mover writes; advisory negatives are admission warnings). |
 | `logTail` | string | Last output lines, written by the mover at the terminal transition — `Restore completed: snapshot <id>` on success, the actionable error + kopia stderr tail on failure. Capped 4KiB. |
 | `failure` | {`kopiaErrorClass`,`message`,`stderrTail`?,`exitCode`?,`retryRecommended`} | Structured terminal-failure detail, written by the mover before it exits non-zero. §4.10 |
 

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -157,7 +157,9 @@ The empty-volume path applies to `fromPolicy`/`identity` sources on **every** ba
 
 ### `waitTimeout` — wait before giving up
 
-`waitTimeout` (a Go-style duration, e.g. `5m`) opens a grace window, anchored at the Restore's **creation**, during which "no matching snapshot yet" means *wait and re-check* (every ~15 s, surfacing `Resolved=False reason=WaitingForSnapshot` on the conditions) instead of giving up. `onMissingSnapshot` applies only once the window closes. Use it when the Restore may be applied before the thing that produces its snapshot — a schedule about to fire, a GitOps apply ordering, a populator claim racing the first backup.
+`waitTimeout` (a Go-style duration, e.g. `5m`) opens a grace window, anchored at the Restore's **creation**, during which "no matching snapshot yet" means *wait and re-check* instead of giving up. `onMissingSnapshot` applies only once the window closes. Use it when the Restore may be applied before the thing that produces its snapshot — a schedule about to fire, a GitOps apply ordering, a populator claim racing the first backup.
+
+Where the waiting happens depends on the source. A `snapshotRef` (waiting for the referenced `Snapshot` CR to gain an id) re-checks **in the controller** (~15 s, surfacing `Resolved=False reason=WaitingForSnapshot` on the conditions). A `fromPolicy`/`identity` source re-lists the repository **inside the restore Job** (the same mover run that does the restore, so it works on every backend) — the `Restore` shows `Restoring` for that window rather than a per-poll condition. Either way the window is measured from creation, so it's bounded even across controller restarts or Job pod retries. Because the wait runs inside the Job for the latter, `waitTimeout` must be shorter than the Job's `failurePolicy.activeDeadlineSeconds` — the admission webhook rejects a Restore that sets both with `waitTimeout` ≥ the deadline.
 
 ## Mover, cache & failure policy
 

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -60,30 +60,11 @@ source:
 Whatever the source resolves to is written ONCE to `status.resolved.kopiaSnapshotID` and reused for the rest of the restore's life. New snapshots appearing mid-flight (a schedule firing) cannot change which snapshot this Restore writes.
 ///
 
-/// warning | `fromPolicy` / `identity`-without-`snapshotID` need the repo reachable by the **controller**
+/// note | `fromPolicy` / `identity`-without-`snapshotID` resolve "latest" on **every** backend
 
-Resolving "latest / `asOf` / `offset` for a policy" lists snapshots **in-process in the controller** (not in a mover Job), so the controller must be able to reach the repository:
+Resolving "latest / `asOf` / `offset` for a policy" lists the repository's snapshots **inside the restore mover Job**, which reaches every backend the same way a backup does — so this works on S3, Azure, GCS, B2, SFTP, WebDAV, rclone, and filesystem alike. No controller-side repo mount is needed.
 
-- **Object stores** (S3, Azure, GCS, B2, SFTP, WebDAV, rclone): not supported for in-process listing — name the snapshot explicitly with `snapshotRef`, or `identity` with a pinned `snapshotID`. A `fromPolicy` restore against an object-store repository fails loudly with exactly that fix.
-- **Filesystem repositories**: the repository must be mounted into the **controller** pod at the repository's `backend.filesystem.path`, and the controller must run as a UID/GID that can read it. By default only the mover Jobs mount the repo, so `fromPolicy`/`identity` resolution fails with an actionable error (`the filesystem repository path '…' is not accessible to the controller`) until you add the mount. `snapshotRef` and a pinned `identity.snapshotID` need **no** controller mount.
-
-Mount a filesystem repo into the controller via Helm (matching the NFS/PVC the repo lives on, here `/repo`):
-
-```yaml
-controller:
-    extraVolumes:
-        - name: repo
-          nfs: { server: nfs.example.com, path: /tank/kopiur }
-    extraVolumeMounts:
-        - name: repo
-          mountPath: /repo # == backend.filesystem.path
-podSecurityContext:
-    runAsNonRoot: true
-    runAsUser: 1234 # a UID/GID that can read the repo
-    runAsGroup: 1234
-    fsGroup: 1234
-    fsGroupChangePolicy: OnRootMismatch
-```
+If no matching snapshot exists yet, `onMissingSnapshot` applies (`Continue` comes up empty — deploy-or-restore; `Fail` fails the Restore). `waitTimeout` keeps the Job re-checking for the snapshot to appear before that decision — so it must be shorter than the Job's `failurePolicy.activeDeadlineSeconds` (the admission webhook enforces this when you set both).
 
 ///
 
@@ -172,11 +153,7 @@ The defaults are the point: an _explicit_ restore that finds nothing is an error
 
 On `Continue` with no snapshot, Kopiur **actually provisions the empty volume** — it doesn't just mark the `Restore` complete. For `target.populator: {}` it provisions an empty prime PVC and rebinds it to the claiming PVC (so a workload pod can bind and start); for `target.pvc` it creates the empty PVC. The "no snapshot ⇒ empty" decision is **pinned to `status.resolved` (`resolution: NoSnapshot`) once and never re-resolved**, so a snapshot that appears *later* can never silently restore over a volume the app is already using — re-create the `Restore` if you want to pick up a new snapshot. The Restore reports `Completed` with `Resolved=True reason=NoSnapshotContinue`.
 
-/// note | Deploy-or-restore-to-empty needs a filesystem-backed repository
-
-The empty-volume path applies to `fromPolicy`/`identity` sources against a **filesystem** repository. For object-store backends (S3/Azure/GCS/B2), an in-controller source resolution isn't supported, so `fromPolicy` with no snapshot surfaces an error rather than coming up empty — use an explicit `snapshotRef`, or seed the first snapshot.
-
-///
+The empty-volume path applies to `fromPolicy`/`identity` sources on **every** backend — the restore Job resolves the source in-place, so an object-store `fromPolicy` with no snapshot comes up empty under `Continue` just like a filesystem one.
 
 ### `waitTimeout` — wait before giving up
 

--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -244,9 +244,9 @@ This `fromPolicy` source is what powers **deploy-or-restore**: the same manifest
 
 ///
 
-/// warning | `fromPolicy` needs a filesystem repository
+/// note | `fromPolicy` resolves "latest" on every backend
 
-Resolving "latest for a policy" lists snapshots in-process, which requires a repo the controller can mount — so it works for **filesystem** backends only. On S3 and the other object-store backends, name the snapshot explicitly (`snapshotRef` / `--from-snapshot`) or pin an exact ID via the [`identity` source](restores.md#identity--a-raw-kopia-identity); the operator fails loudly with that exact fix if you try.
+Resolving "latest for a policy" lists the repository's snapshots inside the restore Job, so it works on S3 and the other object-store backends just as it does on a filesystem repo — no controller-side repo mount needed. You can still name the snapshot explicitly (`snapshotRef` / `--from-snapshot`) or pin an exact ID via the [`identity` source](restores.md#identity--a-raw-kopia-identity) when you don't want "latest".
 
 ///
 


### PR DESCRIPTION
## What & why

A `Restore` from an object-store repository (S3, Azure, GCS, B2, SFTP, WebDAV, rclone) used to require an explicit snapshot id. `fromPolicy` and `identity`-without-id hard-errored (`UnsupportedSourceResolution`) because the controller resolved the snapshot by listing the repository **in-process**, which only works for a locally-mounted filesystem repo. So filesystem restores "just worked" and object-store restores didn't.

`offset: 0` (latest) was already the default — it just lived on a code path S3 never reached.

## Approach

Move repo-touching resolution into the restore **mover Job**, which reaches every backend the same way a backup does. Split by what each part needs:

- **Stays in the controller** (Kubernetes-only): `snapshotRef` and explicit `identity.snapshotID`.
- **Defers to the mover** (`fromPolicy` / `identity`-without-id): the controller resolves only the *identity* and dispatches an unresolved selector; the mover lists → filters (`asOf`) → picks (`offset`, 0 = latest) → polls until the snapshot appears or `waitTimeout` closes → restores, then pins `status.resolved` itself.

This deletes the filesystem-only `list_for_identity`, the `UnsupportedSourceResolution` / `FilesystemResolutionUnmounted` errors, and the controller-mount footgun (#137), unifying both backends onto one path.

## Changes

- **kopia**: new `selection` module (`filter_as_of` / `pick_offset`) shared with the mover.
- **mover**: `RestoreOp.snapshot_id` → externally-tagged `RestoreSelection { Snapshot | Resolve(RestoreSelector) }`; work-spec version `1 → 2`; in-Job `resolve_and_restore` with the wait-loop and `onMissingSnapshot` (`Continue` → empty / `Fail` → error); mover pins `status.resolved`.
- **controller**: `resolve_snapshot` → `ResolveOutcome { Pinned | Deferred }`; new `Resolution::Deferred`; populator gate/finalize key off the selection and the pinned outcome.
- **validation**: `waitTimeout` must be shorter than an explicit `failurePolicy.activeDeadlineSeconds` (the wait now runs inside the Job).
- **e2e**: real S3 `--from-policy` round-trip (was asserting `InvalidSpec`).
- **docs**: dropped the filesystem-only / controller-mount caveats in `restores.md`, `cli/backup-restore.md`, `walkthrough.md`.

The type-safety thesis is preserved — `RestoreSelection` / `ResolveOutcome` / `Resolution` are exhaustively matched, no `_ =>` in the reconcile paths.

## Verification

- `mise run test` ✓ · `clippy` ✓ · `fmt-check` ✓ · `gen-check` ✓ (no CRD drift — surface unchanged)
- ⚠️ The e2e suite (`mise run //crates/e2e:test`) compiles but needs a kind + MinIO cluster to run — the new S3 `--from-policy` round-trip should be run there before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)