### PR TITLE
fix(mover): report Restoring phase for restore progress updates

### DIFF
--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -335,7 +335,12 @@ async fn execute(
         tokio::select! {
             result = &mut op => return result,
             _ = ticker.tick() => {
-                reporter.report(&StatusUpdate::running(chrono::Utc::now())).await;
+                let now = chrono::Utc::now();
+                let update = match &spec.operation {
+                    Operation::Restore(_) => StatusUpdate::restoring(now),
+                    _ => StatusUpdate::running(now),
+                };
+                reporter.report(&update).await;
             }
         }
     }

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -301,6 +301,24 @@ impl StatusUpdate {
         }
     }
 
+    /// A restore "in progress" update. The Restore CRD's in-flight phase is
+    /// `Restoring` — NOT `Running` (the Snapshot phase); writing `Running` here
+    /// is rejected by the apiserver with a 422 (the enum forbids it), so the
+    /// phase string is sourced from [`RestorePhase::Restoring`] to stay locked
+    /// to the CRD — mirroring [`StatusUpdate::completed`].
+    pub fn restoring(observed_at: DateTime<Utc>) -> Self {
+        StatusUpdate {
+            phase: RestorePhase::Restoring.label().to_string(),
+            observed_at,
+            snapshot: None,
+            timing: None,
+            stats: None,
+            failure: None,
+            log_tail: None,
+            resolved: None,
+        }
+    }
+
     /// A successful backup update from a kopia create result. `logTail` carries
     /// the documented `Snapshot created: <id>` line (ADR §3.4).
     pub fn succeeded_backup(result: &SnapshotCreateResult, observed_at: DateTime<Utc>) -> Self {
@@ -1046,6 +1064,23 @@ mod tests {
             body["status"]["logTail"],
             "Restore completed: snapshot k1f1ec0a8"
         );
+    }
+
+    #[test]
+    fn restore_in_flight_phase_is_restoring_not_running() {
+        // Regression: the mover's periodic progress update used `running()`
+        // ("Running"), but the Restore CRD enum only allows "Restoring", so the
+        // status PATCH was rejected 422 and every restore flooded the controller
+        // logs. The restore in-flight phase MUST match RestorePhase::Restoring.
+        let u = StatusUpdate::restoring(ts());
+        assert_eq!(u.phase, "Restoring");
+        assert_eq!(u.phase, RestorePhase::Restoring.label());
+        assert_ne!(u.phase, MoverPhase::Running.as_str());
+        // A progress update never sets terminal fields (the status-churn rule).
+        assert!(u.failure.is_none());
+        assert!(u.log_tail.is_none());
+        let body = u.as_patch_body();
+        assert_eq!(body["status"]["phase"], "Restoring");
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The mover's periodic progress update in `execute()` always uses `StatusUpdate::running()`, which writes `phase: "Running"`. That value is valid for `SnapshotPhase`, but the `RestorePhase` enum has no `Running` (its in-flight phase is `Restoring`). So during every restore, each progress PATCH is rejected by the apiserver with a 422:

```
status PATCH failed ... Restore "<app>-restore" is invalid:
[status.phase: Unsupported value: "Running": supported values:
"Pending", "Resolving", "Restoring", "Completed", "Failed"]
```

The restore data transfer is unaffected (kopia still runs), but the controller logs are flooded and the Restore's progress/phase can't be reported by the mover.

This mirrors the already-fixed terminal-phase case: `completed()` deliberately writes `RestorePhase::Completed` instead of `MoverPhase::Succeeded` for exactly the same reason. The progress path was simply missed.

## Fix

- Add `StatusUpdate::restoring()`, which sources its phase from `RestorePhase::Restoring`.
- In `execute()`, pick `restoring()` for `Operation::Restore` and `running()` for every other operation.
- Add regression test `restore_in_flight_phase_is_restoring_not_running`.

## Testing

- `cargo test -p kopiur-mover --lib status::` → 25 passed
- `cargo clippy -p kopiur-mover` → clean
