### PR TITLE
feat: native gdrive backend, rclone/bootstrap timeouts, CRD cleanups (#152, #154, #155)

### DIFF
--- a/crates/api/README.md
+++ b/crates/api/README.md
@@ -93,6 +93,7 @@ let summary = match &backend {
     Backend::Sftp(_) => "sftp".into(),
     Backend::WebDav(_) => "webdav".into(),
     Backend::Rclone(_) => "rclone".into(),
+    Backend::Gdrive(_) => "gdrive".into(),
 };
 assert_eq!(summary, "s3://my-backups");
 

--- a/crates/api/src/backend.rs
+++ b/crates/api/src/backend.rs
@@ -61,6 +61,10 @@ pub enum Backend {
     /// Any rclone remote (kopia shells out to `rclone`), broadening reach to
     /// providers without a native kopia backend.
     Rclone(RcloneBackend),
+    /// Google Drive via kopia's native `gdrive` provider (service-account JSON).
+    /// kopia marks this provider experimental / not maintained, and a native
+    /// gdrive repository is not interchangeable with an rclone-backed Drive remote.
+    Gdrive(GdriveBackend),
 }
 
 impl Backend {
@@ -96,6 +100,7 @@ impl Backend {
             Backend::Sftp(_) => "Sftp",
             Backend::WebDav(_) => "WebDav",
             Backend::Rclone(_) => "Rclone",
+            Backend::Gdrive(_) => "Gdrive",
         }
     }
 }
@@ -260,4 +265,85 @@ pub struct RcloneBackend {
     /// `remote_path`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config_secret_ref: Option<SecretRef>,
+    /// How long kopia waits for its embedded `rclone serve` to come up before
+    /// failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+    /// `15s`; raise it for slow remotes whose repository metadata/indexes load
+    /// through the rclone/WebDAV bridge and take longer than the default budget.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub startup_timeout: Option<String>,
+}
+
+/// Google Drive backend using kopia's native `gdrive` provider.
+///
+/// kopia marks this provider experimental / not maintained, so prefer a native
+/// object store where one is available. A native gdrive repository is not
+/// interchangeable with an rclone-backed Drive remote — the two lay out data
+/// differently and cannot read each other.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GdriveBackend {
+    /// Google Drive folder ID that holds the kopia repository.
+    pub folder_id: String,
+    /// Secret holding the Google service-account JSON used to reach the folder,
+    /// read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+    /// falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+    /// instance metadata).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub credentials_secret_ref: Option<SecretRef>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::testutil::from_yaml;
+
+    #[test]
+    fn gdrive_backend_round_trips() {
+        let b: Backend = from_yaml(
+            r#"
+gdrive:
+  folderId: 0ABCDEF
+  credentialsSecretRef: { name: gdrive-sa }
+"#,
+        );
+        match &b {
+            Backend::Gdrive(g) => {
+                assert_eq!(g.folder_id, "0ABCDEF");
+                assert_eq!(
+                    g.credentials_secret_ref.as_ref().map(|r| r.name.as_str()),
+                    Some("gdrive-sa")
+                );
+            }
+            other => panic!("expected gdrive, got {other:?}"),
+        }
+        assert_eq!(b.kind_str(), "Gdrive");
+        // Externally tagged, camelCase — the wire key is the variant, not `kind`.
+        let json = serde_json::to_value(&b).unwrap();
+        assert_eq!(json["gdrive"]["folderId"], "0ABCDEF");
+    }
+
+    #[test]
+    fn rclone_startup_timeout_round_trips() {
+        let b: Backend = from_yaml(
+            r#"
+rclone:
+  remotePath: "remote:bucket"
+  startupTimeout: 2m
+"#,
+        );
+        let Backend::Rclone(r) = &b else {
+            panic!("expected rclone, got {b:?}")
+        };
+        assert_eq!(r.remote_path, "remote:bucket");
+        assert_eq!(r.startup_timeout.as_deref(), Some("2m"));
+
+        // Absent startupTimeout stays None and is omitted on the wire.
+        let bare: Backend = from_yaml("rclone: { remotePath: \"remote:bucket\" }");
+        let Backend::Rclone(r) = &bare else {
+            panic!("expected rclone")
+        };
+        assert!(r.startup_timeout.is_none());
+        let json = serde_json::to_value(&bare).unwrap();
+        assert!(json["rclone"].get("startupTimeout").is_none());
+    }
 }

--- a/crates/api/src/cluster_repository.rs
+++ b/crates/api/src/cluster_repository.rs
@@ -11,7 +11,9 @@ use crate::common::{
     RepositoryMode, default_namespace_delete_policy, default_repository_mode,
 };
 use crate::maintenance::RepositoryMaintenanceSpec;
-use crate::repository::{CatalogStatus, RepositoryHealthSpec, RepositoryPhase, StorageStats};
+use crate::repository::{
+    BootstrapSpec, CatalogStatus, RepositoryHealthSpec, RepositoryPhase, StorageStats,
+};
 use crate::server::{ClusterServerSpec, ServerStatus};
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
 use kube::CustomResource;
@@ -57,6 +59,10 @@ pub struct ClusterRepositorySpec {
     /// What to do when the repository does not yet exist (absent means it must already exist).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub create: Option<CreateBehavior>,
+    /// Tuning for the one-shot bootstrap Job that connects/creates an object-store
+    /// repository the operator cannot reach in-process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap: Option<BootstrapSpec>,
     /// Base mover configuration inherited by every mover this repository spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover_defaults: Option<MoverDefaults>,

--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -145,11 +145,17 @@ pub struct CredentialProjection {
 }
 
 /// Behavior when the repository does not yet exist.
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateBehavior {
-    /// Create the repository if it does not exist yet; off by default.
-    #[serde(default)]
+    /// Create the repository if it does not exist yet — on by default. Repository
+    /// create/connect is idempotent: pointing `create` at an already-initialized
+    /// repository just connects to it (it never re-creates or clobbers), so the
+    /// only effect of the default is that a genuinely-absent repository is
+    /// bootstrapped instead of erroring. Set `false` for a strictly read-only or
+    /// externally-managed repository the operator must never create.
+    #[serde(default = "default_true")]
+    #[schemars(default = "default_true")]
     pub enabled: bool,
     /// kopia encryption algorithm for a freshly-created repository (creation-time only).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -163,6 +169,39 @@ pub struct CreateBehavior {
     /// Reed-Solomon ECC parity for a freshly-created repository (creation-time only, immutable after).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ecc: Option<Ecc>,
+}
+
+impl Default for CreateBehavior {
+    /// Mirrors the serde/schema default: create-on-first-use is on.
+    fn default() -> Self {
+        CreateBehavior {
+            enabled: true,
+            encryption: None,
+            splitter: None,
+            hash: None,
+            ecc: None,
+        }
+    }
+}
+
+/// Whether the operator should create the repository when it does not yet exist.
+///
+/// Pure resolver shared by the controller and tests so the "absent means create"
+/// default cannot fork: an absent `spec.create` resolves to `true` (create on
+/// first use), and an explicit `create.enabled` is honored as written. Repository
+/// create/connect is idempotent, so create-on is the least-surprise default; set
+/// `create.enabled: false` to opt out.
+///
+/// ```
+/// use kopiur_api::common::{create_enabled, CreateBehavior};
+///
+/// assert!(create_enabled(None)); // absent → create on
+/// assert!(create_enabled(Some(&CreateBehavior::default())));
+/// let off = CreateBehavior { enabled: false, ..CreateBehavior::default() };
+/// assert!(!create_enabled(Some(&off)));
+/// ```
+pub fn create_enabled(create: Option<&CreateBehavior>) -> bool {
+    create.map(|c| c.enabled).unwrap_or(true)
 }
 
 /// Reed-Solomon error-correcting-code parity for a freshly-created repository.
@@ -305,16 +344,7 @@ pub struct ObjectRef {
 }
 
 /// Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-///
-/// ```
-/// use kopiur_api::common::DeletionPolicy;
-///
-/// // Produced backups default to deleting the snapshot with the CR.
-/// assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-/// // Variants serialize to their bare PascalCase names (plain string enum).
-/// assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-/// assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-/// ```
+/// Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum DeletionPolicy {
     /// Finalizer runs `kopia snapshot delete <id>` then removes the finalizer; default for produced snapshots.

--- a/crates/api/src/creds.rs
+++ b/crates/api/src/creds.rs
@@ -23,6 +23,7 @@ pub fn backend_auth_secret_ref(backend: &Backend) -> Option<&crate::common::Secr
         Backend::Sftp(b) => b.auth.as_ref().and_then(|a| a.secret_ref.as_ref()),
         Backend::WebDav(b) => b.auth.as_ref().and_then(|a| a.secret_ref.as_ref()),
         Backend::Rclone(b) => b.config_secret_ref.as_ref(),
+        Backend::Gdrive(b) => b.credentials_secret_ref.as_ref(),
         Backend::Filesystem(_) => None,
     }
 }
@@ -71,6 +72,7 @@ pub fn backend_workload_identity(
         | Backend::Sftp(_)
         | Backend::WebDav(_)
         | Backend::Rclone(_)
+        | Backend::Gdrive(_)
         | Backend::Filesystem(_) => None,
     }
 }

--- a/crates/api/src/maintenance.rs
+++ b/crates/api/src/maintenance.rs
@@ -98,18 +98,8 @@ pub struct Ownership {
     pub takeover_policy: TakeoverPolicy,
 }
 
-/// What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-///
-/// ```
-/// use kopiur_api::TakeoverPolicy;
-///
-/// // The safest default: never seize a lease another owner holds.
-/// assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-/// assert_eq!(
-///     serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-///     serde_json::json!("PromptCondition"),
-/// );
-/// ```
+/// What to do when another owner already holds the lease. Defaults to `Never`
+/// (the safest: never seize a lease another owner holds).
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum TakeoverPolicy {
     /// Never take over a lease another owner holds (default, safest).
@@ -347,17 +337,8 @@ pub struct MaintenanceStatus {
     pub manual_run: Option<ManualRunStatus>,
 }
 
-/// Which maintenance kind a manual (annotation-requested) run performs. Closed
-/// enum; the wire values are the `run-mode` annotation values.
-///
-/// ```
-/// use kopiur_api::maintenance::ManualRunMode;
-///
-/// assert_eq!(ManualRunMode::default(), ManualRunMode::Quick);
-/// assert_eq!(ManualRunMode::parse("full"), Some(ManualRunMode::Full));
-/// assert_eq!(ManualRunMode::parse("FULL"), None); // exact, lowercase
-/// assert_eq!(serde_json::to_value(ManualRunMode::Quick).unwrap(), "quick");
-/// ```
+/// Which maintenance kind a manual (annotation-requested) run performs; the wire
+/// values are the `run-mode` annotation values. Defaults to `quick`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum ManualRunMode {
@@ -696,5 +677,14 @@ failurePolicy:
             "Force"
         );
         assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
+    }
+
+    #[test]
+    fn manual_run_mode_parses_exact_lowercase_and_defaults_to_quick() {
+        assert_eq!(ManualRunMode::default(), ManualRunMode::Quick);
+        assert_eq!(ManualRunMode::parse("quick"), Some(ManualRunMode::Quick));
+        assert_eq!(ManualRunMode::parse("full"), Some(ManualRunMode::Full));
+        assert_eq!(ManualRunMode::parse("FULL"), None); // exact, lowercase only
+        assert_eq!(serde_json::to_value(ManualRunMode::Quick).unwrap(), "quick");
     }
 }

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -2,7 +2,7 @@
 
 use crate::backend::Backend;
 use crate::common::{
-    CatalogBounds, CreateBehavior, Encryption, MoverDefaults, NamespaceDeletePolicy,
+    CatalogBounds, CreateBehavior, Encryption, FailurePolicy, MoverDefaults, NamespaceDeletePolicy,
     RepositoryMode, default_namespace_delete_policy, default_repository_mode,
 };
 use crate::maintenance::RepositoryMaintenanceSpec;
@@ -55,6 +55,10 @@ pub struct RepositorySpec {
     /// What to do when the repository does not yet exist (absent means it must already exist).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub create: Option<CreateBehavior>,
+    /// Tuning for the one-shot bootstrap Job that connects/creates an object-store
+    /// repository the operator cannot reach in-process.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap: Option<BootstrapSpec>,
     /// Base mover configuration inherited by every mover this repository spawns.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mover_defaults: Option<MoverDefaults>,
@@ -81,6 +85,22 @@ pub struct RepositorySpec {
     /// Repository health thresholds (tunes the index-blob-count warning).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub health: Option<RepositoryHealthSpec>,
+}
+
+/// Tuning for the one-shot bootstrap Job, shared by `Repository` and
+/// `ClusterRepository`. Bootstrap connects (or, with `create`, creates) an
+/// object-store repository the operator cannot reach in-process.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BootstrapSpec {
+    /// Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+    /// a connect may run before the Job is marked failed (default 120s); raise it
+    /// for a slow backend — e.g. an rclone remote whose repository metadata and
+    /// indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+    /// `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+    /// shape parity but is not honored by the bootstrap Job.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub failure_policy: Option<FailurePolicy>,
 }
 
 /// Repository health thresholds, shared by `Repository` and `ClusterRepository`.
@@ -116,20 +136,7 @@ pub fn resolve_index_blob_warn_threshold(health: Option<&RepositoryHealthSpec>) 
         .unwrap_or(crate::consts::DEFAULT_INDEX_BLOB_WARN_THRESHOLD)
 }
 
-/// Lifecycle phase of a repository. ADR §3.1 status.
-///
-/// A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-///
-/// ```
-/// use kopiur_api::repository::RepositoryPhase;
-///
-/// assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-/// // Serializes as a bare string (closed unit enum).
-/// assert_eq!(
-///     serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-///     serde_json::json!("Ready")
-/// );
-/// ```
+/// Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum RepositoryPhase {
     /// Accepted by the API server but not yet reconciled.
@@ -267,6 +274,35 @@ suspend: true
         assert_eq!(json["suspend"], true);
         let reparsed: RepositorySpec = serde_json::from_value(json).expect("reparse");
         assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn bootstrap_failure_policy_round_trips() {
+        let spec: RepositorySpec = from_yaml(
+            r#"
+backend: { rclone: { remotePath: "mydrive:backups", startupTimeout: 2m } }
+encryption: { passwordSecretRef: { name: s } }
+bootstrap:
+  failurePolicy:
+    activeDeadlineSeconds: 600
+    backoffLimit: 1
+"#,
+        );
+        let fp = spec
+            .bootstrap
+            .as_ref()
+            .and_then(|b| b.failure_policy.as_ref())
+            .expect("bootstrap.failurePolicy");
+        assert_eq!(fp.active_deadline_seconds, Some(600));
+        assert_eq!(fp.backoff_limit, Some(1));
+        // Absent bootstrap stays None.
+        let bare: RepositorySpec = from_yaml(
+            r#"
+backend: { filesystem: { path: /repo } }
+encryption: { passwordSecretRef: { name: s } }
+"#,
+        );
+        assert!(bare.bootstrap.is_none());
     }
 
     #[test]

--- a/crates/api/src/repository_replication.rs
+++ b/crates/api/src/repository_replication.rs
@@ -53,17 +53,7 @@ pub struct RepositoryReplicationSpec {
     pub suspend: bool,
 }
 
-/// Lifecycle phase of a replication. Closed enum. ADR-0005 §13(d).
-///
-/// ```
-/// use kopiur_api::repository_replication::RepositoryReplicationPhase;
-///
-/// assert_eq!(RepositoryReplicationPhase::default(), RepositoryReplicationPhase::Pending);
-/// assert_eq!(
-///     serde_json::to_value(RepositoryReplicationPhase::Replicating).unwrap(),
-///     "Replicating"
-/// );
-/// ```
+/// Lifecycle phase of a replication.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum RepositoryReplicationPhase {
     /// Admitted, not yet run (also the default).

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -231,15 +231,9 @@ pub struct RestorePolicy {
     pub wait_timeout: Option<String>,
 }
 
-/// What to do when the resolved source matches no snapshot. Closed enum. ADR §4.6 (G7).
-///
-/// ```
-/// use kopiur_api::restore::OnMissingSnapshot;
-///
-/// // Fail-closed is the default so an explicit restore can't silently no-op.
-/// assert_eq!(OnMissingSnapshot::default(), OnMissingSnapshot::Fail);
-/// assert_eq!(serde_json::to_value(OnMissingSnapshot::Continue).unwrap(), "Continue");
-/// ```
+/// What to do when the resolved source matches no snapshot. Defaults to `Fail`
+/// (fail-closed) so an explicit restore can never silently no-op; choose
+/// `Continue` to provision an empty volume instead (deploy-or-restore).
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum OnMissingSnapshot {
     /// Fail-closed; the default for explicit `snapshotRef`/`identity` sources.

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -47,19 +47,10 @@ pub struct SnapshotSpec {
     pub pin: bool,
 }
 
-/// How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin`
-/// label. Closed enum. ADR §3.4.
-///
-/// Origin drives the deletion-policy default (ADR §4.5): `discovered` backups are
-/// forced to `Retain` because the operator did not create those snapshots.
-///
-/// ```
-/// use kopiur_api::Origin;
-///
-/// assert_eq!(Origin::default(), Origin::Scheduled);
-/// // Serializes camelCase, matching the `origin` label/status value.
-/// assert_eq!(serde_json::to_value(Origin::Discovered).unwrap(), "discovered");
-/// ```
+/// How a `Snapshot` came to exist. Canonical value mirrored from the
+/// `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy
+/// default: `discovered` backups are forced to `Retain` because the operator did
+/// not create those snapshots.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Origin {
@@ -72,17 +63,7 @@ pub enum Origin {
     Discovered,
 }
 
-/// Lifecycle phase of a `Snapshot`. Closed enum. ADR §3.4 status.
-///
-/// ```
-/// use kopiur_api::{SnapshotPhase, PhaseLabel};
-///
-/// assert_eq!(SnapshotPhase::default(), SnapshotPhase::Pending);
-/// // `PhaseLabel::label` gives the stable string used in status/metrics.
-/// assert_eq!(SnapshotPhase::Succeeded.label(), "Succeeded");
-/// // Every variant is enumerated for metric reset.
-/// assert_eq!(SnapshotPhase::ALL.len(), 6);
-/// ```
+/// Lifecycle phase of a `Snapshot`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum SnapshotPhase {
     /// Admitted, not yet started (also the default).
@@ -134,7 +115,7 @@ impl crate::common::PhaseLabel for SnapshotPhase {
     }
 }
 
-/// Observed state of a [`Snapshot`]. ADR §3.4 status.
+/// Observed state of a [`Snapshot`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct SnapshotStatus {

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -49,12 +49,14 @@ pub struct SnapshotPolicySpec {
     pub volume_snapshot_class_name: Option<String>,
     /// Multi-PVC consistency grouping; `None` opts into independent per-PVC snapshots.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(default = "default_group_by")]
     pub group_by: Option<GroupBy>,
     /// GFS retention, enforced by the operator pruning `Snapshot` CRs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention: Option<Retention>,
     /// Default `deletionPolicy` for `Snapshot` CRs created against this config.
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(default = "recipe_default_deletion_policy")]
     pub default_deletion_policy: Option<DeletionPolicy>,
     /// Compression algorithm + per-extension opt-outs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -115,6 +117,7 @@ pub struct Source {
     pub source_path_override: Option<String>,
     /// How a `pvcSelector`-matched PVC's source path is derived (`pvcName` vs `pvcNamespacedName`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(default = "default_source_path_strategy")]
     pub source_path_strategy: Option<SourcePathStrategy>,
 }
 
@@ -186,18 +189,9 @@ pub enum CopyMethod {
     Direct,
 }
 
-/// Multi-PVC grouping strategy. Closed enum. ADR §4.9.
-///
-/// Defaults to a consistent group snapshot; `None` must be set *explicitly* to
-/// accept independent per-PVC snapshots, because a silent per-PVC fallback would
-/// produce inconsistent backups (the data-integrity hazard ADR §4.9 guards against).
-///
-/// ```
-/// use kopiur_api::GroupBy;
-///
-/// assert_eq!(GroupBy::default(), GroupBy::VolumeGroupSnapshot);
-/// assert_eq!(serde_json::to_value(GroupBy::None).unwrap(), "None");
-/// ```
+/// Multi-PVC grouping strategy. Defaults to a consistent group snapshot across
+/// all PVCs; set `None` *explicitly* to accept independent per-PVC snapshots,
+/// because a silent per-PVC fallback would produce inconsistent backups.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum GroupBy {
     /// Consistent group snapshot across all PVCs (default for multi-PVC).
@@ -207,20 +201,16 @@ pub enum GroupBy {
     None,
 }
 
-/// How a selector-matched PVC's source path is derived. Closed enum. ADR §3.3/§4.2.
-///
-/// Only relevant for `pvcSelector` sources, where one recipe expands to many PVCs
-/// and each needs a distinct kopia source path.
-///
-/// ```
-/// use kopiur_api::SourcePathStrategy;
-///
-/// assert_eq!(SourcePathStrategy::default(), SourcePathStrategy::PvcName);
-/// assert_eq!(
-///     serde_json::to_value(SourcePathStrategy::PvcNamespacedName).unwrap(),
-///     "PvcNamespacedName"
-/// );
-/// ```
+/// schemars default for `PvcSnapshotPolicy::group_by` — the consistent group
+/// snapshot. Returns the field's `Option` type so schemars emits the schema
+/// `default:` (`VolumeGroupSnapshot`) for `kubectl explain`.
+fn default_group_by() -> Option<GroupBy> {
+    Some(GroupBy::VolumeGroupSnapshot)
+}
+
+/// How a selector-matched PVC's source path is derived. Only relevant for
+/// `pvcSelector` sources, where one recipe expands to many PVCs and each needs a
+/// distinct kopia source path. Defaults to `PvcName`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 pub enum SourcePathStrategy {
     /// Path derived from the PVC name alone (default).
@@ -228,6 +218,19 @@ pub enum SourcePathStrategy {
     PvcName,
     /// Path derived from `<namespace>/<name>` to disambiguate same-named PVCs across namespaces.
     PvcNamespacedName,
+}
+
+/// schemars default for `PvcSnapshotPolicy::source_path_strategy` — `PvcName`.
+/// Returns the field's `Option` type so schemars emits the schema `default:`.
+fn default_source_path_strategy() -> Option<SourcePathStrategy> {
+    Some(SourcePathStrategy::PvcName)
+}
+
+/// schemars default for `PvcSnapshotPolicy::default_deletion_policy` — `Delete`,
+/// the deletion policy produced `Snapshot` CRs inherit. Returns the field's
+/// `Option` type so schemars emits the schema `default:`.
+fn recipe_default_deletion_policy() -> Option<crate::common::DeletionPolicy> {
+    Some(crate::common::DeletionPolicy::Delete)
 }
 
 /// Compression policy.
@@ -328,30 +331,9 @@ pub struct Hooks {
     pub after_snapshot: Vec<Hook>,
 }
 
-/// One of three hook forms. ADR §4.8.
-///
-/// Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-/// or `{ httpRequest: {...} }`. Exactly one variant by construction.
-///
-/// Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-///
-/// ```
-/// use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-///
-/// // Construct directly — the type system guarantees exactly one variant.
-/// let hook = Hook::HttpRequest(HttpRequestHook {
-///     url: "https://example/notify".into(),
-///     method: Some("POST".into()),
-///     body: None,
-///     timeout: None,
-///     continue_on_failure: false,
-/// });
-/// assert_eq!(hook.kind_str(), "HttpRequest");
-///
-/// // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-/// let json = serde_json::to_value(&hook).unwrap();
-/// assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-/// ```
+/// One of three hook forms. Externally-tagged: the wire shape is
+/// `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+/// and exactly one form is present.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub enum Hook {

--- a/crates/api/src/validate/backend.rs
+++ b/crates/api/src/validate/backend.rs
@@ -102,7 +102,28 @@ pub fn validate_backend(backend: &crate::backend::Backend) -> ValidationResult {
             Some(auth) => validate_backend_auth(auth, "gcs backend"),
             None => Ok(()),
         },
-        Backend::B2(_) | Backend::Sftp(_) | Backend::WebDav(_) | Backend::Rclone(_) => Ok(()),
+        Backend::Rclone(r) => {
+            // kopia's `--rclone-startup-timeout` takes a Go duration; reject a
+            // malformed value at admission instead of failing every connect.
+            if let Some(t) = &r.startup_timeout
+                && crate::duration::parse_go_duration(t).is_none()
+            {
+                return Err(ValidationError::InvalidFieldValue {
+                    field: "rclone backend startupTimeout".to_string(),
+                    reason: format!("must be a Go duration like \"30s\" or \"2m\" (got {t:?})"),
+                });
+            }
+            Ok(())
+        }
+        Backend::Gdrive(g) => {
+            if g.folder_id.trim().is_empty() {
+                return Err(ValidationError::MissingRequiredField {
+                    field: "gdrive backend folderId".to_string(),
+                });
+            }
+            Ok(())
+        }
+        Backend::B2(_) | Backend::Sftp(_) | Backend::WebDav(_) => Ok(()),
     }
 }
 

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -295,7 +295,7 @@ fn diff_immutable_repo_fields(
 /// #         backend: Backend::Filesystem(FilesystemBackend { path: "/r".into(), volume: None }),
 /// #         encryption: Encryption { password_secret_ref: SecretKeyRef { name: "s".into(), namespace: None, key: None } },
 /// #         create: Some(CreateBehavior { enabled: true, encryption: None, splitter: splitter.map(String::from), hash: None, ecc: None }),
-/// #         mover_defaults: None, catalog: None, server: None, maintenance: None, on_namespace_delete: Default::default(), mode: Default::default(), suspend: false, health: None,
+/// #         bootstrap: None, mover_defaults: None, catalog: None, server: None, maintenance: None, on_namespace_delete: Default::default(), mode: Default::default(), suspend: false, health: None,
 /// #     }
 /// # }
 /// // Unchanged splitter → accepted.
@@ -344,6 +344,12 @@ pub fn validate_repository(spec: &RepositorySpec) -> Vec<ValidationError> {
         errs.extend(validate_server(server, spec.mode));
     }
     if let Err(e) = validate_repository_health(spec.health.as_ref(), "Repository") {
+        errs.push(e);
+    }
+    if let Some(b) = &spec.bootstrap
+        && let Some(fp) = &b.failure_policy
+        && let Err(e) = validate_failure_policy(fp, "Repository spec.bootstrap")
+    {
         errs.push(e);
     }
     errs
@@ -540,6 +546,7 @@ fn backend_target_key(backend: &crate::backend::Backend) -> String {
         Backend::Sftp(s) => format!("{}:{}", s.host, s.path),
         Backend::WebDav(w) => w.url.clone(),
         Backend::Rclone(r) => r.remote_path.clone(),
+        Backend::Gdrive(g) => g.folder_id.clone(),
     };
     format!("{kind}:{target}")
 }
@@ -632,6 +639,12 @@ pub fn validate_cluster_repository(spec: &ClusterRepositorySpec) -> Vec<Validati
         errs.extend(validate_server(&server.server, spec.mode));
     }
     if let Err(e) = validate_repository_health(spec.health.as_ref(), "ClusterRepository") {
+        errs.push(e);
+    }
+    if let Some(b) = &spec.bootstrap
+        && let Some(fp) = &b.failure_policy
+        && let Err(e) = validate_failure_policy(fp, "ClusterRepository spec.bootstrap")
+    {
         errs.push(e);
     }
     errs

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -312,6 +312,36 @@ fn filesystem_pvc_and_object_backends_need_no_content_check() {
     assert!(validate_backend(&s3).is_ok());
 }
 
+#[test]
+fn gdrive_requires_a_folder_id() {
+    use crate::backend::{Backend, GdriveBackend};
+    let ok = Backend::Gdrive(GdriveBackend {
+        folder_id: "0ABC".into(),
+        credentials_secret_ref: None,
+    });
+    assert!(validate_backend(&ok).is_ok());
+    let empty = Backend::Gdrive(GdriveBackend {
+        folder_id: "  ".into(),
+        credentials_secret_ref: None,
+    });
+    assert!(validate_backend(&empty).is_err());
+}
+
+#[test]
+fn rclone_startup_timeout_must_be_a_go_duration() {
+    use crate::backend::{Backend, RcloneBackend};
+    let mk = |t: Option<&str>| {
+        Backend::Rclone(RcloneBackend {
+            remote_path: "r:bucket".into(),
+            config_secret_ref: None,
+            startup_timeout: t.map(str::to_string),
+        })
+    };
+    assert!(validate_backend(&mk(Some("2m"))).is_ok());
+    assert!(validate_backend(&mk(None)).is_ok());
+    assert!(validate_backend(&mk(Some("soon"))).is_err());
+}
+
 // --- validate_backend_auth / workload identity ---
 
 fn s3_with_auth(auth: Option<crate::backend::BackendAuth>) -> crate::backend::Backend {
@@ -1005,6 +1035,7 @@ fn repository_inline_retention_hook_passes_today() {
             },
         },
         create: None,
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1251,6 +1282,7 @@ fn repo_spec_with_maintenance(m: Option<RepositoryMaintenanceSpec>) -> Repositor
             },
         },
         create: None,
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1343,6 +1375,7 @@ fn cluster_repository_rejects_all_false() {
             },
         },
         create: None,
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1376,6 +1409,7 @@ fn cluster_repository_rejects_bad_identity_expr() {
             },
         },
         create: None,
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1429,6 +1463,7 @@ fn repo_spec_create(
             hash: hash.map(String::from),
             ecc: None,
         }),
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1484,6 +1519,7 @@ fn cluster_repository_immutability_allows_changed_password_secret_ref() {
             hash: None,
             ecc: None,
         }),
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,
@@ -1579,6 +1615,7 @@ fn cluster_repository_immutability_rejects_changed_splitter() {
             hash: None,
             ecc: None,
         }),
+        bootstrap: None,
         mover_defaults: None,
         catalog: None,
         server: None,

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -238,12 +238,7 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
                 .repository_connect(&spec, kopiur_kopia::CacheTuning::default())
                 .await
             {
-                let create_enabled = repo
-                    .spec
-                    .create
-                    .as_ref()
-                    .map(|c| c.enabled)
-                    .unwrap_or(false);
+                let create_enabled = kopiur_api::common::create_enabled(repo.spec.create.as_ref());
                 // Try create-then-connect when enabled and the failure isn't
                 // "repo already there" (auth/locked); otherwise the connect error
                 // is terminal. A terminal failure (connect OR a failed create)
@@ -712,12 +707,7 @@ async fn bootstrap_cluster_via_mover(
         )));
     }
 
-    let create_enabled = repo
-        .spec
-        .create
-        .as_ref()
-        .map(|c| c.enabled)
-        .unwrap_or(false);
+    let create_enabled = kopiur_api::common::create_enabled(repo.spec.create.as_ref());
     let work_spec = cluster_bootstrap_work_spec(
         backend,
         name,
@@ -768,6 +758,13 @@ async fn bootstrap_cluster_via_mover(
             mount_path: io::filesystem_repo_path(backend).unwrap_or_default(),
             read_only: false,
         });
+    // spec.bootstrap.failurePolicy lets callers raise the deadline for a slow
+    // backend or tune the retry budget; unset keeps the built-in defaults.
+    let bootstrap_fp = repo
+        .spec
+        .bootstrap
+        .as_ref()
+        .and_then(|b| b.failure_policy.as_ref());
     let inputs = MoverJobInputs {
         name: &job_name,
         namespace: &job_ns,
@@ -779,9 +776,15 @@ async fn bootstrap_cluster_via_mover(
         // image-pull failure) becomes terminal-`Failed` instead of hanging — then
         // `finalize_cluster_bootstrap` runs and surfaces a Warning Event.
         limits: JobLimits {
-            active_deadline_seconds: Some(BOOTSTRAP_JOB_DEADLINE_SECS),
+            active_deadline_seconds: Some(
+                bootstrap_fp
+                    .and_then(|fp| fp.active_deadline_seconds)
+                    .unwrap_or(BOOTSTRAP_JOB_DEADLINE_SECS),
+            ),
+            backoff_limit: bootstrap_fp
+                .and_then(|fp| fp.backoff_limit)
+                .unwrap_or(JobLimits::default().backoff_limit),
             ttl_seconds_after_finished: resolved_mover.ttl_seconds_after_finished,
-            ..JobLimits::default()
         },
         resources: resolved_mover.resources.clone(),
         security_context: resolved_mover.security_context.clone(),

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -218,12 +218,7 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
                 .repository_connect(&spec, kopiur_kopia::CacheTuning::default())
                 .await
             {
-                let create_enabled = repo
-                    .spec
-                    .create
-                    .as_ref()
-                    .map(|c| c.enabled)
-                    .unwrap_or(false);
+                let create_enabled = kopiur_api::common::create_enabled(repo.spec.create.as_ref());
                 // Try create-then-connect when enabled and the failure isn't
                 // "repo already there" (auth/locked); otherwise the connect error
                 // is terminal. A terminal failure (connect OR a failed create)
@@ -646,12 +641,7 @@ async fn bootstrap_via_mover(
 
     // Build + apply the Job (ConfigMap carries the work spec; the result is
     // written back into the same ConfigMap under `result.json`).
-    let create_enabled = repo
-        .spec
-        .create
-        .as_ref()
-        .map(|c| c.enabled)
-        .unwrap_or(false);
+    let create_enabled = kopiur_api::common::create_enabled(repo.spec.create.as_ref());
     let work_spec = bootstrap_work_spec(
         backend,
         name,
@@ -736,6 +726,15 @@ async fn bootstrap_via_mover(
         None,
         None,
     );
+    // spec.bootstrap.failurePolicy lets callers raise the deadline for a slow
+    // backend (e.g. an rclone remote whose connect loads metadata through the
+    // rclone/WebDAV bridge) or tune the retry budget; unset keeps the built-in
+    // bootstrap defaults.
+    let bootstrap_fp = repo
+        .spec
+        .bootstrap
+        .as_ref()
+        .and_then(|b| b.failure_policy.as_ref());
     let inputs = MoverJobInputs {
         name: &job_name,
         namespace,
@@ -748,9 +747,15 @@ async fn bootstrap_via_mover(
         // controller never finalizes and the repository hangs `Initializing` with
         // no Event. The deadline forces it terminal so `finalize_bootstrap` runs.
         limits: JobLimits {
-            active_deadline_seconds: Some(BOOTSTRAP_JOB_DEADLINE_SECS),
+            active_deadline_seconds: Some(
+                bootstrap_fp
+                    .and_then(|fp| fp.active_deadline_seconds)
+                    .unwrap_or(BOOTSTRAP_JOB_DEADLINE_SECS),
+            ),
+            backoff_limit: bootstrap_fp
+                .and_then(|fp| fp.backoff_limit)
+                .unwrap_or(JobLimits::default().backoff_limit),
             ttl_seconds_after_finished: resolved_mover.ttl_seconds_after_finished,
-            ..JobLimits::default()
         },
         resources: resolved_mover.resources.clone(),
         security_context: resolved_mover.security_context.clone(),

--- a/crates/controller/tests/integration.rs
+++ b/crates/controller/tests/integration.rs
@@ -85,6 +85,7 @@ fn sample_repository(name: &str) -> Repository {
                 },
             },
             create: None,
+            bootstrap: None,
             mover_defaults: None,
             catalog: None,
             maintenance: None,

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -161,11 +161,19 @@ pub enum ConnectSpec {
         /// `--rclone-args=--config=<path>`. The mover materializes this from the
         /// config Secret at runtime; `None` uses rclone's default config lookup.
         config_file: Option<String>,
+        /// Go-duration value for kopia's `--rclone-startup-timeout` (how long to
+        /// wait for the embedded `rclone serve` to come up). `None` leaves kopia's
+        /// default (`15s`).
+        startup_timeout: Option<String>,
     },
     /// Google Drive backend.
     Gdrive {
         /// Drive folder id that holds the repository.
         folder_id: String,
+        /// Path to a Google service-account JSON inside the mover pod, passed as
+        /// `--credentials-file`. The mover materializes this from the credentials
+        /// Secret at runtime; `None` uses kopia's ambient credential lookup.
+        credentials_file: Option<String>,
     },
     /// Reconnect from a kopia configuration token/file (`repository connect
     /// from-config`). Exactly one of `file`/`token` is meaningful.
@@ -365,6 +373,7 @@ impl ConnectSpec {
             ConnectSpec::Rclone {
                 remote_path,
                 config_file,
+                startup_timeout,
             } => {
                 let mut a = vec!["rclone".into(), "--remote-path".into(), remote_path.clone()];
                 // Forward the rclone config path to the embedded rclone. Must be a
@@ -374,10 +383,20 @@ impl ConnectSpec {
                 if let Some(cfg) = config_file {
                     a.push(format!("--rclone-args=--config={cfg}"));
                 }
+                // kopia's own connect flag (not an rclone arg): how long to wait
+                // for the embedded `rclone serve` before failing the connect.
+                if let Some(t) = startup_timeout {
+                    a.push(format!("--rclone-startup-timeout={t}"));
+                }
                 a
             }
-            ConnectSpec::Gdrive { folder_id } => {
-                vec!["gdrive".into(), "--folder-id".into(), folder_id.clone()]
+            ConnectSpec::Gdrive {
+                folder_id,
+                credentials_file,
+            } => {
+                let mut a = vec!["gdrive".into(), "--folder-id".into(), folder_id.clone()];
+                opt(&mut a, "--credentials-file", credentials_file);
+                a
             }
             ConnectSpec::FromConfig { file, token } => {
                 let mut a = vec!["from-config".into()];

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -232,15 +232,18 @@ fn webdav_rclone_gdrive_backend_args() {
         ConnectSpec::Rclone {
             remote_path: "r:bucket".into(),
             config_file: None,
+            startup_timeout: None,
         }
         .backend_args(),
         vec!["rclone", "--remote-path", "r:bucket"]
     );
-    // The materialized rclone.conf path is forwarded to rclone via --rclone-args.
+    // The materialized rclone.conf path is forwarded to rclone via --rclone-args,
+    // and the startup timeout is kopia's own connect flag (not an rclone arg).
     assert_eq!(
         ConnectSpec::Rclone {
             remote_path: "r:bucket".into(),
             config_file: Some("/var/cache/kopia/creds/rclone.conf".into()),
+            startup_timeout: Some("2m".into()),
         }
         .backend_args(),
         vec![
@@ -248,15 +251,32 @@ fn webdav_rclone_gdrive_backend_args() {
             "--remote-path",
             "r:bucket",
             // One token: a separate `--config=…` value would be misparsed as a flag.
-            "--rclone-args=--config=/var/cache/kopia/creds/rclone.conf"
+            "--rclone-args=--config=/var/cache/kopia/creds/rclone.conf",
+            "--rclone-startup-timeout=2m"
         ]
     );
     assert_eq!(
         ConnectSpec::Gdrive {
-            folder_id: "fid".into()
+            folder_id: "fid".into(),
+            credentials_file: None,
         }
         .backend_args(),
         vec!["gdrive", "--folder-id", "fid"]
+    );
+    // The materialized service-account JSON path is passed via --credentials-file.
+    assert_eq!(
+        ConnectSpec::Gdrive {
+            folder_id: "fid".into(),
+            credentials_file: Some("/var/cache/kopia/creds/gdrive-credentials.json".into()),
+        }
+        .backend_args(),
+        vec![
+            "gdrive",
+            "--folder-id",
+            "fid",
+            "--credentials-file",
+            "/var/cache/kopia/creds/gdrive-credentials.json"
+        ]
     );
 }
 
@@ -367,9 +387,11 @@ fn kind_str_covers_every_variant() {
         ConnectSpec::Rclone {
             remote_path: "r".into(),
             config_file: None,
+            startup_timeout: None,
         },
         ConnectSpec::Gdrive {
             folder_id: "f".into(),
+            credentials_file: None,
         },
         ConnectSpec::FromConfig {
             file: None,

--- a/crates/mover/src/credentials.rs
+++ b/crates/mover/src/credentials.rs
@@ -42,6 +42,9 @@ pub const SFTP_KNOWN_HOSTS_ENV: &str = "KOPIA_SFTP_KNOWN_HOSTS";
 pub const GCS_CREDENTIALS_ENV: &str = "KOPIA_GCS_CREDENTIALS";
 /// rclone `rclone.conf` contents, read from the config Secret → rclone `--config`.
 pub const RCLONE_CONFIG_ENV: &str = "KOPIA_RCLONE_CONFIG";
+/// Google Drive service-account key JSON, read from the credentials Secret →
+/// `--credentials-file`.
+pub const GDRIVE_CREDENTIALS_ENV: &str = "KOPIA_GDRIVE_CREDENTIALS";
 
 /// Filenames written under the staging dir. Stable so the (single-op) mover pod
 /// is deterministic and the paths are easy to reason about in logs.
@@ -49,6 +52,7 @@ const SFTP_KEY_FILE: &str = "sftp_key";
 const SFTP_KNOWN_HOSTS_FILE: &str = "known_hosts";
 const GCS_CREDS_FILE: &str = "gcs-credentials.json";
 const RCLONE_CONF_FILE: &str = "rclone.conf";
+const GDRIVE_CREDS_FILE: &str = "gdrive-credentials.json";
 
 /// Write any file-based backend credentials present in the environment into
 /// `staging_dir`, pointing the matching [`ConnectSpec`] field at the written
@@ -107,6 +111,18 @@ pub fn materialize_with(
                 *config_file = Some(path);
             }
         }
+        ConnectSpec::Gdrive {
+            credentials_file, ..
+        } => {
+            if let Some(path) = write_cred_file(
+                GDRIVE_CREDENTIALS_ENV,
+                staging_dir,
+                GDRIVE_CREDS_FILE,
+                lookup,
+            )? {
+                *credentials_file = Some(path);
+            }
+        }
         ConnectSpec::S3 {
             ambient_credentials,
             ..
@@ -134,7 +150,6 @@ pub fn materialize_with(
         | ConnectSpec::Azure { .. }
         | ConnectSpec::B2 { .. }
         | ConnectSpec::WebDav { .. }
-        | ConnectSpec::Gdrive { .. }
         | ConnectSpec::FromConfig { .. }
         | ConnectSpec::Server { .. } => {}
     }
@@ -325,6 +340,7 @@ mod tests {
         let mut spec = ConnectSpec::Rclone {
             remote_path: "remote:bucket".into(),
             config_file: None,
+            startup_timeout: None,
         };
         materialize(&mut spec, &dir).expect("materialize rclone");
         match &spec {
@@ -335,6 +351,34 @@ mod tests {
             other => panic!("expected rclone config_file, got {other:?}"),
         }
         unsafe { std::env::remove_var(RCLONE_CONFIG_ENV) };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn gdrive_materializes_credentials_file() {
+        let _g = ENV_LOCK.lock().unwrap();
+        let dir = tmp();
+        unsafe { std::env::set_var(GDRIVE_CREDENTIALS_ENV, "{\"type\":\"service_account\"}") };
+        let mut spec = ConnectSpec::Gdrive {
+            folder_id: "fid".into(),
+            credentials_file: None,
+        };
+        materialize(&mut spec, &dir).expect("materialize gdrive");
+        match &spec {
+            ConnectSpec::Gdrive {
+                credentials_file: Some(p),
+                ..
+            } => {
+                assert_eq!(
+                    std::fs::read_to_string(p).unwrap(),
+                    "{\"type\":\"service_account\"}"
+                );
+                let mode = std::fs::metadata(p).unwrap().permissions().mode() & 0o777;
+                assert_eq!(mode, 0o600, "credential file must be 0600, got {mode:o}");
+            }
+            other => panic!("expected gdrive credentials_file, got {other:?}"),
+        }
+        unsafe { std::env::remove_var(GDRIVE_CREDENTIALS_ENV) };
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/crates/mover/src/repo_meta.rs
+++ b/crates/mover/src/repo_meta.rs
@@ -60,7 +60,8 @@ pub fn backend_tls_ca_configmap(backend: &Backend) -> Option<&str> {
         | Backend::Filesystem(_)
         | Backend::Sftp(_)
         | Backend::WebDav(_)
-        | Backend::Rclone(_) => None,
+        | Backend::Rclone(_)
+        | Backend::Gdrive(_) => None,
     }
 }
 
@@ -117,6 +118,10 @@ pub fn backend_to_repository_connect(backend: &Backend) -> RepositoryConnect {
         Backend::WebDav(w) => RepositoryConnect::WebDav { url: w.url.clone() },
         Backend::Rclone(r) => RepositoryConnect::Rclone {
             remote_path: r.remote_path.clone(),
+            startup_timeout: r.startup_timeout.clone(),
+        },
+        Backend::Gdrive(g) => RepositoryConnect::Gdrive {
+            folder_id: g.folder_id.clone(),
         },
     }
 }
@@ -233,8 +238,8 @@ mod tests {
     #[test]
     fn every_backend_maps_to_a_repository_connect() {
         use kopiur_api::backend::{
-            AzureBackend, B2Backend, FilesystemBackend, GcsBackend, RcloneBackend, S3Backend,
-            SftpBackend, WebDavBackend,
+            AzureBackend, B2Backend, FilesystemBackend, GcsBackend, GdriveBackend, RcloneBackend,
+            S3Backend, SftpBackend, WebDavBackend,
         };
         let cases = vec![
             Backend::Filesystem(FilesystemBackend {
@@ -279,6 +284,11 @@ mod tests {
             Backend::Rclone(RcloneBackend {
                 remote_path: "r:bucket".into(),
                 config_secret_ref: None,
+                startup_timeout: None,
+            }),
+            Backend::Gdrive(GdriveBackend {
+                folder_id: "fid".into(),
+                credentials_secret_ref: None,
             }),
         ];
         // Each maps without panicking and converts cleanly to a kopia ConnectSpec

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -775,6 +775,15 @@ pub enum RepositoryConnect {
     Rclone {
         /// Rclone `remote:path`.
         remote_path: String,
+        /// Go-duration for kopia's `--rclone-startup-timeout`; `None` leaves
+        /// kopia's default (`15s`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        startup_timeout: Option<String>,
+    },
+    /// Google Drive backend (kopia native `gdrive`).
+    Gdrive {
+        /// Drive folder id that holds the repository.
+        folder_id: String,
     },
 }
 
@@ -791,6 +800,7 @@ impl RepositoryConnect {
             RepositoryConnect::Sftp { .. } => "Sftp",
             RepositoryConnect::WebDav { .. } => "WebDav",
             RepositoryConnect::Rclone { .. } => "Rclone",
+            RepositoryConnect::Gdrive { .. } => "Gdrive",
         }
     }
 
@@ -866,11 +876,21 @@ impl RepositoryConnect {
                 known_hosts: None,
             },
             RepositoryConnect::WebDav { url } => ConnectSpec::WebDav { url: url.clone() },
-            RepositoryConnect::Rclone { remote_path } => ConnectSpec::Rclone {
+            RepositoryConnect::Rclone {
+                remote_path,
+                startup_timeout,
+            } => ConnectSpec::Rclone {
                 remote_path: remote_path.clone(),
                 // rclone.conf is materialized by the mover from the config Secret
                 // at runtime (see `crate::credentials`).
                 config_file: None,
+                startup_timeout: startup_timeout.clone(),
+            },
+            RepositoryConnect::Gdrive { folder_id } => ConnectSpec::Gdrive {
+                folder_id: folder_id.clone(),
+                // The service-account JSON path is materialized by the mover from
+                // the credentials Secret at runtime (see `crate::credentials`).
+                credentials_file: None,
             },
         }
     }

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -426,10 +426,21 @@ fn object_store_backends_convert_and_roundtrip() {
         (
             RepositoryConnect::Rclone {
                 remote_path: "r:bucket".into(),
+                startup_timeout: Some("2m".into()),
             },
             ConnectSpec::Rclone {
                 remote_path: "r:bucket".into(),
                 config_file: None,
+                startup_timeout: Some("2m".into()),
+            },
+        ),
+        (
+            RepositoryConnect::Gdrive {
+                folder_id: "fid".into(),
+            },
+            ConnectSpec::Gdrive {
+                folder_id: "fid".into(),
+                credentials_file: None,
             },
         ),
     ];

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -62,6 +63,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -224,6 +227,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -249,6 +282,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -403,6 +444,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -461,8 +535,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -968,18 +1048,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2332,21 +2402,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 38
 expression: "body(&artifacts, \"repositoryreplications\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -64,6 +65,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -226,6 +229,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -251,6 +284,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -915,18 +956,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a replication. Closed enum. ADR-0005 §13(d).
-
-                  ```
-                  use kopiur_api::repository_replication::RepositoryReplicationPhase;
-
-                  assert_eq!(RepositoryReplicationPhase::default(), RepositoryReplicationPhase::Pending);
-                  assert_eq!(
-                      serde_json::to_value(RepositoryReplicationPhase::Replicating).unwrap(),
-                      "Replicating"
-                  );
-                  ```
+                description: Lifecycle phase of a replication.
                 enum:
                 - Pending
                 - Replicating

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -43,16 +43,7 @@ spec:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -104,7 +95,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Observed state of a [`Snapshot`]. ADR §3.4 status.
+            description: Observed state of a [`Snapshot`].
             nullable: true
             properties:
               conditions:
@@ -207,19 +198,10 @@ spec:
                 type: integer
               origin:
                 description: |-
-                  How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin`
-                  label. Closed enum. ADR §3.4.
-
-                  Origin drives the deletion-policy default (ADR §4.5): `discovered` backups are
-                  forced to `Retain` because the operator did not create those snapshots.
-
-                  ```
-                  use kopiur_api::Origin;
-
-                  assert_eq!(Origin::default(), Origin::Scheduled);
-                  // Serializes camelCase, matching the `origin` label/status value.
-                  assert_eq!(serde_json::to_value(Origin::Discovered).unwrap(), "discovered");
-                  ```
+                  How a `Snapshot` came to exist. Canonical value mirrored from the
+                  `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy
+                  default: `discovered` backups are forced to `Retain` because the operator did
+                  not create those snapshots.
                 enum:
                 - scheduled
                 - manual
@@ -227,18 +209,7 @@ spec:
                 nullable: true
                 type: string
               phase:
-                description: |-
-                  Lifecycle phase of a `Snapshot`. Closed enum. ADR §3.4 status.
-
-                  ```
-                  use kopiur_api::{SnapshotPhase, PhaseLabel};
-
-                  assert_eq!(SnapshotPhase::default(), SnapshotPhase::Pending);
-                  // `PhaseLabel::label` gives the stable string used in status/metrics.
-                  assert_eq!(SnapshotPhase::Succeeded.label(), "Succeeded");
-                  // Every variant is enumerated for metric reset.
-                  assert_eq!(SnapshotPhase::ALL.len(), 6);
-                  ```
+                description: Lifecycle phase of a `Snapshot`.
                 enum:
                 - Pending
                 - Running

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -59,6 +59,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -221,6 +223,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -246,6 +278,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -400,6 +440,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -458,8 +531,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -965,18 +1044,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2329,21 +2398,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing
@@ -2540,6 +2595,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -2702,6 +2759,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -2727,6 +2814,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -2881,6 +2976,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -2939,8 +3067,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -3468,18 +3602,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -4843,21 +4967,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing
@@ -5014,18 +5124,10 @@ spec:
                     type: boolean
                 type: object
               defaultDeletionPolicy:
+                default: Delete
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -5068,19 +5170,11 @@ spec:
                     type: array
                 type: object
               groupBy:
+                default: VolumeGroupSnapshot
                 description: |-
-                  Multi-PVC grouping strategy. Closed enum. ADR §4.9.
-
-                  Defaults to a consistent group snapshot; `None` must be set *explicitly* to
-                  accept independent per-PVC snapshots, because a silent per-PVC fallback would
-                  produce inconsistent backups (the data-integrity hazard ADR §4.9 guards against).
-
-                  ```
-                  use kopiur_api::GroupBy;
-
-                  assert_eq!(GroupBy::default(), GroupBy::VolumeGroupSnapshot);
-                  assert_eq!(serde_json::to_value(GroupBy::None).unwrap(), "None");
-                  ```
+                  Multi-PVC grouping strategy. Defaults to a consistent group snapshot across
+                  all PVCs; set `None` *explicitly* to accept independent per-PVC snapshots,
+                  because a silent per-PVC fallback would produce inconsistent backups.
                 enum:
                 - VolumeGroupSnapshot
                 - None
@@ -5094,30 +5188,9 @@ spec:
                     description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -5225,30 +5298,9 @@ spec:
                     description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -5882,21 +5934,11 @@ spec:
                       nullable: true
                       type: string
                     sourcePathStrategy:
+                      default: PvcName
                       description: |-
-                        How a selector-matched PVC's source path is derived. Closed enum. ADR §3.3/§4.2.
-
-                        Only relevant for `pvcSelector` sources, where one recipe expands to many PVCs
-                        and each needs a distinct kopia source path.
-
-                        ```
-                        use kopiur_api::SourcePathStrategy;
-
-                        assert_eq!(SourcePathStrategy::default(), SourcePathStrategy::PvcName);
-                        assert_eq!(
-                            serde_json::to_value(SourcePathStrategy::PvcNamespacedName).unwrap(),
-                            "PvcNamespacedName"
-                        );
-                        ```
+                        How a selector-matched PVC's source path is derived. Only relevant for
+                        `pvcSelector` sources, where one recipe expands to many PVCs and each needs a
+                        distinct kopia source path. Defaults to `PvcName`.
                       enum:
                       - PvcName
                       - PvcNamespacedName
@@ -6160,16 +6202,7 @@ spec:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -6221,7 +6254,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Observed state of a [`Snapshot`]. ADR §3.4 status.
+            description: Observed state of a [`Snapshot`].
             nullable: true
             properties:
               conditions:
@@ -6324,19 +6357,10 @@ spec:
                 type: integer
               origin:
                 description: |-
-                  How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin`
-                  label. Closed enum. ADR §3.4.
-
-                  Origin drives the deletion-policy default (ADR §4.5): `discovered` backups are
-                  forced to `Retain` because the operator did not create those snapshots.
-
-                  ```
-                  use kopiur_api::Origin;
-
-                  assert_eq!(Origin::default(), Origin::Scheduled);
-                  // Serializes camelCase, matching the `origin` label/status value.
-                  assert_eq!(serde_json::to_value(Origin::Discovered).unwrap(), "discovered");
-                  ```
+                  How a `Snapshot` came to exist. Canonical value mirrored from the
+                  `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy
+                  default: `discovered` backups are forced to `Retain` because the operator did
+                  not create those snapshots.
                 enum:
                 - scheduled
                 - manual
@@ -6344,18 +6368,7 @@ spec:
                 nullable: true
                 type: string
               phase:
-                description: |-
-                  Lifecycle phase of a `Snapshot`. Closed enum. ADR §3.4 status.
-
-                  ```
-                  use kopiur_api::{SnapshotPhase, PhaseLabel};
-
-                  assert_eq!(SnapshotPhase::default(), SnapshotPhase::Pending);
-                  // `PhaseLabel::label` gives the stable string used in status/metrics.
-                  assert_eq!(SnapshotPhase::Succeeded.label(), "Succeeded");
-                  // Every variant is enumerated for metric reset.
-                  assert_eq!(SnapshotPhase::ALL.len(), 6);
-                  ```
+                description: Lifecycle phase of a `Snapshot`.
                 enum:
                 - Pending
                 - Running
@@ -7228,15 +7241,9 @@ spec:
                 properties:
                   onMissingSnapshot:
                     description: |-
-                      What to do when the resolved source matches no snapshot. Closed enum. ADR §4.6 (G7).
-
-                      ```
-                      use kopiur_api::restore::OnMissingSnapshot;
-
-                      // Fail-closed is the default so an explicit restore can't silently no-op.
-                      assert_eq!(OnMissingSnapshot::default(), OnMissingSnapshot::Fail);
-                      assert_eq!(serde_json::to_value(OnMissingSnapshot::Continue).unwrap(), "Continue");
-                      ```
+                      What to do when the resolved source matches no snapshot. Defaults to `Fail`
+                      (fail-closed) so an explicit restore can never silently no-op; choose
+                      `Continue` to provision an empty volume instead (deploy-or-restore).
                     enum:
                     - Fail
                     - Continue
@@ -8228,17 +8235,8 @@ spec:
                     type: string
                   mode:
                     description: |-
-                      Which maintenance kind a manual (annotation-requested) run performs. Closed
-                      enum; the wire values are the `run-mode` annotation values.
-
-                      ```
-                      use kopiur_api::maintenance::ManualRunMode;
-
-                      assert_eq!(ManualRunMode::default(), ManualRunMode::Quick);
-                      assert_eq!(ManualRunMode::parse("full"), Some(ManualRunMode::Full));
-                      assert_eq!(ManualRunMode::parse("FULL"), None); // exact, lowercase
-                      assert_eq!(serde_json::to_value(ManualRunMode::Quick).unwrap(), "quick");
-                      ```
+                      Which maintenance kind a manual (annotation-requested) run performs; the wire
+                      values are the `run-mode` annotation values. Defaults to `quick`.
                     enum:
                     - quick
                     - full
@@ -8374,6 +8372,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -8536,6 +8536,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -8561,6 +8591,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -9225,18 +9263,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a replication. Closed enum. ADR-0005 §13(d).
-
-                  ```
-                  use kopiur_api::repository_replication::RepositoryReplicationPhase;
-
-                  assert_eq!(RepositoryReplicationPhase::default(), RepositoryReplicationPhase::Pending);
-                  assert_eq!(
-                      serde_json::to_value(RepositoryReplicationPhase::Replicating).unwrap(),
-                      "Replicating"
-                  );
-                  ```
+                description: Lifecycle phase of a replication.
                 enum:
                 - Pending
                 - Replicating

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -111,6 +111,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -273,6 +275,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -298,6 +330,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -452,6 +492,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -510,8 +583,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -1039,18 +1118,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2414,21 +2483,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing

--- a/deploy/crds/maintenances.yaml
+++ b/deploy/crds/maintenances.yaml
@@ -604,17 +604,8 @@ spec:
                     type: string
                   mode:
                     description: |-
-                      Which maintenance kind a manual (annotation-requested) run performs. Closed
-                      enum; the wire values are the `run-mode` annotation values.
-
-                      ```
-                      use kopiur_api::maintenance::ManualRunMode;
-
-                      assert_eq!(ManualRunMode::default(), ManualRunMode::Quick);
-                      assert_eq!(ManualRunMode::parse("full"), Some(ManualRunMode::Full));
-                      assert_eq!(ManualRunMode::parse("FULL"), None); // exact, lowercase
-                      assert_eq!(serde_json::to_value(ManualRunMode::Quick).unwrap(), "quick");
-                      ```
+                      Which maintenance kind a manual (annotation-requested) run performs; the wire
+                      values are the `run-mode` annotation values. Defaults to `quick`.
                     enum:
                     - quick
                     - full

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -59,6 +59,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -221,6 +223,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -246,6 +278,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -400,6 +440,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -458,8 +531,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -965,18 +1044,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2329,21 +2398,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -61,6 +61,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -223,6 +225,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -248,6 +280,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -912,18 +952,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a replication. Closed enum. ADR-0005 §13(d).
-
-                  ```
-                  use kopiur_api::repository_replication::RepositoryReplicationPhase;
-
-                  assert_eq!(RepositoryReplicationPhase::default(), RepositoryReplicationPhase::Pending);
-                  assert_eq!(
-                      serde_json::to_value(RepositoryReplicationPhase::Replicating).unwrap(),
-                      "Replicating"
-                  );
-                  ```
+                description: Lifecycle phase of a replication.
                 enum:
                 - Pending
                 - Replicating

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -460,15 +460,9 @@ spec:
                 properties:
                   onMissingSnapshot:
                     description: |-
-                      What to do when the resolved source matches no snapshot. Closed enum. ADR §4.6 (G7).
-
-                      ```
-                      use kopiur_api::restore::OnMissingSnapshot;
-
-                      // Fail-closed is the default so an explicit restore can't silently no-op.
-                      assert_eq!(OnMissingSnapshot::default(), OnMissingSnapshot::Fail);
-                      assert_eq!(serde_json::to_value(OnMissingSnapshot::Continue).unwrap(), "Continue");
-                      ```
+                      What to do when the resolved source matches no snapshot. Defaults to `Fail`
+                      (fail-closed) so an explicit restore can never silently no-op; choose
+                      `Continue` to provision an empty volume instead (deploy-or-restore).
                     enum:
                     - Fail
                     - Continue

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -71,18 +71,10 @@ spec:
                     type: boolean
                 type: object
               defaultDeletionPolicy:
+                default: Delete
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -125,19 +117,11 @@ spec:
                     type: array
                 type: object
               groupBy:
+                default: VolumeGroupSnapshot
                 description: |-
-                  Multi-PVC grouping strategy. Closed enum. ADR §4.9.
-
-                  Defaults to a consistent group snapshot; `None` must be set *explicitly* to
-                  accept independent per-PVC snapshots, because a silent per-PVC fallback would
-                  produce inconsistent backups (the data-integrity hazard ADR §4.9 guards against).
-
-                  ```
-                  use kopiur_api::GroupBy;
-
-                  assert_eq!(GroupBy::default(), GroupBy::VolumeGroupSnapshot);
-                  assert_eq!(serde_json::to_value(GroupBy::None).unwrap(), "None");
-                  ```
+                  Multi-PVC grouping strategy. Defaults to a consistent group snapshot across
+                  all PVCs; set `None` *explicitly* to accept independent per-PVC snapshots,
+                  because a silent per-PVC fallback would produce inconsistent backups.
                 enum:
                 - VolumeGroupSnapshot
                 - None
@@ -151,30 +135,9 @@ spec:
                     description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -282,30 +245,9 @@ spec:
                     description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -939,21 +881,11 @@ spec:
                       nullable: true
                       type: string
                     sourcePathStrategy:
+                      default: PvcName
                       description: |-
-                        How a selector-matched PVC's source path is derived. Closed enum. ADR §3.3/§4.2.
-
-                        Only relevant for `pvcSelector` sources, where one recipe expands to many PVCs
-                        and each needs a distinct kopia source path.
-
-                        ```
-                        use kopiur_api::SourcePathStrategy;
-
-                        assert_eq!(SourcePathStrategy::default(), SourcePathStrategy::PvcName);
-                        assert_eq!(
-                            serde_json::to_value(SourcePathStrategy::PvcNamespacedName).unwrap(),
-                            "PvcNamespacedName"
-                        );
-                        ```
+                        How a selector-matched PVC's source path is derived. Only relevant for
+                        `pvcSelector` sources, where one recipe expands to many PVCs and each needs a
+                        distinct kopia source path. Defaults to `PvcName`.
                       enum:
                       - PvcName
                       - PvcNamespacedName

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -39,16 +39,7 @@ spec:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -100,7 +91,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Observed state of a [`Snapshot`]. ADR §3.4 status.
+            description: Observed state of a [`Snapshot`].
             nullable: true
             properties:
               conditions:
@@ -203,19 +194,10 @@ spec:
                 type: integer
               origin:
                 description: |-
-                  How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin`
-                  label. Closed enum. ADR §3.4.
-
-                  Origin drives the deletion-policy default (ADR §4.5): `discovered` backups are
-                  forced to `Retain` because the operator did not create those snapshots.
-
-                  ```
-                  use kopiur_api::Origin;
-
-                  assert_eq!(Origin::default(), Origin::Scheduled);
-                  // Serializes camelCase, matching the `origin` label/status value.
-                  assert_eq!(serde_json::to_value(Origin::Discovered).unwrap(), "discovered");
-                  ```
+                  How a `Snapshot` came to exist. Canonical value mirrored from the
+                  `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy
+                  default: `discovered` backups are forced to `Retain` because the operator did
+                  not create those snapshots.
                 enum:
                 - scheduled
                 - manual
@@ -223,18 +205,7 @@ spec:
                 nullable: true
                 type: string
               phase:
-                description: |-
-                  Lifecycle phase of a `Snapshot`. Closed enum. ADR §3.4 status.
-
-                  ```
-                  use kopiur_api::{SnapshotPhase, PhaseLabel};
-
-                  assert_eq!(SnapshotPhase::default(), SnapshotPhase::Pending);
-                  // `PhaseLabel::label` gives the stable string used in status/metrics.
-                  assert_eq!(SnapshotPhase::Succeeded.label(), "Succeeded");
-                  // Every variant is enumerated for metric reset.
-                  assert_eq!(SnapshotPhase::ALL.len(), 6);
-                  ```
+                description: Lifecycle phase of a `Snapshot`.
                 enum:
                 - Pending
                 - Running

--- a/deploy/examples/backends/gdrive.yaml
+++ b/deploy/examples/backends/gdrive.yaml
@@ -1,0 +1,62 @@
+# Backend: Google Drive — kopia native `gdrive` provider (ADR-0003 §3.1)
+#
+# WARNING: kopia marks the `gdrive` provider EXPERIMENTAL / not maintained.
+# Prefer a native object store (S3/GCS/Azure/B2) where one is available. A native
+# gdrive repository is NOT interchangeable with an rclone-backed Drive remote:
+# the two lay out data differently and cannot read each other's repositories.
+#
+# Identifiers (folderId) live in the Repository spec; the Google service-account
+# key JSON lives in a Secret. The mover writes it to a file and passes
+# `--credentials-file` to kopia.
+#
+# Field shapes verified against crates/api: externally-tagged backend
+# (`backend.gdrive`).
+#
+# The `# --8<-- [start:…]` / `# --8<-- [end:…]` lines are snippet-section markers
+# for docs/backends/gdrive.md. They are plain YAML comments — the file stays
+# `kubectl apply -f`-able as-is.
+# --8<-- [start:repository]
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gdrive-repo-creds
+  namespace: backups
+type: Opaque
+stringData:
+  # The full service-account key JSON, verbatim. The mover writes it to a file
+  # and passes `--credentials-file` to kopia. The key MUST be
+  # KOPIA_GDRIVE_CREDENTIALS (a valid env identifier) — a dotted key like
+  # `credentials.json` is dropped by Kubernetes envFrom.
+  KOPIA_GDRIVE_CREDENTIALS: |
+    {
+      "type": "service_account",
+      "project_id": "REPLACE_ME",
+      "private_key_id": "REPLACE_ME",
+      "private_key": "-----BEGIN PRIVATE KEY-----\nREPLACE_ME\n-----END PRIVATE KEY-----\n",
+      "client_email": "kopia@REPLACE_ME.iam.gserviceaccount.com",
+      "client_id": "REPLACE_ME",
+      "token_uri": "https://oauth2.googleapis.com/token"
+    }
+  KOPIA_PASSWORD: "choose-something-long-and-random"
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: gdrive-primary
+  namespace: backups
+spec:
+  backend:
+    gdrive:
+      # The Drive folder ID that holds the repository. Share this folder with the
+      # service account's client_email (above) as an Editor.
+      folderId: REPLACE_ME_FOLDER_ID
+      credentialsSecretRef:
+        name: gdrive-repo-creds # Secret carrying KOPIA_GDRIVE_CREDENTIALS above
+  encryption:
+    passwordSecretRef:
+      name: gdrive-repo-creds # may be the same Secret; it also carries KOPIA_PASSWORD
+      key: KOPIA_PASSWORD
+  # `create` now defaults to enabled (connect-or-create is idempotent); set
+  # `create.enabled: false` only for a strictly read-only / externally-managed repo.
+# --8<-- [end:repository]

--- a/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/files/crds/clusterrepositories.yaml
@@ -111,6 +111,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -273,6 +275,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -298,6 +330,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -452,6 +492,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -510,8 +583,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -1039,18 +1118,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2414,21 +2483,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing

--- a/deploy/helm/kopiur/files/crds/maintenances.yaml
+++ b/deploy/helm/kopiur/files/crds/maintenances.yaml
@@ -604,17 +604,8 @@ spec:
                     type: string
                   mode:
                     description: |-
-                      Which maintenance kind a manual (annotation-requested) run performs. Closed
-                      enum; the wire values are the `run-mode` annotation values.
-
-                      ```
-                      use kopiur_api::maintenance::ManualRunMode;
-
-                      assert_eq!(ManualRunMode::default(), ManualRunMode::Quick);
-                      assert_eq!(ManualRunMode::parse("full"), Some(ManualRunMode::Full));
-                      assert_eq!(ManualRunMode::parse("FULL"), None); // exact, lowercase
-                      assert_eq!(serde_json::to_value(ManualRunMode::Quick).unwrap(), "quick");
-                      ```
+                      Which maintenance kind a manual (annotation-requested) run performs; the wire
+                      values are the `run-mode` annotation values. Defaults to `quick`.
                     enum:
                     - quick
                     - full

--- a/deploy/helm/kopiur/files/crds/repositories.yaml
+++ b/deploy/helm/kopiur/files/crds/repositories.yaml
@@ -59,6 +59,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -221,6 +223,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -246,6 +278,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -400,6 +440,39 @@ spec:
                     - url
                     type: object
                 type: object
+              bootstrap:
+                description: |-
+                  Tuning for the one-shot bootstrap Job that connects/creates an object-store
+                  repository the operator cannot reach in-process.
+                nullable: true
+                properties:
+                  failurePolicy:
+                    description: |-
+                      Failure policy for the bootstrap Job. `activeDeadlineSeconds` caps how long
+                      a connect may run before the Job is marked failed (default 120s); raise it
+                      for a slow backend — e.g. an rclone remote whose repository metadata and
+                      indexes load through kopia's embedded `rclone serve`/WebDAV bridge.
+                      `backoffLimit` bounds retries. `podStartupDeadlineSeconds` is accepted for
+                      shape parity but is not honored by the bootstrap Job.
+                    nullable: true
+                    properties:
+                      activeDeadlineSeconds:
+                        description: Mover `Job.spec.activeDeadlineSeconds` — wall-clock cap after which a running run is killed.
+                        format: int64
+                        nullable: true
+                        type: integer
+                      backoffLimit:
+                        description: Mover `Job.spec.backoffLimit` — retries before a failed run is marked failed.
+                        format: int32
+                        nullable: true
+                        type: integer
+                      podStartupDeadlineSeconds:
+                        description: Seconds a non-starting (wedged) mover pod may sit before the run is failed; default 300s.
+                        format: int64
+                        nullable: true
+                        type: integer
+                    type: object
+                type: object
               catalog:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
@@ -458,8 +531,14 @@ spec:
                         type: integer
                     type: object
                   enabled:
-                    default: false
-                    description: Create the repository if it does not exist yet; off by default.
+                    default: true
+                    description: |-
+                      Create the repository if it does not exist yet — on by default. Repository
+                      create/connect is idempotent: pointing `create` at an already-initialized
+                      repository just connects to it (it never re-creates or clobbers), so the
+                      only effect of the default is that a genuinely-absent repository is
+                      bootstrapped instead of erroring. Set `false` for a strictly read-only or
+                      externally-managed repository the operator must never create.
                     type: boolean
                   encryption:
                     description: kopia encryption algorithm for a freshly-created repository (creation-time only).
@@ -965,18 +1044,8 @@ spec:
                     type: object
                   takeoverPolicy:
                     description: |-
-                      What to do when another owner already holds the lease. Closed enum. ADR §3.7.
-
-                      ```
-                      use kopiur_api::TakeoverPolicy;
-
-                      // The safest default: never seize a lease another owner holds.
-                      assert_eq!(TakeoverPolicy::default(), TakeoverPolicy::Never);
-                      assert_eq!(
-                          serde_json::to_value(TakeoverPolicy::PromptCondition).unwrap(),
-                          serde_json::json!("PromptCondition"),
-                      );
-                      ```
+                      What to do when another owner already holds the lease. Defaults to `Never`
+                      (the safest: never seize a lease another owner holds).
                     enum:
                     - Never
                     - PromptCondition
@@ -2329,21 +2398,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a repository. ADR §3.1 status.
-
-                  A freshly admitted CR starts in the `#[default]` [`RepositoryPhase::Pending`]:
-
-                  ```
-                  use kopiur_api::repository::RepositoryPhase;
-
-                  assert_eq!(RepositoryPhase::default(), RepositoryPhase::Pending);
-                  // Serializes as a bare string (closed unit enum).
-                  assert_eq!(
-                      serde_json::to_value(RepositoryPhase::Ready).unwrap(),
-                      serde_json::json!("Ready")
-                  );
-                  ```
+                description: Lifecycle phase of a repository. A freshly admitted CR starts in `Pending`.
                 enum:
                 - Pending
                 - Initializing

--- a/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/files/crds/repositoryreplications.yaml
@@ -61,6 +61,8 @@ spec:
                   - webDav
                 - required:
                   - rclone
+                - required:
+                  - gdrive
                 properties:
                   azure:
                     description: Azure Blob Storage.
@@ -223,6 +225,36 @@ spec:
                     required:
                     - bucket
                     type: object
+                  gdrive:
+                    description: |-
+                      Google Drive via kopia's native `gdrive` provider (service-account JSON).
+                      kopia marks this provider experimental / not maintained, and a native
+                      gdrive repository is not interchangeable with an rclone-backed Drive remote.
+                    properties:
+                      credentialsSecretRef:
+                        description: |-
+                          Secret holding the Google service-account JSON used to reach the folder,
+                          read by the well-known key `KOPIA_GDRIVE_CREDENTIALS`. Absent means kopia
+                          falls back to ambient credentials (`GOOGLE_APPLICATION_CREDENTIALS` or
+                          instance metadata).
+                        nullable: true
+                        properties:
+                          name:
+                            description: Name of the `Secret`.
+                            type: string
+                          namespace:
+                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            nullable: true
+                            type: string
+                        required:
+                        - name
+                        type: object
+                      folderId:
+                        description: Google Drive folder ID that holds the kopia repository.
+                        type: string
+                    required:
+                    - folderId
+                    type: object
                   rclone:
                     description: |-
                       Any rclone remote (kopia shells out to `rclone`), broadening reach to
@@ -248,6 +280,14 @@ spec:
                         description: |-
                           rclone path in `remote:path` form (the remote name must exist in the
                           supplied rclone config).
+                        type: string
+                      startupTimeout:
+                        description: |-
+                          How long kopia waits for its embedded `rclone serve` to come up before
+                          failing the connect, as a Go duration (e.g. `2m`). kopia's default is
+                          `15s`; raise it for slow remotes whose repository metadata/indexes load
+                          through the rclone/WebDAV bridge and take longer than the default budget.
+                        nullable: true
                         type: string
                     required:
                     - remotePath
@@ -912,18 +952,7 @@ spec:
                 nullable: true
                 type: integer
               phase:
-                description: |-
-                  Lifecycle phase of a replication. Closed enum. ADR-0005 §13(d).
-
-                  ```
-                  use kopiur_api::repository_replication::RepositoryReplicationPhase;
-
-                  assert_eq!(RepositoryReplicationPhase::default(), RepositoryReplicationPhase::Pending);
-                  assert_eq!(
-                      serde_json::to_value(RepositoryReplicationPhase::Replicating).unwrap(),
-                      "Replicating"
-                  );
-                  ```
+                description: Lifecycle phase of a replication.
                 enum:
                 - Pending
                 - Replicating

--- a/deploy/helm/kopiur/files/crds/restores.yaml
+++ b/deploy/helm/kopiur/files/crds/restores.yaml
@@ -460,15 +460,9 @@ spec:
                 properties:
                   onMissingSnapshot:
                     description: |-
-                      What to do when the resolved source matches no snapshot. Closed enum. ADR §4.6 (G7).
-
-                      ```
-                      use kopiur_api::restore::OnMissingSnapshot;
-
-                      // Fail-closed is the default so an explicit restore can't silently no-op.
-                      assert_eq!(OnMissingSnapshot::default(), OnMissingSnapshot::Fail);
-                      assert_eq!(serde_json::to_value(OnMissingSnapshot::Continue).unwrap(), "Continue");
-                      ```
+                      What to do when the resolved source matches no snapshot. Defaults to `Fail`
+                      (fail-closed) so an explicit restore can never silently no-op; choose
+                      `Continue` to provision an empty volume instead (deploy-or-restore).
                     enum:
                     - Fail
                     - Continue

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -71,18 +71,10 @@ spec:
                     type: boolean
                 type: object
               defaultDeletionPolicy:
+                default: Delete
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -125,19 +117,11 @@ spec:
                     type: array
                 type: object
               groupBy:
+                default: VolumeGroupSnapshot
                 description: |-
-                  Multi-PVC grouping strategy. Closed enum. ADR §4.9.
-
-                  Defaults to a consistent group snapshot; `None` must be set *explicitly* to
-                  accept independent per-PVC snapshots, because a silent per-PVC fallback would
-                  produce inconsistent backups (the data-integrity hazard ADR §4.9 guards against).
-
-                  ```
-                  use kopiur_api::GroupBy;
-
-                  assert_eq!(GroupBy::default(), GroupBy::VolumeGroupSnapshot);
-                  assert_eq!(serde_json::to_value(GroupBy::None).unwrap(), "None");
-                  ```
+                  Multi-PVC grouping strategy. Defaults to a consistent group snapshot across
+                  all PVCs; set `None` *explicitly* to accept independent per-PVC snapshots,
+                  because a silent per-PVC fallback would produce inconsistent backups.
                 enum:
                 - VolumeGroupSnapshot
                 - None
@@ -151,30 +135,9 @@ spec:
                     description: Hooks run (in order) after the snapshot completes — e.g. resuming the workload.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -282,30 +245,9 @@ spec:
                     description: Hooks run (in order) before the snapshot is taken — e.g. quiescing a database.
                     items:
                       description: |-
-                        One of three hook forms. ADR §4.8.
-
-                        Externally-tagged: wire shape is `{ workloadExec: {...} }`, `{ runJob: {...} }`,
-                        or `{ httpRequest: {...} }`. Exactly one variant by construction.
-
-                        Not `Eq`: `RunJob` embeds `JobSpec` (k8s-openapi, `PartialEq` only).
-
-                        ```
-                        use kopiur_api::snapshot_policy::{Hook, HttpRequestHook};
-
-                        // Construct directly — the type system guarantees exactly one variant.
-                        let hook = Hook::HttpRequest(HttpRequestHook {
-                            url: "https://example/notify".into(),
-                            method: Some("POST".into()),
-                            body: None,
-                            timeout: None,
-                            continue_on_failure: false,
-                        });
-                        assert_eq!(hook.kind_str(), "HttpRequest");
-
-                        // Externally tagged on the wire: `{ httpRequest: { url: ... } }`.
-                        let json = serde_json::to_value(&hook).unwrap();
-                        assert_eq!(json["httpRequest"]["url"], "https://example/notify");
-                        ```
+                        One of three hook forms. Externally-tagged: the wire shape is
+                        `{ workloadExec: {...} }`, `{ runJob: {...} }`, or `{ httpRequest: {...} }`,
+                        and exactly one form is present.
                       oneOf:
                       - required:
                         - workloadExec
@@ -939,21 +881,11 @@ spec:
                       nullable: true
                       type: string
                     sourcePathStrategy:
+                      default: PvcName
                       description: |-
-                        How a selector-matched PVC's source path is derived. Closed enum. ADR §3.3/§4.2.
-
-                        Only relevant for `pvcSelector` sources, where one recipe expands to many PVCs
-                        and each needs a distinct kopia source path.
-
-                        ```
-                        use kopiur_api::SourcePathStrategy;
-
-                        assert_eq!(SourcePathStrategy::default(), SourcePathStrategy::PvcName);
-                        assert_eq!(
-                            serde_json::to_value(SourcePathStrategy::PvcNamespacedName).unwrap(),
-                            "PvcNamespacedName"
-                        );
-                        ```
+                        How a selector-matched PVC's source path is derived. Only relevant for
+                        `pvcSelector` sources, where one recipe expands to many PVCs and each needs a
+                        distinct kopia source path. Defaults to `PvcName`.
                       enum:
                       - PvcName
                       - PvcNamespacedName

--- a/deploy/helm/kopiur/files/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshots.yaml
@@ -39,16 +39,7 @@ spec:
               deletionPolicy:
                 description: |-
                   Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
-
-                  ```
-                  use kopiur_api::common::DeletionPolicy;
-
-                  // Produced backups default to deleting the snapshot with the CR.
-                  assert_eq!(DeletionPolicy::default(), DeletionPolicy::Delete);
-                  // Variants serialize to their bare PascalCase names (plain string enum).
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Retain).unwrap(), "Retain");
-                  assert_eq!(serde_json::to_value(DeletionPolicy::Orphan).unwrap(), "Orphan");
-                  ```
+                  Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
                 enum:
                 - Delete
                 - Retain
@@ -100,7 +91,7 @@ spec:
                 type: object
             type: object
           status:
-            description: Observed state of a [`Snapshot`]. ADR §3.4 status.
+            description: Observed state of a [`Snapshot`].
             nullable: true
             properties:
               conditions:
@@ -203,19 +194,10 @@ spec:
                 type: integer
               origin:
                 description: |-
-                  How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin`
-                  label. Closed enum. ADR §3.4.
-
-                  Origin drives the deletion-policy default (ADR §4.5): `discovered` backups are
-                  forced to `Retain` because the operator did not create those snapshots.
-
-                  ```
-                  use kopiur_api::Origin;
-
-                  assert_eq!(Origin::default(), Origin::Scheduled);
-                  // Serializes camelCase, matching the `origin` label/status value.
-                  assert_eq!(serde_json::to_value(Origin::Discovered).unwrap(), "discovered");
-                  ```
+                  How a `Snapshot` came to exist. Canonical value mirrored from the
+                  `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy
+                  default: `discovered` backups are forced to `Retain` because the operator did
+                  not create those snapshots.
                 enum:
                 - scheduled
                 - manual
@@ -223,18 +205,7 @@ spec:
                 nullable: true
                 type: string
               phase:
-                description: |-
-                  Lifecycle phase of a `Snapshot`. Closed enum. ADR §3.4 status.
-
-                  ```
-                  use kopiur_api::{SnapshotPhase, PhaseLabel};
-
-                  assert_eq!(SnapshotPhase::default(), SnapshotPhase::Pending);
-                  // `PhaseLabel::label` gives the stable string used in status/metrics.
-                  assert_eq!(SnapshotPhase::Succeeded.label(), "Succeeded");
-                  // Every variant is enumerated for metric reset.
-                  assert_eq!(SnapshotPhase::ALL.len(), 6);
-                  ```
+                description: Lifecycle phase of a `Snapshot`.
                 enum:
                 - Pending
                 - Running

--- a/docs/backends/gdrive.md
+++ b/docs/backends/gdrive.md
@@ -1,0 +1,113 @@
+# Google Drive (native `gdrive`)
+
+kopia has a **native Google Drive backend** (`gdrive`) that talks to Drive
+directly with a Google **service-account** key — no `rclone` in the path. Kopiur
+exposes it as `backend.gdrive`.
+
+/// warning | Experimental / not maintained upstream
+
+kopia marks the `gdrive` provider **experimental and not actively maintained**.
+Prefer a native object store ([S3](s3.md), [GCS](gcs.md), [Azure](azure.md),
+[B2](b2.md)) when you have one. Reach for `gdrive` only when Google Drive is the
+storage you have.
+
+///
+
+/// warning | Not interchangeable with rclone-backed Drive
+
+A native `gdrive` repository and an [rclone](rclone.md) Drive remote lay out data
+**differently** and cannot read each other. Pick one per repository and stay on
+it — you can't switch a repository between them, and a restore must use the same
+backend that wrote the snapshots.
+
+///
+
+## When to use native gdrive vs rclone
+
+Both reach Google Drive. They differ in the connection path:
+
+- **Native `gdrive`** — kopia talks to the Drive API directly with a
+  service-account JSON. Fewer moving parts at connect time; no embedded `rclone
+  serve`/WebDAV bridge.
+- **[rclone](rclone.md) Drive remote** — kopia shells out to `rclone`, which can
+  be slower to come up during `repository connect`. Use it if you already run
+  rclone or need OAuth-user (not service-account) auth.
+
+## Provider prerequisites
+
+1. A **Google Cloud service account** with a JSON key, and the Drive API enabled
+   on its project.
+2. A **Drive folder** to hold the repository. Copy its **folder ID** — the last
+   path segment of the folder URL (`https://drive.google.com/drive/folders/<FOLDER_ID>`).
+3. **Share the folder** with the service account's `client_email` as an
+   **Editor**, or the mover gets a permission error on connect.
+
+## The Secret shape
+
+gdrive is **file-delivered**: the mover reads the whole service-account JSON from
+a well-known env key, writes it to a private (`0600`) file, and runs kopia with
+`--credentials-file`.
+
+| Secret key                 | Required | What it is                                                                       |
+| -------------------------- | -------- | -------------------------------------------------------------------------------- |
+| `KOPIA_GDRIVE_CREDENTIALS` | yes¹     | The **entire service-account key JSON**, verbatim. Materialized → `--credentials-file`. |
+| `KOPIA_PASSWORD`           | **yes**  | The repository encryption password.                                              |
+
+¹ Optional in the schema — when absent, kopia falls back to ambient credentials
+(`GOOGLE_APPLICATION_CREDENTIALS` / instance metadata). In a normal cluster you
+supply the Secret.
+
+/// info | Why `KOPIA_GDRIVE_CREDENTIALS` and not `credentials.json`
+
+The mover loads credentials with `envFrom`, and a dotted key like
+`credentials.json` is not a valid environment-variable name — Kubernetes drops
+it. So the JSON goes under `KOPIA_GDRIVE_CREDENTIALS`; the mover writes it to a
+file for you and passes `--credentials-file`.
+
+///
+
+## The Repository
+
+```yaml
+--8<-- "deploy/examples/backends/gdrive.yaml:repository"
+```
+
+## Fields reference (`backend.gdrive`)
+
+| Field                  | Required | Default | Example                     | What it controls                                                                                      |
+| ---------------------- | -------- | ------- | --------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `folderId`             | yes      | —       | `0AbCdEf...`                | The Drive folder ID that holds the repository (last segment of the folder URL).                       |
+| `credentialsSecretRef` | no¹      | —       | `{ name: gdrive-repo-creds }` | Secret holding the service-account JSON under `KOPIA_GDRIVE_CREDENTIALS`. A `ClusterRepository` adds `namespace:`. |
+
+¹ Optional in the schema; in practice required unless the mover already has
+ambient Google credentials.
+
+## Customization — the values you actually change
+
+- **`folderId`** — which Drive folder backs the repository. Share it with the SA.
+- **`KOPIA_GDRIVE_CREDENTIALS`** — the service-account JSON; rotate by re-pasting.
+- **`create.enabled`** — defaults to `true` (connect-or-create is idempotent);
+  set `false` only for a read-only / externally-managed repository.
+
+## As a `ClusterRepository`
+
+The same `backend.gdrive` stanza works on a cluster-scoped
+[`ClusterRepository`](../repositories.md#clusterrepository-a-shared-repository); the
+`credentialsSecretRef` (and the `encryption.passwordSecretRef`) must carry an
+explicit `namespace:`, and the Secret must exist where the movers run — see
+[Movers](../movers.md).
+
+## Troubleshooting
+
+- **`403` / permission denied on connect** — the Drive folder isn't shared with
+  the service account's `client_email` (needs **Editor**), or the Drive API isn't
+  enabled on the SA's project.
+- **`folderId` not found** — copy the ID from the folder URL, not the folder name.
+- **Slow or contradictory results vs an old rclone Drive repo** — they're
+  different repositories; a native `gdrive` repo can't read rclone-written data.
+
+## See also
+
+- [rclone](rclone.md) — the other way to reach Google Drive (OAuth-user auth).
+- [Repositories & backends](../repositories.md) — concepts: scope, encryption, creation.
+- [Movers, RBAC & credentials](../movers.md) — where the credentials Secret must live.

--- a/docs/backends/index.md
+++ b/docs/backends/index.md
@@ -37,6 +37,7 @@ A backend is chosen by **which key you set** (`backend.s3`, `backend.azure`, …
 | [SFTP](sftp.md)                         | Any server reachable over SSH/SFTP                           | `backend.sftp`       |
 | [WebDAV](webdav.md)                     | Nextcloud, Apache `mod_dav`, …                               | `backend.webDav`     |
 | [rclone](rclone.md)                     | Google Drive, OneDrive, Dropbox, and dozens more             | `backend.rclone`     |
+| [Google Drive (native)](gdrive.md)      | Google Drive via kopia's native `gdrive` (experimental)     | `backend.gdrive`     |
 
 ## How to use these pages
 
@@ -65,6 +66,7 @@ The mover reads these **exact** key names from the Secret you reference and feed
 | [SFTP](sftp.md)                | `KOPIA_SFTP_KEY_DATA`, `KOPIA_SFTP_KNOWN_HOSTS`                           | `backend.sftp`       |
 | [WebDAV](webdav.md)            | `KOPIA_WEBDAV_USERNAME`, `KOPIA_WEBDAV_PASSWORD`                          | `backend.webDav`     |
 | [rclone](rclone.md)            | `KOPIA_RCLONE_CONFIG` _(via `configSecretRef`)_                           | `backend.rclone`     |
+| [Google Drive](gdrive.md)      | `KOPIA_GDRIVE_CREDENTIALS` _(via `credentialsSecretRef`)_                 | `backend.gdrive`     |
 
 /// tip | Cloud clusters: workload identity instead of static keys
 
@@ -80,14 +82,15 @@ WebDAV) are Secret-only — they have no IAM plane to federate with.
 
 /// info | Env-delivered vs. file-delivered credentials
 
-Most backends authenticate via environment variables kopia reads directly — the mover loads the Secret with `envFrom`, so the keys above become env vars. Three backends need their credentials as **files** instead (kopia's SFTP/GCS/rclone flags have no env form, and a Secret key like `ssh-privatekey` isn't a valid env-var name so `envFrom` would silently drop it). For those, the mover reads a well-known env key and writes it to a private (`0600`) file, then points kopia at the path:
+Most backends authenticate via environment variables kopia reads directly — the mover loads the Secret with `envFrom`, so the keys above become env vars. Four backends need their credentials as **files** instead (kopia's SFTP/GCS/rclone/gdrive flags have no env form, and a Secret key like `ssh-privatekey` isn't a valid env-var name so `envFrom` would silently drop it). For those, the mover reads a well-known env key and writes it to a private (`0600`) file, then points kopia at the path:
 
-| Secret key               | Becomes                       | kopia flag           |
-| ------------------------ | ----------------------------- | -------------------- |
-| `KOPIA_SFTP_KEY_DATA`    | the SSH private key file      | `--keyfile`          |
-| `KOPIA_SFTP_KNOWN_HOSTS` | the `known_hosts` file        | `--known-hosts`      |
-| `KOPIA_GCS_CREDENTIALS`  | the service-account JSON file | `--credentials-file` |
-| `KOPIA_RCLONE_CONFIG`    | the `rclone.conf` file        | rclone `--config`    |
+| Secret key                 | Becomes                       | kopia flag           |
+| -------------------------- | ----------------------------- | -------------------- |
+| `KOPIA_SFTP_KEY_DATA`      | the SSH private key file      | `--keyfile`          |
+| `KOPIA_SFTP_KNOWN_HOSTS`   | the `known_hosts` file        | `--known-hosts`      |
+| `KOPIA_GCS_CREDENTIALS`    | the service-account JSON file | `--credentials-file` |
+| `KOPIA_RCLONE_CONFIG`      | the `rclone.conf` file        | rclone `--config`    |
+| `KOPIA_GDRIVE_CREDENTIALS` | the service-account JSON file | `--credentials-file` |
 
 You don't manage the files — just put the value under the right key; the secret never lands on kopia's argv.
 

--- a/docs/backends/rclone.md
+++ b/docs/backends/rclone.md
@@ -109,9 +109,21 @@ Unlike the object-store backends, rclone references its config via
 | ----------------- | -------- | ------- | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `remotePath`      | yes      | —       | `mydrive:backups/kopia`   | rclone path in `remote:path` form. The part before `:` must match a `[section]` in the config; the part after is the folder. |
 | `configSecretRef` | no¹      | —       | `{ name: rclone-config }` | Secret holding the `rclone.conf` (under `KOPIA_RCLONE_CONFIG`). **Not** `auth`. A `ClusterRepository` adds `namespace:`.      |
+| `startupTimeout`  | no       | `15s`   | `2m`                      | How long kopia waits for its embedded `rclone serve` to come up before failing the connect (Go duration). Raise it for slow remotes whose metadata/indexes load through the rclone/WebDAV bridge. |
 
 ¹ Optional in the schema, but in practice required: rclone can't reach a remote
 without its config.
+
+/// tip | Bootstrap timing out on a slow remote?
+
+A valid rclone repository whose connect is slow (kopia starts `rclone serve
+webdav` and loads repo metadata through it) can trip the bootstrap Job's deadline
+before the connect finishes. Two independent knobs help: raise
+**`backend.rclone.startupTimeout`** (kopia's wait for `rclone serve`) and/or
+**`spec.bootstrap.failurePolicy.activeDeadlineSeconds`** (the bootstrap Job's
+wall-clock cap, default 120s) — see [Repositories](../repositories.md).
+
+///
 
 ## Customization — the values you actually change
 

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -23,7 +23,8 @@ Point as many backups as you can at **one** repository. Kopia deduplicates by co
 spec:
     backend: { <one of eight>: { ... } } # WHERE: storage. Exactly one backend.
     encryption: { passwordSecretRef: ... } # the kopia repo password (Secret ref)
-    create: { enabled: true, ecc: { ... } } # initialize the repo if absent (default: off)
+    create: { enabled: true, ecc: { ... } } # initialize the repo if absent (default: on)
+    bootstrap: { failurePolicy: { ... } } # tune the connect/create Job deadline + retries
     moverDefaults: { ... } # base config for EVERY mover (SC, resources, cache, ...)
     catalog: { ... } # bounds "discovered" snapshot materialization
     maintenance: { ... } # default-managed; see the Maintenance guide
@@ -73,6 +74,7 @@ The mover reads these **well-known keys** from the Secret you reference and feed
 | **SFTP**       | `KOPIA_SFTP_KEY_DATA`, `KOPIA_SFTP_KNOWN_HOSTS`                           | Key-based auth; the mover writes both to files (`--keyfile`/`--known-hosts`). See [SFTP](backends/sftp.md). |
 | **WebDAV**     | `KOPIA_WEBDAV_USERNAME`, `KOPIA_WEBDAV_PASSWORD`                          | HTTP basic auth, via `auth.secretRef`.                                                                      |
 | **rclone**     | `KOPIA_RCLONE_CONFIG` (the `rclone.conf`)                                 | Referenced by `backend.rclone.configSecretRef`, not `auth`.                                                 |
+| **gdrive**     | `KOPIA_GDRIVE_CREDENTIALS` (service-account JSON)                         | Native Google Drive; referenced by `backend.gdrive.credentialsSecretRef`. Experimental — see [Google Drive](backends/gdrive.md). |
 | **filesystem** | _(none — local path)_                                                     | Only `KOPIA_PASSWORD` is needed.                                                                            |
 
 /// note | ClusterRepository Secret references need a namespace
@@ -81,9 +83,9 @@ Because a `ClusterRepository` is cluster-scoped it has no namespace of its own, 
 
 ///
 
-## The eight backends
+## The nine backends
 
-Kopiur supports eight backends; each is selected by the `spec.backend.<key>` you set.
+Kopiur supports nine backends; each is selected by the `spec.backend.<key>` you set.
 
 | Backend                                                               | `spec.backend` key | Where it goes             |
 | --------------------------------------------------------------------- | ------------------ | ------------------------- |
@@ -95,6 +97,7 @@ Kopiur supports eight backends; each is selected by the `spec.backend.<key>` you
 | SFTP                                                                  | `sftp`             | a path on an SSH server   |
 | WebDAV                                                                | `webDav`           | a collection URL          |
 | rclone (everything else)                                              | `rclone`           | any rclone remote         |
+| Google Drive (native, experimental)                                   | `gdrive`           | a Drive folder            |
 
 /// tip | Per-backend setup lives on its own page
 
@@ -111,7 +114,7 @@ spec:
             name: repo-creds
             key: KOPIA_PASSWORD # which key inside the Secret holds the password
     create:
-        enabled: true # create the repo if it doesn't exist yet (default: false)
+        enabled: true # create the repo if it doesn't exist yet (default: true)
         # All of the below are consulted ONLY at creation time, then fixed forever
         # (webhook- AND apiserver-immutable: editing them is rejected):
         encryption: AES256-GCM-HMAC-SHA256
@@ -136,11 +139,11 @@ The `encryption.passwordSecretRef` is **not** in this set: you may rename or rep
 
 ///
 
-/// note | `create.enabled` is off by default — on purpose
+/// note | `create.enabled` defaults to **on** — and that's safe
 
-With creation disabled, a typo in `bucket`/`endpoint` surfaces as a connect failure instead of silently spinning up a brand-new empty repository at the wrong address. Enable it for a genuinely new repo; leave it off to require that one already exists.
+Repository create/connect is **idempotent**: every bootstrap *connects first* and only creates when the backend holds no repository yet (see [Safe by construction](#safe-by-construction)). So creating-on-first-use is the least-surprise default — a genuinely-absent repository is initialized instead of erroring, and pointing `create` at one that already exists just adopts it. Omitting `create` entirely (or `create: {}`) is the same as `create.enabled: true`.
 
-If the backend holds **no** repository yet and `create.enabled` is off, the `Repository`/`ClusterRepository` goes `Failed` with a `Bootstrapped=False`, `reason: RepositoryNotInitialized` condition whose message tells you exactly what to do — set `create.enabled: true` to initialize it, or point the backend at an existing repository. (This is distinct from a wrong-password connect, which fails `AuthFailure` and **never** recreates over the existing data — see [Safe by construction](#safe-by-construction) below.)
+Set **`create.enabled: false`** for a strictly read-only or externally-managed repository the operator must never create. With creation disabled, a typo in `bucket`/`endpoint` surfaces as a connect failure (`Bootstrapped=False`, `reason: RepositoryNotInitialized`) instead of spinning up a new empty repository — at the cost of opting in for every genuinely-new repo. (A wrong-password connect fails `AuthFailure` and **never** recreates over existing data — see [Safe by construction](#safe-by-construction) below.)
 
 ///
 
@@ -153,6 +156,33 @@ If the backend holds **no** repository yet and `create.enabled` is off, the `Rep
 - **No repository exists** → kopiur creates one (only because `create.enabled` is on). As a final backstop, kopia's own `repository create` refuses to overwrite an existing repository, so even a misclassified connect cannot clobber your data.
 
 So enabling `create.enabled` for a repository that turns out to already exist is safe: kopiur will adopt it, not re-initialize it.
+
+## `bootstrap` — tuning the connect/create Job
+
+Object-store and volume-backed repositories connect (and, with `create`, create) in a short-lived **bootstrap Job** the operator cannot run in-process. By default that Job is bounded to **120s** so a pod that never schedules (missing mover ServiceAccount, image-pull failure) becomes terminal-`Failed` and surfaces an actionable Event instead of hanging. A valid-but-slow backend can need longer — most commonly an [rclone](backends/rclone.md) remote whose metadata/indexes load through kopia's embedded `rclone serve` bridge.
+
+`spec.bootstrap.failurePolicy` reuses the same shape as a recipe's `failurePolicy`:
+
+```yaml
+spec:
+    bootstrap:
+        failurePolicy:
+            activeDeadlineSeconds: 600 # wall-clock cap for the bootstrap Job (default 120)
+            backoffLimit: 1 # retries before the Job is marked failed (default 2)
+```
+
+| Field                              | Default | What it controls                                                                 |
+| ---------------------------------- | ------- | -------------------------------------------------------------------------------- |
+| `failurePolicy.activeDeadlineSeconds` | `120`   | Wall-clock seconds before the bootstrap Job is killed and marked failed.        |
+| `failurePolicy.backoffLimit`       | `2`     | Pod retries before the Job is failed.                                            |
+
+/// note | `podStartupDeadlineSeconds` is not honored for bootstrap
+
+`failurePolicy` is the shared type, so it also carries `podStartupDeadlineSeconds` — but the bootstrap Job does not consume it (only backup/restore/maintenance movers do). Use `activeDeadlineSeconds` to bound a slow bootstrap.
+
+///
+
+For an rclone-specific connect that's slow *before* metadata even loads, also raise [`backend.rclone.startupTimeout`](backends/rclone.md#fields-reference-backendrclone) (kopia's wait for `rclone serve` to come up).
 
 ## The catalog — discovered snapshots
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
           - SFTP: backends/sftp.md
           - WebDAV: backends/webdav.md
           - rclone: backends/rclone.md
+          - Google Drive (native): backends/gdrive.md
       - Backups & schedules: backups.md
       - Copy methods (Snapshot/Clone/Direct): copy-methods.md
       - PVC access modes & RWOP: access-modes.md


### PR DESCRIPTION
Implements three open issues in one PR. Each is independently scoped; reviewers can read them in any order.

Closes #152
Closes #154
Closes #155

---

## #155 — native Google Drive backend

The internal kopia client already had `ConnectSpec::Gdrive`, but the public `Backend` API never exposed it. This wires it end-to-end:

- New `backend.gdrive { folderId, credentialsSecretRef }` (dedicated `credentialsSecretRef`, mirroring rclone's `configSecretRef`).
- Threads through every exhaustive `Backend` match (kind_str, `backend_auth_secret_ref`, `validate_backend`, repo/replication target keys, `backend_to_repository_connect`), the kopia `gdrive --folder-id --credentials-file` args, `RepositoryConnect`/`to_connect_spec`, and credential materialization (`KOPIA_GDRIVE_CREDENTIALS` → file → `--credentials-file`, exactly the GCS pattern).
- Docs call out that kopia marks `gdrive` **experimental / not maintained**, and that a native gdrive repo is **not interchangeable** with an rclone-backed Drive remote. New `deploy/examples/backends/gdrive.yaml` + `docs/backends/gdrive.md`.

## #154 — fragile rclone repositories

A valid rclone repo whose connect is slow (kopia starts `rclone serve webdav` and loads metadata through it) could be marked failed before the connect finishes. Two independent knobs:

- **`backend.rclone.startupTimeout`** → kopia's native `--rclone-startup-timeout` (Go duration; kopia default `15s`).
- **`spec.bootstrap.failurePolicy`** on `Repository`/`ClusterRepository`, reusing the shared `FailurePolicy`: `activeDeadlineSeconds` overrides the hardcoded **120s** bootstrap-Job deadline, `backoffLimit` the retries. `podStartupDeadlineSeconds` is part of the shared type but **not** honored by bootstrap (documented).

## #152 — CRD-schema quality

- **Descriptions read as user docs.** Stripped internal ADR `§` references and embedded Rust doc-tests from every published CRD `description` — `kubectl explain` no longer returns Rust at the user. The doc-tests move to unit tests where coverage was otherwise lost, so they still compile-check.
- **Machine-readable defaults.** Emit `default:` for the *context-free* defaulted spec enums (`groupBy`, `sourcePathStrategy`, `defaultDeletionPolicy`). Deliberately **excluded** the context-dependent ones — `onMissingSnapshot` (defaults to `Fail` for explicit sources but `Continue` for `fromPolicy`) and `Snapshot.deletionPolicy` (origin-defaulted by the mutating webhook) — because a static apiserver default would be *wrong* there.
- **`create.enabled` defaults to `true`** (behavior change). Repository create/connect is idempotent (connect-or-create, never clobbers), so a genuinely-absent repo is now bootstrapped instead of erroring; set `create.enabled: false` for a read-only / externally-managed repo. Resolved via a shared `create_enabled()` helper so "absent means on" can't fork between call sites.

---

## Testing

- `cargo test --workspace` → 1138 passed
- `cargo clippy --workspace --all-targets` → clean
- `cargo fmt --check` → clean
- `cargo xtask gen-all --check` → no drift (CRDs / RBAC / helm regenerated; insta CRD snapshots updated)
- `mkdocs build --strict` → clean (new gdrive page + snippet resolve)
- New unit tests: gdrive serde + arg-builder + credential materialization; rclone `startupTimeout` parse/arg; bootstrap `failurePolicy` round-trip + validation; gdrive `folderId` validation; `create_enabled` resolver; relocated enum doc-test assertions.

## Notes for reviewers

- The `create.enabled` flip is the one behavior change. It only affects a repo that omits `create` **and** points at a genuinely-absent backend; everything else (adopt-existing, wrong-password-never-recreates) is unchanged. Docs updated in `docs/repositories.md`.
- gdrive has no hermetic e2e (needs real Drive creds); it's covered by unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)