### PR TITLE
chore(renovate): drop the dead cargo postUpgradeTask

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,17 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
-  packageRules: [
-    {
-      matchManagers: ["cargo"],
-      matchDatasources: ["git-refs", "git-tags"],
-      postUpgradeTasks: {
-        commands: ["cargo update --config net.git-fetch-with-cli=true --manifest-path Cargo.toml --package {{{depName}}}"],
-        fileFilters: ["Cargo.lock"],
-        executionMode: "update",
-      },
-    },
-  ],
   postUpgradeTasks: {
     commands: [
       "helm-docs --chart-search-root=deploy/helm --log-level=warn",


### PR DESCRIPTION
## What

Remove the cargo `postUpgradeTask` packageRule from `.renovaterc.json5` (the top-level helm-docs / helm-schema `postUpgradeTask` is untouched).

## Why

It's dead config. The rule only matches cargo deps with datasource `git-refs`/`git-tags` (i.e. `{ git = … }` deps), and kopiur has **none** — every cargo dependency is a crates.io (`crate` datasource) version dep. Renovate's built-in cargo manager already refreshes `Cargo.lock` for those on every update (and auto-retries `package ID specification` transitive conflicts), so the rule never attaches to an upgrade and its `cargo update --package …` command never runs.

It also couldn't do its intended job even on a real git dep: a `postUpgradeTask` runs *after* the built-in cargo `updateArtifacts`, and a later success can't clear an `artifactError` the built-in already recorded — the PR would stay red regardless. (Verified against Renovate 43.244.4 source.)

Part of standardizing the org on registry cargo deps + native Renovate handling — see also home-operations/drm-exporter#33 (qmlib git→crates.io), which removed the same rule there.
