### PR TITLE
chore(renovate): inherit shared chart-docs postUpgradeTasks preset

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,12 +1,4 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["local>home-operations/renovate-config"],
-  postUpgradeTasks: {
-    commands: [
-      "helm-docs --chart-search-root=deploy/helm --log-level=warn",
-      "helm-schema --chart-search-root deploy/helm/kopiur --skip-auto-generation required,additionalProperties --append-newline",
-    ],
-    fileFilters: ["deploy/helm/kopiur/README.md", "deploy/helm/kopiur/values.schema.json"],
-    executionMode: "branch",
-  },
 }


### PR DESCRIPTION
Now that home-operations/renovate-config#25 is merged, `kopiur` inherits the shared `groups.json5`
(toolchain grouping) and `helmPostUpgradeTasks.json5` (chart-doc regen) presets via its existing
`extends: ["local>home-operations/renovate-config"]`.

Removes the now-redundant local config:
- the local helm-docs/helm-schema `postUpgradeTasks` block

Pure deletion — behavior unchanged:
- the shared preset's `--chart-search-root .` reproduces this chart's committed README + values.schema.json byte-for-byte (verified).

Part of the org consolidation Tier-1 rollout.
