### PR TITLE
feat(controller): allow overriding default listen address

### DIFF
--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -47,9 +47,13 @@ pub const OPERATOR_NAMESPACE_ENV: &str = "KOPIUR_NAMESPACE";
 /// mounts an `emptyDir`; set this only when relocating that mount.
 pub const KOPIA_CACHE_DIR_ENV: &str = "KOPIUR_KOPIA_CACHE_DIR";
 
+/// Address that the controller binds to.
+pub const CONTROLLER_ADDR_ENV: &str = "KOPIUR_CONTROLLER_ADDR";
+
 /// Address the controller's HTTP server (`/metrics`, `/healthz`, `/readyz`)
-/// binds to. Matches the chart's `controller.probePort` (8081).
-pub const HTTP_ADDR: &str = "0.0.0.0:8081";
+/// binds to when [`CONTROLLER_ADDR_ENV`] is unset. Matches the chart's
+/// `controller.probePort` (8081).
+pub const DEFAULT_ADDR: &str = "0.0.0.0:8081";
 
 /// Number of tokio worker threads the controller runtime runs. The controller is
 /// I/O-bound — watch streams, debounced reconciles, short idempotent kopia calls —

--- a/crates/controller/src/lib.rs
+++ b/crates/controller/src/lib.rs
@@ -25,6 +25,7 @@ pub mod verification;
 pub mod watch;
 pub mod webhook_tls;
 
+use std::net::SocketAddr;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -130,6 +131,10 @@ pub async fn run() -> anyhow::Result<()> {
         None => KopiaClientFactory::new(),
     };
 
+    let addr: SocketAddr = std::env::var(config::CONTROLLER_ADDR_ENV)
+        .unwrap_or_else(|_| config::DEFAULT_ADDR.to_string())
+        .parse()?;
+
     // Shared Maintenance informer: a single reflector-backed cache the
     // Repository/ClusterRepository reconcilers read to answer "is a Maintenance
     // configured for me?" without an `Api::list` per reconcile. We drive the
@@ -207,7 +212,7 @@ pub async fn run() -> anyhow::Result<()> {
 
     tracing::info!("starting kopiur controllers");
 
-    let http_srv = tokio::spawn(serve_http(metrics.clone()));
+    let http_srv = tokio::spawn(serve_http(addr, metrics.clone()));
     let controllers = spawn_all(client, ctx);
 
     tokio::select! {
@@ -780,7 +785,7 @@ async fn spawn_all(client: Client, ctx: Arc<Context>) {
 /// The controller's HTTP server: `/metrics` (Prometheus exposition) plus real
 /// `/healthz` + `/readyz` endpoints matching the chart's liveness/readiness
 /// probes (the previous raw listener returned the metrics body for any path).
-async fn serve_http(metrics: Metrics) -> anyhow::Result<()> {
+async fn serve_http(addr: SocketAddr, metrics: Metrics) -> anyhow::Result<()> {
     use axum::extract::State;
     use axum::http::header::CONTENT_TYPE;
     use axum::response::IntoResponse;
@@ -802,11 +807,8 @@ async fn serve_http(metrics: Metrics) -> anyhow::Result<()> {
         .route("/readyz", get(health))
         .with_state(metrics);
 
-    let listener = tokio::net::TcpListener::bind(config::HTTP_ADDR).await?;
-    tracing::info!(
-        addr = config::HTTP_ADDR,
-        "http server listening (/metrics, /healthz, /readyz)"
-    );
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(%addr, "http server listening (/metrics, /healthz, /readyz)");
     axum::serve(listener, app).await?;
     Ok(())
 }

--- a/deploy/helm/kopiur/README.md
+++ b/deploy/helm/kopiur/README.md
@@ -66,6 +66,7 @@ Disable the webhook entirely with `webhook.enabled=false` (validation then falls
 | controller.extraVolumeMounts | list | `[]` | Extra volume mounts on the controller container (pairs with extraVolumes). |
 | controller.extraVolumes | list | `[]` | Extra volumes on the controller pod. Use this to make a filesystem-backend repository reachable in-process (hostPath/NFS/PVC) so the controller can run short idempotent kopia ops (ADR §5.4). The e2e harness uses a hostPath here. |
 | controller.leaderElection | object | `{"enabled":true}` | Enable leader election. Required when replicaCount > 1; harmless at 1. |
+| controller.listenAddr | string | `"0.0.0.0:8081"` | Address the controller server binds to (env KOPIUR_CONTROLLER_ADDR) |
 | controller.logLevel | string | `"info"` | DEPRECATED: use the top-level `logging.level` instead. Kept as a fallback for existing values files — `logging.level` wins when both are set. Applies to the controller and webhook (RUST_LOG style: error|warn|info|debug|trace). |
 | controller.nodeSelector | object | `{}` | Scheduling controls. |
 | controller.podAnnotations | object | `{}` |  |

--- a/deploy/helm/kopiur/templates/deployment.tpl
+++ b/deploy/helm/kopiur/templates/deployment.tpl
@@ -80,6 +80,8 @@ spec:
             # ignoring the cgroup CPU quota) and the opt-in WatchList streaming list.
             - name: KOPIUR_WORKER_THREADS
               value: {{ .Values.controller.workerThreads | quote }}
+            - name: KOPIUR_CONTROLLER_ADDR
+              value: {{ .Values.controller.listenAddr | quote }}
             {{- if .Values.controller.streamingLists }}
             - name: KOPIUR_STREAMING_LISTS
               value: "true"

--- a/deploy/helm/kopiur/values.schema.json
+++ b/deploy/helm/kopiur/values.schema.json
@@ -54,6 +54,12 @@
           "title": "leaderElection",
           "type": "object"
         },
+        "listenAddr": {
+          "default": "0.0.0.0:8081",
+          "description": "Address the controller server binds to (env KOPIUR_CONTROLLER_ADDR)",
+          "title": "listenAddr",
+          "type": "string"
+        },
         "logLevel": {
           "default": "info",
           "description": "DEPRECATED: use the top-level `logging.level` instead. Kept as a fallback\nfor existing values files — `logging.level` wins when both are set. Applies to\nthe controller and webhook (RUST_LOG style: error|warn|info|debug|trace).",

--- a/deploy/helm/kopiur/values.yaml
+++ b/deploy/helm/kopiur/values.yaml
@@ -190,6 +190,8 @@ controller:
   # -- Extra pod labels / annotations.
   podLabels: {}
   podAnnotations: {}
+  # -- Address the controller server binds to (env KOPIUR_CONTROLLER_ADDR)
+  listenAddr: "0.0.0.0:8081"
   # -- Liveness/readiness HTTP probe port on the controller (serves /healthz, /readyz, /metrics).
   probePort: 8081
 


### PR DESCRIPTION
## Overview

Fixes #181.

Adds a new environmental variable (`KOPIUR_CONTROLLER_ADDR`) to allow users to set a custom listen address for the controller's HTTP server. Also wires in a new `controller.listenAddr` Helm value to set this (defaults to `0.0.0.0:8081`).

This logic is ~identical to how setting the listen address for the webhook's server works.

## Additional information

I have not extensively tested this.

## Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/home-operations/.github/blob/main/CONTRIBUTING.md)
- AI usage disclosure: No AI used