### PR TITLE
feat(ci): matrix-built binaries with the goreleaser Pro prebuilt builder

### DIFF
--- a/.github/workflows/goreleaser-check.yaml
+++ b/.github/workflows/goreleaser-check.yaml
@@ -2,14 +2,18 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
 name: GoReleaser Check
 
-# Snapshot-build the full release pipeline (all four targets, archives,
-# checksums, SBOMs) on the release job's actual runner whenever a PR touches
-# something that could break it: the goreleaser config, the dependency graph
-# (a bumped dep can introduce C bits zig can't link), the pinned toolchain, or
-# this workflow. Without this, `release.yaml`'s goreleaser job only ever runs
-# on published releases — a regression would surface as a broken release, and
-# build timings would be guesswork. Publishing and cosign signing are skipped
-# (signing needs OIDC, which fork PRs don't get, and adds only seconds).
+# Exercise the full release pipeline on PRs that touch something that could
+# break it: the goreleaser config, the dependency graph (a bumped dep can
+# introduce C bits that fail to link on some target), or the toolchain pins.
+# Without this, release.yaml's plugin/goreleaser jobs only ever run on
+# published releases — a regression would surface as a broken release.
+#
+# Two stages, mirroring release.yaml: the native build matrix (runs for every
+# PR, needs no secrets), then a goreleaser Pro snapshot over the built
+# binaries. The snapshot is skipped on fork PRs — they don't receive
+# GORELEASER_KEY — so forks still get full build coverage, just not the
+# packaging render. Publishing and cosign signing are skipped (signing needs
+# OIDC and adds only seconds).
 on:
   pull_request:
     paths:
@@ -19,40 +23,55 @@ on:
       - .mise/config.toml
       - .mise/mise.lock
       - .github/workflows/goreleaser-check.yaml
+      - .github/workflows/plugin-binaries.yaml
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  binaries:
+    name: Binaries
+    permissions:
+      contents: read
+    uses: ./.github/workflows/plugin-binaries.yaml
+
   snapshot:
-    name: Snapshot Build
-    runs-on: macos-15 # must match release.yaml's goreleaser job (see its comment)
+    name: Snapshot
+    if: ${{ !github.event.pull_request.head.repo.fork }}
+    needs: binaries
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          fetch-depth: 0 # mirror the release job so timings are comparable
+          fetch-depth: 0 # goreleaser derives the snapshot version from tags
           persist-credentials: false
-
-      - name: Setup Mise
-        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
-        with:
-          cache: false
-          experimental: true
-          install_args: --locked
 
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
+      - name: Download plugin binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: kopiur-*
+          path: prebuilt
+
+      # Workflow artifacts drop file modes; goreleaser packages the binaries
+      # as-is, so restore the executable bit before it runs.
+      - name: Restore executable bits
+        run: chmod +x prebuilt/kopiur-*/kopiur
+
       - name: Run GoReleaser (snapshot)
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro # the prebuilt builder is a Pro feature
           version: "~> v2"
           args: release --clean --snapshot --skip=publish,sign
+        env:
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
 
       - name: Inspect rendered artifacts
         run: |

--- a/.github/workflows/plugin-binaries.yaml
+++ b/.github/workflows/plugin-binaries.yaml
@@ -1,0 +1,105 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Plugin Binaries
+
+# Reusable matrix that builds the plugin binary (`kopiur`) natively for every
+# release target and uploads each as a workflow artifact named
+# `kopiur-<os>_<arch>` — the layout goreleaser's prebuilt builder consumes
+# (.goreleaser.yaml `prebuilt.path`). Called by release.yaml (with the release
+# tag as `version`) and goreleaser-check.yaml (unstamped snapshot). Native legs
+# run in parallel (~5 min wall clock) vs ~18 min measured for one runner
+# cross-linking everything with zig; native linking also drops the zig
+# toolchain and the macOS-runner requirement from the packaging job.
+#
+# NOTE: workflow artifacts do not preserve file modes — consumers must
+# `chmod +x` the downloaded binaries before goreleaser packages them.
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: Release tag to stamp into `kopiur --version` (empty = crate version)
+        type: string
+        required: false
+        default: ""
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # No Windows: kopiur-mover (whose pure Job builders the CLI reuses) is
+        # unix-only. Both apple targets build on the arm64 macOS runner — the
+        # SDK links either architecture. musl keeps Linux fully static.
+        include:
+          - target: x86_64-unknown-linux-musl
+            os: ubuntu-24.04
+            slug: linux_amd64
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
+            slug: linux_arm64
+          - target: x86_64-apple-darwin
+            os: macos-15
+            slug: darwin_amd64
+          - target: aarch64-apple-darwin
+            os: macos-15
+            slug: darwin_arm64
+    env:
+      TARGET: ${{ matrix.target }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      # Read the pinned toolchain version out of mise's config without
+      # installing any mise tools — rustup provisions the leg's toolchain so
+      # each runner only downloads its own target's stdlib.
+      - name: Setup Mise
+        uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          cache: false
+          experimental: true
+          install: false
+
+      - name: Resolve Rust version
+        id: rust
+        run: echo "version=$(mise config get tools.rust.version)" >> "$GITHUB_OUTPUT"
+
+      - name: Install musl toolchain
+        if: ${{ contains(matrix.target, 'musl') }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install Rust toolchain
+        env:
+          RUST_VERSION: ${{ steps.rust.outputs.version }}
+        run: |
+          rustup toolchain install "${RUST_VERSION}" --profile minimal
+          rustup default "${RUST_VERSION}"
+          rustup target add "${TARGET}"
+
+      # KOPIUR_VERSION stamps `kopiur --version` with the release tag
+      # (crates/cli/src/consts.rs option_env!). Only exported when a version
+      # was passed — an empty env var would stamp an empty string instead of
+      # falling back to the crate version.
+      - name: Build kopiur
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "${VERSION}" ]; then
+            export KOPIUR_VERSION="${VERSION}"
+          fi
+          cargo build --release --locked --target "${TARGET}" -p kopiur-cli
+
+      - name: Upload binary
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: kopiur-${{ matrix.slug }}
+          path: target/${{ matrix.target }}/release/kopiur
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -232,22 +232,29 @@ jobs:
         run: |-
           cosign sign --yes "ghcr.io/${{ github.repository_owner }}/charts/kopiur:${VERSION}"
 
-  # The kubectl plugin (kubectl-kopiur): one goreleaser run builds all four
-  # targets, attaches archives + split sha256s + SBOMs + cosign signatures to
-  # the release, commits the Homebrew cask to home-operations/homebrew-tap
-  # (like flate/yayamlls), and commits the krew manifest to THIS repo's
-  # plugins/ directory — the kopiur repository doubles as its own krew custom
-  # index. The krew push uses GITHUB_TOKEN, which cannot retrigger workflows.
-  #
-  # Runs on macOS: goreleaser's rust builder links every target with zig via
-  # cargo-zigbuild (musl keeps Linux fully static), and security-framework-sys
-  # (in kube's dependency graph) emits `-framework Security` link flags that
-  # only resolve against a real macOS SDK. mise provides the pinned toolchain:
-  # rust (+ the four target stdlibs), zig, cargo-zigbuild, and cosign.
+  # Native per-target builds of the plugin binary — see plugin-binaries.yaml.
+  plugin:
+    name: Plugin
+    if: ${{ github.event_name == 'release' }}
+    permissions:
+      contents: read
+    uses: ./.github/workflows/plugin-binaries.yaml
+    with:
+      version: ${{ github.event.release.tag_name }}
+
+  # The kubectl plugin (kubectl-kopiur): goreleaser Pro imports the matrix's
+  # prebuilt binaries, attaches archives + split sha256s + SBOMs + cosign
+  # signatures to the release, commits the Homebrew cask to
+  # home-operations/homebrew-tap (like flate/yayamlls), and commits the krew
+  # manifest to THIS repo's plugins/ directory — the kopiur repository doubles
+  # as its own krew custom index. The krew push uses GITHUB_TOKEN, which
+  # cannot retrigger workflows. Nothing compiles or links here, so this runs
+  # on ubuntu; mise provides cosign.
   goreleaser:
     name: GoReleaser
     if: ${{ github.event_name == 'release' }}
-    runs-on: macos-15
+    needs: plugin
+    runs-on: ubuntu-24.04
     permissions:
       contents: write # attach artifacts to the release + push the krew manifest
       id-token: write # keyless Cosign signing of the artifacts
@@ -268,6 +275,17 @@ jobs:
       - name: Install Syft
         uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
+      - name: Download plugin binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: kopiur-*
+          path: prebuilt
+
+      # Workflow artifacts drop file modes; goreleaser packages the binaries
+      # as-is, so restore the executable bit before it runs.
+      - name: Restore executable bits
+        run: chmod +x prebuilt/kopiur-*/kopiur
+
       # One short-lived bot token scoped to exactly the two repos goreleaser
       # pushes to: the tap (Homebrew cask) and this repo (krew manifest into
       # plugins/). Bot-token pushes retrigger workflows — every on-push workflow
@@ -285,10 +303,11 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7.2.2
         with:
-          distribution: goreleaser
+          distribution: goreleaser-pro # the prebuilt builder is a Pro feature
           version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_KEY: ${{ secrets.GORELEASER_KEY }}
           HOMEBREW_TAP_TOKEN: ${{ steps.bot-token.outputs.token }}
           KREW_INDEX_TOKEN: ${{ steps.bot-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ target/
 
 # MkDocs docs site output (`mise run docs`); rustdoc output is under target/.
 /site/
+# Staged binaries for goreleaser's prebuilt builder (local snapshot testing).
+/prebuilt/
 # uv-managed virtualenv for the docs toolchain.
 /.venv/
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,60 +1,50 @@
 ---
-# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# yaml-language-server: $schema=https://goreleaser.com/static/schema-pro.json
 version: 2
 project_name: kubectl-kopiur
 
-# Each target's rust-std must be installed before building (goreleaser does not
-# add rustup targets itself). The mise rust tool declares them (`targets =` in
-# .mise/config.toml) so the toolchain that provides cargo also carries the
-# stdlibs — a `rustup target add` hook here can install into a different
-# RUSTUP_HOME than the active cargo resolves against.
-before:
-  hooks:
-    - cargo fetch --locked
-
 builds:
+  # The binaries are NOT built here: the plugin-binaries.yaml matrix compiles
+  # `kopiur` natively per target (parallel legs, ~5 min wall clock vs ~18 min
+  # measured for one runner cross-linking everything with zig) and the
+  # prebuilt builder (goreleaser Pro) imports them into the artifact catalog,
+  # so archives/checksums/SBOMs/signing/cask/krew all work unchanged. This
+  # also frees the packaging job from macOS — with no linking there is no
+  # Security.framework, so it runs on ubuntu.
+  #
+  # The workflow downloads each `kopiur-<os>_<arch>` artifact into prebuilt/
+  # and restores the executable bit (workflow artifacts drop file modes).
+  #
+  # `binary` must stay `kopiur` (the crates/cli [[bin]] name): brew links the
+  # file as-is as the standalone `kopiur` command, while krew symlinks
+  # `kubectl-kopiur` (the name kubectl discovers) to this file itself — so
+  # installing via both never collides on PATH.
+  #
+  # No Windows target: kopiur-mover (whose pure Job builders the CLI reuses)
+  # is unix-only — no release has ever shipped a Windows asset.
   - id: kubectl-kopiur
-    builder: rust
-    # Must match the crates/cli [[bin]] name — the rust builder collects
-    # target/<triple>/release/<binary> verbatim (no rename). The file ships as
-    # plain `kopiur` so brew and krew never collide: brew links it as the
-    # standalone `kopiur` command, while krew symlinks `kubectl-kopiur` (the
-    # name kubectl discovers) to this file itself.
+    builder: prebuilt
     binary: kopiur
-    # cargo-zigbuild (the rust builder's default command) links every target —
-    # including the C bits in `ring` — with zig's clang, so all the triples
-    # build from ONE runner. That runner must be macOS: `security-framework-sys`
-    # (in kube's graph via hyper-rustls, even though the CLI's webpki-roots
-    # feature compiles its code out) emits `-framework Security` link flags that
-    # only resolve against a real macOS SDK, which Linux runners don't have.
-    # musl keeps the Linux binaries fully static (as the old native matrix did).
-    # No Windows target: kopiur-mover (whose pure Job builders the CLI reuses)
-    # is unix-only, and the old matrix's best-effort Windows leg was already
-    # failing — no release ships a Windows asset. The CLI is rustls-only.
-    targets:
-      - x86_64-unknown-linux-musl
-      - aarch64-unknown-linux-musl
-      - x86_64-apple-darwin
-      - aarch64-apple-darwin
-    flags:
-      - --release
-      - --package=kopiur-cli
-      - --locked
-    env:
-      # consts::VERSION prefers this compile-time stamp over the crate version,
-      # mirroring how the operator images stamp VERSION. release-please has
-      # already bumped Cargo.toml at the tag, so this is belt-and-braces.
-      - KOPIUR_VERSION={{ .Version }}
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    goamd64:
+      - v1
+    prebuilt:
+      path: prebuilt/kopiur-{{ .Os }}_{{ .Arch }}/kopiur
 
 archives:
   - id: kubectl-kopiur
     ids:
       - kubectl-kopiur
 
-# No upx stanza (unlike the Go tools' configs): upx ships no macOS-host builds,
-# and this release job must run on macOS (see the builds comment). The tar.gz
-# archives already compress the download; unpacked binaries also skip upx's
-# AV-false-positive and startup-decompression costs.
+# No upx stanza (unlike the Go tools' configs): modern macOS kills upx-packed
+# binaries outright (Gatekeeper rejects the packed Mach-O), and shrinking only
+# the Linux pair isn't worth the AV-false-positive and startup-decompression
+# costs. The tar.gz archives already compress the download.
 
 checksum:
   algorithm: sha256

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -15,10 +15,7 @@ experimental = true
 config_roots = ["crates/e2e"]
 
 [tools]
-# `targets` carries the cross-compile stdlibs the goreleaser rust builder needs:
-# cargo-zigbuild links every release triple from one macOS runner (musl keeps
-# the Linux binaries fully static).
-rust = { version = "1.95.0", components = "rustfmt,clippy,llvm-tools-preview", targets = "x86_64-unknown-linux-musl,aarch64-unknown-linux-musl,x86_64-apple-darwin,aarch64-apple-darwin" }
+rust = { version = "1.95.0", components = "rustfmt,clippy,llvm-tools-preview" }
 lefthook = "2.1.9"
 # `oxfmt` is distributed only via the npm backend (`mise registry oxfmt` →
 # `npm:oxfmt`), which needs a node/npm to install. Pin node explicitly so the
@@ -37,11 +34,6 @@ shellcheck = "0.11.0"
 kind = "0.32.0"
 kopia = "v0.23.1"
 "aqua:EmbarkStudios/cargo-deny" = "0.19.9"
-# goreleaser's rust builder cross-links every release target (incl. the C bits
-# in `ring`) with zig's clang via cargo-zigbuild — one runner builds all the
-# release triples. See .goreleaser.yaml.
-zig = "0.15.2"
-"aqua:rust-cross/cargo-zigbuild" = "0.23.0"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.7"
 # Docs site toolchain. The docs are an MkDocs Material site (see `mise run docs`);
 # the MkDocs + Material + pymdown-extensions versions are pinned in pyproject.toml

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -103,34 +103,6 @@ url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema
 checksum = "sha256:261f93081473ae8d465b29320f55282d979af9aa2c0585ad82dbc10db4d89175"
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Windows_x86_64.zip"
 
-[[tools."aqua:rust-cross/cargo-zigbuild"]]
-version = "0.23.0"
-backend = "aqua:rust-cross/cargo-zigbuild"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.linux-arm64"]
-checksum = "sha256:5917d5416884cba0f23c2653016f7f2df2ec04e74eb6b259598fecc066f8c429"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-aarch64-unknown-linux-gnu.tar.xz"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.linux-x64"]
-checksum = "sha256:c636e4f72b6f40a40ddf0414c8c6056f78b87eea3be0edf01f08d65fa028a373"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-x86_64-unknown-linux-gnu.tar.xz"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.linux-x64-musl"]
-checksum = "sha256:f0aa9cc8220a84788c6e4a9b6d80422f041659227b680fdef982d5a8ddffddb4"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-x86_64-unknown-linux-musl.tar.xz"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.macos-arm64"]
-checksum = "sha256:3d8f1ad296d3f3e97122607f7c972393c6329801027acb71bb7d17a4e30ef092"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-aarch64-apple-darwin.tar.xz"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.macos-x64"]
-checksum = "sha256:f8c746d12dfae79ac0704c5aa13631a05b24c3e4ee7216eb40f70943bd8ca7b1"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-x86_64-apple-darwin.tar.xz"
-
-[tools."aqua:rust-cross/cargo-zigbuild"."platforms.windows-x64"]
-checksum = "sha256:82ff1207be9e9533267b83dbe33d0b16b30043f116dc336d9a526667fa27622a"
-url = "https://github.com/rust-cross/cargo-zigbuild/releases/download/v0.23.0/cargo-zigbuild-x86_64-pc-windows-msvc.zip"
-
 [[tools."aqua:taiki-e/cargo-llvm-cov"]]
 version = "0.8.7"
 backend = "aqua:taiki-e/cargo-llvm-cov"
@@ -443,15 +415,6 @@ backend = "core:rust"
 
 [tools.rust.options]
 components = "clippy,llvm-tools-preview,rustfmt"
-targets = "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-apple-darwin,x86_64-pc-windows-gnu,x86_64-unknown-linux-musl"
-
-[[tools.rust]]
-version = "1.95.0"
-backend = "core:rust"
-
-[tools.rust.options]
-components = "clippy,llvm-tools-preview,rustfmt"
-targets = "aarch64-apple-darwin,aarch64-unknown-linux-musl,x86_64-apple-darwin,x86_64-unknown-linux-musl"
 
 [[tools.shellcheck]]
 version = "0.11.0"
@@ -516,38 +479,6 @@ url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_darwin_amd64
 [tools.yq."platforms.windows-x64"]
 checksum = "sha256:e279bc506a452eeafcdf364f91a025455e402a8001169083caf01f4b64a544e2"
 url = "https://github.com/mikefarah/yq/releases/download/v4.53.3/yq_windows_amd64.exe"
-
-[[tools.zig]]
-version = "0.15.2"
-backend = "core:zig"
-
-[tools.zig."platforms.linux-arm64"]
-checksum = "sha256:958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f"
-url = "https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz"
-
-[tools.zig."platforms.linux-arm64-musl"]
-checksum = "sha256:958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f"
-url = "https://ziglang.org/download/0.15.2/zig-aarch64-linux-0.15.2.tar.xz"
-
-[tools.zig."platforms.linux-x64"]
-checksum = "sha256:02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
-url = "https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz"
-
-[tools.zig."platforms.linux-x64-musl"]
-checksum = "sha256:02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239"
-url = "https://ziglang.org/download/0.15.2/zig-x86_64-linux-0.15.2.tar.xz"
-
-[tools.zig."platforms.macos-arm64"]
-checksum = "sha256:3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b"
-url = "https://ziglang.org/download/0.15.2/zig-aarch64-macos-0.15.2.tar.xz"
-
-[tools.zig."platforms.macos-x64"]
-checksum = "sha256:375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f"
-url = "https://ziglang.org/download/0.15.2/zig-x86_64-macos-0.15.2.tar.xz"
-
-[tools.zig."platforms.windows-x64"]
-checksum = "sha256:3a0ed1e8799a2f8ce2a6e6290a9ff22e6906f8227865911fb7ddedc3cc14cb0c"
-url = "https://ziglang.org/download/0.15.2/zig-x86_64-windows-0.15.2.zip"
 
 [[tools.zizmor]]
 version = "1.26.1"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,9 +32,8 @@ kopiur-mover = { workspace = true }
 # `webpki-roots` compiles in Mozilla's root store as the TLS fallback for the
 # rare kubeconfig without certificate-authority data (e.g. a cluster fronted by
 # public-CA TLS); the normal path — the cluster CA embedded in kubeconfig — is
-# unaffected. It also compiles out kube's native-roots path, whose macOS
-# Security.framework *symbols* zig's linker cannot resolve — required by the
-# goreleaser release build, which links every target with zig (.goreleaser.yaml).
+# unaffected. It also gives that fallback identical behavior on every platform
+# (kube's native-roots path would consult each OS's own trust store).
 kube = { workspace = true, features = ["client", "runtime", "rustls-tls", "webpki-roots", "ws"] }
 futures = { workspace = true }
 k8s-openapi = { workspace = true, features = ["v1_33"] }


### PR DESCRIPTION
## What

Stacked on #187. Converts the plugin release from one macos-15 runner cross-linking everything with zig (**18m09s measured**) back to the parallel native matrix (**~5 min measured** on the last matrix release), with goreleaser **Pro's `prebuilt` builder** importing the matrix's binaries so all the packaging from #187 — archives, split sha256s, SBOMs, cosign, the Homebrew cask, the krews push — stays exactly as shipped there.

| | #187 (zig mono-job) | this PR (matrix + prebuilt) |
|---|---|---|
| Build | 1× macos-15, cargo-zigbuild, 4 targets serial-ish | 4 native legs in parallel (`plugin-binaries.yaml`) |
| Wall clock | 18m09s measured | ~5 min legs + ~1 min packaging |
| Packaging runner | macos-15 (Security.framework link flags) | **ubuntu-24.04** — nothing links, so no macOS SDK needed |
| Toolchain | mise rust + 4 cross stdlibs + zig + cargo-zigbuild | plain rustup per leg; zig/zigbuild/cross-targets removed from mise |
| goreleaser | OSS, experimental rust builder | **Pro, prebuilt builder** (`GORELEASER_KEY` org secret) |

## Shape

- **`plugin-binaries.yaml`** (reusable, `workflow_call`): the 4-leg native matrix from the pre-#187 workflow, building `kopiur` per target and uploading `kopiur-<os>_<arch>` artifacts. Takes an optional `version` input for the `KOPIUR_VERSION` stamp (only exported when non-empty — an empty env var would stamp an empty string). Both apple targets build on the arm64 macOS runner; musl stays fully static; still no Windows (kopiur-mover is unix-only — that's a source-code blocker no build shape fixes).
- **`release.yaml`**: new `plugin` job calls the matrix with the release tag; the `goreleaser` job moves to ubuntu, downloads the artifacts into `prebuilt/`, **restores the executable bit** (workflow artifacts drop file modes — without the chmod every archive would ship a non-executable binary), and runs `goreleaser-pro`.
- **`.goreleaser.yaml`**: `builder: prebuilt` with `prebuilt.path: prebuilt/kopiur-{{ .Os }}_{{ .Arch }}/kopiur`; the `before` cargo-fetch hook and build env are gone (nothing compiles here). Schema comment → `schema-pro.json`.
- **`goreleaser-check.yaml`**: same two stages on PRs touching release-relevant paths. The matrix runs for every PR (no secrets needed); the snapshot render is skipped on fork PRs (they don't receive `GORELEASER_KEY`) — forks keep full build coverage, just not the packaging render. Renovate PRs now cost ~5 parallel minutes instead of 18 serial macOS minutes.
- **mise**: zig, cargo-zigbuild, and the rust `targets` stdlibs removed; lock regenerated. `webpki-roots` on the CLI **stays** — no longer needed for linking, but it keeps the CA-less-kubeconfig TLS fallback identical on every platform (comment updated to say so).

## Verified locally

Downloaded the goreleaser-pro binary and it validates + snapshots this config **without a license key** (the key gates publishing): staged host-built binaries into the four `prebuilt/` paths and ran `release --snapshot` end-to-end in 5s — cask renders with exactly one `binary "kopiur"` stanza, krew manifest has `bin: kopiur` on all four platforms, archives preserve the executable bit, and the extracted binary runs. `actionlint` + `zizmor` clean on all three workflows; `mise run test` / `clippy` green.

## Before merge

1. `GORELEASER_KEY` must exist as an org secret (pending Carlos's reply).
2. #187 merges first; this branch then rebases onto main.
3. The `GoReleaser Check` run on this PR is the real proof: it exercises matrix → artifacts → chmod → pro snapshot on actual runners. The snapshot leg will fail until the org secret exists — expected until (1).
