### PR TITLE
feat(api)!: gate verification on a verifiable snapshot; nest quick under schedule

### DIFF
--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -298,9 +298,10 @@ pub struct Upload {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Verification {
-    /// Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
+    /// Quick (blob-level) verification tier; absent ⇒ no quick verification. Its cron
+    /// lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub quick: Option<CronSpec>,
+    pub quick: Option<QuickVerification>,
     /// Schedule + knobs for the rarer scratch-restore test; absent ⇒ no deep verification.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub deep: Option<DeepVerification>,
@@ -310,6 +311,24 @@ pub struct Verification {
     /// How many files `quick` verifies fully (`--verify-files-percent`); absent leaves kopia's default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub verify_files_percent: Option<u8>,
+}
+
+/// Quick (blob-level) verification tier: schedule for the frequent `kopia snapshot verify`.
+///
+/// A wrapper so this tier's shape matches `deep` — the cron lives at
+/// `quick.schedule.cron` (GitHub #174). `schedule` is deliberately `Option` for
+/// decode-tolerance: an already-persisted old-shape `quick: { cron: ... }` object
+/// still decodes (serde ignores the unknown `cron` key) as `schedule: None` rather
+/// than failing typed serde — a hard decode failure would wedge the SnapshotPolicy
+/// reflector and poison SnapshotPolicy admission cluster-wide. New writes with the
+/// old shape are rejected at admission by the shared validator, which points at the
+/// move. A persisted `schedule: None` means the quick tier is disabled until updated.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct QuickVerification {
+    /// Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schedule: Option<CronSpec>,
 }
 
 /// Deep (scratch-restore) verification: restore the latest snapshot into an ephemeral volume, then discard.
@@ -852,7 +871,8 @@ suspend: true
 repository: { kind: Repository, name: r }
 sources: [ { pvc: { name: d } } ]
 verification:
-  quick: { cron: "0 4 * * *", jitter: 30m }
+  quick:
+    schedule: { cron: "0 4 * * *", jitter: 30m }
   deep:
     schedule: { cron: "0 5 * * 0", jitter: 1h }
     capacity: 10Gi
@@ -862,7 +882,8 @@ verification:
 "#;
         let spec: SnapshotPolicySpec = from_yaml(yaml);
         let v = spec.verification.as_ref().expect("verification");
-        assert_eq!(v.quick.as_ref().unwrap().cron, "0 4 * * *");
+        let quick = v.quick.as_ref().expect("quick");
+        assert_eq!(quick.schedule.as_ref().unwrap().cron, "0 4 * * *");
         let deep = v.deep.as_ref().expect("deep");
         assert_eq!(deep.schedule.cron, "0 5 * * 0");
         assert_eq!(deep.capacity.as_deref(), Some("10Gi"));
@@ -873,7 +894,10 @@ verification:
         assert_eq!(v.verify_files_percent, Some(10));
 
         let json = serde_json::to_value(&spec).expect("serialize");
-        assert_eq!(json["verification"]["quick"]["cron"], "0 4 * * *");
+        assert_eq!(
+            json["verification"]["quick"]["schedule"]["cron"],
+            "0 4 * * *"
+        );
         let reparsed: SnapshotPolicySpec = serde_json::from_value(json).expect("reparse");
         assert_eq!(spec, reparsed);
 
@@ -887,6 +911,28 @@ verification:
                 .unwrap()
                 .get("verification")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn verification_quick_old_shape_still_decodes() {
+        // GitHub #174: `verification.quick` gained a nested `schedule`. An object
+        // persisted in etcd BEFORE this change carries the flat shape
+        // (`quick: { cron: ... }`). It MUST still decode (serde ignores the unknown
+        // `cron`/`jitter` keys) as `schedule: None` — a hard decode failure would
+        // wedge the SnapshotPolicy reflector and poison admission cluster-wide. The
+        // quick tier is then treated as disabled; the webhook rejects NEW old-shape
+        // writes with a pointer to the move.
+        let old = from_yaml::<SnapshotPolicySpec>(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             verification:\n  quick: { cron: \"0 4 * * *\", jitter: 30m }\n",
+        );
+        let v = old.verification.as_ref().expect("verification");
+        let quick = v.quick.as_ref().expect("quick present");
+        assert!(
+            quick.schedule.is_none(),
+            "old flat `quick: {{cron: ...}}` must decode with schedule: None (quick disabled)"
         );
     }
 

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -84,14 +84,32 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
     // out-of-scope variable — rejected at admission rather than at first verify run.
     if let Some(v) = &spec.verification {
         if let Some(q) = &v.quick {
-            if let Err(e) = validate_cron(&q.cron) {
-                errs.push(e);
-            }
-            if let Err(e) = validate_timezone(q.timezone.as_deref()) {
-                errs.push(e);
-            }
-            if let Err(e) = validate_jitter("spec.verification.quick.jitter", q.jitter.as_deref()) {
-                errs.push(e);
+            // The flat `verification.quick.cron` shape moved under `quick.schedule`
+            // (GitHub #174) — a required schedule would break decode of old persisted
+            // objects, so `schedule` is Option and this validator is the gate that
+            // rejects a re-apply of the old shape with an actionable pointer.
+            match &q.schedule {
+                None => errs.push(ValidationError::InvalidFieldValue {
+                    field: "spec.verification.quick.schedule".to_string(),
+                    reason: "the flat `verification.quick.cron` shape moved to \
+                             `verification.quick.schedule.cron` (matching `deep.schedule`). \
+                             Move your cron/jitter/timezone fields under `schedule:`."
+                        .to_string(),
+                }),
+                Some(s) => {
+                    if let Err(e) = validate_cron(&s.cron) {
+                        errs.push(e);
+                    }
+                    if let Err(e) = validate_timezone(s.timezone.as_deref()) {
+                        errs.push(e);
+                    }
+                    if let Err(e) = validate_jitter(
+                        "spec.verification.quick.schedule.jitter",
+                        s.jitter.as_deref(),
+                    ) {
+                        errs.push(e);
+                    }
+                }
             }
         }
         if let Some(d) = &v.deep {

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -2652,6 +2652,73 @@ fn backup_config_validates_preflight() {
     );
 }
 
+#[test]
+fn backup_config_validates_verification() {
+    // New nested-quick shape is accepted.
+    let ok: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  quick:\n    schedule: { cron: \"0 4 * * *\", jitter: 30m }\n",
+    );
+    assert!(
+        validate_backup_config(&ok).is_empty(),
+        "{:?}",
+        validate_backup_config(&ok)
+    );
+
+    // GitHub #174: a re-applied OLD flat shape (`quick: { cron: ... }`) decodes with
+    // schedule: None, and must be rejected with an actionable pointer to the move —
+    // NOT a cryptic structural error. Assert the field AND the message text.
+    let old_shape: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  quick: { cron: \"0 4 * * *\", jitter: 30m }\n",
+    );
+    let errs = validate_backup_config(&old_shape);
+    let quick_err = errs
+        .iter()
+        .find_map(|e| match e {
+            ValidationError::InvalidFieldValue { field, reason }
+                if field == "spec.verification.quick.schedule" =>
+            {
+                Some(reason)
+            }
+            _ => None,
+        })
+        .unwrap_or_else(|| panic!("expected a quick.schedule rejection, got: {errs:?}"));
+    assert!(
+        quick_err.contains("verification.quick.schedule.cron")
+            && quick_err.contains("Move your cron/jitter/timezone fields under `schedule:`"),
+        "message must name the move actionably, got: {quick_err:?}"
+    );
+
+    // A bad cron under the new schedule is still rejected (the schedule is validated).
+    let bad_cron: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  quick:\n    schedule: { cron: \"not a cron\" }\n",
+    );
+    assert!(
+        validate_backup_config(&bad_cron)
+            .iter()
+            .any(|e| matches!(e, ValidationError::InvalidCron { .. })),
+        "{:?}",
+        validate_backup_config(&bad_cron)
+    );
+
+    // Quick entirely absent ⇒ no verification error (quick is opt-in).
+    let no_quick: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  deep:\n    schedule: { cron: \"0 5 * * 0\" }\n",
+    );
+    assert!(
+        validate_backup_config(&no_quick).is_empty(),
+        "{:?}",
+        validate_backup_config(&no_quick)
+    );
+}
+
 // --- identity shape validation ---
 
 #[test]

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -233,6 +233,9 @@ async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Actio
     // LAST-SNAPSHOT column + the staleness alert). Deterministic (the max endTime
     // over this policy's Succeeded Snapshots), so an unchanged value is a no-op patch.
     let last_successful = latest_successful_snapshot(&ctx.client, &namespace, &name).await?;
+    // Does this policy have a verifiable backup yet? Backs the #168 verification gate
+    // below (captured before `last_successful` is consumed by the status patch).
+    let has_successful_snapshot = last_successful.is_some();
 
     // 2. Enforce GFS retention: list this config's Snapshots, decide which to
     //    delete, and delete each (the Snapshot finalizer governs the snapshot).
@@ -375,7 +378,9 @@ async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Actio
     // requeue on the shorter of the steady cadence and the verify cadence so a due
     // verification fires on time.
     let steady = std::time::Duration::from_secs(300);
-    match crate::verification::verify_step(config, ctx, &repo, &namespace).await? {
+    match crate::verification::verify_step(config, ctx, &repo, &namespace, has_successful_snapshot)
+        .await?
+    {
         Some(verify_requeue) => Ok(Action::requeue(steady.min(verify_requeue))),
         None => Ok(Action::requeue(steady)),
     }

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -141,8 +141,13 @@ pub fn due_tier(
     {
         return Some((VerifyTierKind::Deep, slot));
     }
+    // `quick.schedule == None` ⇒ quick tier disabled. This is the old-shape
+    // decode-tolerance path: a stale persisted `quick: {cron: ...}` decodes as
+    // `schedule: None`, so the quick tier is simply not due (never panics/wedges);
+    // new writes with the old shape are rejected at admission.
     if let Some(q) = &verification.quick
-        && let Ok(slot) = slot_for(seed, q, after, repo_tz)
+        && let Some(schedule) = &q.schedule
+        && let Ok(slot) = slot_for(seed, schedule, after, repo_tz)
         && now >= slot
     {
         return Some((VerifyTierKind::Quick, slot));
@@ -162,7 +167,10 @@ pub fn next_verify_wakeup(
     let after = tier_after(last_verified);
     let mut earliest: Option<DateTime<Utc>> = None;
     for spec in [
-        verification.quick.as_ref(),
+        verification
+            .quick
+            .as_ref()
+            .and_then(|q| q.schedule.as_ref()),
         verification.deep.as_ref().map(|d| &d.schedule),
     ]
     .into_iter()
@@ -660,14 +668,16 @@ async fn has_active_verify_job(job_api: &Api<Job>, policy_name: &str) -> Result<
 mod tests {
     use super::*;
     use kopiur_api::common::CronSpec;
-    use kopiur_api::snapshot_policy::DeepVerification;
+    use kopiur_api::snapshot_policy::{DeepVerification, QuickVerification};
 
     fn verification(quick: Option<&str>, deep: Option<&str>) -> Verification {
         Verification {
-            quick: quick.map(|c| CronSpec {
-                cron: c.into(),
-                jitter: None,
-                timezone: None,
+            quick: quick.map(|c| QuickVerification {
+                schedule: Some(CronSpec {
+                    cron: c.into(),
+                    jitter: None,
+                    timezone: None,
+                }),
             }),
             deep: deep.map(|c| DeepVerification {
                 schedule: CronSpec {
@@ -715,6 +725,28 @@ mod tests {
         let v = verification(None, None);
         assert!(due_tier(&v, "seed", None, Utc::now(), None, true).is_none());
         assert!(due_tier(&v, "seed", None, Utc::now(), None, true).is_none());
+    }
+
+    #[test]
+    fn old_shape_quick_without_schedule_is_disabled_not_paniced() {
+        // GitHub #174 decode-tolerance: a stale persisted `quick: {cron: ...}` object
+        // decodes as `quick: Some(QuickVerification { schedule: None })`. The reconciler
+        // must treat it as "quick tier disabled" — never due, no panic/wedge. (New
+        // writes of this shape are blocked at admission.)
+        let v = Verification {
+            quick: Some(QuickVerification { schedule: None }),
+            deep: None,
+            success_expr: None,
+            verify_files_percent: None,
+        };
+        assert!(
+            due_tier(&v, "seed", None, Utc::now(), None, true).is_none(),
+            "quick with no schedule must be disabled, not due"
+        );
+        // And it doesn't inflate the wakeup either: with no live schedule at all, the
+        // wakeup floors at the running cadence rather than a past-due hot loop.
+        let wake = next_verify_wakeup(&v, "seed", None, Utc::now(), None);
+        assert_eq!(wake, REQUEUE_RUNNING);
     }
 
     // --- #168 gate: no verify before a verifiable snapshot exists ---
@@ -820,7 +852,13 @@ mod tests {
             .with_timezone(&Utc);
         let last_verified = Some(now - chrono::Duration::hours(2));
         let mut v = verification(Some("0 5 * * *"), None);
-        v.quick.as_mut().unwrap().timezone = Some("UTC".into());
+        v.quick
+            .as_mut()
+            .unwrap()
+            .schedule
+            .as_mut()
+            .unwrap()
+            .timezone = Some("UTC".into());
         // Own timezone (UTC) says the slot is due; the repo default
         // (America/Los_Angeles, which would push the slot hours into the future)
         // must be ignored.

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -134,22 +134,23 @@ pub enum DiscoveredProbeScope {
     ClusterWide,
 }
 
-/// **Pure.** Decide where [`repo_has_discovered_snapshots`] should LIST, from whether
-/// the resolved repository is cluster-scoped and the probing policy's namespace.
+/// **Pure.** Decide where [`repo_has_discovered_snapshots`] should LIST, from the
+/// resolved repository's own namespace ([`ResolvedRepository::repo_namespace`]).
 ///
-/// Namespaced repos keep the existing policy-namespace probe (the catalog materializes
-/// their discovered rows in that one namespace). A `ClusterRepository`'s rows land in
-/// arbitrary, per-identity namespaces the reconciler can't enumerate a priori, so the
-/// only correct probe is cluster-wide — otherwise an *adopted* `ClusterRepository`
+/// Namespaced repos probe **their own** namespace, not the probing policy's: the
+/// catalog materializes discovered rows in the repository's namespace
+/// ([`crate::catalog::Placement::Namespace`]), and `RepositoryRef` allows a policy to
+/// reference a `Repository` in a different namespace from its own
+/// (`kopiur_api::validate::repository`) — so a same-namespace assumption silently
+/// never unlocks verification for a cross-namespace-referenced adopted repository. A
+/// `ClusterRepository` (`repo_namespace: None`) scatters its rows across arbitrary,
+/// per-identity namespaces the reconciler can't enumerate a priori, so the only
+/// correct probe there is cluster-wide — otherwise an *adopted* `ClusterRepository`
 /// would never unlock verification before its first child backup (#168 regression).
-pub fn discovered_probe_scope(
-    cluster_scoped: bool,
-    policy_namespace: &str,
-) -> DiscoveredProbeScope {
-    if cluster_scoped {
-        DiscoveredProbeScope::ClusterWide
-    } else {
-        DiscoveredProbeScope::Namespace(policy_namespace.to_string())
+pub fn discovered_probe_scope(repo_namespace: Option<&str>) -> DiscoveredProbeScope {
+    match repo_namespace {
+        Some(ns) => DiscoveredProbeScope::Namespace(ns.to_string()),
+        None => DiscoveredProbeScope::ClusterWide,
     }
 }
 
@@ -316,13 +317,15 @@ pub async fn verify_step(
     // any backup, and the mover fails hard. Unlocked once this policy has a Succeeded
     // snapshot OR its repo already carries discovered (adopted) snapshots. The
     // discovered probe is a cheap labeled LIST (thin IO over the pure gate) — skipped
-    // entirely once a successful backup already unlocks the gate. A cluster-scoped
-    // repository (`repo_namespace == None`) scatters its discovered rows across
-    // per-identity namespaces, so the probe scope is cluster-wide there.
+    // entirely once a successful backup already unlocks the gate. Probed in the
+    // repository's OWN namespace (not the policy's — `RepositoryRef` allows a
+    // cross-namespace reference), or cluster-wide for a cluster-scoped repository
+    // (`repo_namespace == None`), which scatters its discovered rows across
+    // per-identity namespaces.
     let has_discovered = if has_successful {
         false
     } else {
-        let scope = discovered_probe_scope(repo.repo_namespace.is_none(), namespace);
+        let scope = discovered_probe_scope(repo.repo_namespace.as_deref());
         repo_has_discovered_snapshots(&ctx.client, &scope, &repo.owner_ref.uid).await?
     };
     let unlocked = verification_unlocked(has_successful, has_discovered);
@@ -842,23 +845,39 @@ mod tests {
     }
 
     #[test]
-    fn namespaced_repo_probes_the_policy_namespace() {
-        // A namespaced Repository materializes its discovered rows in one namespace
-        // (Placement::Namespace) — keep the existing policy-namespace probe.
+    fn namespaced_repo_same_namespace_as_policy_probes_that_namespace() {
+        // Same-namespace ref (the common case): the repo's own namespace happens to
+        // equal the referencing policy's — unchanged behavior from before this fix.
         assert_eq!(
-            discovered_probe_scope(false, "billing"),
+            discovered_probe_scope(Some("billing")),
             DiscoveredProbeScope::Namespace("billing".into())
+        );
+    }
+
+    #[test]
+    fn namespaced_repo_cross_namespace_ref_probes_the_repos_own_namespace() {
+        // Cross-namespace RepositoryRef (crates/api/src/validate/repository.rs:11-13):
+        // a SnapshotPolicy can live in one namespace while referencing an adopted
+        // Repository that lives in another. Discovered Snapshot CRs materialize in
+        // the REPOSITORY's own namespace (Placement::Namespace, repository.rs:1299),
+        // so the probe must follow the repo, not the policy. A pre-fix
+        // `discovered_probe_scope(false, policy_namespace)` would probe "billing"
+        // here and never see the discovered rows in "storage" — this assertion fails
+        // on that code.
+        assert_eq!(
+            discovered_probe_scope(Some("storage")),
+            DiscoveredProbeScope::Namespace("storage".into())
         );
     }
 
     #[test]
     fn cluster_repo_probes_cluster_wide_so_adopted_repos_unlock() {
         // Regression for the escape hatch no-op: a ClusterRepository's discovered rows
-        // land in per-identity namespaces (Placement::Cluster) — generally NOT the
-        // policy's namespace — so the probe MUST be cluster-wide, or an adopted
+        // land in per-identity namespaces (Placement::Cluster) — generally NOT any
+        // single namespace — so the probe MUST be cluster-wide, or an adopted
         // ClusterRepository never unlocks verification before its first child backup.
         assert_eq!(
-            discovered_probe_scope(true, "billing"),
+            discovered_probe_scope(None),
             DiscoveredProbeScope::ClusterWide
         );
     }

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -25,14 +25,15 @@ use kube::api::ListParams;
 use kube::{Api, ResourceExt};
 
 use kopiur_api::common::{CronSpec, ScratchDefaults};
-use kopiur_api::{SnapshotPolicy, Verification};
+use kopiur_api::{Origin, Snapshot, SnapshotPolicy, Verification};
 use kopiur_mover::workspec::{
     DeepVerify, MoverOptions, MoverWorkSpec, Operation, QuickVerify, ResolvedIdentity, TargetRef,
     VerifyOp, VerifyTier,
 };
 
 use crate::consts::{
-    API_VERSION, COMPONENT_LABEL, VERIFY_COMPONENT, VERIFY_INSTANCE_LABEL, VERIFY_SLOT_ANNOTATION,
+    API_VERSION, COMPONENT_LABEL, ORIGIN_LABEL, REPOSITORY_UID_LABEL, VERIFY_COMPONENT,
+    VERIFY_INSTANCE_LABEL, VERIFY_SLOT_ANNOTATION,
 };
 use crate::context::Context;
 use crate::error::Result;
@@ -49,6 +50,12 @@ const VERIFY_JOB_TTL_SECS: i64 = 3600;
 const REQUEUE_RUNNING: Duration = Duration::from_secs(30);
 /// Requeue after a failed verify Job (re-check / bounded retry once TTL-reaped).
 const REQUEUE_FAILED: Duration = Duration::from_secs(300);
+/// Requeue while verification is gated (no verifiable snapshot yet, #168). The
+/// steady policy cadence — deliberately NOT [`REQUEUE_RUNNING`]'s 30s hot loop,
+/// which [`next_verify_wakeup`] would otherwise produce for the past-due catch-up
+/// slot. The first successful backup re-reconciles the policy promptly via its
+/// child-Snapshot watch, so this never delays the first real verify.
+const REQUEUE_GATED: Duration = Duration::from_secs(300);
 /// Upper bound on any requeue so the schedule is re-evaluated within the heartbeat.
 const REQUEUE_CAP: Duration = Duration::from_secs(1800);
 
@@ -95,17 +102,38 @@ fn slot_for(
     next_fire(&spec.cron, jitter, seed, after, tz)
 }
 
+/// Whether verification is *unlocked*: a snapshot actually exists to verify. Pure.
+///
+/// The `tier_after` catch-up (a "never verified" policy anchors a year ago so the
+/// first slot is immediately past-due) is deliberate for missed slots — but on a
+/// brand-new policy it would fire a verify Job *before any backup exists*, and the
+/// mover fails hard (`deep verify found no snapshot to restore …`, #168). Gate it:
+/// schedule no verify until either this policy has produced a successful backup
+/// (`has_successful`) OR its resolved repository already contains **discovered**
+/// (adopted) snapshots (`has_discovered`) — the adopted-repo escape hatch, where
+/// deep verify legitimately resolves the latest repo snapshot for the identity.
+pub fn verification_unlocked(has_successful: bool, has_discovered: bool) -> bool {
+    has_successful || has_discovered
+}
+
 /// Decide which verification tier is due now, preferring deep (it subsumes quick).
 /// Returns the tier + its scheduled slot, or `None` if nothing is due. Pure given
-/// the policy's `verification`, the seed, the last-verified time, `now`, and the
-/// repository's `scheduleDefaults.timezone` (`repo_tz`, GitHub #174 item 3).
+/// the policy's `verification`, the seed, the last-verified time, `now`, the
+/// repository's `scheduleDefaults.timezone` (`repo_tz`, GitHub #174 item 3), and
+/// whether verification is `unlocked` ([`verification_unlocked`]) — a locked policy
+/// is never due (the #168 gate), so the catch-up slot is not consumed until a
+/// snapshot exists.
 pub fn due_tier(
     verification: &Verification,
     seed: &str,
     last_verified: Option<DateTime<Utc>>,
     now: DateTime<Utc>,
     repo_tz: Option<&str>,
+    unlocked: bool,
 ) -> Option<(VerifyTierKind, DateTime<Utc>)> {
+    if !unlocked {
+        return None;
+    }
     let after = tier_after(last_verified);
     if let Some(d) = &verification.deep
         && let Ok(slot) = slot_for(seed, &d.schedule, after, repo_tz)
@@ -154,6 +182,26 @@ pub fn next_verify_wakeup(
     }
 }
 
+/// The requeue delay when no verify tier is due, honoring the #168 gate. A gated
+/// policy (`!unlocked`) requeues at the steady cadence ([`REQUEUE_GATED`]) — never
+/// [`next_verify_wakeup`]'s past-due 30s hot loop — since it is re-triggered by its
+/// first successful child Snapshot. An unlocked policy sleeps until its next slot
+/// (capped by [`REQUEUE_CAP`]). Pure so the gated-vs-scheduled requeue is testable.
+fn idle_requeue(
+    verification: &Verification,
+    seed: &str,
+    last_verified: Option<DateTime<Utc>>,
+    now: DateTime<Utc>,
+    repo_tz: Option<&str>,
+    unlocked: bool,
+) -> Duration {
+    if unlocked {
+        next_verify_wakeup(verification, seed, last_verified, now, repo_tz).min(REQUEUE_CAP)
+    } else {
+        REQUEUE_GATED
+    }
+}
+
 /// Deterministic, ≤52-char, DNS-1123-safe per-slot verify Job name:
 /// `<policy>-vfy-<q|d>-<unix_slot>` (truncate+hash long policy names, like
 /// maintenance).
@@ -190,6 +238,7 @@ pub async fn verify_step(
     ctx: &Context,
     repo: &ResolvedRepository,
     namespace: &str,
+    has_successful: bool,
 ) -> Result<Option<Duration>> {
     let Some(verification) = config.spec.verification.as_ref() else {
         return Ok(None);
@@ -210,10 +259,36 @@ pub async fn verify_step(
         .as_ref()
         .and_then(|d| d.timezone.as_deref());
 
-    let Some((tier, slot)) = due_tier(verification, &seed, last_verified, now, repo_tz) else {
-        return Ok(Some(
-            next_verify_wakeup(verification, &seed, last_verified, now, repo_tz).min(REQUEUE_CAP),
-        ));
+    // #168 gate: never schedule a verify before a verifiable snapshot exists — the
+    // tier_after catch-up would otherwise fire a Job on the first reconcile, before
+    // any backup, and the mover fails hard. Unlocked once this policy has a Succeeded
+    // snapshot OR its repo already carries discovered (adopted) snapshots. The
+    // discovered probe is a cheap labeled LIST (thin IO over the pure gate) — skipped
+    // entirely once a successful backup already unlocks the gate.
+    let has_discovered = if has_successful {
+        false
+    } else {
+        repo_has_discovered_snapshots(&ctx.client, namespace, &repo.owner_ref.uid).await?
+    };
+    let unlocked = verification_unlocked(has_successful, has_discovered);
+
+    let Some((tier, slot)) = due_tier(verification, &seed, last_verified, now, repo_tz, unlocked)
+    else {
+        if !unlocked {
+            tracing::debug!(
+                policy = %name,
+                "verification gated: no verifiable snapshot yet (no successful backup and no \
+                 discovered snapshots); deferring until the first successful backup"
+            );
+        }
+        return Ok(Some(idle_requeue(
+            verification,
+            &seed,
+            last_verified,
+            now,
+            repo_tz,
+            unlocked,
+        )));
     };
 
     let job_name = verify_job_name(&name, tier, slot);
@@ -552,6 +627,25 @@ fn verify_identity(
     }
 }
 
+/// Whether the policy's resolved repository already carries **discovered** (adopted)
+/// snapshots — the #168 verification escape hatch. A cheap labeled LIST in the
+/// policy's namespace scoped by the repo-uid + `origin=discovered` labels the catalog
+/// scanner stamps on every materialized foreign snapshot (`crate::catalog`); `true`
+/// as soon as one exists. Thin IO over the pure [`verification_unlocked`] gate.
+async fn repo_has_discovered_snapshots(
+    client: &kube::Client,
+    namespace: &str,
+    repo_uid: &str,
+) -> Result<bool> {
+    let api: Api<Snapshot> = Api::namespaced(client.clone(), namespace);
+    let selector = format!(
+        "{REPOSITORY_UID_LABEL}={repo_uid},{ORIGIN_LABEL}={}",
+        Origin::Discovered.label_value()
+    );
+    let lp = ListParams::default().labels(&selector).limit(1);
+    Ok(!api.list(&lp).await?.items.is_empty())
+}
+
 /// Whether any non-terminal verify Job is owned by this policy (single-flight gate).
 async fn has_active_verify_job(job_api: &Api<Job>, policy_name: &str) -> Result<bool> {
     let selector =
@@ -591,16 +685,17 @@ mod tests {
 
     #[test]
     fn first_ever_reconcile_is_due_and_prefers_deep() {
-        // No lastVerified → both due; deep wins (it subsumes quick).
+        // No lastVerified, but UNLOCKED (a successful backup exists) → both due; deep
+        // wins (it subsumes quick). The catch-up semantics are preserved once unlocked.
         let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
-        let (tier, _slot) = due_tier(&v, "seed", None, Utc::now(), None).expect("due");
+        let (tier, _slot) = due_tier(&v, "seed", None, Utc::now(), None, true).expect("due");
         assert_eq!(tier, VerifyTierKind::Deep);
     }
 
     #[test]
     fn quick_only_is_due_when_no_deep() {
         let v = verification(Some("*/5 * * * *"), None);
-        let (tier, _) = due_tier(&v, "seed", None, Utc::now(), None).expect("due");
+        let (tier, _) = due_tier(&v, "seed", None, Utc::now(), None, true).expect("due");
         assert_eq!(tier, VerifyTierKind::Quick);
     }
 
@@ -610,7 +705,7 @@ mod tests {
         let just = now - chrono::Duration::seconds(1);
         let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
         assert!(
-            due_tier(&v, "seed", Some(just), now, None).is_none(),
+            due_tier(&v, "seed", Some(just), now, None, true).is_none(),
             "a tier that just ran must not be immediately due again"
         );
     }
@@ -618,7 +713,64 @@ mod tests {
     #[test]
     fn no_schedules_is_never_due() {
         let v = verification(None, None);
-        assert!(due_tier(&v, "seed", None, Utc::now(), None).is_none());
+        assert!(due_tier(&v, "seed", None, Utc::now(), None, true).is_none());
+        assert!(due_tier(&v, "seed", None, Utc::now(), None, true).is_none());
+    }
+
+    // --- #168 gate: no verify before a verifiable snapshot exists ---
+
+    #[test]
+    fn gated_when_no_successful_and_no_discovered_is_not_due() {
+        // The #168 regression: a brand-new policy (no successful backup, adopted-repo
+        // escape hatch closed) must NOT be due, even though tier_after makes the
+        // first slot past-due. Fails on pre-gate code (which returned Some(Deep)).
+        let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
+        let unlocked = verification_unlocked(false, false);
+        assert!(!unlocked);
+        assert!(
+            due_tier(&v, "seed", None, Utc::now(), None, unlocked).is_none(),
+            "no snapshot to verify → nothing due"
+        );
+    }
+
+    #[test]
+    fn unlocked_by_successful_snapshot_is_due() {
+        let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
+        let unlocked = verification_unlocked(true, false);
+        assert!(unlocked);
+        assert!(due_tier(&v, "seed", None, Utc::now(), None, unlocked).is_some());
+    }
+
+    #[test]
+    fn unlocked_by_discovered_snapshot_is_due_adopted_repo_escape_hatch() {
+        // Adopted repo (05-adopt-existing-repo): no Succeeded snapshot for this policy,
+        // but the repo carries discovered CRs. Deep verify works there, so the gate
+        // must open on the discovered signal alone.
+        let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
+        let unlocked = verification_unlocked(false, true);
+        assert!(unlocked);
+        assert!(due_tier(&v, "seed", None, Utc::now(), None, unlocked).is_some());
+    }
+
+    #[test]
+    fn gated_requeue_is_steady_not_the_30s_hot_loop() {
+        // While gated, the past-due catch-up slot must NOT drive next_verify_wakeup's
+        // 30s REQUEUE_RUNNING; idle_requeue returns the steady cadence instead.
+        let now = Utc::now();
+        let v = verification(Some("*/5 * * * *"), Some("0 3 * * 0"));
+        let gated = idle_requeue(&v, "seed", None, now, None, false);
+        assert_eq!(gated, REQUEUE_GATED);
+        assert!(
+            gated > REQUEUE_RUNNING,
+            "gated requeue must not be the 30s hot loop"
+        );
+        // Unlocked with a past-due slot DOES want the prompt 30s cadence (the caller
+        // then spawns/tracks the Job) — guards that the gate only affects the locked path.
+        assert_eq!(
+            idle_requeue(&v, "seed", None, now, None, true),
+            REQUEUE_RUNNING,
+            "an unlocked past-due policy keeps the prompt cadence"
+        );
     }
 
     #[test]
@@ -644,11 +796,19 @@ mod tests {
         // the repo default.
         let v = verification(Some("0 5 * * *"), None);
         assert!(
-            due_tier(&v, "seed", last_verified, now, None).is_some(),
+            due_tier(&v, "seed", last_verified, now, None, true).is_some(),
             "UTC (no repo default) → 05:00 UTC has already passed"
         );
         assert!(
-            due_tier(&v, "seed", last_verified, now, Some("America/Los_Angeles")).is_none(),
+            due_tier(
+                &v,
+                "seed",
+                last_verified,
+                now,
+                Some("America/Los_Angeles"),
+                true
+            )
+            .is_none(),
             "repo scheduleDefaults.timezone must shift the evaluated slot"
         );
     }
@@ -665,7 +825,15 @@ mod tests {
         // (America/Los_Angeles, which would push the slot hours into the future)
         // must be ignored.
         assert!(
-            due_tier(&v, "seed", last_verified, now, Some("America/Los_Angeles")).is_some(),
+            due_tier(
+                &v,
+                "seed",
+                last_verified,
+                now,
+                Some("America/Los_Angeles"),
+                true
+            )
+            .is_some(),
             "the CronSpec's own timezone must win over the repo default"
         );
     }

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -116,6 +116,43 @@ pub fn verification_unlocked(has_successful: bool, has_discovered: bool) -> bool
     has_successful || has_discovered
 }
 
+/// Where to look for a repository's **discovered** (adopted) `Snapshot` CRs when
+/// probing the #168 escape hatch. Derived purely from whether the policy's resolved
+/// repository is namespaced or cluster-scoped — the two placements the catalog uses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DiscoveredProbeScope {
+    /// Namespaced [`Repository`](kopiur_api::Repository): the catalog materializes
+    /// discovered rows in a single namespace ([`crate::catalog::Placement::Namespace`]),
+    /// so a namespaced LIST there suffices.
+    Namespace(String),
+    /// Cluster-scoped [`ClusterRepository`](kopiur_api::ClusterRepository): the catalog
+    /// scatters discovered rows across identity-hostname namespaces / the
+    /// `fallbackNamespace` ([`crate::catalog::Placement::Cluster`]) — generally NOT the
+    /// policy's namespace — so probe cluster-wide. The `repository-uid` label already
+    /// scopes the LIST to this repository's rows, so the wide scan can't false-positive
+    /// on another repo's discovered snapshots.
+    ClusterWide,
+}
+
+/// **Pure.** Decide where [`repo_has_discovered_snapshots`] should LIST, from whether
+/// the resolved repository is cluster-scoped and the probing policy's namespace.
+///
+/// Namespaced repos keep the existing policy-namespace probe (the catalog materializes
+/// their discovered rows in that one namespace). A `ClusterRepository`'s rows land in
+/// arbitrary, per-identity namespaces the reconciler can't enumerate a priori, so the
+/// only correct probe is cluster-wide — otherwise an *adopted* `ClusterRepository`
+/// would never unlock verification before its first child backup (#168 regression).
+pub fn discovered_probe_scope(
+    cluster_scoped: bool,
+    policy_namespace: &str,
+) -> DiscoveredProbeScope {
+    if cluster_scoped {
+        DiscoveredProbeScope::ClusterWide
+    } else {
+        DiscoveredProbeScope::Namespace(policy_namespace.to_string())
+    }
+}
+
 /// Decide which verification tier is due now, preferring deep (it subsumes quick).
 /// Returns the tier + its scheduled slot, or `None` if nothing is due. Pure given
 /// the policy's `verification`, the seed, the last-verified time, `now`, the
@@ -181,12 +218,19 @@ pub fn next_verify_wakeup(
         }
     }
     match earliest {
+        // A future slot: sleep until it (floored/capped).
         Some(slot) if slot > now => (slot - now)
             .to_std()
             .unwrap_or(REQUEUE_CAP)
             .min(REQUEUE_CAP)
             .max(REQUEUE_RUNNING),
-        _ => REQUEUE_RUNNING,
+        // A past-due slot: the prompt 30s cadence, since the caller then spawns and
+        // tracks the Job.
+        Some(_) => REQUEUE_RUNNING,
+        // No live schedule at all (e.g. an old-shape quick-only policy whose
+        // `quick.schedule` decoded to `None`, with no deep): nothing will ever come
+        // due, so floor at the steady cadence rather than the 30s hot loop.
+        None => REQUEUE_GATED,
     }
 }
 
@@ -272,11 +316,14 @@ pub async fn verify_step(
     // any backup, and the mover fails hard. Unlocked once this policy has a Succeeded
     // snapshot OR its repo already carries discovered (adopted) snapshots. The
     // discovered probe is a cheap labeled LIST (thin IO over the pure gate) — skipped
-    // entirely once a successful backup already unlocks the gate.
+    // entirely once a successful backup already unlocks the gate. A cluster-scoped
+    // repository (`repo_namespace == None`) scatters its discovered rows across
+    // per-identity namespaces, so the probe scope is cluster-wide there.
     let has_discovered = if has_successful {
         false
     } else {
-        repo_has_discovered_snapshots(&ctx.client, namespace, &repo.owner_ref.uid).await?
+        let scope = discovered_probe_scope(repo.repo_namespace.is_none(), namespace);
+        repo_has_discovered_snapshots(&ctx.client, &scope, &repo.owner_ref.uid).await?
     };
     let unlocked = verification_unlocked(has_successful, has_discovered);
 
@@ -636,16 +683,21 @@ fn verify_identity(
 }
 
 /// Whether the policy's resolved repository already carries **discovered** (adopted)
-/// snapshots — the #168 verification escape hatch. A cheap labeled LIST in the
-/// policy's namespace scoped by the repo-uid + `origin=discovered` labels the catalog
-/// scanner stamps on every materialized foreign snapshot (`crate::catalog`); `true`
-/// as soon as one exists. Thin IO over the pure [`verification_unlocked`] gate.
+/// snapshots — the #168 verification escape hatch. A cheap labeled LIST scoped by the
+/// repo-uid + `origin=discovered` labels the catalog scanner stamps on every
+/// materialized foreign snapshot (`crate::catalog`); `true` as soon as one exists.
+/// The [`DiscoveredProbeScope`] (from [`discovered_probe_scope`]) selects namespaced
+/// vs cluster-wide so an adopted `ClusterRepository`'s scattered rows are seen. Thin
+/// IO over the pure [`verification_unlocked`] gate.
 async fn repo_has_discovered_snapshots(
     client: &kube::Client,
-    namespace: &str,
+    scope: &DiscoveredProbeScope,
     repo_uid: &str,
 ) -> Result<bool> {
-    let api: Api<Snapshot> = Api::namespaced(client.clone(), namespace);
+    let api: Api<Snapshot> = match scope {
+        DiscoveredProbeScope::Namespace(ns) => Api::namespaced(client.clone(), ns),
+        DiscoveredProbeScope::ClusterWide => Api::all(client.clone()),
+    };
     let selector = format!(
         "{REPOSITORY_UID_LABEL}={repo_uid},{ORIGIN_LABEL}={}",
         Origin::Discovered.label_value()
@@ -743,10 +795,15 @@ mod tests {
             due_tier(&v, "seed", None, Utc::now(), None, true).is_none(),
             "quick with no schedule must be disabled, not due"
         );
-        // And it doesn't inflate the wakeup either: with no live schedule at all, the
-        // wakeup floors at the running cadence rather than a past-due hot loop.
+        // And it doesn't spin either: with no live schedule at all, the wakeup floors
+        // at the steady cadence rather than the 30s past-due hot loop, so an unmigrated
+        // quick-only policy doesn't re-reconcile every 30s forever.
         let wake = next_verify_wakeup(&v, "seed", None, Utc::now(), None);
-        assert_eq!(wake, REQUEUE_RUNNING);
+        assert_eq!(wake, REQUEUE_GATED);
+        // idle_requeue agrees when the policy is unlocked (a successful backup exists):
+        // no live schedule => steady cadence, not the hot loop.
+        let idle = idle_requeue(&v, "seed", None, Utc::now(), None, true);
+        assert_eq!(idle, REQUEUE_GATED);
     }
 
     // --- #168 gate: no verify before a verifiable snapshot exists ---
@@ -782,6 +839,28 @@ mod tests {
         let unlocked = verification_unlocked(false, true);
         assert!(unlocked);
         assert!(due_tier(&v, "seed", None, Utc::now(), None, unlocked).is_some());
+    }
+
+    #[test]
+    fn namespaced_repo_probes_the_policy_namespace() {
+        // A namespaced Repository materializes its discovered rows in one namespace
+        // (Placement::Namespace) — keep the existing policy-namespace probe.
+        assert_eq!(
+            discovered_probe_scope(false, "billing"),
+            DiscoveredProbeScope::Namespace("billing".into())
+        );
+    }
+
+    #[test]
+    fn cluster_repo_probes_cluster_wide_so_adopted_repos_unlock() {
+        // Regression for the escape hatch no-op: a ClusterRepository's discovered rows
+        // land in per-identity namespaces (Placement::Cluster) — generally NOT the
+        // policy's namespace — so the probe MUST be cluster-wide, or an adopted
+        // ClusterRepository never unlocks verification before its first child backup.
+        assert_eq!(
+            discovered_probe_scope(true, "billing"),
+            DiscoveredProbeScope::ClusterWide
+        );
     }
 
     #[test]

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -65,6 +65,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "verify",
     "vfydeep",
     "vfyinh",
+    "vfygate",
     "repl-src",
     "repl-dst",
     "projgate",

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -8,6 +8,10 @@
 //!   `mkdir /scratch: permission denied`. With `capacity`/`storageClassName`
 //!   unset the scratch volume is an `emptyDir`; the run must succeed and stamp
 //!   `status.lastVerified`.
+//! - gate (GitHub #168): a brand-new policy with `verification` configured but
+//!   NO backup yet must not spawn a verify Job (the mover would fail hard
+//!   against an empty repository); the first verify catches up promptly once
+//!   the first backup succeeds.
 //!
 //! Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; driven by
 //! `mise run //crates/e2e:test`. Skips gracefully without a cluster.
@@ -17,11 +21,13 @@
 mod common;
 use common::*;
 
+use std::time::Duration;
+
 use kube::Api;
-use kube::api::{ListParams, Patch, PatchParams};
+use kube::api::{ListParams, Patch, PatchParams, PostParams};
 
 use k8s_openapi::api::batch::v1::Job;
-use kopiur_api::{Repository, SnapshotPolicy};
+use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wait_until};
 
 /// Verification (ADR-0005 §4): a `SnapshotPolicy.spec.verification.quick` with an
@@ -266,5 +272,138 @@ async fn deep_verify_scratch_inherits_repo_mover_defaults() {
         cache_cap.as_deref(),
         Some("2Gi"),
         "verify cache PVC must inherit moverDefaults.cache.capacity"
+    );
+}
+
+/// GitHub #168 regression: a brand-new `SnapshotPolicy` with BOTH verification
+/// tiers configured — but no backup yet — must NOT spawn a verify Job. Before the
+/// fix, `due_tier`'s catch-up logic anchored a never-verified policy a year in the
+/// past, so the very first reconcile treated every configured tier as already
+/// past-due and spawned a verify Job against a repository with zero snapshots;
+/// the mover failed hard (`deep verify found no snapshot to restore …`).
+/// Verification unlocks on this policy's first successful backup (or, for an
+/// adopted repository, discovered snapshots already present — not exercised
+/// here), at which point the catch-up fires promptly (asserted below).
+///
+/// Deliberately does NOT call `ensure_seed` (every other test in this file does)
+/// — that is exactly the scenario #168 needs: `verification` configured before
+/// any snapshot exists.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn verification_gated_until_first_successful_snapshot_168() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    // A Ready Repository + SnapshotPolicy with NO Snapshot at all (mirrors
+    // ensure_seed's fixtures minus the seed leg) — the #168 precondition.
+    ensure_empty_policy(
+        &client,
+        "e2e-vfy-gate-repo",
+        "e2e-vfy-gate-policy",
+        "vfygate",
+    )
+    .await;
+
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    // Both tiers, every minute, new nested shape: gives pre-fix code the best
+    // chance to fire a verify Job well within the assertion window below.
+    let patch = serde_json::json!({
+        "spec": { "verification": {
+            "quick": { "schedule": { "cron": "* * * * *" } },
+            "deep": { "schedule": { "cron": "* * * * *" } },
+            "successExpr": "stats.errors == 0"
+        } }
+    });
+    policies
+        .patch(
+            "e2e-vfy-gate-policy",
+            &PatchParams::default(),
+            &Patch::Merge(&patch),
+        )
+        .await
+        .expect("patch verification onto the SnapshotPolicy");
+
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let selector = "app.kubernetes.io/component=verify,\
+                    kopiur.home-operations.com/verify=e2e-vfy-gate-policy";
+
+    // --- Gated: no verify Job for a fixed window, and no lastVerified/Failed
+    // verify reported. 45s comfortably exceeds both the every-minute cron cadence
+    // and the controller's reconcile-on-create — on pre-fix code the past-due
+    // catch-up slot is consumed on the very first reconcile (seconds, not
+    // minutes), so a real regression is unambiguous well inside this window
+    // (same margin as the `QUIET_WINDOW` precedent in steady_state.rs).
+    tokio::time::sleep(Duration::from_secs(45)).await;
+    let found = jobs
+        .list(&ListParams::default().labels(selector))
+        .await
+        .expect("list verify Jobs")
+        .items;
+    assert!(
+        found.is_empty(),
+        "no verify Job may exist before any snapshot succeeds (#168), found: {:?}",
+        found
+            .iter()
+            .map(|j| j.metadata.name.clone())
+            .collect::<Vec<_>>()
+    );
+    let gated_status = status_json(&policies, "e2e-vfy-gate-policy").await;
+    assert!(
+        gated_status
+            .get("lastVerified")
+            .and_then(|v| v.as_str())
+            .is_none(),
+        "status.lastVerified must stay unset while gated, got: {gated_status:?}"
+    );
+
+    // --- Unlock the gate: create/seed the first backup, the same mechanism
+    // `ensure_seed`'s snapshot leg uses, and wait for it to Succeed.
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-vfy-gate-seed",
+                "e2e-vfy-gate-policy",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create the first Snapshot");
+    wait_phase(&backups, "e2e-vfy-gate-seed", "Succeeded")
+        .await
+        .expect("the first backup should succeed");
+
+    // --- Catch-up: now unlocked, the first due verify fires promptly and stamps
+    // lastVerified (reuses the assertion pattern of the quick-verify test above).
+    wait_until(
+        "SnapshotPolicy.status.lastVerified is stamped after the first successful backup (#168 catch-up)",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = status_json(&policies, "e2e-vfy-gate-policy").await;
+            Ok(s.get("lastVerified")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty())
+                .map(|_| ()))
+        },
+    )
+    .await
+    .expect(
+        "verification must catch up promptly once the first successful backup unlocks the gate",
+    );
+
+    let after_unlock = jobs
+        .list(&ListParams::default().labels(selector))
+        .await
+        .expect("list verify Jobs")
+        .items;
+    assert!(
+        !after_unlock.is_empty(),
+        "a verify Job must have fired after the first successful backup unlocked verification"
     );
 }

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -50,7 +50,7 @@ async fn verification_quick_with_success_expr_stamps_last_verified() {
     // a successExpr asserting the verify reported zero errors.
     let patch = serde_json::json!({
         "spec": { "verification": {
-            "quick": { "cron": "* * * * *" },
+            "quick": { "schedule": { "cron": "* * * * *" } },
             "successExpr": "stats.errors == 0"
         } }
     });

--- a/crates/mover/src/error.rs
+++ b/crates/mover/src/error.rs
@@ -234,8 +234,9 @@ pub enum MoverError {
 
     /// Deep verification found no snapshot to scratch-restore.
     #[error(
-        "deep verify found no snapshot to restore for source path {source_path:?}; run a backup \
-         first or set verify.deep.snapshotID explicitly"
+        "deep verify found no snapshot to restore for source path {source_path:?}: the \
+         repository has no snapshot for this identity yet. Run a backup first (the operator \
+         normally schedules verification only after the first successful backup)"
     )]
     VerifyNoSnapshot {
         /// The identity source path the lookup keyed on.
@@ -580,6 +581,26 @@ mod tests {
         // an environmental/config problem: a blind re-run won't help
         assert_eq!(err.kopia_class(), KopiaErrorClass::Unknown);
         assert!(!err.retry_recommended());
+    }
+
+    #[test]
+    fn verify_no_snapshot_message_is_what_why_fix_without_the_nonexistent_field() {
+        let err = MoverError::VerifyNoSnapshot {
+            source_path: "/pvc/agregarr".into(),
+        };
+        let msg = err.to_string();
+        // what: no snapshot found for the source path
+        assert!(msg.contains("/pvc/agregarr"), "{msg}");
+        assert!(msg.contains("no snapshot to restore"), "{msg}");
+        // why: the repository has no snapshot for this identity yet
+        assert!(msg.contains("no snapshot for this identity yet"), "{msg}");
+        // fix: run a backup first
+        assert!(msg.contains("Run a backup first"), "{msg}");
+        // must NOT recommend the nonexistent CRD field
+        assert!(
+            !msg.contains("snapshotID") && !msg.contains("snapshotId"),
+            "message must not reference the nonexistent verify.deep.snapshotID field: {msg}"
+        );
     }
 
     #[test]

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -6205,24 +6205,31 @@ spec:
                     - schedule
                     type: object
                   quick:
-                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
+                    description: |-
+                      Quick (blob-level) verification tier; absent ⇒ no quick verification. Its cron
+                      lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
-                      cron:
-                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
-                        type: string
-                      jitter:
-                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                      schedule:
+                        description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true
-                        type: string
-                      timezone:
-                        description: |-
-                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
-                          the enclosing schedule's timezone, else the controller default (UTC).
-                        nullable: true
-                        type: string
-                    required:
-                    - cron
+                        properties:
+                          cron:
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
+                            type: string
+                          jitter:
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
+                        required:
+                        - cron
+                        type: object
                     type: object
                   successExpr:
                     description: CEL pass/fail predicate over the verify result; applies to both tiers.

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -996,24 +996,31 @@ spec:
                     - schedule
                     type: object
                   quick:
-                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
+                    description: |-
+                      Quick (blob-level) verification tier; absent ⇒ no quick verification. Its cron
+                      lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
-                      cron:
-                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
-                        type: string
-                      jitter:
-                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                      schedule:
+                        description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true
-                        type: string
-                      timezone:
-                        description: |-
-                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
-                          the enclosing schedule's timezone, else the controller default (UTC).
-                        nullable: true
-                        type: string
-                    required:
-                    - cron
+                        properties:
+                          cron:
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
+                            type: string
+                          jitter:
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
+                        required:
+                        - cron
+                        type: object
                     type: object
                   successExpr:
                     description: CEL pass/fail predicate over the verify result; applies to both tiers.

--- a/deploy/examples/scenarios/06-verification-drill.yaml
+++ b/deploy/examples/scenarios/06-verification-drill.yaml
@@ -44,10 +44,12 @@ spec:
     keepDaily: 14
   # The operator verifies restorability on this cadence — no CronJob needed.
   verification:
-    # Quick: blob-level `kopia snapshot verify`, often.
+    # Quick: blob-level `kopia snapshot verify`, often. Its cron lives under
+    # `quick.schedule` (matching `deep.schedule`).
     quick:
-      cron: "0 4 * * *"
-      jitter: 30m
+      schedule:
+        cron: "0 4 * * *"
+        jitter: 30m
     # Deep: scratch-restore the latest snapshot into a throwaway volume, weekly.
     deep:
       schedule:

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -996,24 +996,31 @@ spec:
                     - schedule
                     type: object
                   quick:
-                    description: Schedule for the frequent blob-level `kopia snapshot verify`; absent ⇒ no quick verification.
+                    description: |-
+                      Quick (blob-level) verification tier; absent ⇒ no quick verification. Its cron
+                      lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
-                      cron:
-                        description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
-                        type: string
-                      jitter:
-                        description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                      schedule:
+                        description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true
-                        type: string
-                      timezone:
-                        description: |-
-                          IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
-                          the enclosing schedule's timezone, else the controller default (UTC).
-                        nullable: true
-                        type: string
-                    required:
-                    - cron
+                        properties:
+                          cron:
+                            description: The cron expression, parsed by `croner`; may contain an `H` placeholder for deterministic jitter.
+                            type: string
+                          jitter:
+                            description: Optional deterministic jitter window as a Go-style duration string (e.g. `30m`).
+                            nullable: true
+                            type: string
+                          timezone:
+                            description: |-
+                              IANA timezone the cron is evaluated in (e.g. `America/Chicago`); absent uses
+                              the enclosing schedule's timezone, else the controller default (UTC).
+                            nullable: true
+                            type: string
+                        required:
+                        - cron
+                        type: object
                     type: object
                   successExpr:
                     description: CEL pass/fail predicate over the verify result; applies to both tiers.

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -248,7 +248,8 @@ Opt-in. When absent, nothing runs. When set, the operator runs a frequent blob-l
 
 ```yaml
 verification:
-    quick: { cron: "0 4 * * *", jitter: 30m } # blob-level verify, often
+    quick: # blob-level `kopia snapshot verify`, often
+        schedule: { cron: "0 4 * * *", jitter: 30m }
     deep: # scratch-restore the latest snapshot into a throwaway volume, rarely
         schedule: { cron: "0 5 * * 0", jitter: 1h }
         capacity: 100Gi # size a fresh ephemeral PVC for the restore (omit = emptyDir)
@@ -265,23 +266,55 @@ get my data back?"_ — it restores the latest snapshot into a throwaway volume,
 checks the result, and discards it. That is the closest thing to a real recovery,
 so you run it rarely. Schedule the two independently.
 
-/// note | Why `deep` is an object but `quick` is just a cron
+/// note | Both tiers nest their cron under `schedule:`
 
-This asymmetry trips people up, so it's deliberate: `quick` is a bare cron
-(`{ cron, jitter }`) because an integrity check needs **nothing but a schedule**.
-`deep` is a nested object because a restore drill needs somewhere to restore _to_
-— so alongside its `schedule` it carries the scratch-volume knobs (`capacity`,
-`storageClassName`) that `quick` has no use for. Grouping the schedule and its
-storage under one `deep:` key keeps "deep verify is off" and "deep verify is on,
-configured like this" a single on/off unit, and gives future deep-only options a
-home without reshaping the API. The two tiers share `successExpr` and
-`status.lastVerified`; only `deep` has a scratch volume.
+`quick` and `deep` share the same shape: `{ schedule: CronSpec, ... }`. Each
+tier's cron/jitter/timezone lives under its own `schedule:` key — `quick.schedule`,
+`deep.schedule` — instead of a bare `{ cron, jitter }` on the tier itself. `deep`
+additionally carries the scratch-volume knobs (`capacity`, `storageClassName`)
+that `quick` has no use for, since a restore drill needs somewhere to restore
+_to_. Grouping each tier's schedule (and, for `deep`, its storage) under its own
+key keeps "this tier is off" / "this tier is on, configured like this" a single
+unit, and gives future per-tier options a home without reshaping the API. The two
+tiers share `successExpr` and `status.lastVerified`; only `deep` has a scratch
+volume.
 
 ///
+
+!!! warning "Upgrading from the old flat `quick: { cron, jitter }` shape"
+    `verification.quick` used to be a bare `{ cron, jitter, timezone }` (GitHub #174). An
+    already-persisted `SnapshotPolicy` in that old shape keeps decoding fine, but with
+    its quick tier treated as **disabled** (no schedule to run) until you migrate it.
+    Re-applying that old shape as a **new** write is rejected at admission with a
+    message pointing at the move: nest the same fields under `quick.schedule`, e.g.
+    `quick: { cron: "0 4 * * *", jitter: 30m }` becomes
+    `quick: { schedule: { cron: "0 4 * * *", jitter: 30m } }`.
 
 Deep verify restores into a throwaway scratch volume, then discards it. `capacity` and `storageClassName` size and place that volume: **set `capacity`** and the operator provisions a fresh generic-ephemeral PVC (auto-deleted with the Job) of that size — size it to comfortably hold the restored snapshot; **omit `capacity`** and scratch falls back to a node-ephemeral `emptyDir` (zero-config, but bounded by node disk — fine for small snapshots). `storageClassName` only applies when `capacity` is set — a class with no capacity is a no-op (an `emptyDir` has no StorageClass), which the operator surfaces as a `ScratchStorageClassIgnored` condition + Warning Event on the `SnapshotPolicy`.
 
 You can set the scratch size/class **once** at the repository level via [`moverDefaults.scratch`](repositories.md#moverdefaults--one-place-to-configure-every-mover) instead of repeating it on every policy; the `verification.deep` fields here override that repo default field-wise.
+
+### verification scheduling — gated until there is something to verify
+
+Verification only ever runs against a snapshot that actually exists. On a
+brand-new `SnapshotPolicy` the operator does **not** schedule a verify Job the
+moment `verification` is added — it waits until either:
+
+- this policy has produced its **first successful backup** (a `Snapshot` that
+  reached `Succeeded`), or
+- the resolved repository already carries **discovered** (adopted) snapshots —
+  the escape hatch for an [adopted repository](scenarios/adopt-existing-repo.md),
+  where a deep verify legitimately restores the latest repo snapshot for the
+  identity even though this policy has never run a backup itself.
+
+While gated, `status.lastVerified` stays unset and no verify Job is created; the
+`SnapshotPolicy` keeps reconciling on a steady background cadence rather than the
+tight polling it uses once a verify Job is actually in flight — there is nothing
+wrong to report, just nothing to verify yet. As soon as the gate opens (typically:
+the first backup succeeds), the operator catches up and runs the first due
+verification promptly, without waiting for the next cron slot. Before this gate
+existed, a fresh policy with `verification` configured but no backup yet could
+spawn a verify Job that failed hard against an empty repository (GitHub #168).
 
 `successExpr` is a CEL predicate (returns `bool`) over the verify result. The environment is:
 
@@ -293,7 +326,7 @@ You can set the scratch size/class **once** at the repository level via [`moverD
 It is validated at admission, so a typo or out-of-scope variable is rejected on `kubectl apply`. See the [verification-drill scenario](scenarios/verification-drills.md).
 
 !!! tip "A timezone for the verify crons"
-    Each verification cron is a `CronSpec`, so it takes the same `timezone` as a backup schedule: `quick: { cron: "0 4 * * *", jitter: 30m, timezone: America/Chicago }` evaluates `0 4 * * *` as 4 a.m. **Chicago time** (DST-correct), not UTC. Set it per cron (`quick`, `deep.schedule`); absent falls back to the target repository's [`scheduleDefaults.timezone`](repositories.md#scheduledefaults--set-the-cron-timezone-once) (set it once there instead of repeating it on every policy), else UTC.
+    Each verification cron is a `CronSpec`, so it takes the same `timezone` as a backup schedule: `quick: { schedule: { cron: "0 4 * * *", jitter: 30m, timezone: America/Chicago } }` evaluates `0 4 * * *` as 4 a.m. **Chicago time** (DST-correct), not UTC. Set it per cron (`quick.schedule`, `deep.schedule`); absent falls back to the target repository's [`scheduleDefaults.timezone`](repositories.md#scheduledefaults--set-the-cron-timezone-once) (set it once there instead of repeating it on every policy), else UTC.
 
 ### suspend — pause a recipe
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -490,12 +490,18 @@ Externally tagged — `workloadExec` / `runJob` / `httpRequest`. Each carries
 
 ### Verification
 
-`{ quick?: CronSpec, deep?: { schedule, storageClassName?, capacity? }, successExpr?,
-verifyFilesPercent? }` — `successExpr` is a CEL bool predicate over
+`{ quick?: { schedule?: CronSpec }, deep?: { schedule: CronSpec, storageClassName?,
+capacity? }, successExpr?, verifyFilesPercent? }` — both tiers nest their cron under
+`schedule:` (`quick.schedule`, `deep.schedule`); `quick.schedule` is itself `Option`
+so an old-shape persisted object (`quick: { cron, jitter }`, pre-#174) still decodes,
+with the quick tier disabled until migrated — a **new** write of that old shape is
+rejected at admission. `successExpr` is a CEL bool predicate over
 `stats{files,bytes,errors}`/`snapshot`/`restored{files,checksumMatches}`/`tier`
 (`"quick"`|`"deep"`), validated at admission. For `quick`, `stats.files`/`stats.bytes`
 are filled from the verified snapshot's manifest (so `stats.files > 0` is meaningful);
-`restored` is deep-only. §4
+`restored` is deep-only. Scheduling is gated on a first successful backup (or
+discovered snapshots on an adopted repo) existing — see
+[Backups → verification scheduling](backups.md#verification-scheduling--gated-until-there-is-something-to-verify). §4
 
 ### Preflight
 

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -116,22 +116,37 @@ within a snapshot. Absent knobs leave kopia's default.
 ### `verification`
 
 First-class backup verification that proves snapshots are **restorable**, not just
-that maintenance ran. Opt-in: when absent, no verification runs. Two tiers:
+that maintenance ran. Opt-in: when absent, no verification runs. Two tiers, both
+shaped `{ schedule: CronSpec, ... }`:
 
-- `quick` — a schedule for the frequent blob-level `kopia snapshot verify`; absent
-  means no quick verification. `verifyFilesPercent` (`--verify-files-percent`) tunes
-  how many files it verifies fully (absent leaves kopia's default).
-- `deep` — a schedule plus knobs for the rarer scratch-restore restorability test,
-  which restores the latest snapshot into an ephemeral volume, sanity-checks it,
-  then discards it. `deep.schedule` is its cron+jitter (e.g. weekly);
-  `deep.capacity` sizes the ephemeral scratch PVC (e.g. `10Gi`) — absent falls
-  back to a node-ephemeral `emptyDir`; `deep.storageClassName` picks the scratch
-  PVC's StorageClass (absent uses the cluster default, and only applies when
-  `capacity` is set).
+- `quick` — a `QuickVerification { schedule?: CronSpec }`: the frequent blob-level
+  `kopia snapshot verify`. `quick.schedule` absent means no quick verification.
+  `verifyFilesPercent` (`--verify-files-percent`, a sibling of `quick`/`deep` on
+  `verification` itself) tunes how many files it verifies fully (absent leaves
+  kopia's default).
+- `deep` — a `DeepVerification { schedule: CronSpec, storageClassName?, capacity? }`:
+  the rarer scratch-restore restorability test, which restores the latest snapshot
+  into an ephemeral volume, sanity-checks it, then discards it. `deep.schedule` is
+  its cron+jitter (e.g. weekly); `deep.capacity` sizes the ephemeral scratch PVC
+  (e.g. `10Gi`) — absent falls back to a node-ephemeral `emptyDir`;
+  `deep.storageClassName` picks the scratch PVC's StorageClass (absent uses the
+  cluster default, and only applies when `capacity` is set).
 - `successExpr` — a CEL pass/fail predicate over the verify result, applied to both
   tiers. The environment exposes `stats{files,bytes,errors}`, `snapshot`, and (deep
   only) `restored{files,checksumMatches}`; returning `false` fails the run, killing
   the silent "0 files" success. Example: `"stats.files > 0 && stats.errors == 0"`.
+
+Scheduling is gated: a policy with `verification` set does not spawn a verify Job
+until it has either a first successful backup or (an adopted repository) discovered
+snapshots already present — see
+[Backups → verification scheduling](../../backups.md#verification-scheduling--gated-until-there-is-something-to-verify).
+
+/// note | Old flat `quick: { cron, jitter }` shape
+`quick`'s `schedule` field is `Option` specifically so an already-persisted old-shape
+object (`quick: { cron, jitter }`, pre-#174) keeps decoding — with the quick tier
+treated as disabled until migrated. A **new** write in that old shape is rejected at
+admission with a message pointing at the `quick.schedule` move.
+///
 
 ### `preflight`
 

--- a/docs/scenarios/verification-drills.md
+++ b/docs/scenarios/verification-drills.md
@@ -25,7 +25,8 @@ extra RBAC:
 ```yaml
 spec:
     verification:
-        quick: { cron: "0 4 * * *", jitter: 30m } # blob-level `kopia snapshot verify`, often
+        quick: # blob-level `kopia snapshot verify`, often
+            schedule: { cron: "0 4 * * *", jitter: 30m }
         deep: # scratch-restore the latest snapshot into a throwaway volume, rarely
             schedule: { cron: "0 5 * * 0", jitter: 1h }
             capacity: 100Gi # size a fresh ephemeral PVC for the restore (omit = emptyDir)
@@ -35,8 +36,13 @@ spec:
 ```
 
 - **`quick`** is a cheap, frequent blob-level integrity check; **`deep`** is a rare
-  full scratch-restore into a throwaway volume (then discarded). Schedule each
-  independently.
+  full scratch-restore into a throwaway volume (then discarded). Both tiers nest
+  their cron under `schedule:` (`quick.schedule`, `deep.schedule`); `deep` additionally
+  carries the scratch-volume knobs below. Schedule each independently.
+- **Gated until there's something to verify** — a brand-new policy does not spawn a
+  verify Job before it has a first successful backup (or, for an adopted repository,
+  discovered snapshots already in it). See
+  [Backups → verification scheduling](../backups.md#verification-scheduling--gated-until-there-is-something-to-verify).
 - **`deep` scratch sizing** — set **`capacity`** to provision a fresh generic-ephemeral
   PVC (auto-deleted with the Job), sized to hold the restored snapshot;
   **`storageClassName`** places it (omit = cluster default). Omit `capacity` and


### PR DESCRIPTION
Fixes #168. Implements item 1 of #174.

> **Stacked on #190** (`fix/metrics-store-backed-gauges`) — rebased onto it for the shared e2e-harness fixes; GitHub will retarget to `main` when that merges. Local full-suite run: 27/31 binaries green incl. the #168 scenario live; the 4 failures are condition-timeouts on a loaded dev box (isolated retry running) — CI is the clean-environment arbiter.

## What

### 1. Verification waits until there is something to verify (#168)

Verify jobs no longer fire the moment a policy is created. The scheduler is **gated** until the policy has a successful child Snapshot **or** its repository has discovered snapshots (the adopted-repo case — `05-adopt-existing-repo` keeps working, including ClusterRepository placements and cross-namespace repository refs, both of which got dedicated probe fixes during review). While gated: no Job, the cron slot isn't consumed, steady 300s requeue. The first successful backup unlocks catch-up, so the first verify fires right after it. The mover's `VerifyNoSnapshot` message no longer recommends `verify.deep.snapshotID` — a field that never existed on the CRD.

### 2. BREAKING: `verification.quick` nests its cron under `schedule:` (#174 item 1)

```yaml
verification:
  quick:
    schedule: { cron: "H 5 * * *", jitter: 1h }   # was: quick: { cron: ... }
  deep:
    schedule: { cron: "H 5 * * 0" }
    storageClassName: fast
```

**Migration story (deliberately decode-tolerant)** — `schedule` is modeled as optional so:
- **Persisted old-shape objects keep decoding** (quick tier disabled until updated) — one stale object can no longer stall the SnapshotPolicy reflector or poison webhook admissions cluster-wide.
- **New writes with the old shape are rejected at admission** with a message that names the exact move.
- Docs previously *defended* the asymmetry as deliberate; rewritten, with an upgrade admonition.

## Maintainer callouts

- Gated state is surfaced at debug-log level only (no natural status seam existed; deliberately no new machinery).
- Unmigrated quick-only policies requeue at the steady cadence (300s), not a hot loop.

## Verification

- Unit: gate pure-fn tests (incl. adopted-repo + cross-namespace probes, RED-verified regression), decode-tolerance via the cluster's parse path, validator negatives with message-text assertions. `cargo test --workspace` / `clippy -D warnings` / `fmt` / `gen-check` green post-rebase.
- e2e: new scenario reproduces #168 exactly (no seed → no vfy Job in a 45s window → first success → verify fires, `lastVerified` stamps). **Full-suite run on this branch in progress** — two NFS-repo backend tests failed with mount-level `remote I/O error` (environmental, under retry; unrelated to this branch's surface). Will mark ready when the run + retry conclude.
