### PR TITLE
feat(api): default files.ignoreRules to OS-artifact excludes (lost+found and friends)

### DIFF
--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -174,6 +174,41 @@ fn default_copy_method() -> CopyMethod {
     CopyMethod::Snapshot
 }
 
+/// The default OS-artifact exclude set for `Files.ignore_rules` — filesystem/NAS
+/// junk that is never intentional user data, so excluding it by default is
+/// additive-safe. Per-entry rationale:
+///
+/// - `/lost+found` — root-anchored ext4/fsck recovery dir. Anchored (leading
+///   `/`) so a *nested* user directory named `lost+found` is left alone; only
+///   the source root's own fsck dir is excluded.
+/// - `System Volume Information`, `$RECYCLE.BIN` — Windows/SMB-client
+///   artifacts that show up on samba-share-backed PVCs.
+/// - `@eaDir` — Synology NAS extended-attribute/thumbnail metadata junk.
+/// - `.snapshot` — NAS-exposed snapshot pseudo-directories (NetApp-style).
+///   Deliberately **unanchored** (no leading `/`): these appear at *every*
+///   level of a NetApp-backed export, not just the root, and backing one up
+///   recursively would multiply the backup size by re-capturing older
+///   snapshot generations as regular file data. Flip side: a legitimate
+///   directory named `.snapshot` at any depth is also excluded — set
+///   `ignoreRules` explicitly if you have one (your list replaces the default).
+///
+/// A named fn so it backs BOTH `#[serde(default = ...)]` (the common case: an
+/// absent `files:` block, handled by the controller glue in
+/// `kopiur_mover::workspec` since the apiserver only server-side-defaults
+/// NESTED fields when the parent object is present) AND
+/// `#[schemars(default = ...)]` (so the default is visible in the generated
+/// CRD schema / `kubectl explain`, and applies when `files: {}` is present
+/// without `ignoreRules`). ONE source of truth for both layers.
+pub fn default_ignore_rules() -> Vec<String> {
+    vec![
+        "/lost+found".to_string(),
+        "System Volume Information".to_string(),
+        "$RECYCLE.BIN".to_string(),
+        "@eaDir".to_string(),
+        ".snapshot".to_string(),
+    ]
+}
+
 /// Volume snapshot copy method. Closed enum. ADR §3.3.
 ///
 /// ```
@@ -256,8 +291,16 @@ pub struct Compression {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct Files {
-    /// Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    /// Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`).
+    /// Absent ⇒ [`default_ignore_rules`] (OS-artifact junk: `/lost+found`,
+    /// `System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot`). An
+    /// explicit list REPLACES the default wholesale (re-add any entries you
+    /// still want); explicit `ignoreRules: []` opts fully out. NOT
+    /// `skip_serializing_if` — an explicit empty list must round-trip as `[]`,
+    /// not vanish back to "absent" (which would silently resurrect the
+    /// default on the next parse).
+    #[serde(default = "default_ignore_rules")]
+    #[schemars(default = "default_ignore_rules")]
     pub ignore_rules: Vec<String>,
     /// Honor `CACHEDIR.TAG`.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -560,6 +603,124 @@ mod tests {
         // And it serializes (not skip-elided), so the materialized value round-trips.
         let json = serde_json::to_value(&spec).unwrap();
         assert_eq!(json["copyMethod"], "Snapshot");
+    }
+
+    /// The 5-entry OS-artifact default set, in the fixed order `default_ignore_rules`
+    /// returns it — shared by every assertion below so the list itself has one
+    /// source of truth in the test file too.
+    fn expected_default_ignore_rules() -> Vec<String> {
+        vec![
+            "/lost+found".to_string(),
+            "System Volume Information".to_string(),
+            "$RECYCLE.BIN".to_string(),
+            "@eaDir".to_string(),
+            ".snapshot".to_string(),
+        ]
+    }
+
+    #[test]
+    fn files_ignore_rules_carries_static_openapi_default_in_crd() {
+        // `files.ignoreRules` must carry a real schema `default:` (the 5-entry
+        // OS-artifact set) so it appears in `kubectl explain`. Mirrors
+        // `copy_method_carries_static_openapi_default_in_crd`.
+        let crd = SnapshotPolicy::crd();
+        let json = serde_json::to_value(&crd).expect("serialize CRD");
+        let default = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["files"]["properties"]["ignoreRules"]["default"];
+        let want: Vec<serde_json::Value> = expected_default_ignore_rules()
+            .into_iter()
+            .map(serde_json::Value::String)
+            .collect();
+        assert_eq!(
+            default,
+            &serde_json::Value::Array(want),
+            "files.ignoreRules must emit the 5-entry OS-artifact `default:` in the CRD schema; got {default:?}"
+        );
+    }
+
+    #[test]
+    fn ignore_rules_defaults_when_files_block_absent_entirely() {
+        // The load-bearing case: apiserver server-side-defaulting only fires for
+        // NESTED fields when the parent object is present, so a spec that omits
+        // `files:` altogether never gets `Files.ignoreRules`'s schema default
+        // applied by the apiserver. The *serde* default on `Files::ignore_rules`
+        // only helps once `files: {}` exists — it can't fire on a wholly-`None`
+        // `spec.files`. This asserts the glue tier's contract: the mover work-spec
+        // seam (`kopiur_mover::workspec::PolicyArgsSpec::from_policy`) is the layer
+        // that must apply `default_ignore_rules()` for THIS shape; see the mover
+        // crate's `workspec` tests for that half.
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\n",
+        );
+        assert!(
+            spec.files.is_none(),
+            "a spec omitting `files:` entirely must parse to `None`, not a defaulted `Files`"
+        );
+    }
+
+    #[test]
+    fn ignore_rules_defaults_when_files_block_present_but_empty() {
+        // `files: {}` (parent present, `ignoreRules` absent): the serde default
+        // DOES fire here, and this is also what the schemars `default:` covers for
+        // apiserver server-side-defaulting.
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\nfiles: {}\n",
+        );
+        let files = spec.files.expect("files: {} must parse to Some(Files)");
+        assert_eq!(files.ignore_rules, expected_default_ignore_rules());
+    }
+
+    #[test]
+    fn ignore_rules_explicit_empty_list_opts_out_and_round_trips() {
+        // Regression test for the opt-out subtlety: an explicit `ignoreRules: []`
+        // must deserialize as present-empty (serde defaults only fire when the KEY
+        // is ABSENT, not when it's present-and-empty) and — critically — must
+        // round-trip back through serialize/deserialize as `[]`, not vanish to
+        // "absent" and silently resurrect the default. This is why `ignore_rules`
+        // does NOT carry `skip_serializing_if`.
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\nfiles: { ignoreRules: [] }\n",
+        );
+        let files = spec
+            .files
+            .as_ref()
+            .expect("files: {...} must parse to Some(Files)");
+        assert!(
+            files.ignore_rules.is_empty(),
+            "explicit `ignoreRules: []` must opt fully out, got {:?}",
+            files.ignore_rules
+        );
+
+        // The round-trip: serialize back to JSON, the `ignoreRules` key must still
+        // be PRESENT (as `[]`), not omitted.
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(
+            json["files"]["ignoreRules"],
+            serde_json::json!([]),
+            "an explicit empty ignoreRules must serialize as `[]`, not be omitted \
+             (omission would deserialize back to the 5-entry default)"
+        );
+
+        // And re-parsing that JSON must still yield the empty, opted-out list —
+        // not the default reappearing.
+        let reparsed: SnapshotPolicySpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+        assert!(reparsed.files.expect("files").ignore_rules.is_empty());
+    }
+
+    #[test]
+    fn ignore_rules_explicit_custom_list_replaces_default_wholesale() {
+        // An explicit non-empty list REPLACES the default outright — it is not
+        // merged/appended. Re-adding a default entry you still want is on the
+        // user (documented in docs/backups.md).
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\nfiles: { ignoreRules: [\"*.tmp\", \"lost+found\"] }\n",
+        );
+        let files = spec.files.expect("files");
+        assert_eq!(
+            files.ignore_rules,
+            vec!["*.tmp".to_string(), "lost+found".to_string()]
+        );
     }
 
     #[test]

--- a/crates/e2e/tests/policy_knobs.rs
+++ b/crates/e2e/tests/policy_knobs.rs
@@ -1,8 +1,9 @@
 //! e2e: SnapshotPolicy "knob" surfaces that previously had no end-to-end guard —
-//! `errorHandling.ignoreFileErrors` (against a REAL unreadable file) and the
+//! `errorHandling.ignoreFileErrors` (against a REAL unreadable file), the
 //! `compression` / `upload` tuning (asserted at the controller→mover work-spec
 //! contract, the seam where a regression would silently drop them while the
-//! snapshot still succeeded).
+//! snapshot still succeeded), and the default `files.ignoreRules` OS-artifact
+//! exclude set (task PR4 — proven against a REAL `lost+found` dir end to end).
 //!
 //! Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; skip gracefully off-cluster.
 
@@ -14,14 +15,14 @@ use common::{
     cr, ensure_repo, observed_snapshot_count, repository_json, snapshot_json, snapshot_policy_json,
     wait_for_job, wait_phase,
 };
-use kube::Api;
-use kube::api::PostParams;
+use kube::api::{DeleteParams, PostParams};
+use kube::{Api, Client};
 
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::ConfigMap;
+use k8s_openapi::api::core::v1::{ConfigMap, Pod};
 
-use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
-use kopiur_e2e::{E2E_NAMESPACE, Need, World, consts};
+use kopiur_api::{Repository, Restore, Snapshot, SnapshotPolicy};
+use kopiur_e2e::{E2E_NAMESPACE, Need, World, builders, consts, wait};
 
 const SUBPATH: &str = "errh";
 const REPO: &str = "e2e-knobs-repo";
@@ -209,4 +210,205 @@ async fn compression_and_upload_knobs_reach_the_mover_contract() {
     wait_phase(&backups, "e2e-knobs", "Succeeded")
         .await
         .expect("the tuned backup should succeed (kopia accepted the policy flags)");
+}
+
+// --- task PR4: default `files.ignoreRules` OS-artifact excludes ---
+
+/// Seed the test's OWN dynamic source PVC (never the shared `e2e-src` — content
+/// written there would contaminate other shards' assertions, mirrors
+/// `hooks.rs`'s `ensure_hooks_world`) with a `lost+found/` dir (the default
+/// exclude the test proves) plus a `keep.txt` control file (proves the backup
+/// isn't just empty/failed).
+async fn ensure_ignore_rules_source(client: &Client, src_pvc: &str) {
+    use kopiur_e2e::apply::{Fixture, apply_all};
+    let fixtures: Vec<Fixture> = vec![builders::dynamic_pvc(E2E_NAMESPACE, src_pvc, "1Gi").into()];
+    apply_all(client, &fixtures).await.expect("source PVC");
+
+    let seeder = format!("{src_pvc}-seed");
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if pods.get_opt(&seeder).await.ok().flatten().is_none() {
+        let pod = builders::one_shot_pod(
+            E2E_NAMESPACE,
+            &seeder,
+            &[
+                "sh",
+                "-c",
+                "mkdir -p /data/lost+found && echo leftover > /data/lost+found/leftover.txt \
+                 && echo keep > /data/keep.txt",
+            ],
+            &[(src_pvc, "/data")],
+        );
+        let _ = pods.create(&PostParams::default(), &pod).await;
+    }
+    wait::pod_succeeded(client, E2E_NAMESPACE, &seeder)
+        .await
+        .expect("ignore-rules source seeder pod should succeed");
+}
+
+/// Restore `snapshot` into a fresh PVC and assert, via a reader pod, that
+/// `keep.txt` (the control file) IS present and `lost+found` (the default
+/// exclude) is ABSENT — proving the default `files.ignoreRules` set actually
+/// excludes at the kopia layer, end to end.
+async fn assert_lost_and_found_excluded(client: &Client, snapshot: &str) {
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let name = format!("{snapshot}-verify");
+    let dst = format!("{snapshot}-dst");
+    let restore = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": REPO },
+            "source": { "snapshotRef": { "name": snapshot } },
+            "target": { "pvc": { "name": dst, "capacity": "1Gi" } }
+        }
+    });
+    let _ = restores.create(&PostParams::default(), &cr(restore)).await;
+    wait_phase(&restores, &name, "Completed")
+        .await
+        .expect("verification restore should complete");
+
+    let reader = format!("{snapshot}-reader");
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if pods.get_opt(&reader).await.ok().flatten().is_none() {
+        let script = "test -f /restore/keep.txt && test ! -e /restore/lost+found";
+        let pod = builders::one_shot_pod(
+            E2E_NAMESPACE,
+            &reader,
+            &["sh", "-c", script],
+            &[(dst.as_str(), "/restore")],
+        );
+        let _ = pods.create(&PostParams::default(), &pod).await;
+    }
+    wait::pod_succeeded(client, E2E_NAMESPACE, &reader)
+        .await
+        .unwrap_or_else(|e| {
+            panic!(
+                "keep.txt must survive the default backup AND lost+found must be excluded by \
+                 the default ignoreRules set: {e}"
+            )
+        });
+    let _ = restores.delete(&name, &DeleteParams::default()).await;
+    let _ = pods.delete(&reader, &DeleteParams::default()).await;
+}
+
+/// The load-bearing end-to-end proof for task PR4: a `SnapshotPolicy` with NO
+/// `files` block at all (the common case — most policies never set it) must
+/// still exclude the default OS-artifact set at the kopia layer. A negative
+/// control proves the fixture is real: WITHOUT the default (explicit
+/// `ignoreRules: []`, full opt-out) the same `lost+found` dir survives the
+/// round trip, so the positive case passing means the default actually did the
+/// excluding, not that the fixture never had anything to exclude.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test)"]
+async fn default_ignore_rules_exclude_lost_and_found_end_to_end() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("fixtures ready");
+    let client = world.client().clone();
+    ensure_knobs_repo(&client).await;
+
+    let configs: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // Positive case: absent `files:` — the default set must exclude lost+found.
+    let src_default = "e2e-ignorerules-src-default";
+    ensure_ignore_rules_source(&client, src_default).await;
+    let cfg_default = snapshot_policy_json(
+        E2E_NAMESPACE,
+        "e2e-ignorerules-default-cfg",
+        "Repository",
+        REPO,
+        serde_json::json!({ "sources": [ { "pvc": { "name": src_default } } ] }),
+    );
+    let _ = configs
+        .create(&PostParams::default(), &cr(cfg_default))
+        .await;
+    let _ = backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-ignorerules-default",
+                "e2e-ignorerules-default-cfg",
+                serde_json::json!({}),
+            )),
+        )
+        .await;
+    wait_phase(&backups, "e2e-ignorerules-default", "Succeeded")
+        .await
+        .expect("default backup (no files: block) should succeed");
+    assert_lost_and_found_excluded(&client, "e2e-ignorerules-default").await;
+
+    // Negative control: explicit `ignoreRules: []` (full opt-out) — the same
+    // source's lost+found dir must NOT be excluded, proving the positive case
+    // above genuinely exercised the default rather than an inert fixture.
+    let src_optout = "e2e-ignorerules-src-optout";
+    ensure_ignore_rules_source(&client, src_optout).await;
+    let cfg_optout = snapshot_policy_json(
+        E2E_NAMESPACE,
+        "e2e-ignorerules-optout-cfg",
+        "Repository",
+        REPO,
+        serde_json::json!({
+            "sources": [ { "pvc": { "name": src_optout } } ],
+            "files": { "ignoreRules": [] }
+        }),
+    );
+    let _ = configs
+        .create(&PostParams::default(), &cr(cfg_optout))
+        .await;
+    let _ = backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-ignorerules-optout",
+                "e2e-ignorerules-optout-cfg",
+                serde_json::json!({}),
+            )),
+        )
+        .await;
+    wait_phase(&backups, "e2e-ignorerules-optout", "Succeeded")
+        .await
+        .expect("opt-out backup (ignoreRules: []) should succeed");
+
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let name = "e2e-ignorerules-optout-verify";
+    let dst = "e2e-ignorerules-optout-dst";
+    let restore = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": REPO },
+            "source": { "snapshotRef": { "name": "e2e-ignorerules-optout" } },
+            "target": { "pvc": { "name": dst, "capacity": "1Gi" } }
+        }
+    });
+    let _ = restores.create(&PostParams::default(), &cr(restore)).await;
+    wait_phase(&restores, name, "Completed")
+        .await
+        .expect("opt-out verification restore should complete");
+    let reader = "e2e-ignorerules-optout-reader";
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if pods.get_opt(reader).await.ok().flatten().is_none() {
+        let pod = builders::one_shot_pod(
+            E2E_NAMESPACE,
+            reader,
+            &["sh", "-c", "test -e /restore/lost+found"],
+            &[(dst, "/restore")],
+        );
+        let _ = pods.create(&PostParams::default(), &pod).await;
+    }
+    wait::pod_succeeded(&client, E2E_NAMESPACE, reader)
+        .await
+        .expect(
+            "with ignoreRules: [] (opt-out), lost+found must SURVIVE the round trip — if this \
+             failed, the fixture no longer proves the positive case above meant anything",
+        );
 }

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -191,7 +191,14 @@ impl PolicyArgsSpec {
             // (Some(true)) — an unset/false leaves kopia's default rather than forcing
             // `--no-ignore-cache-dirs`, matching the "absent = kopia default" contract.
             Some(f) => (f.ignore_rules.clone(), f.ignore_cache_dirs.then_some(true)),
-            None => (Vec::new(), None),
+            // The apiserver only server-side-defaults NESTED fields when the parent
+            // object is present, so a `SnapshotPolicy` that omits `files:` entirely
+            // (the common case) never gets `Files.ignore_rules`'s schema default
+            // applied. Fall back to the SAME `default_ignore_rules()` fn the API
+            // layer wires as the serde/schemars default, so there is one source of
+            // truth for the OS-artifact exclude set regardless of which of the two
+            // "absent" shapes (`files:` missing vs. `files: {}`) the spec took.
+            None => (kopiur_api::snapshot_policy::default_ignore_rules(), None),
         };
         let eh = spec.error_handling.as_ref();
         let up = spec.upload.as_ref();

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -599,9 +599,11 @@ fn policy_args_from_policy_maps_all_flattened_knobs() {
     assert_eq!(args.splitter, None);
 }
 
-#[test]
-fn policy_args_from_empty_policy_is_empty() {
-    let spec = kopiur_api::SnapshotPolicySpec {
+/// A `SnapshotPolicySpec` with every optional policy surface left `None`/empty
+/// except the one field the test overrides — shared by the two ignoreRules
+/// glue tests below (and easy to spot the ONE field each varies).
+fn empty_policy_spec() -> kopiur_api::SnapshotPolicySpec {
+    kopiur_api::SnapshotPolicySpec {
         repository: kopiur_api::common::RepositoryRef {
             kind: Default::default(),
             name: "r".into(),
@@ -625,8 +627,53 @@ fn policy_args_from_empty_policy_is_empty() {
         hooks: None,
         mover: None,
         credential_projection: None,
-    };
-    assert!(PolicyArgsSpec::from_policy(&spec).is_empty());
+    }
+}
+
+/// The load-bearing glue test (task PR4): the apiserver only server-side-defaults
+/// NESTED fields when the parent object is present, so a `SnapshotPolicy` that
+/// omits `files:` entirely NEVER gets `Files.ignoreRules`'s schema default
+/// applied — the controller glue (`PolicyArgsSpec::from_policy`'s `None` arm)
+/// must apply `kopiur_api::snapshot_policy::default_ignore_rules()` itself. This
+/// is the seam a regression would silently skip: `files: None` must still reach
+/// the mover with the 5-entry OS-artifact exclude set.
+#[test]
+fn policy_args_from_absent_files_block_gets_default_ignore_rules() {
+    let spec = empty_policy_spec();
+    assert!(spec.files.is_none());
+    let p = PolicyArgsSpec::from_policy(&spec);
+    assert_eq!(
+        p.ignore,
+        kopiur_api::snapshot_policy::default_ignore_rules()
+    );
+    // ignore_cache_dirs is untouched by the ignoreRules default — still None
+    // (absent `files:` leaves kopia's own default for that knob).
+    assert_eq!(p.ignore_cache_dirs, None);
+    assert!(
+        !p.is_empty(),
+        "a non-empty `ignore` means the mover DOES run `kopia policy set`"
+    );
+}
+
+/// The explicit opt-out (`files: { ignoreRules: [] }`) must NOT be overridden by
+/// the glue's default — only the wholly-absent `files: None` case falls back to
+/// `default_ignore_rules()`. A present-but-empty `Files` is honored verbatim.
+#[test]
+fn policy_args_from_explicit_opt_out_files_is_empty() {
+    use kopiur_api::snapshot_policy::Files;
+    let mut spec = empty_policy_spec();
+    spec.files = Some(Files {
+        ignore_rules: vec![],
+        ignore_cache_dirs: false,
+        ignore_identical_snapshots: false,
+    });
+    let p = PolicyArgsSpec::from_policy(&spec);
+    assert!(
+        p.ignore.is_empty(),
+        "explicit ignoreRules: [] must opt fully out, got {:?}",
+        p.ignore
+    );
+    assert!(p.is_empty());
 }
 
 // --- §13(e) throttle mapping ---

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -5320,7 +5320,21 @@ spec:
                     description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
+                    default:
+                    - /lost+found
+                    - System Volume Information
+                    - $RECYCLE.BIN
+                    - '@eaDir'
+                    - .snapshot
+                    description: |-
+                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`).
+                      Absent ⇒ [`default_ignore_rules`] (OS-artifact junk: `/lost+found`,
+                      `System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot`). An
+                      explicit list REPLACES the default wholesale (re-add any entries you
+                      still want); explicit `ignoreRules: []` opts fully out. NOT
+                      `skip_serializing_if` — an explicit empty list must round-trip as `[]`,
+                      not vanish back to "absent" (which would silently resurrect the
+                      default on the next parse).
                     items:
                       type: string
                     type: array

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -111,7 +111,21 @@ spec:
                     description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
+                    default:
+                    - /lost+found
+                    - System Volume Information
+                    - $RECYCLE.BIN
+                    - '@eaDir'
+                    - .snapshot
+                    description: |-
+                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`).
+                      Absent ⇒ [`default_ignore_rules`] (OS-artifact junk: `/lost+found`,
+                      `System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot`). An
+                      explicit list REPLACES the default wholesale (re-add any entries you
+                      still want); explicit `ignoreRules: []` opts fully out. NOT
+                      `skip_serializing_if` — an explicit empty list must round-trip as `[]`,
+                      not vanish back to "absent" (which would silently resurrect the
+                      default on the next parse).
                     items:
                       type: string
                     type: array

--- a/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/files/crds/snapshotpolicies.yaml
@@ -111,7 +111,21 @@ spec:
                     description: Skip taking a new snapshot when the source is identical to the previous one.
                     type: boolean
                   ignoreRules:
-                    description: Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`).
+                    default:
+                    - /lost+found
+                    - System Volume Information
+                    - $RECYCLE.BIN
+                    - '@eaDir'
+                    - .snapshot
+                    description: |-
+                      Filename/path globs to exclude from the snapshot (e.g. `*.tmp`, `*/cache/*`).
+                      Absent ⇒ [`default_ignore_rules`] (OS-artifact junk: `/lost+found`,
+                      `System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot`). An
+                      explicit list REPLACES the default wholesale (re-add any entries you
+                      still want); explicit `ignoreRules: []` opts fully out. NOT
+                      `skip_serializing_if` — an explicit empty list must round-trip as `[]`,
+                      not vanish back to "absent" (which would silently resurrect the
+                      default on the next parse).
                     items:
                       type: string
                     type: array

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -204,7 +204,7 @@ compression:
     compressor: zstd
     neverCompress: ["*.zip", "*.gz", "*.mp4"] # skip already-compressed files
 files:
-    ignoreRules: ["*.tmp", "*/cache/*", "lost+found"] # paths kopia skips
+    ignoreRules: ["*.tmp", "*/cache/*"] # paths kopia skips, REPLACING the default set (see below)
     ignoreCacheDirs: true # honor CACHEDIR.TAG
     ignoreIdenticalSnapshots: false # take a new snapshot even if nothing changed
 extraArgs: [] # escape hatch for kopia flags not modeled above
@@ -220,6 +220,75 @@ extraArgs: [] # escape hatch for kopia flags not modeled above
 | `extraArgs` | Pass-through kopia flags for anything not modeled above. |
 
 The object **splitter** is not here — it is a repository property fixed at creation and lives on [`Repository.create.splitter`](repositories.md#encryption-and-repository-creation), where it applies repository-wide.
+
+#### `files.ignoreRules` default: OS-artifact excludes
+
+`ignoreRules` defaults to a 5-entry OS-artifact exclude set, so a `SnapshotPolicy`
+that omits `files` entirely — or sets `files: {}` — never snapshots filesystem
+junk that is never intentional user data:
+
+```yaml
+ignoreRules:
+    - /lost+found # ext4/fsck recovery dir — anchored to the source ROOT only
+    - System Volume Information # Windows/SMB-client artifact on samba-share PVCs
+    - $RECYCLE.BIN # Windows/SMB-client artifact on samba-share PVCs
+    - "@eaDir" # Synology NAS extended-attribute/thumbnail metadata junk
+    - .snapshot # NAS-exposed snapshot pseudo-dirs (NetApp-style); UNANCHORED
+```
+
+Per-entry rationale:
+
+- **`/lost+found`** — root-anchored (leading `/`), so only the source root's
+  own ext4 fsck-recovery directory is excluded; a *nested* directory a user
+  happens to name `lost+found` deeper in the tree is left alone.
+- **`System Volume Information`**, **`$RECYCLE.BIN`** — Windows/SMB-client
+  artifacts that appear on samba-share-backed PVCs.
+- **`@eaDir`** — Synology NAS extended-attribute/thumbnail metadata junk.
+- **`.snapshot`** — NAS-exposed snapshot pseudo-directories (NetApp-style).
+  Deliberately **unanchored** (no leading `/`): these appear at *every* level
+  of a NetApp-backed export, not just the root, and backing one up recursively
+  would multiply the backup size by re-capturing older snapshot generations as
+  regular file data. The flip side of being unanchored: a *legitimate* directory
+  you happen to name `.snapshot`, at any depth, is also excluded — if you have
+  one, set `ignoreRules` explicitly (your list replaces the default wholesale).
+
+!!! warning "An explicit `ignoreRules` REPLACES the default — it does not merge"
+    Setting `files.ignoreRules` to any list, including a single-entry list,
+    **replaces** the default 5-entry set wholesale; it is not appended to it. If
+    you set `ignoreRules: ["*.tmp"]` you get `*.tmp` excluded and NOTHING else —
+    `/lost+found` and the rest of the default set are no longer excluded. Re-add
+    any default entries you still want alongside your own globs. Setting
+    `ignoreRules: []` explicitly opts out of ignoring anything at all (a full
+    snapshot of everything, including the OS junk above).
+
+!!! tip "Carrying `ignoreRules: [\"/lost+found\"]` in every SnapshotPolicy today?"
+    If your manifests (or a kustomize component applied to every app) paste in
+    `ignoreRules: ["/lost+found"]` by hand, you can delete that block — the
+    default now covers it, plus four more entries. Keeping it explicit pins you
+    to exactly that one-entry list (see the replace-semantics warning above), so
+    only keep it if you deliberately want `/lost+found` excluded and nothing
+    else from the default set.
+
+**Recommended extras** — desktop/editor junk that is deliberately **not**
+defaulted (copy this list into your own `ignoreRules` alongside anything else
+you need; remember it replaces, so include the default entries you want too):
+
+```yaml
+files:
+    ignoreRules:
+        # Kopiur's defaults:
+        - /lost+found
+        - System Volume Information
+        - $RECYCLE.BIN
+        - "@eaDir"
+        - .snapshot
+        # Desktop/editor junk — opt in per-workload, not defaulted:
+        - .DS_Store # macOS Finder metadata — harmless to drop, but not universal (server workloads never see it)
+        - "._*" # macOS AppleDouble sidecar files — CAN carry real xattrs/resource forks; dropping by default risks silent data loss for some workloads
+        - Thumbs.db # Windows Explorer thumbnail cache
+        - desktop.ini # Windows Explorer per-folder display settings
+        - .Trash-* # Linux desktop trash dirs — contents are recoverable deletions, but deliberately not auto-discarded by default
+```
 
 ### errorHandling — let a snapshot complete with errors
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -118,7 +118,7 @@ Short name `kopiasp`, plural `snapshotpolicies`. Print columns: `REPOSITORY`,
 | `retention` | [Retention](#retention) | — | GFS — the only successful-retention driver. |
 | `defaultDeletionPolicy` | enum(`Delete`\|`Retain`\|`Orphan`) | `Delete` (effective) | Default `deletionPolicy` for child `Snapshot`s. |
 | `compression` | {`compressor`?,`neverCompress`[]} | — | kopia compressor + per-glob opt-out. |
-| `files` | {`ignoreRules`[],`ignoreCacheDirs`,`ignoreIdenticalSnapshots`} | — | kopia files policy: ignore globs, honor `CACHEDIR.TAG`, skip identical re-snapshots. |
+| `files` | {`ignoreRules`[],`ignoreCacheDirs`,`ignoreIdenticalSnapshots`} | — | kopia files policy: ignore globs, honor `CACHEDIR.TAG`, skip identical re-snapshots. `ignoreRules` defaults to a 5-entry OS-artifact exclude set (`/lost+found`, `System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot`) applied even when `files` is omitted entirely; an explicit list REPLACES the default (not merged), and `ignoreRules: []` opts fully out. See [Backups → ignoreRules default](backups.md#filesignorerules-default-os-artifact-excludes). |
 | `extraArgs` | []string | — | Escape hatch for kopia flags. |
 | `errorHandling` | {`ignoreFileErrors`,`ignoreDirErrors`,`ignoreUnknownTypes`} | all `false` | Let a snapshot complete-with-errors. §13(b) |
 | `upload` | {`maxParallelSnapshots`?,`maxParallelFileReads`?} | — | Upload parallelism. §13(f) |

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -90,9 +90,19 @@ uncompressed (e.g. already-compressed media).
 ### `files`
 
 File-ignore policy. `ignoreRules` are filename/path globs to exclude from the
-snapshot (e.g. `*.tmp`, `*/cache/*`, `lost+found`); `ignoreCacheDirs` honors
-`CACHEDIR.TAG`; `ignoreIdenticalSnapshots` skips taking a new snapshot when the
-source is identical to the previous one.
+snapshot (e.g. `*.tmp`, `*/cache/*`); `ignoreCacheDirs` honors `CACHEDIR.TAG`;
+`ignoreIdenticalSnapshots` skips taking a new snapshot when the source is
+identical to the previous one.
+
+`ignoreRules` defaults to a 5-entry OS-artifact exclude set — `/lost+found`,
+`System Volume Information`, `$RECYCLE.BIN`, `@eaDir`, `.snapshot` — applied even
+when `files` is omitted from the spec entirely (the apiserver only
+server-side-defaults *nested* fields when the parent object is present, so this
+default is additionally applied by the controller when resolving the mover work
+spec). An explicit `ignoreRules` list **replaces** the default wholesale rather
+than merging with it; `ignoreRules: []` opts fully out of ignoring anything. See
+[Backups → `files.ignoreRules` default](../../backups.md#filesignorerules-default-os-artifact-excludes)
+for the per-entry rationale and a copy-paste "recommended extras" block.
 
 ### `extraArgs`
 


### PR DESCRIPTION
## What

`SnapshotPolicy.spec.files.ignoreRules` now **defaults** to an OS-artifact exclude set instead of empty:

| Default rule | Why |
|---|---|
| `/lost+found` | ext4 fsck recovery dir at the volume root (root-anchored — a nested user dir named `lost+found` is untouched) |
| `System Volume Information` | Windows/SMB-client artifact on samba-share PVCs (can hold VSS data) |
| `$RECYCLE.BIN` | Windows recycle bin droppings from SMB clients |
| `@eaDir` | Synology extended-attribute/thumbnail metadata junk |
| `.snapshot` | NAS-exposed snapshot pseudo-dirs (NetApp-style) — **unanchored** because they appear at every level; backing one up recursively re-captures older snapshot generations as file data. Flip side (documented): a legitimate dir named `.snapshot` is also excluded — set `ignoreRules` explicitly if you have one |

## Semantics (all four pinned by tests)

- `files:` absent → defaults apply (enforced in the mover-input glue, because the apiserver only defaults *nested* fields when the parent object exists)
- `files: {}` → defaults apply
- explicit custom list → **replaces** the defaults wholesale (re-add entries you still want)
- explicit `ignoreRules: []` → full opt-out, no ignores (round-trip-safe: `skip_serializing_if` dropped on this field so an explicit empty list can never re-default)

The 5-entry default is visible in the CRD schema (`kubectl explain snapshotpolicy.spec.policy.files.ignoreRules`).

> **Migration note**: if you carry `ignoreRules: ["/lost+found"]` in your manifests today (e.g. a kustomize component), you can delete it to inherit the full default set. Keeping it pins you to exactly that one rule — same behavior as before this change, no regression.

Deliberately **not** defaulted (documented as a copy-paste "recommended extras" block instead): `.DS_Store`, `._*` (can carry real macOS xattrs), `Thumbs.db`, `desktop.ini`, `.Trash-*` (recoverable deletions).

## Behavior-change note for release notes

Existing SnapshotPolicies that omit `files:` start excluding the five artifacts above on their next backup. This only ever *removes junk* from future snapshots; set `ignoreRules: []` to restore the old include-everything behavior.

## Verification

- 5 new API tests (schema default in CRD, all four semantics via the cluster's parse path) + mover-glue tests for the absent-`files` and opt-out arms.
- New e2e scenario with its own PVC/seeder (no shared-fixture contamination): backs up a source containing `lost+found/`, restores, asserts the junk is absent while a sibling real file survives; negative control with `ignoreRules: []` asserts `lost+found` is kept.
- `cargo test --workspace` (65 suites) / clippy `-D warnings` / fmt / `gen-check` / mkdocs strict all green on top of current `main`.
