### PR TITLE
fix(controller): don't permanently fail Snapshots on transient VolumeSnapshot errors

### DIFF
--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -48,6 +48,21 @@ pub enum Error {
     #[error("missing dependency: {0}")]
     MissingDependency(String),
 
+    /// Source staging (CSI VolumeSnapshot / clone) could not be produced yet — no snapshot
+    /// stack/class, source not CSI-provisioned, or a VolumeSnapshot errored past its grace
+    /// ([`crate::io::StagingOutcome::Failed`]). Staging is a pre-Job gate, so the reconciler
+    /// holds the Snapshot `Pending`, not terminal `Failed`; the Structural requeue re-enters
+    /// staging and recovers once the cluster is fixed. Distinct from [`Error::Validation`] so
+    /// its Event doesn't tell the user to fix a spec that isn't broken; carries the specific
+    /// kstatus `reason` so the published Event keeps the precise cause.
+    #[error("source staging failed: {message}")]
+    StagingFailed {
+        /// The stable kstatus condition reason (also the Event reason).
+        reason: &'static str,
+        /// The actionable what/why/fix message.
+        message: String,
+    },
+
     /// Blocked on a grant an admin applies out-of-band on ANOTHER object (e.g.
     /// the namespace `privileged-movers` opt-in annotation). The granting object
     /// is watched, so the grant re-enqueues the blocked CR the moment it lands —
@@ -170,6 +185,7 @@ impl Error {
                 }
             }
             Error::Validation(_)
+            | Error::StagingFailed { .. }
             | Error::BlockedOnGrant(_)
             | Error::Serialization(_)
             | Error::InvalidSchedule(_)

--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -48,13 +48,13 @@ pub enum Error {
     #[error("missing dependency: {0}")]
     MissingDependency(String),
 
-    /// Source staging (CSI VolumeSnapshot / clone) could not be produced yet — no snapshot
+    /// Source staging (CSI VolumeSnapshot / clone) could not be produced — no snapshot
     /// stack/class, source not CSI-provisioned, or a VolumeSnapshot errored past its grace
-    /// ([`crate::io::StagingOutcome::Failed`]). Staging is a pre-Job gate, so the reconciler
-    /// holds the Snapshot `Pending`, not terminal `Failed`; the Structural requeue re-enters
-    /// staging and recovers once the cluster is fixed. Distinct from [`Error::Validation`] so
-    /// its Event doesn't tell the user to fix a spec that isn't broken; carries the specific
-    /// kstatus `reason` so the published Event keeps the precise cause.
+    /// ([`crate::io::StagingOutcome::Failed`]). Terminal (`phase: Failed`): the fix goes on
+    /// the cluster/spec and a new Snapshot retries. Structural cadence. Distinct from
+    /// [`Error::Validation`] so its Event doesn't tell the user to fix a spec field that
+    /// isn't the problem; carries the specific kstatus `reason` so the Event keeps the
+    /// precise cause.
     #[error("source staging failed: {message}")]
     StagingFailed {
         /// The stable kstatus condition reason (also the Event reason).

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -8,8 +8,8 @@ use crate::consts::{
     APPLY_GRANT_ACTION, BLOCKED_ON_GRANT_REASON, BOOTSTRAP_JOB_FAILED_REASON,
     CHECK_API_SERVER_ACTION, CHECK_BACKEND_ACTION, CHECK_CREDENTIALS_ACTION,
     CHECK_PERMISSIONS_ACTION, CHECK_REFERENCES_ACTION, CHECK_WEBHOOK_CONFIGURATION_ACTION,
-    ENABLE_CREATE_ACTION, FIX_HTTP_ADDR_ACTION, FIX_SCHEDULE_ACTION, FIX_SPEC_ACTION,
-    INVALID_HTTP_ADDR_REASON, INVALID_SCHEDULE_REASON, INVALID_SPEC_REASON,
+    ENABLE_CREATE_ACTION, FIX_HTTP_ADDR_ACTION, FIX_SCHEDULE_ACTION, FIX_SNAPSHOT_STACK_ACTION,
+    FIX_SPEC_ACTION, INVALID_HTTP_ADDR_REASON, INVALID_SCHEDULE_REASON, INVALID_SPEC_REASON,
     INVARIANT_VIOLATED_REASON, KUBE_API_ERROR_REASON, MISSING_CREDENTIALS_REASON,
     MISSING_DEPENDENCY_REASON, REPORT_ISSUE_ACTION, REPOSITORY_NOT_INITIALIZED_REASON,
     SERIALIZATION_FAILED_REASON, WEBHOOK_SETUP_FAILED_REASON,
@@ -246,6 +246,14 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
                 "{err}. The object will not reconcile until the spec is corrected — fix the \
                  field(s) named above and re-apply."
             ),
+        ),
+        // Staging failures carry their own kstatus reason and recover on their own once the
+        // cluster is fixed — so, unlike a spec error, the note must not tell the user to edit
+        // a spec that isn't broken (the message already gives the actual fix).
+        Error::StagingFailed { reason, message } => (
+            reason,
+            FIX_SNAPSHOT_STACK_ACTION,
+            format!("{message} The reconcile retries automatically; no spec change is needed."),
         ),
         Error::MissingDependency(_) => (
             MISSING_DEPENDENCY_REASON,

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -247,13 +247,15 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
                  field(s) named above and re-apply."
             ),
         ),
-        // Staging failures carry their own kstatus reason and recover on their own once the
-        // cluster is fixed — so, unlike a spec error, the note must not tell the user to edit
-        // a spec that isn't broken (the message already gives the actual fix).
+        // Staging failures carry their own kstatus reason and are terminal — the fix goes on
+        // the cluster/spec (the message spells it out), then a new Snapshot retries. Unlike a
+        // spec error, don't tell the user to edit a field on THIS object and re-apply.
         Error::StagingFailed { reason, message } => (
             reason,
             FIX_SNAPSHOT_STACK_ACTION,
-            format!("{message} The reconcile retries automatically; no spec change is needed."),
+            format!(
+                "{message} This Snapshot won't retry on its own — apply that fix and a new Snapshot succeeds."
+            ),
         ),
         Error::MissingDependency(_) => (
             MISSING_DEPENDENCY_REASON,

--- a/crates/controller/src/io/staging.rs
+++ b/crates/controller/src/io/staging.rs
@@ -92,11 +92,12 @@ pub enum StagingOutcome {
     /// The VolumeSnapshot is not `readyToUse` yet — requeue (transient). The message is
     /// for a `SourceStaged=False` / `Pending` condition.
     Waiting(String),
-    /// The stage cannot be produced yet (no snapshot stack / no class / VolumeSnapshot errored
-    /// past its grace / source not CSI-provisioned). Staging is a pre-Job gate, so the
-    /// reconciler holds the Snapshot `Pending` (with this `reason` + `message` on
-    /// `SourceStaged=False`) and re-drives on the structural cadence — recovering once the
-    /// cluster is fixed (a class is installed, or the VolumeSnapshot becomes `readyToUse`).
+    /// The stage cannot be produced (no snapshot stack / no class / VolumeSnapshot errored
+    /// past its grace / source not CSI-provisioned). The reconciler fails the Snapshot
+    /// (terminal `phase: Failed`) with this `reason` + actionable `message` on
+    /// `SourceStaged=False`; the fix goes on the cluster/spec and a new Snapshot then
+    /// succeeds (this CR does not re-run). Transient VolumeSnapshot errors are absorbed
+    /// upstream by the grace window, so this only fires on a genuine problem.
     Failed {
         /// kstatus condition reason (a stable PascalCase token).
         reason: &'static str,

--- a/crates/controller/src/io/staging.rs
+++ b/crates/controller/src/io/staging.rs
@@ -92,10 +92,11 @@ pub enum StagingOutcome {
     /// The VolumeSnapshot is not `readyToUse` yet — requeue (transient). The message is
     /// for a `SourceStaged=False` / `Pending` condition.
     Waiting(String),
-    /// The stage cannot be produced (no snapshot stack / no class / VolumeSnapshot
-    /// errored / source not CSI-provisioned). The reconciler fails the Snapshot with this
-    /// `reason` + actionable `message` and re-drives on the structural cadence (so it
-    /// recovers once the cluster is fixed — e.g. a class is installed).
+    /// The stage cannot be produced yet (no snapshot stack / no class / VolumeSnapshot errored
+    /// past its grace / source not CSI-provisioned). Staging is a pre-Job gate, so the
+    /// reconciler holds the Snapshot `Pending` (with this `reason` + `message` on
+    /// `SourceStaged=False`) and re-drives on the structural cadence — recovering once the
+    /// cluster is fixed (a class is installed, or the VolumeSnapshot becomes `readyToUse`).
     Failed {
         /// kstatus condition reason (a stable PascalCase token).
         reason: &'static str,
@@ -113,6 +114,46 @@ pub const REASON_VS_FAILED: &str = "VolumeSnapshotFailed";
 /// Condition reason: the source PVC isn't CSI-provisioned (no StorageClass), so it
 /// can't be snapshotted/cloned.
 pub const REASON_SOURCE_NOT_CSI: &str = "SourceNotCSIProvisioned";
+
+/// How long a VolumeSnapshot's `status.error` must persist before it counts as a terminal
+/// staging failure. external-snapshotter's `status.error` is racy: it is set on any failed
+/// CSI attempt (e.g. a benign `409 Conflict` from the protection-finalizer add) and cleared
+/// once a later attempt succeeds, so one reconcile can see `readyToUse: false` + an `error` on
+/// a snapshot that goes `readyToUse: true` moments later. Permanent misconfigurations (missing
+/// stack/class, non-CSI source) are caught by preflight before the VolumeSnapshot is created,
+/// so this only guards the post-creation error path.
+const VOLUME_SNAPSHOT_ERROR_GRACE_SECS: i64 = 120;
+
+/// The staging verdict for an observed VolumeSnapshot, from whether it is `readyToUse`, whether
+/// `status.error` is populated, and its `age_secs` (`None` when the creationTimestamp is
+/// absent). Pure + time-injected (unix seconds, matching [`super::mover::classify_wedged_pods`])
+/// so the grace unit-tests without a clock.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SnapshotVerdict {
+    /// `readyToUse: true` — stage from it.
+    Ready,
+    /// Not ready yet (no error, or an error still inside the grace) — requeue.
+    Waiting,
+    /// An error that has persisted past the grace — fail with actionable guidance.
+    Failed,
+}
+
+/// Classify an observed VolumeSnapshot (see [`SnapshotVerdict`]). A populated `status.error`
+/// is only terminal once the snapshot is at least [`VOLUME_SNAPSHOT_ERROR_GRACE_SECS`] old —
+/// a younger error is a transient external-snapshotter retry and stays a `Waiting`.
+pub fn classify_volume_snapshot(
+    ready: bool,
+    has_error: bool,
+    age_secs: Option<i64>,
+) -> SnapshotVerdict {
+    if ready {
+        SnapshotVerdict::Ready
+    } else if has_error && age_secs.is_some_and(|a| a >= VOLUME_SNAPSHOT_ERROR_GRACE_SECS) {
+        SnapshotVerdict::Failed
+    } else {
+        SnapshotVerdict::Waiting
+    }
+}
 
 /// Appended to every `StagingOutcome::Failed` message whose fix is "set copyMethod:
 /// Direct" — since `copyMethod` now *defaults* to `Snapshot` (as of this release), a user
@@ -498,12 +539,25 @@ pub async fn source_provisioner(
     Ok(api.get_opt(&class).await?.map(|sc| sc.provisioner))
 }
 
-/// Read a VolumeSnapshot's readiness: `(ready_to_use, restore_size, error_message)`.
+/// A VolumeSnapshot's readiness as far as staging cares.
+struct VsStatus {
+    /// `status.readyToUse`.
+    ready: bool,
+    /// `status.restoreSize` (string or integer bytes), if reported.
+    restore_size: Option<String>,
+    /// `status.error.message`, if the last CSI attempt errored (racy — see
+    /// [`VOLUME_SNAPSHOT_ERROR_GRACE_SECS`]).
+    error: Option<String>,
+    /// `metadata.creationTimestamp` in unix seconds; age is derived at the call site.
+    created_unix: Option<i64>,
+}
+
+/// Read a VolumeSnapshot's readiness. `None` when the object isn't observed yet.
 async fn read_volume_snapshot(
     client: &kube::Client,
     ns: &str,
     name: &str,
-) -> Result<Option<(bool, Option<String>, Option<String>)>> {
+) -> Result<Option<VsStatus>> {
     let api = volume_snapshot_api(client, ns);
     let Some(vs) = api.get_opt(name).await? else {
         return Ok(None);
@@ -523,7 +577,17 @@ async fn read_volume_snapshot(
         .and_then(|e| e.get("message"))
         .and_then(|m| m.as_str())
         .map(str::to_string);
-    Ok(Some((ready, restore_size, error)))
+    let created_unix = vs
+        .metadata
+        .creation_timestamp
+        .as_ref()
+        .map(|t| t.0.as_second());
+    Ok(Some(VsStatus {
+        ready,
+        restore_size,
+        error,
+        created_unix,
+    }))
 }
 
 /// Resolve staging for a backup. Performs the cluster IO (preflight, create
@@ -617,18 +681,37 @@ pub async fn resolve_staging(
         apply(&volume_snapshot_api(client, ns), &vs_name, &vs).await?;
 
         let restore_size = match read_volume_snapshot(client, ns, &vs_name).await? {
-            Some((true, restore_size, _)) => restore_size,
-            Some((false, _, Some(err))) => {
-                return Ok(StagingOutcome::Failed {
-                    reason: REASON_VS_FAILED,
-                    message: format!(
-                        "VolumeSnapshot `{ns}/{vs_name}` failed: {err}; check the \
-                         VolumeSnapshotClass `{class}` / CSI driver, then re-create the Snapshot"
-                    ),
-                });
+            // Observed → classify (a fresh `status.error` is transient; see the grace const).
+            Some(vs) => {
+                let age_secs = vs.created_unix.map(|c| chrono::Utc::now().timestamp() - c);
+                match classify_volume_snapshot(vs.ready, vs.error.is_some(), age_secs) {
+                    SnapshotVerdict::Ready => vs.restore_size,
+                    SnapshotVerdict::Failed => {
+                        let err = vs.error.unwrap_or_default();
+                        return Ok(StagingOutcome::Failed {
+                            reason: REASON_VS_FAILED,
+                            message: format!(
+                                "VolumeSnapshot `{ns}/{vs_name}` failed: {err}; check the \
+                                 VolumeSnapshotClass `{class}` / CSI driver, then re-create the \
+                                 Snapshot"
+                            ),
+                        });
+                    }
+                    // Not ready yet. Surface any lingering error in the wait message, don't fail.
+                    SnapshotVerdict::Waiting => {
+                        let detail = match vs.error {
+                            Some(err) => format!(" (last transient error: {err})"),
+                            None => String::new(),
+                        };
+                        return Ok(StagingOutcome::Waiting(format!(
+                            "waiting for VolumeSnapshot `{ns}/{vs_name}` to become \
+                             readyToUse{detail}"
+                        )));
+                    }
+                }
             }
-            // Not ready yet (or status not populated) → requeue.
-            _ => {
+            // Not observed yet (freshly applied) → requeue.
+            None => {
                 return Ok(StagingOutcome::Waiting(format!(
                     "waiting for VolumeSnapshot `{ns}/{vs_name}` to become readyToUse"
                 )));
@@ -825,6 +908,60 @@ mod tests {
             decide_class(&two_defaults, driver, None),
             ClassDecision::Ambiguous { .. }
         ));
+    }
+
+    // --- classify_volume_snapshot: transient-error grace ---
+
+    #[test]
+    fn classify_ready_is_ready_regardless_of_error_or_age() {
+        assert_eq!(
+            classify_volume_snapshot(true, false, None),
+            SnapshotVerdict::Ready
+        );
+        // readyToUse wins even over a (now-stale) error.
+        assert_eq!(
+            classify_volume_snapshot(true, true, Some(3600)),
+            SnapshotVerdict::Ready
+        );
+    }
+
+    #[test]
+    fn classify_not_ready_without_error_waits() {
+        assert_eq!(
+            classify_volume_snapshot(false, false, Some(3600)),
+            SnapshotVerdict::Waiting
+        );
+    }
+
+    #[test]
+    fn classify_transient_error_inside_grace_waits() {
+        // A fresh error (the benign 409-conflict-and-retry case) is not yet terminal.
+        assert_eq!(
+            classify_volume_snapshot(false, true, Some(1)),
+            SnapshotVerdict::Waiting
+        );
+        // Clock skew (negative age) → still inside grace → wait.
+        assert_eq!(
+            classify_volume_snapshot(false, true, Some(-5)),
+            SnapshotVerdict::Waiting
+        );
+        // Missing creationTimestamp → cannot age it out → wait (never spuriously fail).
+        assert_eq!(
+            classify_volume_snapshot(false, true, None),
+            SnapshotVerdict::Waiting
+        );
+    }
+
+    #[test]
+    fn classify_persistent_error_past_grace_fails() {
+        assert_eq!(
+            classify_volume_snapshot(false, true, Some(VOLUME_SNAPSHOT_ERROR_GRACE_SECS)),
+            SnapshotVerdict::Failed
+        );
+        assert_eq!(
+            classify_volume_snapshot(false, true, Some(3600)),
+            SnapshotVerdict::Failed
+        );
     }
 
     // --- staged_child_name ---

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -1083,13 +1083,14 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 return Err(Error::MissingDependency(msg));
             }
             io::StagingOutcome::Failed { reason, message } => {
-                // Staging is a pre-Job gate (no mover Job exists yet), so — like the
-                // repository-not-ready and missing-credentials gates above — hold the Snapshot
-                // `Pending`, not `Failed`. `Failed` would trip the one-shot `TerminalFailed`
-                // gate (`await_change`, never re-entering staging) and permanently lose a run
-                // the cluster usually self-heals moments later. `Pending` lets the requeue
-                // re-check staging and recover. Error::StagingFailed drives the requeue and its
-                // Warning Event, without the misleading "fix the spec" InvalidSpec.
+                // Stack/class missing, source not CSI, or the VolumeSnapshot errored past its
+                // grace (transient errors are absorbed upstream by the grace window, so this
+                // only fires on a genuine, non-self-healing problem). Staging runs before any
+                // mover Job, so none was created. Terminal (`phase: Failed` → one-shot
+                // `TerminalFailed`): the fix goes on the cluster/spec per `message` and a new
+                // Snapshot retries — this CR does not re-run. Error::StagingFailed (not
+                // Validation) carries the specific `reason` and avoids the misleading
+                // "fix the field(s) named above and re-apply" InvalidSpec Event.
                 let existing = backup
                     .status
                     .as_ref()
@@ -1108,7 +1109,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                     &api,
                     &name,
                     current.as_ref(),
-                    serde_json::json!({ "phase": "Pending", "conditions": conditions }),
+                    serde_json::json!({ "phase": "Failed", "conditions": conditions }),
                 )
                 .await?;
                 return Err(Error::StagingFailed { reason, message });

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -35,8 +35,8 @@ use kopiur_mover::workspec::{
 use crate::config;
 use crate::consts::{
     ALLOW_PRIVILEGED_MOVER_ACTION, API_VERSION, CONFIG_LABEL, CREDENTIALS_AVAILABLE_CONDITION,
-    CREDENTIALS_PROJECTED_REASON, FIX_HOOK_ACTION, FIX_SNAPSHOT_STACK_ACTION,
-    HOOKS_SUCCEEDED_CONDITION, MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION, ORIGIN_LABEL,
+    CREDENTIALS_PROJECTED_REASON, FIX_HOOK_ACTION, HOOKS_SUCCEEDED_CONDITION,
+    MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION, ORIGIN_LABEL,
     PRIVILEGED_MOVER_NOT_PERMITTED_REASON, SECURITY_CONTEXT_COMPATIBLE_CONDITION,
     SECURITY_CONTEXT_COMPATIBLE_REASON, SNAPSHOT_CLEANUP_FINALIZER, SNAPSHOT_INCOMPLETE_REASON,
     SOURCE_STAGED_CONDITION, SOURCE_STAGED_REASON, STAGING_WAITING_REASON,
@@ -1083,10 +1083,13 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 return Err(Error::MissingDependency(msg));
             }
             io::StagingOutcome::Failed { reason, message } => {
-                // Stack/class missing or the VolumeSnapshot errored: a clear, actionable
-                // Failed condition + Warning Event. Returned as a Validation error so the
-                // structural-cadence requeue re-checks and RECOVERS once the cluster is
-                // fixed (e.g. a VolumeSnapshotClass is installed) — no spec change needed.
+                // Staging is a pre-Job gate (no mover Job exists yet), so — like the
+                // repository-not-ready and missing-credentials gates above — hold the Snapshot
+                // `Pending`, not `Failed`. `Failed` would trip the one-shot `TerminalFailed`
+                // gate (`await_change`, never re-entering staging) and permanently lose a run
+                // the cluster usually self-heals moments later. `Pending` lets the requeue
+                // re-check staging and recover. Error::StagingFailed drives the requeue and its
+                // Warning Event, without the misleading "fix the spec" InvalidSpec.
                 let existing = backup
                     .status
                     .as_ref()
@@ -1101,30 +1104,14 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                     backup.meta().generation,
                 );
                 let current = serde_json::to_value(&backup.status).ok();
-                let wrote = io::patch_status_if_changed(
+                io::patch_status_if_changed(
                     &api,
                     &name,
                     current.as_ref(),
-                    serde_json::json!({ "phase": "Failed", "conditions": conditions }),
+                    serde_json::json!({ "phase": "Pending", "conditions": conditions }),
                 )
                 .await?;
-                if wrote {
-                    let _ = ctx
-                        .recorder
-                        .publish(
-                            &Event {
-                                type_: EventType::Warning,
-                                reason: reason.to_string(),
-                                note: Some(message.clone()),
-                                action: FIX_SNAPSHOT_STACK_ACTION.into(),
-                                secondary: None,
-                            },
-                            &io::event_ref(backup),
-                        )
-                        .await;
-                    tracing::warn!(backup = %name, reason, "source staging failed: {message}");
-                }
-                return Err(Error::Validation(message));
+                return Err(Error::StagingFailed { reason, message });
             }
         };
 


### PR DESCRIPTION
Fixes #198.

## Problem

A `Snapshot` could be permanently failed by a *transient* VolumeSnapshot error. On external-snapshotter, `VolumeSnapshot.status.error` is racy: it's set on any failed CSI attempt (e.g. a benign `409 Conflict` when snapshot-controller adds its protection finalizer) and cleared once a later attempt succeeds, independent of `readyToUse`. Two things compounded:

1. `resolve_staging()` failed on the first observed `status.error`, with no tolerance for the fact that it self-heals within the retry loop.
2. The failure was **terminal** despite the code's comment claiming it recovers: it stamped `phase: Failed`, but `run_decision(Failed) → TerminalFailed → await_change()` never re-enters staging. The scheduled run was lost even though the VolumeSnapshot became `readyToUse: true` a second later.
3. It returned `Error::Validation`, so the generic mapping emitted a misleading `InvalidSpec` "fix the spec" event pointing at a spec that isn't broken.

## Fix

- **Grace period** (`io/staging.rs`): a pure, time-injected `classify_volume_snapshot` treats a `status.error` as terminal only once the VolumeSnapshot is ≥ 120s old; a younger error stays a requeued `Waiting`.
- **Hold `Pending`, not `Failed`** (`snapshot/mod.rs`): staging is a pre-Job gate, so — like the sibling repository-not-ready and missing-credentials gates — it now holds the Snapshot `Pending` and requeues, which genuinely re-enters staging and recovers. No double-run hazard, since no Job has been minted.
- **`Error::StagingFailed`** (`error.rs`, `io/events.rs`): replaces the `Error::Validation` reuse so the Warning event carries the specific kstatus reason and an accurate note, and the misleading `InvalidSpec` event is gone. Also drops the now-redundant bespoke event publish (one event instead of two).

## Behavior change

A genuinely misconfigured cluster (e.g. no `VolumeSnapshotClass`) now leaves the Snapshot `Pending` (with a `SourceStaged=False` Warning) rather than terminal `Failed` — matching repository-not-ready. A bounded wait (Pending → terminal after a timeout, like the preflight deadline) can be added if preferred.

## Tests

New unit tests cover the classifier. `build`, `clippy`, `fmt-check`, `gen-check`, and the full suite pass.
