### PR TITLE
docs(upgrade): add 0.5.x → 0.6.0 CRD migration guide

### DIFF
--- a/deploy/helm/kopiur/README.md
+++ b/deploy/helm/kopiur/README.md
@@ -55,7 +55,7 @@ Disable the webhook entirely with `webhook.enabled=false` (validation then falls
 
 ### CRDs
 
-The 8 CRDs ship in the chart's special `crds/` directory. Helm installs them on `helm install`, and — because Helm never touches `crds/` on `helm upgrade` — an accidental `helm uninstall` leaves them (and every `kopiur.home-operations.com` object) untouched, exactly what you want for a backup operator. The flip side: a plain helm-CLI **upgrade** does not update the CRD schema as the `v1alpha1` API evolves. For a helm-CLI upgrade, apply the new schema yourself with `kubectl apply -f deploy/crds/`; GitOps tooling with a `CreateReplace` CRD policy (e.g. Flux) upgrades the `crds/`-shipped CRDs automatically.
+The 8 CRDs ship in the chart's special `crds/` directory. Helm installs them on `helm install`, and — because Helm never touches `crds/` on `helm upgrade` — an accidental `helm uninstall` leaves them (and every `kopiur.home-operations.com` object) untouched, exactly what you want for a backup operator. The flip side: a plain helm-CLI **upgrade** does not update the CRD schema as the `v1alpha1` API evolves. For a helm-CLI upgrade, apply the new schema yourself with `kubectl apply -f deploy/crds/`; GitOps tooling with a `CreateReplace` CRD policy (e.g. Flux) upgrades the `crds/`-shipped CRDs automatically. **Upgrading from 0.5.x to 0.6.0 is a one-time special case** — the CRDs moved out of Helm-templated resources into this `crds/` directory, so the crossing removes and re-installs them (cascade-deleting your CRs) unless you pin them first; see [`docs/upgrade.md`](../../../docs/upgrade.md) before upgrading.
 
 ## Values
 

--- a/deploy/helm/kopiur/README.md.gotmpl
+++ b/deploy/helm/kopiur/README.md.gotmpl
@@ -53,7 +53,7 @@ Disable the webhook entirely with `webhook.enabled=false` (validation then falls
 
 ### CRDs
 
-The 8 CRDs ship in the chart's special `crds/` directory. Helm installs them on `helm install`, and — because Helm never touches `crds/` on `helm upgrade` — an accidental `helm uninstall` leaves them (and every `kopiur.home-operations.com` object) untouched, exactly what you want for a backup operator. The flip side: a plain helm-CLI **upgrade** does not update the CRD schema as the `v1alpha1` API evolves. For a helm-CLI upgrade, apply the new schema yourself with `kubectl apply -f deploy/crds/`; GitOps tooling with a `CreateReplace` CRD policy (e.g. Flux) upgrades the `crds/`-shipped CRDs automatically.
+The 8 CRDs ship in the chart's special `crds/` directory. Helm installs them on `helm install`, and — because Helm never touches `crds/` on `helm upgrade` — an accidental `helm uninstall` leaves them (and every `kopiur.home-operations.com` object) untouched, exactly what you want for a backup operator. The flip side: a plain helm-CLI **upgrade** does not update the CRD schema as the `v1alpha1` API evolves. For a helm-CLI upgrade, apply the new schema yourself with `kubectl apply -f deploy/crds/`; GitOps tooling with a `CreateReplace` CRD policy (e.g. Flux) upgrades the `crds/`-shipped CRDs automatically. **Upgrading from 0.5.x to 0.6.0 is a one-time special case** — the CRDs moved out of Helm-templated resources into this `crds/` directory, so the crossing removes and re-installs them (cascade-deleting your CRs) unless you pin them first; see [`docs/upgrade.md`](../../../docs/upgrade.md) before upgrading.
 
 {{ template "chart.valuesSection" . }}
 

--- a/deploy/helm/kopiur/templates/NOTES.txt
+++ b/deploy/helm/kopiur/templates/NOTES.txt
@@ -4,7 +4,8 @@ Install scope: {{ .Values.installScope }}{{ if eq .Values.installScope "cluster"
 CRDs: shipped in the chart's crds/ directory — installed on `helm install`, but
       Helm never upgrades them on `helm upgrade`. For a helm-CLI upgrade, apply
       the new schema yourself: kubectl apply -f deploy/crds/ (GitOps CreateReplace
-      handles this automatically).
+      handles this automatically). Upgrading FROM 0.5.x is a one-time special case
+      (the CRDs moved into crds/) — see docs/upgrade.md before upgrading.
 Webhook: {{ if .Values.webhook.enabled }}enabled (failurePolicy={{ .Values.webhook.failurePolicy }}){{ else }}disabled{{ end }}
 
 1. Verify the controller is running:

--- a/docs/gitops.md
+++ b/docs/gitops.md
@@ -166,8 +166,18 @@ is therefore a snapshot-gated **delete-and-repopulate**, not a silent `git push`
 back up, delete the old PVC, then let the populator-backed PVC provision. Plan the
 cutover deliberately.
 
+## Upgrading across the 0.6.0 CRD move
+
+Upgrading **from 0.5.x to 0.6.0** relocated the CRDs into Helm's `crds/` directory.
+Under GitOps that crossing removes and re-installs the CRDs (cascade-deleting your
+CRs) unless you pin them first, and recovering afterwards is a reconcile-from-Git —
+reinstall the release to recreate the CRDs, then reconcile the apps that own the CRs.
+The full pre-upgrade step and the Flux/Argo recovery sequence live on the
+[Upgrading](upgrade.md#upgrading-05x--060-one-time-crd-migration) page.
+
 ## See also
 
+- [Upgrading](upgrade.md) — the one-time 0.5.x → 0.6.0 CRD migration and recovery.
 - [Restores → deploy-or-restore](restores.md#deploy-or-restore-gitops) — the one-bundle GitOps pattern.
 - [Field reference](field-reference.md) — the conditions and status fields per kind.
 - [Observability](dev/observability.md) — metrics + the `resource_phase` gauge.

--- a/docs/install.md
+++ b/docs/install.md
@@ -126,6 +126,8 @@ The 8 CRDs ship in the chart's special `crds/` directory. Helm treats that direc
 
 The CRDs and RBAC shipped by the chart are **generated** by `cargo xtask gen-crds` / `cargo xtask gen-rbac` and checked in under `deploy/crds/` and `deploy/rbac/`. Those xtasks are the source of truth.
 
+Upgrading **from 0.5.x to 0.6.0** is a special case: the CRDs used to be release-owned templates and moved into this `crds/` directory, so the crossing removes and re-installs them (cascade-deleting your CRs) unless you pin them first. See [Upgrading → 0.5.x → 0.6.0](upgrade.md#upgrading-05x--060-one-time-crd-migration) before you upgrade.
+
 ## First backup
 
 After install, create a repository and start backing up a PVC. The smallest end-to-end example is `deploy/examples/01-single-pvc-scheduled.yaml`:
@@ -169,9 +171,11 @@ See [`docs/dev/observability.md`](dev/observability.md) for the full metric list
 ## Upgrade / uninstall
 
 ```bash
-helm upgrade kopiur deploy/helm/kopiur -n kopiur-system   # re-applies CRD schema
-helm uninstall kopiur -n kopiur-system                     # see CRD caution above
+helm upgrade kopiur deploy/helm/kopiur -n kopiur-system   # does NOT touch crds/ — apply schema changes yourself (see CRD lifecycle)
+helm uninstall kopiur -n kopiur-system                     # leaves the crds/ CRDs (and your CRs) in place
 ```
+
+Upgrading **from 0.5.x** needs a one-time pre-step so the CRD move doesn't delete your resources — see [Upgrading](upgrade.md).
 
 ## See also
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -287,6 +287,20 @@ $ kubectl get snapshotschedule <name> -n <ns> \
 - If the operator was down across a slot and `startingDeadlineSeconds` elapsed, that slot is skipped on purpose (no late stampede).
 - Repeated failures show up as `status.consecutiveFailures`; the failing `Snapshot` CRs (bounded by `failedJobsHistoryLimit`) carry the reason.
 
+## CRDs or CRs disappeared after upgrading to 0.6.0
+
+Upgrading **from 0.5.x to 0.6.0** moves the CRDs into Helm's `crds/` directory. On
+that one crossing Helm prunes the old release-owned CRDs and cascade-deletes every
+`kopiur.home-operations.com` object — this is expected, not a bug in the operator.
+
+```console
+$ kubectl get crd -l app.kubernetes.io/part-of=kopiur   # gone or fewer than 8?
+```
+
+Pin the CRDs **before** upgrading to avoid it, or recover from Git afterwards — both
+are in [Upgrading → 0.5.x → 0.6.0](upgrade.md#upgrading-05x--060-one-time-crd-migration).
+Your kopia snapshots are untouched; only the Kubernetes CR objects are affected.
+
 ## Maintenance isn't running
 
 Maintenance waits for the repository and coordinates a single owner. Check the `Maintenance` resource:

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,0 +1,103 @@
+# Upgrading Kopiur
+
+This page covers upgrading the operator across releases. Most upgrades are a
+routine `helm upgrade` (or a Flux/Argo reconcile) — bump the chart version, roll
+the Deployments, done. The one exception so far is **0.5.x → 0.6.0**, which moves
+the CRDs between two Helm mechanisms and needs one deliberate step to avoid data
+loss. Read that section before you cross it.
+
+## Upgrading 0.5.x → 0.6.0 (one-time CRD migration)
+
+/// danger | This upgrade removes and re-installs the CRDs
+Crossing **0.5.x → 0.6.0** prunes the old, release-owned CRDs and **cascade-deletes
+every `kopiur.home-operations.com` object** — your `Repository`,
+`ClusterRepository`, `Snapshot`, `Restore`, `SnapshotPolicy`, `SnapshotSchedule`,
+`Maintenance`, and `RepositoryReplication` resources. It is a **one-time** event on
+this specific crossing; upgrades from 0.6.0 onward are safe. Do the pre-upgrade step
+below **before** you upgrade.
+///
+
+### Why this happens
+
+In **0.5.x** the 8 CRDs were rendered as ordinary Helm templates, so they were
+**owned by the Helm release**. In **0.6.0** they moved into Helm's special `crds/`
+directory (see [CRD lifecycle](install.md#crd-lifecycle) for the steady-state
+contract), which Helm installs on `helm install` but never tracks as part of the
+release.
+
+Because 0.6.0 no longer renders the CRDs as release-owned templates, a `helm upgrade`
+(or a Flux reconcile) sees them **leave the release manifest** and **prunes them** —
+and deleting a CRD deletes every custom resource of that kind. Helm then installs the
+`crds/`-directory copies, but that path only runs on a fresh install, so the net
+effect is the CRDs (and your CRs) getting removed and re-installed.
+
+/// note | Your backups themselves are safe
+Only the **Kubernetes CR objects** are affected. The **kopia snapshots in your
+repository are not touched** — the backup data is intact. GitOps re-applies the CRs
+straight from Git (see [recovery](#recovery--if-you-already-upgraded)); non-GitOps
+users can re-adopt the existing snapshots via a discovered `Restore`.
+///
+
+### Safe path — pin the CRDs before you upgrade
+
+While you are **still on 0.5.x**, annotate the live CRDs with
+`helm.sh/resource-policy: keep`. Helm honors that annotation during the upgrade and
+**skips the prune**, so the CRDs — and all your CRs — survive. The new
+`crds/`-directory install then finds them already present and does nothing.
+
+```console
+# Run against your 0.5.x release, BEFORE upgrading / reconciling to 0.6.0
+$ for crd in $(kubectl get crd -l app.kubernetes.io/part-of=kopiur -o name); do
+    kubectl annotate "$crd" helm.sh/resource-policy=keep --overwrite
+  done
+```
+
+If the label selector returns nothing on your install, annotate the eight CRDs by
+name instead:
+
+```console
+$ for name in repositories clusterrepositories snapshotpolicies snapshots \
+              snapshotschedules restores maintenances repositoryreplications; do
+    kubectl annotate "crd/${name}.kopiur.home-operations.com" \
+      helm.sh/resource-policy=keep --overwrite
+  done
+```
+
+Now upgrade as usual (`helm upgrade …`, or bump the chart in Git and let Flux/Argo
+reconcile). Afterwards, confirm the CRDs and your resources are still present:
+
+```console
+$ kubectl get crd -l app.kubernetes.io/part-of=kopiur
+$ kubectl get repositories,snapshots,restores -A
+```
+
+### Recovery — if you already upgraded
+
+If you crossed to 0.6.0 without pinning the CRDs, re-apply everything from Git. For
+Flux, reinstall the release (which recreates the CRDs from the `crds/` directory),
+then reconcile the repository and each app so their CRs come back:
+
+```console
+$ flux reconcile -n kopiur-system hr kopiur --force --reset          # recreate the CRDs
+$ flux reconcile ks -n kopiur-system kopiur-repository --with-source  # may need running twice
+$ flux reconcile ks -n <app-namespace> <app> --with-source           # per app: recreate its CRs
+```
+
+/// warning | Watch the finalizers
+Each `Snapshot` CR owns its kopia snapshot through a **finalizer**, so a deleted
+`Snapshot` sits in `Terminating` until the finalizer clears rather than vanishing
+immediately. You may have to reconcile the `HelmRelease` **more than once** while the
+finalizers settle. Track progress with `kubectl get snapshots -A` before assuming a
+reconcile is complete.
+///
+
+Argo users apply the same idea: sync the CRD application first (a `CreateReplace` sync
+policy recreates the `crds/`-shipped CRDs), then sync the applications that own the CRs.
+See [GitOps with Kopiur](gitops.md) for the CRD sync-wave guidance.
+
+## See also
+
+- [Installing Kopiur → CRD lifecycle](install.md#crd-lifecycle) — the steady-state
+  `crds/`-directory contract and how to apply schema changes on later upgrades.
+- [GitOps with Kopiur](gitops.md) — CRD sync waves, `CreateReplace`, and the Flux/Argo
+  reconcile model.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -156,6 +156,7 @@ nav:
   - User guide:
       - Getting started: getting-started.md
       - Installation: install.md
+      - Upgrading: upgrade.md
       - GitOps (Flux / Argo): gitops.md
       # NOTE: with `navigation.indexes` on, a page whose source file is named
       # index.md must be a SECTION index (first child of its own section). Listed


### PR DESCRIPTION
## What & why

Upgrading the chart **0.5.x → 0.6.0** silently removes and re-installs the 8 CRDs,
cascade-deleting every `kopiur.home-operations.com` custom object. Users hit this on
release day and had to recover CRs from Git. Nothing in the docs warned about it.

### Root cause

The 0.6.0 chart restructure (#203/#206, `abe07d6`) moved the CRDs between two Helm
mechanisms with opposite lifecycles:

| | 0.5.x — templated CRDs | 0.6.0 — special `crds/` dir |
|---|---|---|
| Files | `files/crds/*.yaml` rendered by `templates/install-crds.tpl` | `crds/*.yaml` |
| Tracked in the release? | **yes** (release-owned) | **no** (install-only) |
| `helm upgrade` | re-applies | skipped |

Because 0.6.0 no longer renders the CRDs as release-owned templates, `helm upgrade`
(or a Flux reconcile) sees them leave the release manifest and **prunes them** —
deleting a CRD deletes every CR of that kind. `Snapshot` CRs linger in `Terminating`
behind their finalizers. It's a one-time crossing; upgrades from 0.6.0 on are safe.

## Changes (docs-only)

- **`docs/upgrade.md`** (new): the mechanism, the **safe pre-upgrade step** (annotate
  the live CRDs with `helm.sh/resource-policy=keep` so Helm skips the prune —
  respected because Helm's upgrade-delete path refreshes the live object before
  reading the annotation), and the field-verified **Flux recovery** for anyone
  already bitten. Added to the `nav:` under User guide.
- **`docs/install.md`**: cross-links to the new page; fixes the misleading
  `helm upgrade … # re-applies CRD schema` comment (Helm never touches `crds/` on
  upgrade).
- **`docs/gitops.md`** / **`docs/troubleshooting.md`**: cross-links + a "CRDs
  disappeared after upgrading" troubleshooting entry.
- **`NOTES.txt`** + chart **`README.md.gotmpl`** (regenerated `README.md`): one-line
  pointer for helm-CLI users.

No chart/behavior changes — the `crds/` design (org operator-chart shape) is kept; it
is safer on uninstall going forward. `CHANGELOG.md` is release-please-managed and
left untouched.

## Verification

- `mise run docs` (`mkdocs build --strict`) is green — validates the new nav file and
  every cross-page/intra-page anchor.
- `mise run helm-docs` regenerates `README.md` from the `.gotmpl` with only the
  intended change.

### Suggested follow-up (not in this PR)

The pre-emptive `keep`-annotation advice matches Helm's documented + source behavior
(`Update()` calls `info.Get()` before checking `resource-policy`, so a live
annotation is honored). A throwaway-kind smoke test — install 0.5.2, annotate,
upgrade to 0.6.0, assert the CRDs + a test CR survive — would turn "documented" into
"proven" if we want a regression guard.

https://claude.ai/code/session_01VwL9k9BuuYveAEMWyTveMf