### PR TITLE
feat: expose kopia CLI tuning flags across the CRDs (closes #216)

### DIFF
--- a/crates/api/src/repository_replication.rs
+++ b/crates/api/src/repository_replication.rs
@@ -54,6 +54,56 @@ pub struct RepositoryReplicationSpec {
     /// Pause this replication; a suspended replication runs no syncs (default `false`).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub suspend: bool,
+    /// Tuning knobs for the underlying `kopia repository sync-to` invocation
+    /// (issue #216). `None` reproduces today's behavior: sequential copy
+    /// (`--parallel` unset), additive sync (no `--delete`), kopia's own
+    /// `--must-exist`/`--times`/`--update` defaults, and no throughput cap.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sync: Option<SyncOptions>,
+}
+
+/// Tuning knobs for `kopia repository sync-to` (issue #216): copy parallelism,
+/// destination pruning, and the blob-sync tri-states/throughput caps kopia
+/// exposes on the command. Every field's `None`/`false` reproduces kopia's own
+/// default, so an absent `sync` block is exactly today's behavior. Pure scalars
+/// (no k8s-openapi embeds), so this derives `Eq` unlike its parent spec.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SyncOptions {
+    /// `--parallel`: number of concurrent blob-copy workers (kopia default `1` —
+    /// sequential, the root cause of #216's multi-week seed times to R2).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
+    /// `--delete`: prune destination-only blobs so the mirror is an exact copy
+    /// (kopia default `false` — additive sync, never removes destination
+    /// content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true`
+    /// key on backup-adjacent YAML is dangerously ambiguous at a glance.
+    ///
+    /// CAUTION: with this `true`, blobs present at the destination but absent
+    /// from the source are deleted on every run.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub delete_extra: bool,
+    /// `--[no-]must-exist`: fail the sync instead of initializing the
+    /// destination's repository-format blob (kopia default `false` — sync-to may
+    /// create the destination layout on first run).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub must_exist: Option<bool>,
+    /// `--[no-]times`: synchronize blob modification times to the destination,
+    /// when the destination backend supports it (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub times: Option<bool>,
+    /// `--[no-]update`: update blobs already present at the destination when the
+    /// source copy is newer (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update: Option<bool>,
+    /// `--max-download-speed`: cap read throughput from the source, in
+    /// bytes/sec (kopia default: unlimited).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_download_speed_bytes_per_second: Option<i64>,
+    /// `--max-upload-speed`: cap write throughput to the destination, in
+    /// bytes/sec (kopia default: unlimited).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_upload_speed_bytes_per_second: Option<i64>,
 }
 
 /// Lifecycle phase of a replication.
@@ -190,6 +240,68 @@ schedule: { cron: "0 6 * * 0" }
         assert_eq!(spec.source_ref.kind, RepositoryKind::Repository);
         let json = serde_json::to_value(&spec).unwrap();
         assert!(json.get("suspend").is_none());
+        // #216: no `sync` block set → the field is entirely absent on the wire,
+        // reproducing today's argv exactly (no dormant defaults sneak in).
+        assert!(spec.sync.is_none());
+        assert!(json.get("sync").is_none());
+    }
+
+    #[test]
+    fn sync_options_roundtrip_full_block() {
+        // #216: every `spec.sync` tuning knob round-trips through the cluster's
+        // YAML → serde_json::Value → typed path.
+        let yaml = r#"
+sourceRef: { name: nas-primary }
+destination: { filesystem: { path: /mirror } }
+schedule: { cron: "0 5 * * *" }
+sync:
+  parallel: 8
+  deleteExtra: true
+  mustExist: false
+  times: true
+  update: false
+  maxDownloadSpeedBytesPerSecond: 1000000
+  maxUploadSpeedBytesPerSecond: 500000
+"#;
+        let spec: RepositoryReplicationSpec = from_yaml(yaml);
+        let sync = spec.sync.expect("sync block set");
+        assert_eq!(sync.parallel, Some(8));
+        assert!(sync.delete_extra);
+        assert_eq!(sync.must_exist, Some(false));
+        assert_eq!(sync.times, Some(true));
+        assert_eq!(sync.update, Some(false));
+        assert_eq!(sync.max_download_speed_bytes_per_second, Some(1_000_000));
+        assert_eq!(sync.max_upload_speed_bytes_per_second, Some(500_000));
+
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(json["sync"]["parallel"], 8);
+        assert_eq!(json["sync"]["deleteExtra"], true);
+        assert_eq!(json["sync"]["mustExist"], false);
+        let reparsed: RepositoryReplicationSpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn sync_options_omits_unset_leaf_fields() {
+        // A `sync` block that only sets `parallel` must not serialize the other
+        // (unset) knobs — `deleteExtra`'s `false` default also skips (Not::not).
+        let yaml = r#"
+sourceRef: { name: nas-primary }
+destination: { filesystem: { path: /mirror } }
+schedule: { cron: "0 5 * * *" }
+sync:
+  parallel: 4
+"#;
+        let spec: RepositoryReplicationSpec = from_yaml(yaml);
+        let json = serde_json::to_value(&spec).unwrap();
+        let sync_json = &json["sync"];
+        assert_eq!(sync_json["parallel"], 4);
+        assert!(sync_json.get("deleteExtra").is_none());
+        assert!(sync_json.get("mustExist").is_none());
+        assert!(sync_json.get("times").is_none());
+        assert!(sync_json.get("update").is_none());
+        assert!(sync_json.get("maxDownloadSpeedBytesPerSecond").is_none());
+        assert!(sync_json.get("maxUploadSpeedBytesPerSecond").is_none());
     }
 
     #[test]

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -204,11 +204,16 @@ pub struct PvcTemplate {
     pub access_modes: Vec<String>,
 }
 
-/// kopia restore behavior knobs.
+/// kopia restore behavior knobs (M2 flag sweep). Every `Option` field's `None`
+/// reproduces kopia's own default — an all-`None`, `enableFileDeletion: false`
+/// instance yields the exact same `restore_args` argv produced before these
+/// fields existed. The tri-state booleans map to kopia's `--[no-]flag` grammar
+/// (`Some(true)` → `--flag`, `Some(false)` → `--no-flag`, `None` → omit).
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct RestoreOptions {
     /// Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+    /// Wired to kopia's `--[no-]delete-extra` (previously a silent no-op — see issue #216 gap sweep).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub enable_file_deletion: bool,
     /// Continue past permission errors during restore (default true).
@@ -217,6 +222,40 @@ pub struct RestoreOptions {
     /// Write files atomically via a temp file + rename (default true).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub write_files_atomically: Option<bool>,
+    /// `--parallel`: restore parallelism (kopia default `8`; `1` disables parallelism).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
+    /// `--[no-]write-sparse-files`: attempt to write files sparsely, allocating the
+    /// minimum disk space needed (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_sparse_files: Option<bool>,
+    /// `--[no-]skip-owners`: skip restoring file owners (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_owners: Option<bool>,
+    /// `--[no-]skip-permissions`: skip restoring file permissions (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_permissions: Option<bool>,
+    /// `--[no-]skip-times`: skip restoring file modification times (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_times: Option<bool>,
+    /// `--[no-]overwrite-files`: overwrite existing files in the target (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_files: Option<bool>,
+    /// `--[no-]overwrite-directories`: overwrite existing directories in the target
+    /// (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_directories: Option<bool>,
+    /// `--[no-]overwrite-symlinks`: overwrite existing symlinks in the target
+    /// (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_symlinks: Option<bool>,
+    /// `--[no-]ignore-errors`: ignore all restore errors and continue (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_errors: Option<bool>,
+    /// `--[no-]skip-existing`: skip files/symlinks that already exist in the target
+    /// (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_existing: Option<bool>,
 }
 
 /// How the restore reacts to a missing snapshot and how long it waits.
@@ -491,6 +530,83 @@ policy:
         let json = serde_json::to_value(&spec).expect("serialize");
         let reparsed: RestoreSpec = serde_json::from_value(json).expect("reparse");
         assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn restore_options_full_flag_sweep_roundtrip() {
+        // M2 flag sweep: every new `options` knob round-trips through the cluster's
+        // YAML → serde_json::Value → typed path.
+        let yaml = r#"
+source: { snapshotRef: { name: b } }
+target: { pvcRef: { name: d } }
+options:
+  enableFileDeletion: true
+  ignorePermissionErrors: false
+  writeFilesAtomically: true
+  parallel: 4
+  writeSparseFiles: true
+  skipOwners: true
+  skipPermissions: false
+  skipTimes: true
+  overwriteFiles: false
+  overwriteDirectories: false
+  overwriteSymlinks: true
+  ignoreErrors: false
+  skipExisting: true
+"#;
+        let spec: RestoreSpec = from_yaml(yaml);
+        let o = spec.options.as_ref().expect("options set");
+        assert!(o.enable_file_deletion);
+        assert_eq!(o.ignore_permission_errors, Some(false));
+        assert_eq!(o.write_files_atomically, Some(true));
+        assert_eq!(o.parallel, Some(4));
+        assert_eq!(o.write_sparse_files, Some(true));
+        assert_eq!(o.skip_owners, Some(true));
+        assert_eq!(o.skip_permissions, Some(false));
+        assert_eq!(o.skip_times, Some(true));
+        assert_eq!(o.overwrite_files, Some(false));
+        assert_eq!(o.overwrite_directories, Some(false));
+        assert_eq!(o.overwrite_symlinks, Some(true));
+        assert_eq!(o.ignore_errors, Some(false));
+        assert_eq!(o.skip_existing, Some(true));
+
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(json["options"]["parallel"], 4);
+        assert_eq!(json["options"]["skipExisting"], true);
+        let reparsed: RestoreSpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn restore_options_omits_unset_leaf_fields() {
+        // A minimal `options` block that only sets `enableFileDeletion` must not
+        // serialize the other (unset) knobs.
+        let yaml = r#"
+source: { snapshotRef: { name: b } }
+target: { pvcRef: { name: d } }
+options:
+  enableFileDeletion: true
+"#;
+        let spec: RestoreSpec = from_yaml(yaml);
+        let json = serde_json::to_value(&spec).unwrap();
+        let opts_json = &json["options"];
+        assert_eq!(opts_json["enableFileDeletion"], true);
+        for key in [
+            "ignorePermissionErrors",
+            "writeFilesAtomically",
+            "parallel",
+            "writeSparseFiles",
+            "skipOwners",
+            "skipPermissions",
+            "skipTimes",
+            "overwriteFiles",
+            "overwriteDirectories",
+            "overwriteSymlinks",
+            "ignoreErrors",
+            "skipExisting",
+        ] {
+            assert!(opts_json.get(key).is_none(), "{key} should be absent");
+        }
     }
 
     #[test]

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -45,6 +45,13 @@ pub struct SnapshotSpec {
     /// Exempt this snapshot from GFS retention.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub pin: bool,
+    /// Free-form text recorded on the kopia snapshot manifest
+    /// (`snapshot create --description`). Per-invocation by nature —
+    /// scheduled/discovered `Snapshot`s never set this (no templated
+    /// descriptions).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(max = 1024))]
+    pub description: Option<String>,
 }
 
 /// How a `Snapshot` came to exist. Canonical value mirrored from the

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -393,6 +393,19 @@ pub struct QuickVerification {
     /// Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub schedule: Option<CronSpec>,
+    /// `--parallel`: verification parallelism (kopia default: 8).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
+    /// `--file-parallelism`: parallelism for file verification (kopia default: unset).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_parallelism: Option<u32>,
+    /// `--file-queue-length`: queue length for file verification (kopia default: 20000).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_queue_length: Option<u32>,
+    /// `--max-errors`: stop after this many errors (kopia default: 0, meaning stop
+    /// at the first error).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_errors: Option<u32>,
 }
 
 /// Deep (scratch-restore) verification: restore the latest snapshot into an ephemeral volume, then discard.
@@ -407,6 +420,10 @@ pub struct DeepVerification {
     /// Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capacity: Option<String>,
+    /// `restore --parallel`: restore parallelism for the scratch-restore (deep verify
+    /// IS a restore under the hood); absent leaves kopia's default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
 }
 
 /// Pre/post snapshot hook lists.
@@ -1146,6 +1163,63 @@ verification:
             quick.schedule.is_none(),
             "old flat `quick: {{cron: ...}}` must decode with schedule: None (quick disabled)"
         );
+    }
+
+    #[test]
+    fn verification_quick_and_deep_tuning_knobs_roundtrip() {
+        // M3 (issue #216 category sweep): quick gains `--parallel`/`--file-parallelism`/
+        // `--file-queue-length`/`--max-errors`; deep gains `--parallel` (it restores
+        // under the hood). All optional, absent ⇒ kopia's own default.
+        let yaml = r#"
+repository: { kind: Repository, name: r }
+sources: [ { pvc: { name: d } } ]
+verification:
+  quick:
+    schedule: { cron: "0 4 * * *" }
+    parallel: 2
+    fileParallelism: 4
+    fileQueueLength: 100
+    maxErrors: 1
+  deep:
+    schedule: { cron: "0 5 * * 0" }
+    parallel: 2
+"#;
+        let spec: SnapshotPolicySpec = from_yaml(yaml);
+        let v = spec.verification.as_ref().expect("verification");
+        let quick = v.quick.as_ref().expect("quick");
+        assert_eq!(quick.parallel, Some(2));
+        assert_eq!(quick.file_parallelism, Some(4));
+        assert_eq!(quick.file_queue_length, Some(100));
+        assert_eq!(quick.max_errors, Some(1));
+        let deep = v.deep.as_ref().expect("deep");
+        assert_eq!(deep.parallel, Some(2));
+
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(json["verification"]["quick"]["parallel"], 2);
+        assert_eq!(json["verification"]["quick"]["fileParallelism"], 4);
+        assert_eq!(json["verification"]["quick"]["fileQueueLength"], 100);
+        assert_eq!(json["verification"]["quick"]["maxErrors"], 1);
+        assert_eq!(json["verification"]["deep"]["parallel"], 2);
+        let reparsed: SnapshotPolicySpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+
+        // Absent ⇒ None, and the keys are omitted entirely (no dormant defaults).
+        let bare_yaml = r#"
+repository: { kind: Repository, name: r }
+sources: [ { pvc: { name: d } } ]
+verification:
+  quick:
+    schedule: { cron: "0 4 * * *" }
+  deep:
+    schedule: { cron: "0 5 * * 0" }
+"#;
+        let bare: SnapshotPolicySpec = from_yaml(bare_yaml);
+        let bv = bare.verification.as_ref().expect("verification");
+        assert!(bv.quick.as_ref().unwrap().parallel.is_none());
+        assert!(bv.deep.as_ref().unwrap().parallel.is_none());
+        let bare_json = serde_json::to_value(&bare).expect("serialize");
+        assert!(bare_json["verification"]["quick"].get("parallel").is_none());
+        assert!(bare_json["verification"]["deep"].get("parallel").is_none());
     }
 
     #[test]

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -344,6 +344,12 @@ pub struct ErrorHandling {
     /// Continue past entries of unknown type (`--ignore-unknown-types`).
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub ignore_unknown_types: bool,
+    /// Abort the snapshot at the first error instead of collecting and
+    /// continuing (`snapshot create --fail-fast`; kopia default: false). This
+    /// is a `snapshot create` argv flag, not a `policy set` knob, but lives
+    /// beside its semantic opposites (`ignore*Errors`) for discoverability.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub fail_fast: bool,
 }
 
 /// Upload parallelism (kopia's upload policy); absent knobs leave kopia's default.
@@ -356,6 +362,13 @@ pub struct Upload {
     /// `--max-parallel-file-reads`: file-read concurrency within a snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_parallel_file_reads: Option<i64>,
+    /// `snapshot create --upload-limit-mb`: abort the snapshot once this many
+    /// MB have been uploaded (kopia default: 0 — unlimited). Named `limitMb`
+    /// rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter;
+    /// like `failFast`, this is a `snapshot create` argv flag, not a `policy
+    /// set` knob, but lives here beside its parallelism siblings.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub limit_mb: Option<i64>,
 }
 
 /// First-class backup verification proving snapshots are restorable; opt-in, with quick and deep tiers.
@@ -1018,9 +1031,11 @@ errorHandling:
   ignoreFileErrors: true
   ignoreDirErrors: false
   ignoreUnknownTypes: true
+  failFast: true
 upload:
   maxParallelSnapshots: 4
   maxParallelFileReads: 8
+  limitMb: 100
 suspend: true
 "#;
         let spec: SnapshotPolicySpec = from_yaml(yaml);
@@ -1028,15 +1043,19 @@ suspend: true
         assert!(eh.ignore_file_errors);
         assert!(!eh.ignore_dir_errors);
         assert!(eh.ignore_unknown_types);
+        assert!(eh.fail_fast);
         let up = spec.upload.as_ref().expect("upload");
         assert_eq!(up.max_parallel_snapshots, Some(4));
         assert_eq!(up.max_parallel_file_reads, Some(8));
+        assert_eq!(up.limit_mb, Some(100));
         assert!(spec.suspend);
 
         let json = serde_json::to_value(&spec).expect("serialize");
         assert_eq!(json["suspend"], true);
         assert_eq!(json["errorHandling"]["ignoreFileErrors"], true);
+        assert_eq!(json["errorHandling"]["failFast"], true);
         assert_eq!(json["upload"]["maxParallelSnapshots"], 4);
+        assert_eq!(json["upload"]["limitMb"], 100);
         let reparsed: SnapshotPolicySpec = serde_json::from_value(json).expect("reparse");
         assert_eq!(spec, reparsed);
 

--- a/crates/api/src/validate/mod.rs
+++ b/crates/api/src/validate/mod.rs
@@ -86,6 +86,20 @@ pub fn validate_nfs_volume(nfs: &NfsVolume, context: &str) -> ValidationResult {
     Ok(())
 }
 
+/// A numeric knob must be at least `min` — the shared one-liner behind every
+/// `Option<u32>` count / `Option<i64>` bytes-per-second field (e.g.
+/// `RepositoryReplication.spec.sync.parallel`), so the rule and its message
+/// shape are written once instead of re-derived per field. `field` names the
+/// exact path for the message (e.g. `"RepositoryReplication spec.sync.parallel"`).
+/// Callers only invoke this for a `Some` value — an absent knob is always valid
+/// and never reaches this helper.
+pub fn require_min(field: &str, value: i64, min: i64) -> Option<ValidationError> {
+    (value < min).then(|| ValidationError::InvalidFieldValue {
+        field: field.to_string(),
+        reason: format!("must be >= {min} (got {value})"),
+    })
+}
+
 /// Validate a `MoverSpec`. `inheritSecurityContextFrom` copies **both** the workload
 /// pod's container and pod security contexts, so it is **mutually exclusive** with
 /// **both** explicit `securityContext` and `podSecurityContext`: the mover's effective

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -542,6 +542,31 @@ pub fn validate_repository_replication(spec: &RepositoryReplicationSpec) -> Vec<
     {
         errs.push(e);
     }
+    if let Some(sync) = &spec.sync {
+        if let Some(p) = sync.parallel
+            && let Some(e) = require_min("RepositoryReplication spec.sync.parallel", p.into(), 1)
+        {
+            errs.push(e);
+        }
+        if let Some(s) = sync.max_download_speed_bytes_per_second
+            && let Some(e) = require_min(
+                "RepositoryReplication spec.sync.maxDownloadSpeedBytesPerSecond",
+                s,
+                1,
+            )
+        {
+            errs.push(e);
+        }
+        if let Some(s) = sync.max_upload_speed_bytes_per_second
+            && let Some(e) = require_min(
+                "RepositoryReplication spec.sync.maxUploadSpeedBytesPerSecond",
+                s,
+                1,
+            )
+        {
+            errs.push(e);
+        }
+    }
     errs
 }
 

--- a/crates/api/src/validate/restore.rs
+++ b/crates/api/src/validate/restore.rs
@@ -169,5 +169,11 @@ pub fn validate_restore_spec(spec: &RestoreSpec) -> Vec<ValidationError> {
     {
         errs.push(e);
     }
+    if let Some(o) = &spec.options
+        && let Some(p) = o.parallel
+        && let Some(e) = require_min("Restore spec.options.parallel", p.into(), 1)
+    {
+        errs.push(e);
+    }
     errs
 }

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -65,6 +65,14 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
     {
         errs.push(e);
     }
+    // `snapshot create --upload-limit-mb` (M4 flag sweep, issue #216): a count
+    // knob, must be at least 1 (0 or negative disables the flag's own purpose).
+    if let Some(u) = &spec.upload
+        && let Some(mb) = u.limit_mb
+        && let Some(e) = require_min("SnapshotPolicy spec.upload.limitMb", mb, 1)
+    {
+        errs.push(e);
+    }
     // Data-loss guard: a retention that selects no snapshots prunes EVERY Snapshot the
     // moment it runs. `retention: None` means "don't prune" (safe) and is not flagged;
     // only an explicit but empty/all-zero retention is the trap.

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -111,6 +111,36 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
                     }
                 }
             }
+            // `kopia snapshot verify` tuning knobs: counts must be at least 1.
+            // `maxErrors` is deliberately unconstrained — 0 is a valid, meaningful
+            // value (kopia's own default, "stop at the first error").
+            if let Some(p) = q.parallel
+                && let Some(e) = require_min(
+                    "SnapshotPolicy spec.verification.quick.parallel",
+                    p.into(),
+                    1,
+                )
+            {
+                errs.push(e);
+            }
+            if let Some(p) = q.file_parallelism
+                && let Some(e) = require_min(
+                    "SnapshotPolicy spec.verification.quick.fileParallelism",
+                    p.into(),
+                    1,
+                )
+            {
+                errs.push(e);
+            }
+            if let Some(p) = q.file_queue_length
+                && let Some(e) = require_min(
+                    "SnapshotPolicy spec.verification.quick.fileQueueLength",
+                    p.into(),
+                    1,
+                )
+            {
+                errs.push(e);
+            }
         }
         if let Some(d) = &v.deep {
             if let Err(e) = validate_cron(&d.schedule.cron) {
@@ -123,6 +153,16 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
                 "spec.verification.deep.schedule.jitter",
                 d.schedule.jitter.as_deref(),
             ) {
+                errs.push(e);
+            }
+            // `restore --parallel` under the hood (deep verify IS a restore).
+            if let Some(p) = d.parallel
+                && let Some(e) = require_min(
+                    "SnapshotPolicy spec.verification.deep.parallel",
+                    p.into(),
+                    1,
+                )
+            {
                 errs.push(e);
             }
         }

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -1852,6 +1852,7 @@ fn replication_spec(
         },
         mover: None,
         suspend: false,
+        sync: None,
     }
 }
 
@@ -1919,6 +1920,72 @@ fn replication_rejects_invalid_destination_backend_content() {
     assert!(
         errs.iter()
             .any(|e| matches!(e, ValidationError::InvalidFieldValue { .. }))
+    );
+}
+
+#[test]
+fn replication_sync_all_zero_is_valid() {
+    // #216: a `sync` block is optional and every field individually optional;
+    // a fully-populated but in-range block must not error.
+    use crate::backend::{Backend, S3Backend};
+    use crate::repository_replication::SyncOptions;
+    let mut spec = replication_spec(
+        repo_ref(RepositoryKind::Repository, None),
+        Backend::S3(S3Backend {
+            bucket: "mirror".into(),
+            prefix: None,
+            endpoint: None,
+            region: None,
+            auth: None,
+            tls: None,
+        }),
+        "0 5 * * *",
+    );
+    spec.sync = Some(SyncOptions {
+        parallel: Some(4),
+        delete_extra: true,
+        must_exist: Some(false),
+        times: Some(true),
+        update: Some(false),
+        max_download_speed_bytes_per_second: Some(1_000_000),
+        max_upload_speed_bytes_per_second: Some(500_000),
+    });
+    assert!(validate_repository_replication(&spec).is_empty());
+}
+
+#[test]
+fn replication_sync_rejects_zero_parallel_and_zero_speeds() {
+    // #216: `parallel`/the speed caps must be >= 1 — 0 is meaningless for a copy
+    // parallelism or a throughput cap, and would otherwise silently reach kopia's
+    // argv as `--parallel 0` etc.
+    use crate::backend::{Backend, S3Backend};
+    use crate::repository_replication::SyncOptions;
+    let mut spec = replication_spec(
+        repo_ref(RepositoryKind::Repository, None),
+        Backend::S3(S3Backend {
+            bucket: "mirror".into(),
+            prefix: None,
+            endpoint: None,
+            region: None,
+            auth: None,
+            tls: None,
+        }),
+        "0 5 * * *",
+    );
+    spec.sync = Some(SyncOptions {
+        parallel: Some(0),
+        max_download_speed_bytes_per_second: Some(0),
+        max_upload_speed_bytes_per_second: Some(0),
+        ..Default::default()
+    });
+    let errs = validate_repository_replication(&spec);
+    let invalid_count = errs
+        .iter()
+        .filter(|e| matches!(e, ValidationError::InvalidFieldValue { .. }))
+        .count();
+    assert_eq!(
+        invalid_count, 3,
+        "parallel + both speed caps must each be rejected independently, got {errs:?}"
     );
 }
 

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -713,6 +713,38 @@ fn restore_pvc_target_requires_capacity() {
 }
 
 #[test]
+fn restore_options_parallel_must_be_at_least_one() {
+    // M2 flag sweep: options.parallel is a count knob (require_min, same shared
+    // helper as RepositoryReplication.spec.sync.parallel) — 0 would otherwise
+    // silently reach kopia's argv as `--parallel 0`.
+    use crate::common::ObjectRef;
+    use crate::restore::RestoreOptions;
+    let mut spec = restore_with(
+        RestoreSource::SnapshotRef(ObjectRef {
+            name: "b".into(),
+            namespace: None,
+        }),
+        None,
+    );
+    spec.options = Some(RestoreOptions {
+        parallel: Some(0),
+        ..Default::default()
+    });
+    let errs = validate_restore_spec(&spec);
+    assert!(
+        errs.iter()
+            .any(|e| matches!(e, ValidationError::InvalidFieldValue { field, .. } if field.contains("parallel"))),
+        "expected an InvalidFieldValue for options.parallel, got {errs:?}"
+    );
+
+    spec.options = Some(RestoreOptions {
+        parallel: Some(4),
+        ..Default::default()
+    });
+    assert!(validate_restore_spec(&spec).is_empty());
+}
+
+#[test]
 fn restore_as_of_must_be_rfc3339_and_message_says_how_to_fix() {
     use crate::restore::FromPolicy;
     let spec = restore_with(

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -1231,6 +1231,7 @@ fn backup_aggregate_rejects_discovered_delete() {
         policy_ref: None,
         tags: None,
         failure_policy: None,
+        description: None,
         deletion_policy: Some(DeletionPolicy::Delete),
         pin: false,
     };
@@ -2999,6 +3000,44 @@ fn backup_config_validates_verification_tuning_knobs() {
         "{:?}",
         validate_backup_config(&ok)
     );
+}
+
+#[test]
+fn backup_config_rejects_zero_upload_limit_mb() {
+    // M4 flag sweep (issue #216 category sweep): `upload.limitMb` is a count
+    // knob (require_min, same shared validator as the M2/M3 sweeps).
+    let zero: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         upload:\n  limitMb: 0\n",
+    );
+    let errs = validate_backup_config(&zero);
+    assert!(
+        errs.iter().any(|e| matches!(
+            e,
+            ValidationError::InvalidFieldValue { field, .. }
+                if field == "SnapshotPolicy spec.upload.limitMb"
+        )),
+        "expected a limitMb rejection, got: {errs:?}"
+    );
+
+    let ok: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         upload:\n  limitMb: 100\n",
+    );
+    assert!(
+        validate_backup_config(&ok).is_empty(),
+        "{:?}",
+        validate_backup_config(&ok)
+    );
+
+    // Absent ⇒ no error (limitMb is opt-in).
+    let absent: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n",
+    );
+    assert!(validate_backup_config(&absent).is_empty());
 }
 
 // --- identity shape validation ---

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -2932,6 +2932,75 @@ fn backup_config_validates_verification() {
     );
 }
 
+#[test]
+fn backup_config_validates_verification_tuning_knobs() {
+    // Zero is rejected for the count knobs (>= 1) on both tiers.
+    for (yaml, field) in [
+        (
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: data } } ]\n\
+             verification:\n  quick:\n    schedule: { cron: \"0 4 * * *\" }\n    parallel: 0\n",
+            "SnapshotPolicy spec.verification.quick.parallel",
+        ),
+        (
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: data } } ]\n\
+             verification:\n  quick:\n    schedule: { cron: \"0 4 * * *\" }\n    fileParallelism: 0\n",
+            "SnapshotPolicy spec.verification.quick.fileParallelism",
+        ),
+        (
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: data } } ]\n\
+             verification:\n  quick:\n    schedule: { cron: \"0 4 * * *\" }\n    fileQueueLength: 0\n",
+            "SnapshotPolicy spec.verification.quick.fileQueueLength",
+        ),
+        (
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: data } } ]\n\
+             verification:\n  deep:\n    schedule: { cron: \"0 5 * * 0\" }\n    parallel: 0\n",
+            "SnapshotPolicy spec.verification.deep.parallel",
+        ),
+    ] {
+        let spec: SnapshotPolicySpec = crate::testutil::from_yaml(yaml);
+        let errs = validate_backup_config(&spec);
+        assert!(
+            errs.iter().any(|e| matches!(
+                e,
+                ValidationError::InvalidFieldValue { field: f, .. } if f == field
+            )),
+            "expected a rejection of {field}, got: {errs:?}"
+        );
+    }
+
+    // maxErrors: 0 is kopia's own default ("stop at first error") — unconstrained,
+    // never rejected.
+    let max_errors_zero: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  quick:\n    schedule: { cron: \"0 4 * * *\" }\n    maxErrors: 0\n",
+    );
+    assert!(
+        validate_backup_config(&max_errors_zero).is_empty(),
+        "{:?}",
+        validate_backup_config(&max_errors_zero)
+    );
+
+    // Positive values on all knobs are accepted.
+    let ok: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         verification:\n  \
+           quick:\n    schedule: { cron: \"0 4 * * *\" }\n    parallel: 2\n    \
+             fileParallelism: 4\n    fileQueueLength: 100\n    maxErrors: 1\n  \
+           deep:\n    schedule: { cron: \"0 5 * * 0\" }\n    parallel: 2\n",
+    );
+    assert!(
+        validate_backup_config(&ok).is_empty(),
+        "{:?}",
+        validate_backup_config(&ok)
+    );
+}
+
 // --- identity shape validation ---
 
 #[test]

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -673,6 +673,11 @@ pub struct SnapshotNowArgs {
     #[arg(long)]
     pub pin: bool,
 
+    /// Free-form text recorded on the kopia snapshot manifest
+    /// (`snapshot create --description`).
+    #[arg(long, value_name = "TEXT")]
+    pub description: Option<String>,
+
     /// Mover Job retry budget (Job backoffLimit).
     #[arg(long, value_name = "N")]
     pub backoff_limit: Option<i32>,

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -495,6 +495,46 @@ pub struct RestoreArgs {
     #[arg(long, value_name = "BOOL")]
     pub write_files_atomically: Option<bool>,
 
+    /// Restore parallelism (kopia default: 8; 1 disables parallelism).
+    #[arg(long, value_name = "N")]
+    pub parallel: Option<u32>,
+
+    /// Whether restored files are written sparsely (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub write_sparse_files: Option<bool>,
+
+    /// Whether file owners are skipped during restore (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub skip_owners: Option<bool>,
+
+    /// Whether file permissions are skipped during restore (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub skip_permissions: Option<bool>,
+
+    /// Whether file times are skipped during restore (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub skip_times: Option<bool>,
+
+    /// Whether existing files in the target are overwritten (kopia default: true).
+    #[arg(long, value_name = "BOOL")]
+    pub overwrite_files: Option<bool>,
+
+    /// Whether existing directories in the target are overwritten (kopia default: true).
+    #[arg(long, value_name = "BOOL")]
+    pub overwrite_directories: Option<bool>,
+
+    /// Whether existing symlinks in the target are overwritten (kopia default: true).
+    #[arg(long, value_name = "BOOL")]
+    pub overwrite_symlinks: Option<bool>,
+
+    /// Whether all restore errors are ignored (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub ignore_errors: Option<bool>,
+
+    /// Whether files/symlinks already present in the target are skipped (kopia default: false).
+    #[arg(long, value_name = "BOOL")]
+    pub skip_existing: Option<bool>,
+
     // --- missing-snapshot policy ---
     /// What to do when no snapshot matches (operator default: fail, except
     /// continue for --from-policy).

--- a/crates/cli/src/cmd/restore.rs
+++ b/crates/cli/src/cmd/restore.rs
@@ -30,6 +30,41 @@ fn source_token(args: &RestoreArgs) -> &str {
     }
 }
 
+/// Build `spec.options` from the parsed flags, or `None` when nothing was set
+/// (so a bare restore carries no optional noise on the wire). Split out of
+/// [`build_restore`] so its 13-flag "is anything set" check doesn't compound
+/// that function's cognitive complexity with the source/target dispatch.
+fn restore_options_from_args(args: &RestoreArgs) -> Option<RestoreOptions> {
+    let anything_set = args.enable_file_deletion
+        || args.ignore_permission_errors.is_some()
+        || args.write_files_atomically.is_some()
+        || args.parallel.is_some()
+        || args.write_sparse_files.is_some()
+        || args.skip_owners.is_some()
+        || args.skip_permissions.is_some()
+        || args.skip_times.is_some()
+        || args.overwrite_files.is_some()
+        || args.overwrite_directories.is_some()
+        || args.overwrite_symlinks.is_some()
+        || args.ignore_errors.is_some()
+        || args.skip_existing.is_some();
+    anything_set.then_some(RestoreOptions {
+        enable_file_deletion: args.enable_file_deletion,
+        ignore_permission_errors: args.ignore_permission_errors,
+        write_files_atomically: args.write_files_atomically,
+        parallel: args.parallel,
+        write_sparse_files: args.write_sparse_files,
+        skip_owners: args.skip_owners,
+        skip_permissions: args.skip_permissions,
+        skip_times: args.skip_times,
+        overwrite_files: args.overwrite_files,
+        overwrite_directories: args.overwrite_directories,
+        overwrite_symlinks: args.overwrite_symlinks,
+        ignore_errors: args.ignore_errors,
+        skip_existing: args.skip_existing,
+    })
+}
+
 /// Build the `Restore` CR from the parsed flags. Pure — `now` is injected so
 /// names are deterministic under test. The exactly-one-of invariants are
 /// enforced by clap groups; this maps each flag set 1:1 onto the
@@ -79,18 +114,7 @@ pub fn build_restore(args: &RestoreArgs, namespace: &str, now: DateTime<Utc>) ->
         namespace: args.repository_namespace.clone(),
     });
 
-    let options = if args.enable_file_deletion
-        || args.ignore_permission_errors.is_some()
-        || args.write_files_atomically.is_some()
-    {
-        Some(RestoreOptions {
-            enable_file_deletion: args.enable_file_deletion,
-            ignore_permission_errors: args.ignore_permission_errors,
-            write_files_atomically: args.write_files_atomically,
-        })
-    } else {
-        None
-    };
+    let options = restore_options_from_args(args);
 
     let policy = if args.on_missing_snapshot.is_some() || args.wait_timeout.is_some() {
         Some(RestorePolicy {
@@ -518,6 +542,54 @@ mod tests {
         assert_eq!(spec["failurePolicy"]["activeDeadlineSeconds"], 600);
         assert_eq!(spec["repository"]["kind"], "ClusterRepository");
         assert_eq!(spec["repository"]["name"], "nas");
+    }
+
+    #[test]
+    fn every_m2_flag_sweep_option_flag_lands_in_the_spec() {
+        // M2 flag sweep: EVERY new kopia restore tuning flag must round-trip
+        // (the same bug class `every_option_flag_lands_in_the_spec` guards for
+        // the original three options, split into its own test so this doesn't
+        // compound that test's cognitive complexity).
+        let args = parse(&[
+            "--from-snapshot",
+            "snap1",
+            "--to-pvc",
+            "data",
+            "--parallel",
+            "4",
+            "--write-sparse-files",
+            "true",
+            "--skip-owners",
+            "true",
+            "--skip-permissions",
+            "false",
+            "--skip-times",
+            "true",
+            "--overwrite-files",
+            "false",
+            "--overwrite-directories",
+            "false",
+            "--overwrite-symlinks",
+            "true",
+            "--ignore-errors",
+            "false",
+            "--skip-existing",
+            "true",
+        ]);
+        let wire = serde_json::to_value(build_restore(&args, "media", at())).unwrap();
+        let opts = &wire["spec"]["options"];
+        assert_eq!(opts["parallel"], 4);
+        assert_eq!(opts["writeSparseFiles"], true);
+        assert_eq!(opts["skipOwners"], true);
+        assert_eq!(opts["skipPermissions"], false);
+        assert_eq!(opts["skipTimes"], true);
+        assert_eq!(opts["overwriteFiles"], false);
+        assert_eq!(opts["overwriteDirectories"], false);
+        assert_eq!(opts["overwriteSymlinks"], true);
+        assert_eq!(opts["ignoreErrors"], false);
+        assert_eq!(opts["skipExisting"], true);
+        // Untouched flags stay absent.
+        assert!(opts.get("enableFileDeletion").is_none());
     }
 
     #[test]

--- a/crates/cli/src/cmd/snapshot.rs
+++ b/crates/cli/src/cmd/snapshot.rs
@@ -52,6 +52,7 @@ pub fn build_snapshot(args: &SnapshotNowArgs, namespace: &str, now: DateTime<Utc
             failure_policy,
             deletion_policy: args.deletion_policy.map(Into::into),
             pin: args.pin,
+            description: args.description.clone(),
         },
     );
     snapshot.metadata.namespace = Some(namespace.to_string());
@@ -272,6 +273,7 @@ mod tests {
             tags: vec![],
             deletion_policy: None,
             pin: false,
+            description: None,
             backoff_limit: None,
             active_deadline_seconds: None,
             pod_startup_deadline_seconds: None,
@@ -302,7 +304,13 @@ mod tests {
         );
         assert_eq!(wire["spec"]["policyRef"]["name"], "nightly");
         // Unset options must be ABSENT on the wire, not null/false noise.
-        for key in ["tags", "failurePolicy", "deletionPolicy", "pin"] {
+        for key in [
+            "tags",
+            "failurePolicy",
+            "deletionPolicy",
+            "pin",
+            "description",
+        ] {
             assert!(wire["spec"].get(key).is_none(), "{key} should be absent");
         }
         let reparsed: Snapshot = serde_json::from_value(wire).unwrap();
@@ -317,6 +325,7 @@ mod tests {
         a.tags = vec![("reason".into(), "pre-upgrade".into())];
         a.deletion_policy = Some(DeletionPolicyArg::Retain);
         a.pin = true;
+        a.description = Some("pre-upgrade snapshot".into());
         a.backoff_limit = Some(0);
         a.active_deadline_seconds = Some(120);
         let wire = serde_json::to_value(build_snapshot(&a, "media", at())).unwrap();
@@ -324,6 +333,7 @@ mod tests {
         assert_eq!(wire["spec"]["tags"]["reason"], "pre-upgrade");
         assert_eq!(wire["spec"]["deletionPolicy"], "Retain");
         assert_eq!(wire["spec"]["pin"], true);
+        assert_eq!(wire["spec"]["description"], "pre-upgrade snapshot");
         assert_eq!(wire["spec"]["failurePolicy"]["backoffLimit"], 0);
         assert_eq!(wire["spec"]["failurePolicy"]["activeDeadlineSeconds"], 120);
     }

--- a/crates/controller/src/cache.rs
+++ b/crates/controller/src/cache.rs
@@ -212,6 +212,7 @@ mod tests {
             },
             storage_class_name: storage_class.map(str::to_string),
             capacity: capacity.map(str::to_string),
+            parallel: None,
         }
     }
 

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -600,6 +600,9 @@ async fn materialize_discovered(
             deletion_policy: Some(DeletionPolicy::Retain),
             // Discovered snapshots are not pinned by the operator.
             pin: false,
+            // Discovered snapshots never carry a templated description (out
+            // of scope for M4 — description is per-invocation only).
+            description: None,
         },
     );
     backup.metadata = io::child_meta(&cr_name, namespace, labels, Some(owner.clone()));
@@ -1114,6 +1117,7 @@ mod tests {
                     failure_policy: None,
                     deletion_policy: None,
                     pin: false,
+                    description: None,
                 },
             );
             let mut labels = BTreeMap::new();

--- a/crates/controller/src/repository_replication.rs
+++ b/crates/controller/src/repository_replication.rs
@@ -340,12 +340,19 @@ pub fn build_replication_work_spec(
     namespace: &str,
     cr_name: &str,
 ) -> MoverWorkSpec {
+    let sync = repl.spec.sync.unwrap_or_default();
     MoverWorkSpec {
         version: 1,
         operation: Operation::Replicate(ReplicateOp {
             destination: backend_to_repository_connect(&repl.spec.destination),
             // Additive sync by default (never prune the destination automatically).
-            delete_extra: false,
+            delete_extra: sync.delete_extra,
+            parallel: sync.parallel,
+            must_exist: sync.must_exist,
+            times: sync.times,
+            update: sync.update,
+            max_download_speed_bytes_per_second: sync.max_download_speed_bytes_per_second,
+            max_upload_speed_bytes_per_second: sync.max_upload_speed_bytes_per_second,
         }),
         // Replication does not snapshot; a stable sentinel identity (like maintenance).
         identity: ResolvedIdentity {
@@ -581,6 +588,7 @@ mod tests {
                 },
                 mover: None,
                 suspend: false,
+                sync: None,
             },
         );
         r.metadata.uid = Some("uid-repl-1".into());
@@ -691,11 +699,51 @@ mod tests {
             Operation::Replicate(op) => {
                 assert_eq!(op.destination.kind_str(), "S3");
                 assert!(!op.delete_extra);
+                // No `spec.sync` set → every knob defaults, reproducing today's argv.
+                assert_eq!(op.parallel, None);
+                assert_eq!(op.must_exist, None);
+                assert_eq!(op.times, None);
+                assert_eq!(op.update, None);
+                assert_eq!(op.max_download_speed_bytes_per_second, None);
+                assert_eq!(op.max_upload_speed_bytes_per_second, None);
             }
             other => panic!("expected replicate op, got {}", other.kind_str()),
         }
         assert_eq!(ws.repository.kind_str(), "Filesystem");
         assert_eq!(ws.target_ref.kind, "RepositoryReplication");
+    }
+
+    #[test]
+    fn work_spec_maps_every_sync_field_to_the_replicate_op() {
+        // #216 controller-glue guard: this is the regression test for the exact
+        // bug class the whole change exists to kill — `spec.sync` plumbed through
+        // to CRD/validator/workspec but the controller still hardcoding `None`.
+        // Every field set on `spec.sync` must land on the corresponding `op` field.
+        use kopiur_api::repository_replication::SyncOptions;
+        let mut r = repl_with("0 5 * * *", None);
+        r.spec.sync = Some(SyncOptions {
+            parallel: Some(6),
+            delete_extra: true,
+            must_exist: Some(true),
+            times: Some(false),
+            update: Some(true),
+            max_download_speed_bytes_per_second: Some(2_000_000),
+            max_upload_speed_bytes_per_second: Some(3_000_000),
+        });
+        let repo = sample_repo();
+        let ws = build_replication_work_spec(&r, &repo, "ns", "offsite");
+        match &ws.operation {
+            Operation::Replicate(op) => {
+                assert_eq!(op.parallel, Some(6));
+                assert!(op.delete_extra);
+                assert_eq!(op.must_exist, Some(true));
+                assert_eq!(op.times, Some(false));
+                assert_eq!(op.update, Some(true));
+                assert_eq!(op.max_download_speed_bytes_per_second, Some(2_000_000));
+                assert_eq!(op.max_upload_speed_bytes_per_second, Some(3_000_000));
+            }
+            other => panic!("expected replicate op, got {}", other.kind_str()),
+        }
     }
 
     #[test]

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -1455,14 +1455,9 @@ async fn run_restore_mover(
         hostname: namespace.to_string(),
         source_path: target_path.clone(),
     };
-    // Carry the Restore CRD's options (ADR §4.6) through to the mover so kopia
-    // honors them. `None` lets kopia use its defaults.
-    let (ignore_permission_errors, write_files_atomically) = restore
-        .spec
-        .options
-        .as_ref()
-        .map(|o| (o.ignore_permission_errors, o.write_files_atomically))
-        .unwrap_or((None, None));
+    // Carry the Restore CRD's options (ADR §4.6, M2 flag sweep) through to the
+    // mover so kopia honors them. `None` lets kopia use its defaults.
+    let flags = restore_flags(&restore.spec.options);
     // Effective cache config (repository cacheDefaults overlaid by this restore's
     // mover.cache, ADR §3.1) drives both the connect budgets and the cache volume.
     let effective_cache = crate::cache::effective_cache(
@@ -1483,8 +1478,19 @@ async fn run_restore_mover(
             source: selection.clone(),
             target_path: target_path.clone(),
             anchor,
-            ignore_permission_errors,
-            write_files_atomically,
+            ignore_permission_errors: flags.ignore_permission_errors,
+            write_files_atomically: flags.write_files_atomically,
+            parallel: flags.parallel,
+            write_sparse_files: flags.write_sparse_files,
+            skip_owners: flags.skip_owners,
+            skip_permissions: flags.skip_permissions,
+            skip_times: flags.skip_times,
+            overwrite_files: flags.overwrite_files,
+            overwrite_directories: flags.overwrite_directories,
+            overwrite_symlinks: flags.overwrite_symlinks,
+            ignore_errors: flags.ignore_errors,
+            skip_existing: flags.skip_existing,
+            delete_extra: flags.delete_extra,
         }),
         identity,
         repository: restore_connect(&repo)?,
@@ -1963,6 +1969,51 @@ async fn resolve_restore_repository(
 /// Map a resolved repository backend to the mover connect spec for a restore.
 fn restore_connect(repo: &ResolvedRepository) -> Result<RepositoryConnect> {
     crate::snapshot::repository_connect_pub(repo)
+}
+
+/// The `Restore` CRD's kopia restore behavior knobs (ADR §4.6, M2 flag sweep),
+/// carried through to the mover work-spec's `RestoreOp`.
+struct RestoreFlags {
+    ignore_permission_errors: Option<bool>,
+    write_files_atomically: Option<bool>,
+    parallel: Option<u32>,
+    write_sparse_files: Option<bool>,
+    skip_owners: Option<bool>,
+    skip_permissions: Option<bool>,
+    skip_times: Option<bool>,
+    overwrite_files: Option<bool>,
+    overwrite_directories: Option<bool>,
+    overwrite_symlinks: Option<bool>,
+    ignore_errors: Option<bool>,
+    skip_existing: Option<bool>,
+    delete_extra: bool,
+}
+
+/// Map `Restore.spec.options` onto the mover work-spec's restore flags. Pure so
+/// it is unit-testable without a cluster — the regression guard for the M2 gap
+/// sweep's bug class: plumbing that exists end-to-end (CRD field → workspec →
+/// kopia client) but the controller never reads the field (`enableFileDeletion`
+/// was exactly this: settable via CRD/CLI/migrate, consumed by nothing, so a
+/// user's "exact mirror" restore was silently additive). An absent `options`
+/// block maps every field to its all-`None`/`false` zero value, reproducing
+/// today's argv exactly.
+fn restore_flags(options: &Option<kopiur_api::restore::RestoreOptions>) -> RestoreFlags {
+    let o = options.clone().unwrap_or_default();
+    RestoreFlags {
+        ignore_permission_errors: o.ignore_permission_errors,
+        write_files_atomically: o.write_files_atomically,
+        parallel: o.parallel,
+        write_sparse_files: o.write_sparse_files,
+        skip_owners: o.skip_owners,
+        skip_permissions: o.skip_permissions,
+        skip_times: o.skip_times,
+        overwrite_files: o.overwrite_files,
+        overwrite_directories: o.overwrite_directories,
+        overwrite_symlinks: o.overwrite_symlinks,
+        ignore_errors: o.ignore_errors,
+        skip_existing: o.skip_existing,
+        delete_extra: o.enable_file_deletion,
+    }
 }
 
 /// Mover `Job` limits from the restore's `failurePolicy`, falling back to ADR

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -408,3 +408,98 @@ fn pvc_is_bound_reads_volume_name_or_phase() {
         "metadata": { "name": "p" }, "spec": {}, "status": { "phase": "Pending" },
     }))));
 }
+
+// --- restore_flags (M2 flag sweep controller-glue guard) ---
+
+#[test]
+fn restore_flags_absent_options_map_to_all_none() {
+    // No `spec.options` set → every knob defaults, reproducing today's argv.
+    let flags = restore_flags(&None);
+    assert_eq!(flags.ignore_permission_errors, None);
+    assert_eq!(flags.write_files_atomically, None);
+    assert_eq!(flags.parallel, None);
+    assert_eq!(flags.write_sparse_files, None);
+    assert_eq!(flags.skip_owners, None);
+    assert_eq!(flags.skip_permissions, None);
+    assert_eq!(flags.skip_times, None);
+    assert_eq!(flags.overwrite_files, None);
+    assert_eq!(flags.overwrite_directories, None);
+    assert_eq!(flags.overwrite_symlinks, None);
+    assert_eq!(flags.ignore_errors, None);
+    assert_eq!(flags.skip_existing, None);
+    assert!(!flags.delete_extra);
+}
+
+#[test]
+fn restore_flags_maps_every_options_field() {
+    use kopiur_api::restore::RestoreOptions;
+    let flags = restore_flags(&Some(RestoreOptions {
+        enable_file_deletion: false,
+        ignore_permission_errors: Some(true),
+        write_files_atomically: Some(false),
+        parallel: Some(6),
+        write_sparse_files: Some(true),
+        skip_owners: Some(false),
+        skip_permissions: Some(true),
+        skip_times: Some(false),
+        overwrite_files: Some(true),
+        overwrite_directories: Some(false),
+        overwrite_symlinks: Some(true),
+        ignore_errors: Some(false),
+        skip_existing: Some(true),
+    }));
+    assert_eq!(flags.ignore_permission_errors, Some(true));
+    assert_eq!(flags.write_files_atomically, Some(false));
+    assert_eq!(flags.parallel, Some(6));
+    assert_eq!(flags.write_sparse_files, Some(true));
+    assert_eq!(flags.skip_owners, Some(false));
+    assert_eq!(flags.skip_permissions, Some(true));
+    assert_eq!(flags.skip_times, Some(false));
+    assert_eq!(flags.overwrite_files, Some(true));
+    assert_eq!(flags.overwrite_directories, Some(false));
+    assert_eq!(flags.overwrite_symlinks, Some(true));
+    assert_eq!(flags.ignore_errors, Some(false));
+    assert_eq!(flags.skip_existing, Some(true));
+    assert!(!flags.delete_extra);
+}
+
+#[test]
+fn restore_flags_enable_file_deletion_regression() {
+    // THE regression test for the confirmed bug: `enableFileDeletion: true` was
+    // documented as "exact mirror" deletion, settable via CRD/CLI/migrate, but
+    // consumed by nothing — the controller only ever read
+    // ignore_permission_errors/write_files_atomically. This must now map
+    // through to `delete_extra`, which `RestoreOp::restore_options()` turns
+    // into `Some(true)` and `restore_args` turns into `--delete-extra`.
+    use kopiur_api::restore::RestoreOptions;
+    let flags = restore_flags(&Some(RestoreOptions {
+        enable_file_deletion: true,
+        ..Default::default()
+    }));
+    assert!(
+        flags.delete_extra,
+        "enableFileDeletion: true must set delete_extra on the mover work-spec"
+    );
+
+    // End-to-end through the mover's RestoreOp -> kopia client RestoreOptions ->
+    // argv, proving the whole chain (not just this one hop).
+    let op = RestoreOp {
+        source: RestoreSelection::Snapshot("s".into()),
+        target_path: "/data".into(),
+        anchor: Default::default(),
+        ignore_permission_errors: flags.ignore_permission_errors,
+        write_files_atomically: flags.write_files_atomically,
+        parallel: flags.parallel,
+        write_sparse_files: flags.write_sparse_files,
+        skip_owners: flags.skip_owners,
+        skip_permissions: flags.skip_permissions,
+        skip_times: flags.skip_times,
+        overwrite_files: flags.overwrite_files,
+        overwrite_directories: flags.overwrite_directories,
+        overwrite_symlinks: flags.overwrite_symlinks,
+        ignore_errors: flags.ignore_errors,
+        skip_existing: flags.skip_existing,
+        delete_extra: flags.delete_extra,
+    };
+    assert_eq!(op.restore_options().delete_extra, Some(true));
+}

--- a/crates/controller/src/snapshot/build.rs
+++ b/crates/controller/src/snapshot/build.rs
@@ -29,7 +29,7 @@ pub(super) type SnapshotRun<'a> = (
     Vec<CredsEnvFrom>,
 );
 pub(super) fn build_backup_run(
-    _backup: &Snapshot,
+    backup: &Snapshot,
     config: &SnapshotPolicy,
     repo: &ResolvedRepository,
     namespace: &str,
@@ -108,6 +108,18 @@ pub(super) fn build_backup_run(
             // (compression / files / errorHandling / upload / extraArgs). Wired so
             // these never stay inert (ADR-0005 §13(b)/§13(f), ADR-0004 §4b).
             policy: policy_args_for(config),
+            // `snapshot create` argv flags (M4 flag sweep, issue #216 category
+            // sweep) — NOT `policy set` knobs, so they ride here rather than
+            // `policy_args_for`'s `PolicyArgsSpec`. `failFast`/`limitMb` are
+            // the recipe's (`SnapshotPolicy`); `description` is this run's
+            // (`Snapshot.spec`), matching the recipe/invocation split.
+            fail_fast: config
+                .spec
+                .error_handling
+                .as_ref()
+                .and_then(|e| e.fail_fast.then_some(true)),
+            upload_limit_mb: config.spec.upload.as_ref().and_then(|u| u.limit_mb),
+            description: backup.spec.description.clone(),
         }),
         identity,
         repository: repository_connect(repo)?,

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -307,6 +307,7 @@ fn dummy_backup() -> Snapshot {
             failure_policy: None,
             deletion_policy: None,
             pin: false,
+            description: None,
         },
     )
 }
@@ -458,6 +459,84 @@ fn build_backup_run_maps_pvc_source_to_pvc_mount() {
         }
     );
     assert_eq!(src.mount_path, "/pvc/pg-data");
+}
+
+#[test]
+fn build_backup_run_maps_snapshot_create_knobs_and_keeps_them_off_policy_args() {
+    // M4 flag sweep (issue #216 category sweep): `failFast`/`limitMb` (the
+    // recipe's `SnapshotPolicy.spec.{errorHandling,upload}`) and `description`
+    // (this run's `Snapshot.spec`) all land on `SnapshotOp` — they are
+    // `snapshot create` argv flags, not `policy set` knobs, so they must NOT
+    // appear on `op.policy` (`PolicyArgsSpec`).
+    use kopiur_api::snapshot_policy::{ErrorHandling, PvcSource, Source, Upload};
+    let mut cfg = config_with_source(
+        "pg",
+        Source {
+            pvc: Some(PvcSource {
+                name: "pg-data".into(),
+            }),
+            pvc_selector: None,
+            nfs: None,
+            source_path_override: None,
+            source_path_strategy: None,
+        },
+    );
+    cfg.spec.error_handling = Some(ErrorHandling {
+        fail_fast: true,
+        ..Default::default()
+    });
+    cfg.spec.upload = Some(Upload {
+        limit_mb: Some(250),
+        ..Default::default()
+    });
+    let mut backup = dummy_backup();
+    backup.spec.description = Some("pre-upgrade snapshot".into());
+    let repo = resolved_s3_repo();
+    let (ws, _source_volume, _repo, _creds) =
+        build_backup_run(&backup, &cfg, &repo, "ns", "pg").unwrap();
+    let op = match &ws.operation {
+        Operation::Snapshot(op) => op,
+        other => panic!("expected a Snapshot op, got {}", other.kind_str()),
+    };
+    assert_eq!(op.fail_fast, Some(true));
+    assert_eq!(op.upload_limit_mb, Some(250));
+    assert_eq!(op.description.as_deref(), Some("pre-upgrade snapshot"));
+
+    // The non-leak guard: `PolicyArgsSpec` structurally has no failFast/limitMb
+    // fields, and this proves it at the JSON boundary too.
+    let policy_json = serde_json::to_value(&op.policy).unwrap();
+    assert!(policy_json.get("failFast").is_none());
+    assert!(policy_json.get("limitMb").is_none());
+
+    // Absent errorHandling/upload/description ⇒ None on SnapshotOp (kopia's
+    // own defaults, today's argv).
+    let (ws2, ..) = build_backup_run(
+        &dummy_backup(),
+        &config_with_source(
+            "pg2",
+            Source {
+                pvc: Some(PvcSource {
+                    name: "pg-data".into(),
+                }),
+                pvc_selector: None,
+                nfs: None,
+                source_path_override: None,
+                source_path_strategy: None,
+            },
+        ),
+        &repo,
+        "ns",
+        "pg2",
+    )
+    .unwrap();
+    match &ws2.operation {
+        Operation::Snapshot(op2) => {
+            assert_eq!(op2.fail_fast, None);
+            assert_eq!(op2.upload_limit_mb, None);
+            assert_eq!(op2.description, None);
+        }
+        other => panic!("expected a Snapshot op, got {}", other.kind_str()),
+    }
 }
 
 #[test]

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -507,6 +507,7 @@ mod tests {
                 failure_policy: None,
                 deletion_policy: None,
                 pin: false,
+                description: None,
             },
         );
         b.status = Some(SnapshotStatus {
@@ -632,6 +633,7 @@ mod tests {
                 failure_policy: None,
                 deletion_policy: None,
                 pin: false,
+                description: None,
             },
         );
         running.status = Some(SnapshotStatus {

--- a/crates/controller/src/snapshot_schedule.rs
+++ b/crates/controller/src/snapshot_schedule.rs
@@ -781,6 +781,9 @@ async fn create_scheduled_backup(
             failure_policy: None,
             deletion_policy: None,
             pin: false,
+            // Scheduled backups never carry a templated description (out of
+            // scope for M4 — description is per-invocation only).
+            description: None,
         },
     );
     backup.metadata = io::child_meta(backup_name, namespace, labels, Some(owner));
@@ -1166,6 +1169,7 @@ mod tests {
                     failure_policy: None,
                     deletion_policy: None,
                     pin: false,
+                    description: None,
                 },
             );
             s.status = Some(SnapshotStatus {

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -543,15 +543,25 @@ pub fn build_verify_work_spec(
     tier: VerifyTierKind,
 ) -> MoverWorkSpec {
     let tier = match tier {
+        // M3 (issue #216 category sweep): quick.parallel/fileParallelism/
+        // fileQueueLength/maxErrors were dormant plumbing — the workspec and kopia
+        // client already supported them, but this arm hardcoded `None`, silently
+        // dropping any value the user set on `verification.quick`.
         VerifyTierKind::Quick => VerifyTier::Quick(QuickVerify {
             verify_files_percent: verification.verify_files_percent,
-            max_errors: None,
-            parallel: None,
+            max_errors: verification.quick.as_ref().and_then(|q| q.max_errors),
+            parallel: verification.quick.as_ref().and_then(|q| q.parallel),
+            file_parallelism: verification.quick.as_ref().and_then(|q| q.file_parallelism),
+            file_queue_length: verification
+                .quick
+                .as_ref()
+                .and_then(|q| q.file_queue_length),
         }),
         VerifyTierKind::Deep => VerifyTier::Deep(DeepVerify {
             scratch_path: DEEP_SCRATCH_PATH.to_string(),
             // The mover resolves the latest snapshot for the identity itself.
             snapshot_id: None,
+            parallel: verification.deep.as_ref().and_then(|d| d.parallel),
         }),
     };
     // The source identity (first source) so a deep restore targets the right path.
@@ -733,6 +743,10 @@ mod tests {
                     jitter: None,
                     timezone: None,
                 }),
+                parallel: None,
+                file_parallelism: None,
+                file_queue_length: None,
+                max_errors: None,
             }),
             deep: deep.map(|c| DeepVerification {
                 schedule: CronSpec {
@@ -742,6 +756,7 @@ mod tests {
                 },
                 storage_class_name: None,
                 capacity: None,
+                parallel: None,
             }),
             success_expr: None,
             verify_files_percent: None,
@@ -789,7 +804,10 @@ mod tests {
         // must treat it as "quick tier disabled" — never due, no panic/wedge. (New
         // writes of this shape are blocked at admission.)
         let v = Verification {
-            quick: Some(QuickVerification { schedule: None }),
+            quick: Some(QuickVerification {
+                schedule: None,
+                ..Default::default()
+            }),
             deep: None,
             success_expr: None,
             verify_files_percent: None,
@@ -1089,6 +1107,51 @@ mod tests {
     }
 
     #[test]
+    fn quick_work_spec_maps_tuning_knobs_not_hardcoded_none() {
+        // M3 (issue #216 category sweep) regression: `verification.quick.{parallel,
+        // fileParallelism,fileQueueLength,maxErrors}` are dormant plumbing without
+        // this mapping — the workspec and kopia client already support them, but
+        // `build_verify_work_spec` used to hardcode `max_errors: None, parallel:
+        // None` (and never had the other two at all), silently dropping every value
+        // a user set. This must fail on the pre-fix hardcoded-`None` mapping.
+        let mut v = verification(Some("0 4 * * *"), None);
+        v.quick = Some(QuickVerification {
+            schedule: Some(CronSpec {
+                cron: "0 4 * * *".into(),
+                jitter: None,
+                timezone: None,
+            }),
+            parallel: Some(2),
+            file_parallelism: Some(4),
+            file_queue_length: Some(100),
+            max_errors: Some(1),
+        });
+        let policy = sample_policy(v.clone());
+        let repo = sample_repo();
+        let ws = build_verify_work_spec(&policy, &repo, "ns", "pg", &v, VerifyTierKind::Quick);
+        match &ws.operation {
+            Operation::Verify(op) => match &op.tier {
+                VerifyTier::Quick(q) => {
+                    assert_eq!(q.parallel, Some(2), "parallel must reach the workspec");
+                    assert_eq!(
+                        q.file_parallelism,
+                        Some(4),
+                        "fileParallelism must reach the workspec"
+                    );
+                    assert_eq!(
+                        q.file_queue_length,
+                        Some(100),
+                        "fileQueueLength must reach the workspec"
+                    );
+                    assert_eq!(q.max_errors, Some(1), "maxErrors must reach the workspec");
+                }
+                other => panic!("expected quick tier, got {}", other.kind_str()),
+            },
+            other => panic!("expected verify op, got {}", other.kind_str()),
+        }
+    }
+
+    #[test]
     fn deep_work_spec_carries_deep_tier_with_scratch_path() {
         let v = verification(None, Some("0 5 * * 0"));
         let policy = sample_policy(v.clone());
@@ -1099,6 +1162,35 @@ mod tests {
                 VerifyTier::Deep(d) => {
                     assert_eq!(d.scratch_path, DEEP_SCRATCH_PATH);
                     assert!(d.snapshot_id.is_none());
+                }
+                other => panic!("expected deep tier, got {}", other.kind_str()),
+            },
+            other => panic!("expected verify op, got {}", other.kind_str()),
+        }
+    }
+
+    #[test]
+    fn deep_work_spec_maps_parallel_not_hardcoded_none() {
+        // M3 regression, deep side: `verification.deep.parallel` must reach
+        // `DeepVerify.parallel` (the mover maps it into `restore --parallel`).
+        let mut v = verification(None, Some("0 5 * * 0"));
+        v.deep = Some(DeepVerification {
+            schedule: CronSpec {
+                cron: "0 5 * * 0".into(),
+                jitter: None,
+                timezone: None,
+            },
+            storage_class_name: None,
+            capacity: None,
+            parallel: Some(2),
+        });
+        let policy = sample_policy(v.clone());
+        let repo = sample_repo();
+        let ws = build_verify_work_spec(&policy, &repo, "ns", "pg", &v, VerifyTierKind::Deep);
+        match &ws.operation {
+            Operation::Verify(op) => match &op.tier {
+                VerifyTier::Deep(d) => {
+                    assert_eq!(d.parallel, Some(2), "parallel must reach the workspec");
                 }
                 other => panic!("expected deep tier, got {}", other.kind_str()),
             },
@@ -1170,6 +1262,7 @@ mod tests {
                 },
                 storage_class_name: storage_class.map(Into::into),
                 capacity: capacity.map(Into::into),
+                parallel: None,
             }),
             success_expr: None,
             verify_files_percent: None,

--- a/crates/controller/tests/integration.rs
+++ b/crates/controller/tests/integration.rs
@@ -188,6 +188,7 @@ async fn backup_gets_finalizer_and_delete_path_removes_cr() {
             failure_policy: None,
             deletion_policy: Some(kopiur_api::DeletionPolicy::Orphan),
             pin: false,
+            description: None,
         },
     );
     b.finalizers_mut()

--- a/crates/e2e/tests/policy_knobs.rs
+++ b/crates/e2e/tests/policy_knobs.rs
@@ -212,6 +212,105 @@ async fn compression_and_upload_knobs_reach_the_mover_contract() {
         .expect("the tuned backup should succeed (kopia accepted the policy flags)");
 }
 
+/// M4 flag sweep (issue #216 category sweep): `errorHandling.failFast` +
+/// `upload.limitMb` (recipe, `SnapshotPolicy`) and `description`
+/// (per-invocation, `Snapshot`) all reach the controller→mover work-spec
+/// ConfigMap as `SnapshotOp` fields (`snapshot create` argv, NOT `policy set`
+/// knobs — so they must NOT appear under `operation.snapshot.policy`), and
+/// kopia accepts them (`Succeeded`).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test)"]
+async fn snapshot_create_knobs_reach_the_mover_contract() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("fixtures ready");
+    let client = world.client().clone();
+    ensure_knobs_repo(&client).await;
+
+    let configs: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cfg = snapshot_policy_json(
+        E2E_NAMESPACE,
+        "e2e-create-knobs-cfg",
+        "Repository",
+        REPO,
+        serde_json::json!({
+            "errorHandling": { "failFast": true },
+            "upload": { "limitMb": 100 }
+        }),
+    );
+    let _ = configs.create(&PostParams::default(), &cr(cfg)).await;
+    let _ = backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-create-knobs",
+                "e2e-create-knobs-cfg",
+                serde_json::json!({ "description": "e2e m4 flag sweep" }),
+            )),
+        )
+        .await;
+
+    // The work-spec ConfigMap (same name as the mover Job) carries all three
+    // knobs directly on `operation.snapshot` — NOT under `.policy` (the
+    // `policy set` args), proving the recipe/invocation split holds end to end.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let _ = wait_for_job(&jobs, "e2e-create-knobs").await;
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cm = cms
+        .get("e2e-create-knobs")
+        .await
+        .expect("work-spec ConfigMap");
+    let spec_json = cm
+        .data
+        .as_ref()
+        .and_then(|d| d.get("work-spec.json"))
+        .expect("work-spec.json key");
+    let spec: serde_json::Value =
+        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+    let snapshot_op = spec
+        .pointer("/operation/snapshot")
+        .unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        snapshot_op.get("failFast").and_then(|v| v.as_bool()),
+        Some(true),
+        "errorHandling.failFast must reach SnapshotOp; op: {snapshot_op}"
+    );
+    assert_eq!(
+        snapshot_op.get("uploadLimitMb").and_then(|v| v.as_i64()),
+        Some(100),
+        "upload.limitMb must reach SnapshotOp as uploadLimitMb; op: {snapshot_op}"
+    );
+    assert_eq!(
+        snapshot_op.get("description").and_then(|v| v.as_str()),
+        Some("e2e m4 flag sweep"),
+        "Snapshot.spec.description must reach SnapshotOp; op: {snapshot_op}"
+    );
+    // Recipe knobs must NOT leak into the `policy set` args.
+    let policy = snapshot_op
+        .get("policy")
+        .cloned()
+        .unwrap_or(serde_json::Value::Null);
+    assert!(
+        policy.get("failFast").is_none(),
+        "failFast must not leak into policy set args; policy: {policy}"
+    );
+    assert!(
+        policy.get("limitMb").is_none(),
+        "limitMb must not leak into policy set args; policy: {policy}"
+    );
+
+    // End-to-end close: kopia accepted the flags.
+    wait_phase(&backups, "e2e-create-knobs", "Succeeded")
+        .await
+        .expect("the tuned backup should succeed (kopia accepted --fail-fast/--upload-limit-mb/--description)");
+}
+
 // --- task PR4: default `files.ignoreRules` OS-artifact excludes ---
 
 /// Seed the test's OWN dynamic source PVC (never the shared `e2e-src` — content

--- a/crates/e2e/tests/replication.rs
+++ b/crates/e2e/tests/replication.rs
@@ -10,7 +10,10 @@ mod common;
 use common::*;
 
 use kube::Api;
-use kube::api::{DeleteParams, PostParams};
+use kube::api::{DeleteParams, ListParams, PostParams};
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ConfigMap;
 
 use kopiur_api::{Repository, RepositoryReplication};
 use kopiur_e2e::{E2E_NAMESPACE, Need, World, consts, default_timeout, poll_interval, wait_until};
@@ -62,14 +65,65 @@ async fn repository_replication_mirrors_to_second_filesystem_repo() {
                     // PVC root regardless of the mount path, so the `repl-dst` verifier
                     // (which mounts the same PVC at `/repo`) still reads the mirror.
                     "destination": { "filesystem": { "path": "/repo-dst", "volume": { "pvc": { "name": consts::isolated_repo_pvc("repl-dst") } } } },
-                    "schedule": { "cron": "* * * * *" }
+                    "schedule": { "cron": "* * * * *" },
+                    // #216: sync-to tuning — asserted both at the mover's actual
+                    // behavior (the run still succeeds/records lastReplicated with a
+                    // real `--parallel`/`--delete` on argv) AND at the work-spec
+                    // ConfigMap contract below (the seam where a regression would
+                    // silently drop the knobs while the run still succeeded).
+                    "sync": { "parallel": 2, "deleteExtra": true }
                 }
             })),
         )
         .await
         .expect("create RepositoryReplication to a second filesystem repo");
 
-    // Within a couple of minutes a replication runs and records lastReplicated.
+    // The work-spec ConfigMap (same name as the per-slot mover Job) carries the
+    // #216 sync knobs — the controller→mover contract, mirroring the
+    // `policy_knobs` compression/upload-knobs pattern.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let selector = format!(
+        "app.kubernetes.io/component=replication,kopiur.home-operations.com/replication={name}"
+    );
+    let job_name = wait_until(
+        "a replication mover Job is created",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let list = jobs.list(&ListParams::default().labels(&selector)).await?;
+            Ok(list.items.into_iter().find_map(|j| j.metadata.name))
+        },
+    )
+    .await
+    .expect("a replication mover Job should be created");
+    let cm = cms
+        .get(&job_name)
+        .await
+        .expect("replication work-spec ConfigMap");
+    let spec_json = cm
+        .data
+        .as_ref()
+        .and_then(|d| d.get("work-spec.json"))
+        .expect("work-spec.json key");
+    let spec: serde_json::Value =
+        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+    let replicate = spec
+        .pointer("/operation/replicate")
+        .unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        replicate.get("parallel").and_then(|v| v.as_i64()),
+        Some(2),
+        "sync.parallel must reach the mover contract; replicate: {replicate}"
+    );
+    assert_eq!(
+        replicate.get("deleteExtra").and_then(|v| v.as_bool()),
+        Some(true),
+        "sync.deleteExtra must reach the mover contract; replicate: {replicate}"
+    );
+
+    // Within a couple of minutes a replication runs and records lastReplicated —
+    // proving kopia actually accepted `--parallel 2 --delete` on argv.
     wait_until(
         "RepositoryReplication records a successful run (status.lastReplicated)",
         default_timeout(),

--- a/crates/e2e/tests/restore.rs
+++ b/crates/e2e/tests/restore.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod};
 
 use kopiur_api::{ClusterRepository, Repository, Restore, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{
@@ -1176,6 +1176,88 @@ async fn restore_completed_reports_kstatus_ready() {
         Some(1),
         "the Completed patch must stamp observedGeneration; status: {s}"
     );
+    cleanup_restore(&restores, name).await;
+}
+
+/// M2 flag sweep (issue #216 gap analysis): `Restore.spec.options.{parallel,
+/// overwriteFiles,skipTimes}` must reach the mover's work-spec ConfigMap
+/// contract (asserted directly on the ConfigMap, mirroring the RepositoryReplication
+/// `sync` knobs e2e pattern — the seam where a regression would silently drop
+/// the knobs while the run still succeeded) AND the restore must still
+/// complete with the snapshot's content intact, proving kopia actually
+/// accepted the flags on argv rather than merely that the CRD field parsed.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test)"]
+async fn restore_options_flag_sweep_reaches_work_spec_and_completes() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("fixtures ready");
+    let client = world.client().clone();
+    ensure_seed_backup(&client).await;
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    let name = "e2e-r-flags";
+    cleanup_restore(&restores, name).await;
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(restore_json(
+                name,
+                serde_json::json!({
+                    "options": { "parallel": 2, "overwriteFiles": true, "skipTimes": true }
+                }),
+            )),
+        )
+        .await
+        .expect("create Restore with an options flag sweep");
+
+    // The work-spec ConfigMap shares the mover Job's name, which for a
+    // pvc-create target (restore_json's default) equals the Restore's own name.
+    let cm = wait_until(
+        "restore work-spec ConfigMap is created",
+        default_timeout(),
+        poll_interval(),
+        || async { cms.get_opt(name).await },
+    )
+    .await
+    .expect("restore work-spec ConfigMap should be created");
+    let spec_json = cm
+        .data
+        .as_ref()
+        .and_then(|d| d.get("work-spec.json"))
+        .expect("work-spec.json key");
+    let spec: serde_json::Value =
+        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+    let restore_op = spec
+        .pointer("/operation/restore")
+        .unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        restore_op.get("parallel").and_then(|v| v.as_i64()),
+        Some(2),
+        "options.parallel must reach the mover contract; restore: {restore_op}"
+    );
+    assert_eq!(
+        restore_op.get("overwriteFiles").and_then(|v| v.as_bool()),
+        Some(true),
+        "options.overwriteFiles must reach the mover contract; restore: {restore_op}"
+    );
+    assert_eq!(
+        restore_op.get("skipTimes").and_then(|v| v.as_bool()),
+        Some(true),
+        "options.skipTimes must reach the mover contract; restore: {restore_op}"
+    );
+
+    // Within the run, kopia must actually accept `--parallel 2 --overwrite-files
+    // --skip-times` — a bad flag SHAPE would fail here, not just in the CM check.
+    wait_phase(&restores, name, "Completed")
+        .await
+        .expect("restore with the M2 flag sweep must complete");
+
     cleanup_restore(&restores, name).await;
 }
 

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -27,8 +27,42 @@ use kube::Api;
 use kube::api::{ListParams, Patch, PatchParams, PostParams};
 
 use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ConfigMap;
 use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wait_until};
+
+/// Wait for a verify Job matching `selector`, then return its work-spec
+/// ConfigMap's `work-spec.json`, parsed. Verify Job names are per-slot
+/// (`<policy>-vfy-<q|d>-<unix_slot>`, [`crate::verify_job_name`] in the
+/// controller), not deterministic like other mover Jobs, so the CM is looked up
+/// by the FOUND Job's own name (the controller applies the CM under the same
+/// name as the Job — `io::apply_mover_objects`) rather than a name built here.
+async fn verify_work_spec_json(client: &kube::Client, selector: &str) -> serde_json::Value {
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let job = wait_until(
+        "verify mover Job created",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let lp = ListParams::default().labels(selector);
+            Ok(jobs.list(&lp).await?.items.into_iter().next())
+        },
+    )
+    .await
+    .expect("a verify Job should be spawned");
+    let job_name = job.metadata.name.expect("Job has a name");
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cm = cms
+        .get(&job_name)
+        .await
+        .unwrap_or_else(|_| panic!("work-spec ConfigMap {job_name}"));
+    let spec_json = cm
+        .data
+        .as_ref()
+        .and_then(|d| d.get("work-spec.json"))
+        .expect("work-spec.json key");
+    serde_json::from_str(spec_json).expect("work-spec parses as JSON")
+}
 
 /// Verification (ADR-0005 §4): a `SnapshotPolicy.spec.verification.quick` with an
 /// every-minute cron and a `successExpr` over the result drives a `kopia snapshot
@@ -53,10 +87,20 @@ async fn verification_quick_with_success_expr_stamps_last_verified() {
 
     let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     // Patch verification onto the existing policy: every-minute quick verify, gated by
-    // a successExpr asserting the verify reported zero errors.
+    // a successExpr asserting the verify reported zero errors. Also sets the M3
+    // (issue #216 category sweep) tuning knobs — parallel/fileParallelism/
+    // fileQueueLength/maxErrors — the regression guard for the dormant-plumbing bug
+    // where the controller hardcoded `max_errors: None, parallel: None` regardless
+    // of what the CRD carried.
     let patch = serde_json::json!({
         "spec": { "verification": {
-            "quick": { "schedule": { "cron": "* * * * *" } },
+            "quick": {
+                "schedule": { "cron": "* * * * *" },
+                "parallel": 2,
+                "fileParallelism": 4,
+                "fileQueueLength": 100,
+                "maxErrors": 1
+            },
             "successExpr": "stats.errors == 0"
         } }
     });
@@ -85,6 +129,36 @@ async fn verification_quick_with_success_expr_stamps_last_verified() {
     .await
     .expect(
         "a passing quick verify (successExpr stats.errors == 0) must stamp status.lastVerified",
+    );
+
+    // The work-spec ConfigMap the mover actually ran against carries the tuning
+    // knobs — not just that the run succeeded, but that the knobs reached the
+    // mover contract (`operation.verify.tier.quick.*`).
+    let selector = "app.kubernetes.io/component=verify,\
+                    kopiur.home-operations.com/verify=e2e-verify-policy";
+    let spec = verify_work_spec_json(&client, selector).await;
+    let quick = spec
+        .pointer("/operation/verify/tier/quick")
+        .unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        quick.get("parallel").and_then(|v| v.as_i64()),
+        Some(2),
+        "verification.quick.parallel must reach the mover contract; quick: {quick}"
+    );
+    assert_eq!(
+        quick.get("fileParallelism").and_then(|v| v.as_i64()),
+        Some(4),
+        "verification.quick.fileParallelism must reach the mover contract; quick: {quick}"
+    );
+    assert_eq!(
+        quick.get("fileQueueLength").and_then(|v| v.as_i64()),
+        Some(100),
+        "verification.quick.fileQueueLength must reach the mover contract; quick: {quick}"
+    );
+    assert_eq!(
+        quick.get("maxErrors").and_then(|v| v.as_i64()),
+        Some(1),
+        "verification.quick.maxErrors must reach the mover contract; quick: {quick}"
     );
 }
 
@@ -120,10 +194,12 @@ async fn verification_deep_scratch_restore_stamps_last_verified() {
     let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     // Every-minute deep verify, capacity/storageClassName UNSET -> emptyDir scratch
     // (the path that regressed). The successExpr exercises the deep-only `restored`
-    // environment, so a stamped lastVerified proves the scratch-restore ran.
+    // environment, so a stamped lastVerified proves the scratch-restore ran. Also
+    // sets `parallel` (M3 / issue #216 category sweep): deep verify IS a restore
+    // under the hood, so this maps to `restore --parallel` in the mover.
     let patch = serde_json::json!({
         "spec": { "verification": {
-            "deep": { "schedule": { "cron": "* * * * *" } },
+            "deep": { "schedule": { "cron": "* * * * *" }, "parallel": 2 },
             "successExpr": "restored.files >= 0 && restored.checksumMatches"
         } }
     });
@@ -152,6 +228,20 @@ async fn verification_deep_scratch_restore_stamps_last_verified() {
     .expect(
         "a passing deep verify must mount a writable /scratch (emptyDir) and stamp \
          status.lastVerified — failure here is the `mkdir /scratch: permission denied` regression",
+    );
+
+    // The work-spec ConfigMap carries `parallel` through to the mover contract
+    // (`operation.verify.tier.deep.parallel`).
+    let selector = "app.kubernetes.io/component=verify,\
+                    kopiur.home-operations.com/verify=e2e-vfy-deep-policy";
+    let spec = verify_work_spec_json(&client, selector).await;
+    let deep = spec
+        .pointer("/operation/verify/tier/deep")
+        .unwrap_or(&serde_json::Value::Null);
+    assert_eq!(
+        deep.get("parallel").and_then(|v| v.as_i64()),
+        Some(2),
+        "verification.deep.parallel must reach the mover contract; deep: {deep}"
     );
 }
 

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -472,6 +472,24 @@ pub struct VerifyOptions {
     pub file_queue_length: Option<u32>,
 }
 
+/// Options for `kopia snapshot create` (M4 flag sweep, issue #216 category
+/// sweep). All-default reproduces kopia's own defaults / today's argv:
+/// `fail_fast: None` (kopia default: keep going past per-file errors, subject
+/// to the `errorHandling.ignore*Errors` policy knobs), `upload_limit_mb: None`
+/// (kopia default: unlimited), `description: None` (kopia default: empty).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SnapshotCreateOptions {
+    /// `--[no-]fail-fast`: abort the snapshot at the first error instead of
+    /// collecting and continuing (kopia default: false — collect and continue).
+    pub fail_fast: Option<bool>,
+    /// `--upload-limit-mb`: abort the snapshot once this many MB have been
+    /// uploaded (kopia default: 0 — unlimited).
+    pub upload_limit_mb: Option<i64>,
+    /// `--description`: free-form text recorded on the snapshot manifest
+    /// (kopia default: empty).
+    pub description: Option<String>,
+}
+
 /// Options for `kopia restore` / `kopia snapshot restore`. The tri-state
 /// booleans map to kopia's `--[no-]flag` form: `Some(true)` → `--flag`,
 /// `Some(false)` → `--no-flag`, `None` → omit (kopia default). M2 flag sweep
@@ -1109,7 +1127,8 @@ impl KopiaClient {
     }
 
     /// Create a snapshot of `source_path` with the given `tags`
-    /// (`key:value`). Returns the parsed create result.
+    /// (`key:value`) and kopia's own defaults for `snapshot create`'s tuning
+    /// knobs. Returns the parsed create result.
     ///
     /// `override_source`, when set, is passed to kopia as `--override-source`
     /// (format `username@hostname:path`). This is how Kopiur records snapshots
@@ -1123,20 +1142,28 @@ impl KopiaClient {
         tags: &BTreeMap<String, String>,
         override_source: Option<&str>,
     ) -> Result<SnapshotCreateResult, KopiaError> {
-        let mut args = vec![
-            "snapshot".into(),
-            "create".into(),
-            source_path.to_string(),
-            "--json".into(),
-        ];
-        if let Some(src) = override_source {
-            args.push("--override-source".into());
-            args.push(src.to_string());
-        }
-        for (k, v) in tags {
-            args.push("--tags".into());
-            args.push(format!("{k}:{v}"));
-        }
+        self.snapshot_create_with(
+            source_path,
+            tags,
+            override_source,
+            &SnapshotCreateOptions::default(),
+        )
+        .await
+    }
+
+    /// Create a snapshot honoring the operator's [`SnapshotCreateOptions`]
+    /// (`failFast`, `uploadLimitMb`, `description` — M4 flag sweep, issue #216).
+    /// Same identity/tags contract as [`Self::snapshot_create`], which now
+    /// delegates here with an all-default `opts` (byte-for-byte the same argv
+    /// as before this option struct existed).
+    pub async fn snapshot_create_with(
+        &self,
+        source_path: &str,
+        tags: &BTreeMap<String, String>,
+        override_source: Option<&str>,
+        opts: &SnapshotCreateOptions,
+    ) -> Result<SnapshotCreateResult, KopiaError> {
+        let args = snapshot_create_args(source_path, tags, override_source, opts);
         self.run_json(&args, "snapshot create result").await
     }
 
@@ -1612,6 +1639,45 @@ fn restore_args(id: &str, target_dir: &str, opts: &RestoreOptions) -> Vec<String
     if let Some(p) = opts.parallel {
         args.push("--parallel".into());
         args.push(p.to_string());
+    }
+    args
+}
+
+/// Build the args for `kopia snapshot create <source> --json [flags]` plus
+/// options. Pure so it is unit-testable without spawning kopia. `--fail-fast`
+/// is a kingpin `--[no-]flag` tri-state (smoke-tested against the pinned
+/// kopia 0.23.1: `snapshot create --fail-fast --upload-limit-mb 100
+/// --description "smoke test"` is accepted; the real-kopia integration test
+/// in `crates/kopia/tests/integration_roundtrip.rs` is the permanent guard).
+/// All-default `opts` reproduces the pre-M4 argv byte-for-byte (tested).
+fn snapshot_create_args(
+    source_path: &str,
+    tags: &BTreeMap<String, String>,
+    override_source: Option<&str>,
+    opts: &SnapshotCreateOptions,
+) -> Vec<String> {
+    let mut args = vec![
+        "snapshot".into(),
+        "create".into(),
+        source_path.to_string(),
+        "--json".into(),
+    ];
+    if let Some(src) = override_source {
+        args.push("--override-source".into());
+        args.push(src.to_string());
+    }
+    for (k, v) in tags {
+        args.push("--tags".into());
+        args.push(format!("{k}:{v}"));
+    }
+    push_tristate(&mut args, "fail-fast", opts.fail_fast);
+    if let Some(mb) = opts.upload_limit_mb {
+        args.push("--upload-limit-mb".into());
+        args.push(mb.to_string());
+    }
+    if let Some(desc) = &opts.description {
+        args.push("--description".into());
+        args.push(desc.clone());
     }
     args
 }

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -464,8 +464,12 @@ pub struct VerifyOptions {
     pub verify_files_percent: Option<u8>,
     /// `--max-errors`: stop after this many errors (0 = never stop early).
     pub max_errors: Option<u32>,
-    /// `--parallel`: verification parallelism.
+    /// `--parallel`: verification parallelism (kopia default: 8).
     pub parallel: Option<u32>,
+    /// `--file-parallelism`: parallelism for file verification (kopia default: unset).
+    pub file_parallelism: Option<u32>,
+    /// `--file-queue-length`: queue length for file verification (kopia default: 20000).
+    pub file_queue_length: Option<u32>,
 }
 
 /// Options for `kopia restore` / `kopia snapshot restore`. The tri-state
@@ -1626,6 +1630,14 @@ fn verify_args(opts: &VerifyOptions) -> Vec<String> {
     if let Some(p) = opts.parallel {
         args.push("--parallel".into());
         args.push(p.to_string());
+    }
+    if let Some(p) = opts.file_parallelism {
+        args.push("--file-parallelism".into());
+        args.push(p.to_string());
+    }
+    if let Some(q) = opts.file_queue_length {
+        args.push("--file-queue-length".into());
+        args.push(q.to_string());
     }
     args
 }

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -485,6 +485,37 @@ pub struct RestoreOptions {
     pub parallel: Option<u32>,
 }
 
+/// Options for `kopia repository sync-to` (ADR-0005 §13(d) / issue #216). Every
+/// field's `None`/`false` reproduces kopia's own default — an all-`None`,
+/// `delete_extra: false` instance yields the exact same argv `sync_to_args`
+/// produced before this struct existed. The tri-state booleans map to kopia's
+/// `--[no-]flag` grammar, same as [`RestoreOptions`]: `Some(true)` → `--flag`,
+/// `Some(false)` → `--no-flag`, `None` → omit (kopia default).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SyncToOptions {
+    /// `--parallel`: copy parallelism to the destination (kopia default `1` —
+    /// sequential; the root cause of #216's multi-week initial-seed times).
+    pub parallel: Option<u32>,
+    /// `--delete`: prune destination-only blobs for a true mirror (kopia
+    /// default `false` — additive sync, never removes destination content).
+    pub delete_extra: bool,
+    /// `--[no-]must-exist`: fail instead of initializing the destination's
+    /// repository-format blob (kopia default `false`).
+    pub must_exist: Option<bool>,
+    /// `--[no-]times`: synchronize blob modification times to the destination,
+    /// when supported (kopia default `true`).
+    pub times: Option<bool>,
+    /// `--[no-]update`: update blobs already present at the destination when
+    /// the source copy is newer (kopia default `true`).
+    pub update: Option<bool>,
+    /// `--max-download-speed`: cap read throughput from the source, bytes/sec
+    /// (kopia default: unlimited).
+    pub max_download_speed_bytes_per_second: Option<i64>,
+    /// `--max-upload-speed`: cap write throughput to the destination, bytes/sec
+    /// (kopia default: unlimited).
+    pub max_upload_speed_bytes_per_second: Option<i64>,
+}
+
 /// Policy fields kopia applies via `kopia policy set`. Mirrors the operator's
 /// `SnapshotPolicy.spec.policy` without depending on the api crate, so the kopia
 /// crate stays controller-agnostic. The caller translates the CRD policy into
@@ -1011,21 +1042,21 @@ impl KopiaClient {
     }
 
     /// Mirror the *connected* repository's blobs to a destination backend
-    /// (`kopia repository sync-to <destination> [flags]`), ADR-0005 §13(d). The
-    /// caller must already be connected to the **source** repository; this copies
-    /// its blobs to `destination`. The destination's backend args are built by
-    /// `ConnectSpec::backend_args` (the same builder connect/create use), so a new
-    /// backend variant is wired through automatically. `--must-exist=false` lets the
-    /// first sync create the destination layout; `--delete` (when `delete_extra`)
-    /// prunes blobs at the destination no longer present at the source (a true
-    /// mirror). Destination credentials are supplied via the environment, never on
-    /// argv, exactly like connect/create. Success is exit code 0.
+    /// (`kopia repository sync-to <destination> [flags]`), ADR-0005 §13(d) / issue
+    /// #216. The caller must already be connected to the **source** repository;
+    /// this copies its blobs to `destination`. The destination's backend args are
+    /// built by `ConnectSpec::backend_args` (the same builder connect/create use),
+    /// so a new backend variant is wired through automatically. `opts` carries the
+    /// tuning knobs (parallelism, `--delete`, the must-exist/times/update
+    /// tri-states, throughput caps) — see [`SyncToOptions`]. Destination
+    /// credentials are supplied via the environment, never on argv, exactly like
+    /// connect/create. Success is exit code 0.
     pub async fn repository_sync_to(
         &self,
         destination: &ConnectSpec,
-        delete_extra: bool,
+        opts: &SyncToOptions,
     ) -> Result<(), KopiaError> {
-        self.repository_sync_to_with_env(destination, delete_extra, &BTreeMap::new())
+        self.repository_sync_to_with_env(destination, opts, &BTreeMap::new())
             .await
     }
 
@@ -1042,10 +1073,10 @@ impl KopiaClient {
     pub async fn repository_sync_to_with_env(
         &self,
         destination: &ConnectSpec,
-        delete_extra: bool,
+        opts: &SyncToOptions,
         dest_env: &BTreeMap<String, Option<String>>,
     ) -> Result<(), KopiaError> {
-        let args = sync_to_args(destination, delete_extra);
+        let args = sync_to_args(destination, opts);
         self.run_ok_with_env(&args, dest_env).await.map(|_| ())
     }
 
@@ -1576,19 +1607,34 @@ fn connect_args(spec: &ConnectSpec, cache: CacheTuning, readonly: bool) -> Vec<S
 }
 
 /// Build the args for `kopia repository sync-to <destination> [flags]`. Pure so it
-/// is unit-testable without spawning kopia (ADR-0005 §13(d)). The destination's
-/// backend selection reuses `ConnectSpec::backend_args`, so every backend is wired
-/// through. `--must-exist=false` allows the first sync to create the destination
-/// layout; `--delete` prunes destination-only blobs for a true mirror.
-fn sync_to_args(destination: &ConnectSpec, delete_extra: bool) -> Vec<String> {
+/// is unit-testable without spawning kopia (ADR-0005 §13(d) / issue #216). The
+/// destination's backend selection reuses `ConnectSpec::backend_args`, so every
+/// backend is wired through. `--must-exist`/`--times`/`--update` are kopia
+/// (kingpin) BOOLEAN flags: `--must-exist=false` is a parse error (`unexpected
+/// false`) — but the `--no-must-exist`/`--no-times`/`--no-update` negated forms
+/// ARE accepted (smoke-tested against kopia 0.23.1), so [`push_tristate`] is used
+/// for all three exactly like `snapshot restore`'s tri-states. `None` on any
+/// field omits its flag entirely, leaving kopia's own default in effect.
+fn sync_to_args(destination: &ConnectSpec, opts: &SyncToOptions) -> Vec<String> {
     let mut args = vec!["repository".into(), "sync-to".into()];
     args.extend(destination.backend_args());
-    // `--must-exist` is a kopia (kingpin) BOOLEAN flag: present (`--must-exist`) or
-    // absent — `--must-exist=false` is a parse error (`unexpected false`). Its default
-    // is false (sync-to initializes the destination if it isn't yet a repository),
-    // exactly what a mirror wants, so omit it rather than emit an invalid `=false`.
-    if delete_extra {
+    if let Some(p) = opts.parallel {
+        args.push("--parallel".into());
+        args.push(p.to_string());
+    }
+    if opts.delete_extra {
         args.push("--delete".into());
+    }
+    push_tristate(&mut args, "must-exist", opts.must_exist);
+    push_tristate(&mut args, "times", opts.times);
+    push_tristate(&mut args, "update", opts.update);
+    if let Some(s) = opts.max_download_speed_bytes_per_second {
+        args.push("--max-download-speed".into());
+        args.push(s.to_string());
+    }
+    if let Some(s) = opts.max_upload_speed_bytes_per_second {
+        args.push("--max-upload-speed".into());
+        args.push(s.to_string());
     }
     args
 }

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -470,17 +470,41 @@ pub struct VerifyOptions {
 
 /// Options for `kopia restore` / `kopia snapshot restore`. The tri-state
 /// booleans map to kopia's `--[no-]flag` form: `Some(true)` → `--flag`,
-/// `Some(false)` → `--no-flag`, `None` → omit (kopia default).
+/// `Some(false)` → `--no-flag`, `None` → omit (kopia default). M2 flag sweep
+/// (issue #216 gap analysis) added everything below `overwrite_files`; all of
+/// them, plus `delete_extra`, were previously either absent or dormant (the
+/// mover's `RestoreOp::restore_options()` dropped them via `..Default::default()`).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RestoreOptions {
     /// `--[no-]ignore-permission-errors` (kopia default: true).
     pub ignore_permission_errors: Option<bool>,
     /// `--[no-]write-files-atomically`.
     pub write_files_atomically: Option<bool>,
-    /// `--[no-]overwrite-files`.
+    /// `--[no-]overwrite-files` (kopia default: true).
     pub overwrite_files: Option<bool>,
-    /// `--skip-existing`: skip files/symlinks that already exist in the target.
-    pub skip_existing: bool,
+    /// `--[no-]overwrite-directories` (kopia default: true).
+    pub overwrite_directories: Option<bool>,
+    /// `--[no-]overwrite-symlinks` (kopia default: true).
+    pub overwrite_symlinks: Option<bool>,
+    /// `--[no-]write-sparse-files` (kopia default: false).
+    pub write_sparse_files: Option<bool>,
+    /// `--[no-]skip-owners` (kopia default: false).
+    pub skip_owners: Option<bool>,
+    /// `--[no-]skip-permissions` (kopia default: false).
+    pub skip_permissions: Option<bool>,
+    /// `--[no-]skip-times` (kopia default: false).
+    pub skip_times: Option<bool>,
+    /// `--[no-]ignore-errors` (kopia default: false).
+    pub ignore_errors: Option<bool>,
+    /// `--[no-]skip-existing`: skip files/symlinks that already exist in the
+    /// target (kopia default: false). A genuine kingpin tri-state, not a
+    /// presence-only flag — widened from a bare `bool`.
+    pub skip_existing: Option<bool>,
+    /// `--[no-]delete-extra`: delete files/directories/symlinks present in the
+    /// restore path but absent from the snapshot (kopia default: false). Backs
+    /// `Restore.spec.options.enableFileDeletion`, which was previously a silent
+    /// no-op — this struct had no field for it at all.
+    pub delete_extra: Option<bool>,
     /// `--parallel`: restore parallelism (1 disables).
     pub parallel: Option<u32>,
 }
@@ -1545,7 +1569,11 @@ pub fn split_policy_scopes(mut policy: PolicyArgs) -> (PolicyArgs, Option<Policy
 }
 
 /// Build the args for `kopia snapshot restore <id> <target>` plus options. Pure
-/// so it is unit-testable without spawning kopia.
+/// so it is unit-testable without spawning kopia. Every `--[no-]flag` form here
+/// was smoke-tested against the pinned kopia 0.23.1 (`kopia snapshot restore
+/// --help`); the real-kopia integration test in
+/// `crates/kopia/tests/integration_roundtrip.rs` is the permanent guard that
+/// kopia actually accepts them, not just that the argv shape looks right.
 fn restore_args(id: &str, target_dir: &str, opts: &RestoreOptions) -> Vec<String> {
     let mut args = vec![
         "snapshot".into(),
@@ -1564,9 +1592,19 @@ fn restore_args(id: &str, target_dir: &str, opts: &RestoreOptions) -> Vec<String
         opts.write_files_atomically,
     );
     push_tristate(&mut args, "overwrite-files", opts.overwrite_files);
-    if opts.skip_existing {
-        args.push("--skip-existing".into());
-    }
+    push_tristate(
+        &mut args,
+        "overwrite-directories",
+        opts.overwrite_directories,
+    );
+    push_tristate(&mut args, "overwrite-symlinks", opts.overwrite_symlinks);
+    push_tristate(&mut args, "write-sparse-files", opts.write_sparse_files);
+    push_tristate(&mut args, "skip-owners", opts.skip_owners);
+    push_tristate(&mut args, "skip-permissions", opts.skip_permissions);
+    push_tristate(&mut args, "skip-times", opts.skip_times);
+    push_tristate(&mut args, "ignore-errors", opts.ignore_errors);
+    push_tristate(&mut args, "skip-existing", opts.skip_existing);
+    push_tristate(&mut args, "delete-extra", opts.delete_extra);
     if let Some(p) = opts.parallel {
         args.push("--parallel".into());
         args.push(p.to_string());

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -437,8 +437,9 @@ fn restore_args_tristate_and_flags() {
         ignore_permission_errors: Some(false),
         write_files_atomically: Some(true),
         overwrite_files: Some(false),
-        skip_existing: true,
+        skip_existing: Some(true),
         parallel: Some(4),
+        ..Default::default()
     };
     assert_eq!(
         restore_args("s", "/t", &opts),
@@ -454,6 +455,81 @@ fn restore_args_tristate_and_flags() {
             "--parallel",
             "4"
         ]
+    );
+}
+
+#[test]
+fn restore_args_m2_flag_sweep_all_new_tristates_and_delete_extra() {
+    // M2 flag sweep (issue #216 gap analysis): every new tri-state, in the
+    // `Some(false)` → `--no-*` form, plus `delete_extra` — the
+    // `enableFileDeletion` bug-fix's client-layer regression guard.
+    let opts = RestoreOptions {
+        overwrite_directories: Some(false),
+        overwrite_symlinks: Some(false),
+        write_sparse_files: Some(false),
+        skip_owners: Some(false),
+        skip_permissions: Some(false),
+        skip_times: Some(false),
+        ignore_errors: Some(false),
+        delete_extra: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(
+        restore_args("s", "/t", &opts),
+        vec![
+            "snapshot",
+            "restore",
+            "s",
+            "/t",
+            "--no-overwrite-directories",
+            "--no-overwrite-symlinks",
+            "--no-write-sparse-files",
+            "--no-skip-owners",
+            "--no-skip-permissions",
+            "--no-skip-times",
+            "--no-ignore-errors",
+            "--no-delete-extra",
+        ]
+    );
+
+    // The `Some(true)` form emits the bare (non-negated) flag — this is the
+    // regression test for the `enableFileDeletion` bug: today's code has NO
+    // path that can ever produce `--delete-extra` on argv.
+    let all_true = RestoreOptions {
+        overwrite_directories: Some(true),
+        overwrite_symlinks: Some(true),
+        write_sparse_files: Some(true),
+        skip_owners: Some(true),
+        skip_permissions: Some(true),
+        skip_times: Some(true),
+        ignore_errors: Some(true),
+        skip_existing: Some(true),
+        delete_extra: Some(true),
+        ..Default::default()
+    };
+    let argv = restore_args("s", "/t", &all_true);
+    for flag in [
+        "--overwrite-directories",
+        "--overwrite-symlinks",
+        "--write-sparse-files",
+        "--skip-owners",
+        "--skip-permissions",
+        "--skip-times",
+        "--ignore-errors",
+        "--skip-existing",
+        "--delete-extra",
+    ] {
+        assert!(
+            argv.contains(&flag.to_string()),
+            "{flag} missing in {argv:?}"
+        );
+    }
+
+    // All-`None` (the zero-value default) is byte-for-byte identical to the
+    // pre-M2 bare argv (no dormant knob sneaks a flag in when nothing was set).
+    assert_eq!(
+        restore_args("s", "/t", &RestoreOptions::default()),
+        vec!["snapshot", "restore", "s", "/t"]
     );
 }
 

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -543,6 +543,8 @@ fn verify_args_builds_flags() {
         verify_files_percent: Some(10),
         max_errors: Some(3),
         parallel: Some(8),
+        file_parallelism: None,
+        file_queue_length: None,
     };
     assert_eq!(
         verify_args(&opts),
@@ -555,6 +557,31 @@ fn verify_args_builds_flags() {
             "3",
             "--parallel",
             "8"
+        ]
+    );
+
+    // The two new knobs (M3 / issue #216 category sweep) — each independently absent
+    // by default, and both emitted in kopia's `snapshot verify --help` order when set.
+    let opts_full = VerifyOptions {
+        verify_files_percent: None,
+        max_errors: Some(1),
+        parallel: Some(2),
+        file_parallelism: Some(4),
+        file_queue_length: Some(100),
+    };
+    assert_eq!(
+        verify_args(&opts_full),
+        vec![
+            "snapshot",
+            "verify",
+            "--max-errors",
+            "1",
+            "--parallel",
+            "2",
+            "--file-parallelism",
+            "4",
+            "--file-queue-length",
+            "100"
         ]
     );
 }

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -529,8 +529,9 @@ fn direct_credential_env_names_per_backend() {
 
 #[test]
 fn sync_to_args_builds_destination_and_flags() {
-    // ADR-0005 §13(d): destination backend args (+ optional --delete). `--must-exist`
-    // is OMITTED (its kopia default is false; `--must-exist=false` is a parse error).
+    // ADR-0005 §13(d) / issue #216: destination backend args + tuning flags.
+    // All-`None`/`false` opts must yield EXACTLY today's argv (no dormant knob
+    // sneaks a flag in when nothing was configured).
     let dest = ConnectSpec::S3 {
         bucket: "mirror".into(),
         endpoint: Some("https://offsite".into()),
@@ -541,7 +542,7 @@ fn sync_to_args_builds_destination_and_flags() {
         ambient_credentials: false,
     };
     assert_eq!(
-        sync_to_args(&dest, false),
+        sync_to_args(&dest, &SyncToOptions::default()),
         vec![
             "repository",
             "sync-to",
@@ -554,18 +555,24 @@ fn sync_to_args_builds_destination_and_flags() {
             "us-east-1",
         ]
     );
-    // No `--must-exist=false` (it would fail kopia's flag parser).
+    // No `must-exist`/`times`/`update` flag at all when unset.
     assert!(
-        !sync_to_args(&dest, false)
+        !sync_to_args(&dest, &SyncToOptions::default())
             .iter()
-            .any(|a| a.contains("must-exist"))
+            .any(|a| a.contains("must-exist") || a.contains("times") || a.contains("update"))
     );
     // delete_extra appends --delete (a true mirror).
     let fs = ConnectSpec::Filesystem {
         path: "/mirror".into(),
     };
     assert_eq!(
-        sync_to_args(&fs, true),
+        sync_to_args(
+            &fs,
+            &SyncToOptions {
+                delete_extra: true,
+                ..Default::default()
+            }
+        ),
         vec![
             "repository",
             "sync-to",
@@ -574,6 +581,55 @@ fn sync_to_args_builds_destination_and_flags() {
             "/mirror",
             "--delete"
         ]
+    );
+}
+
+#[test]
+fn sync_to_args_builds_parallel_and_tristates_and_speeds() {
+    // #216: --parallel is the headline fix; the tri-states use the SAME
+    // --no-* negated form as `snapshot restore` (push_tristate), not the
+    // `policy set` `--flag=false` grammar.
+    let fs = ConnectSpec::Filesystem {
+        path: "/mirror".into(),
+    };
+    let opts = SyncToOptions {
+        parallel: Some(8),
+        delete_extra: false,
+        must_exist: Some(false),
+        times: Some(true),
+        update: Some(false),
+        max_download_speed_bytes_per_second: Some(1_000_000),
+        max_upload_speed_bytes_per_second: Some(500_000),
+    };
+    assert_eq!(
+        sync_to_args(&fs, &opts),
+        vec![
+            "repository",
+            "sync-to",
+            "filesystem",
+            "--path",
+            "/mirror",
+            "--parallel",
+            "8",
+            "--no-must-exist",
+            "--times",
+            "--no-update",
+            "--max-download-speed",
+            "1000000",
+            "--max-upload-speed",
+            "500000",
+        ]
+    );
+    // The `Some(true)` form emits the bare (non-negated) flag.
+    assert!(
+        sync_to_args(
+            &fs,
+            &SyncToOptions {
+                must_exist: Some(true),
+                ..Default::default()
+            }
+        )
+        .contains(&"--must-exist".to_string())
     );
 }
 
@@ -611,7 +667,10 @@ async fn sync_to_env_overlay_sets_destination_and_unsets_source_only_vars() {
     };
 
     // No overlay → the source credentials pass through unchanged.
-    client.repository_sync_to(&dest, false).await.unwrap();
+    client
+        .repository_sync_to(&dest, &SyncToOptions::default())
+        .await
+        .unwrap();
     assert_eq!(
         std::fs::read_to_string(&out).unwrap().trim(),
         "KEY=source-key TOKEN=source-token"
@@ -627,7 +686,7 @@ async fn sync_to_env_overlay_sets_destination_and_unsets_source_only_vars() {
         ("AWS_SESSION_TOKEN".to_string(), None),
     ]);
     client
-        .repository_sync_to_with_env(&dest, false, &overlay)
+        .repository_sync_to_with_env(&dest, &SyncToOptions::default(), &overlay)
         .await
         .unwrap();
     assert_eq!(

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -534,6 +534,71 @@ fn restore_args_m2_flag_sweep_all_new_tristates_and_delete_extra() {
 }
 
 #[test]
+fn snapshot_create_args_default_is_todays_argv() {
+    // M4 flag sweep (issue #216 category sweep): all-default `opts` must
+    // reproduce the pre-M4 argv byte-for-byte — no dormant knob sneaks a flag
+    // in when nothing was set.
+    let mut tags = BTreeMap::new();
+    tags.insert("app".to_string(), "db".to_string());
+    assert_eq!(
+        snapshot_create_args("/data", &tags, None, &SnapshotCreateOptions::default()),
+        vec!["snapshot", "create", "/data", "--json", "--tags", "app:db"]
+    );
+    assert_eq!(
+        snapshot_create_args(
+            "/data",
+            &BTreeMap::new(),
+            Some("u@h:/data"),
+            &SnapshotCreateOptions::default()
+        ),
+        vec![
+            "snapshot",
+            "create",
+            "/data",
+            "--json",
+            "--override-source",
+            "u@h:/data"
+        ]
+    );
+}
+
+#[test]
+fn snapshot_create_args_fail_fast_upload_limit_and_description() {
+    // Smoke-tested against pinned kopia 0.23.1: `snapshot create --fail-fast
+    // --upload-limit-mb 100 --description "smoke test"` is accepted.
+    let opts = SnapshotCreateOptions {
+        fail_fast: Some(true),
+        upload_limit_mb: Some(100),
+        description: Some("smoke test".to_string()),
+    };
+    assert_eq!(
+        snapshot_create_args("/data", &BTreeMap::new(), None, &opts),
+        vec![
+            "snapshot",
+            "create",
+            "/data",
+            "--json",
+            "--fail-fast",
+            "--upload-limit-mb",
+            "100",
+            "--description",
+            "smoke test"
+        ]
+    );
+    // `fail_fast: Some(false)` emits the negated kingpin form, same grammar as
+    // `snapshot restore`'s tri-states (push_tristate), not `policy set`'s
+    // valued tri-states.
+    let opts_false = SnapshotCreateOptions {
+        fail_fast: Some(false),
+        ..Default::default()
+    };
+    assert_eq!(
+        snapshot_create_args("/data", &BTreeMap::new(), None, &opts_false),
+        vec!["snapshot", "create", "/data", "--json", "--no-fail-fast"]
+    );
+}
+
+#[test]
 fn verify_args_builds_flags() {
     assert_eq!(
         verify_args(&VerifyOptions::default()),

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -10,8 +10,8 @@ pub mod session;
 
 pub use client::{
     CacheTuning, ConnectSpec, CreateOptions, KopiaClient, KopiaClientBuilder, MaintenanceMode,
-    PolicyArgs, RestoreOptions, ServerAuthMode, ServerStartSpec, SyncToOptions, ThrottleArgs,
-    VerifyOptions, split_policy_scopes,
+    PolicyArgs, RestoreOptions, ServerAuthMode, ServerStartSpec, SnapshotCreateOptions,
+    SyncToOptions, ThrottleArgs, VerifyOptions, split_policy_scopes,
 };
 pub use error::{KopiaError, KopiaErrorClass, notfound_is_uninitialized};
 pub use model::{

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -10,8 +10,8 @@ pub mod session;
 
 pub use client::{
     CacheTuning, ConnectSpec, CreateOptions, KopiaClient, KopiaClientBuilder, MaintenanceMode,
-    PolicyArgs, RestoreOptions, ServerAuthMode, ServerStartSpec, ThrottleArgs, VerifyOptions,
-    split_policy_scopes,
+    PolicyArgs, RestoreOptions, ServerAuthMode, ServerStartSpec, SyncToOptions, ThrottleArgs,
+    VerifyOptions, split_policy_scopes,
 };
 pub use error::{KopiaError, KopiaErrorClass, notfound_is_uninitialized};
 pub use model::{

--- a/crates/kopia/tests/fake_shim.rs
+++ b/crates/kopia/tests/fake_shim.rs
@@ -354,9 +354,34 @@ async fn snapshot_verify_passes_flags() {
             verify_files_percent: Some(5),
             max_errors: Some(0),
             parallel: None,
+            file_parallelism: None,
+            file_queue_length: None,
         })
         .await
         .expect("verify flags must pass through");
+}
+
+#[tokio::test]
+async fn snapshot_verify_passes_parallelism_flags() {
+    // M3 (issue #216 category sweep): the two new tuning knobs must reach argv too.
+    // Smoke-tested against the pinned kopia 0.23.1: `snapshot verify --parallel 2
+    // --file-parallelism 4 --file-queue-length 100 --max-errors 1` is accepted;
+    // `verify_args`'s own field order (max-errors, parallel, file-parallelism,
+    // file-queue-length) is just as valid to kopia's kingpin parser.
+    let s = argv_gate_shim(
+        "snapshot verify --max-errors 1 --parallel 2 --file-parallelism 4 --file-queue-length 100",
+    );
+    let client = client_for(&s);
+    client
+        .snapshot_verify(&VerifyOptions {
+            verify_files_percent: None,
+            max_errors: Some(1),
+            parallel: Some(2),
+            file_parallelism: Some(4),
+            file_queue_length: Some(100),
+        })
+        .await
+        .expect("verify parallelism flags must pass through");
 }
 
 #[tokio::test]

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -350,3 +350,77 @@ async fn sync_to_accepts_parallel_and_tristate_flags() {
         "the mirrored snapshot must appear at the destination"
     );
 }
+
+/// Real-kopia guard for the M2 restore flag sweep (issue #216 gap analysis):
+/// `kopia snapshot restore` accepts `--parallel 2`, `--skip-times`, and —
+/// critically — `--delete-extra`, the flag `enableFileDeletion` was
+/// **previously unable to reach at all** (a silent no-op bug: the CRD field
+/// existed, but `kopiur_kopia::RestoreOptions` had no `delete_extra` field and
+/// `restore_args` never emitted the flag). Restoring into a target that
+/// already contains a file NOT present in the snapshot proves `--delete-extra`
+/// actually deletes it — not just that kopia accepted the flag on argv.
+///
+/// Per the semantic gotcha: `--delete-extra` only takes effect if the restore
+/// itself succeeds, and kopia's `overwrite-directories` default is already
+/// `true`, so this test must NOT pass `--no-overwrite-directories` (that would
+/// make the restore fail against the pre-populated, non-empty target).
+#[tokio::test]
+#[cfg_attr(not(feature = "integration"), ignore)]
+async fn restore_accepts_m2_flag_sweep_and_deletes_extra_files() {
+    let repo_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+    let restore_dir = tempfile::tempdir().unwrap();
+
+    std::fs::write(source_dir.path().join("keep.txt"), b"from the snapshot\n").unwrap();
+
+    let client = isolated_client(config_dir.path());
+    client
+        .repository_create(
+            &ConnectSpec::Filesystem {
+                path: repo_dir.path().to_path_buf(),
+            },
+            Default::default(),
+            &Default::default(),
+        )
+        .await
+        .expect("repository create");
+    let created = client
+        .snapshot_create(
+            source_dir.path().to_str().unwrap(),
+            &BTreeMap::new(),
+            Some("m2user@m2host:/data"),
+        )
+        .await
+        .expect("snapshot create");
+
+    // Pre-populate the restore target with a file NOT in the snapshot — the
+    // thing `--delete-extra` is supposed to remove. Without `enableFileDeletion`
+    // wired up, this file would silently survive the restore (the additive-only
+    // bug this milestone fixes).
+    std::fs::write(restore_dir.path().join("stale.txt"), b"leftover\n").unwrap();
+
+    client
+        .snapshot_restore_with(
+            &created.id,
+            restore_dir.path().to_str().unwrap(),
+            &RestoreOptions {
+                parallel: Some(2),
+                skip_times: Some(true),
+                delete_extra: Some(true),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("restore with --parallel 2 --skip-times --delete-extra should succeed");
+
+    // The snapshot's content is present...
+    let kept = std::fs::read(restore_dir.path().join("keep.txt")).expect("keep.txt restored");
+    assert_eq!(kept, b"from the snapshot\n");
+    // ...and the pre-existing extra file is GONE — proving kopia actually
+    // accepted and acted on `--delete-extra`, not just that argv parsed.
+    assert!(
+        !restore_dir.path().join("stale.txt").exists(),
+        "stale.txt should have been deleted by --delete-extra"
+    );
+}

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -429,3 +429,57 @@ async fn restore_accepts_m2_flag_sweep_and_deletes_extra_files() {
         "stale.txt should have been deleted by --delete-extra"
     );
 }
+
+#[tokio::test]
+#[cfg_attr(not(feature = "integration"), ignore)]
+async fn snapshot_create_accepts_m4_flag_sweep_and_records_the_description() {
+    // M4 flag sweep (issue #216 category sweep): `snapshot create --fail-fast
+    // --upload-limit-mb <n> --description <text>` is accepted by real kopia
+    // (smoke-tested against 0.23.1 in the design doc; this is the permanent
+    // guard), and the description round-trips onto the created snapshot's
+    // JSON (not just accepted argv).
+    let repo_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+
+    std::fs::write(source_dir.path().join("a.txt"), b"m4 flag sweep\n").unwrap();
+
+    let client = isolated_client(config_dir.path());
+    client
+        .repository_create(
+            &ConnectSpec::Filesystem {
+                path: repo_dir.path().to_path_buf(),
+            },
+            Default::default(),
+            &Default::default(),
+        )
+        .await
+        .expect("repository create");
+
+    let created = client
+        .snapshot_create_with(
+            source_dir.path().to_str().unwrap(),
+            &BTreeMap::new(),
+            Some("m4user@m4host:/data"),
+            &kopiur_kopia::SnapshotCreateOptions {
+                fail_fast: Some(true),
+                upload_limit_mb: Some(100),
+                description: Some("m4 flag sweep smoke test".to_string()),
+            },
+        )
+        .await
+        .expect("snapshot create --fail-fast --upload-limit-mb 100 --description should succeed");
+    assert_eq!(created.description, "m4 flag sweep smoke test");
+
+    // `snapshot list` shows the same description was actually persisted on
+    // the manifest, not just echoed back by `create`'s own JSON.
+    let list = client
+        .snapshot_list(None)
+        .await
+        .expect("snapshot list after m4 create");
+    let entry = list
+        .iter()
+        .find(|e| e.id == created.id)
+        .expect("created snapshot present in list");
+    assert_eq!(entry.description, "m4 flag sweep smoke test");
+}

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -1,10 +1,12 @@
 //! Real kopia filesystem round-trip integration test.
 //!
 //! Gated behind the `integration` feature and `#[ignore]` by default so the
-//! hermetic `cargo test` never invokes the real binary. Run with:
+//! hermetic `cargo test` never invokes the real binary (the `integration`
+//! feature lifts the `#[ignore]`, so it is not needed on the command line).
+//! Run with:
 //!
 //! ```text
-//! cargo test -p kopiur-kopia --features integration -- --ignored
+//! cargo test -p kopiur-kopia --features integration
 //! ```
 //!
 //! It creates a filesystem repo in a tempdir, snapshots a tempdir with known
@@ -325,6 +327,9 @@ async fn sync_to_accepts_parallel_and_tristate_flags() {
             &SyncToOptions {
                 parallel: Some(2),
                 times: Some(false),
+                must_exist: Some(false),
+                update: Some(false),
+                max_upload_speed_bytes_per_second: Some(1_000_000),
                 ..Default::default()
             },
         )

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -221,14 +221,19 @@ async fn verbs_roundtrip() {
         "ignore policy should exclude *.tmp"
     );
 
-    // Verify integrity (read 100% of files).
+    // Verify integrity (read 100% of files). Also exercises the M3 (issue #216
+    // category sweep) tuning knobs `--file-parallelism`/`--file-queue-length`
+    // against the real kopia binary — the permanent regression guard that kopia
+    // actually accepts these flag forms, not just that the argv shape looks right.
     client
         .snapshot_verify(&VerifyOptions {
             verify_files_percent: Some(100),
+            file_parallelism: Some(2),
+            file_queue_length: Some(100),
             ..Default::default()
         })
         .await
-        .expect("verify");
+        .expect("verify with file-parallelism/file-queue-length");
 
     // Restore honoring options (atomic writes, ignore permission errors).
     client

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -16,7 +16,8 @@
 use std::collections::BTreeMap;
 
 use kopiur_kopia::{
-    ConnectSpec, KopiaClient, MaintenanceMode, PolicyArgs, RestoreOptions, VerifyOptions,
+    ConnectSpec, KopiaClient, MaintenanceMode, PolicyArgs, RestoreOptions, SyncToOptions,
+    VerifyOptions,
 };
 
 /// Build a client whose env isolates kopia state inside `config_dir` so the
@@ -267,5 +268,85 @@ async fn verbs_roundtrip() {
     assert!(
         !restore_dir.path().join("skip.tmp").exists(),
         "ignored file should not be in the snapshot/restore"
+    );
+}
+
+/// Real-kopia guard for issue #216: `kopia repository sync-to` accepts the
+/// tuning flags `sync_to_args` builds — `--parallel`, the `--no-*` tri-state
+/// forms (`--no-times`), and the throughput caps — against a real filesystem
+/// destination. This is the permanent regression guard for the kingpin
+/// flag-form risk noted on `sync_to_args`/`push_tristate`: a bad flag SHAPE
+/// (e.g. `--must-exist=false`) would fail here even though the pure arg-builder
+/// unit tests only check the argv shape, not that kopia accepts it.
+#[tokio::test]
+#[cfg_attr(not(feature = "integration"), ignore)]
+async fn sync_to_accepts_parallel_and_tristate_flags() {
+    let source_repo_dir = tempfile::tempdir().unwrap();
+    let dest_repo_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+
+    std::fs::write(source_dir.path().join("a.txt"), b"hello sync-to\n").unwrap();
+
+    let client = isolated_client(config_dir.path());
+    client
+        .repository_create(
+            &ConnectSpec::Filesystem {
+                path: source_repo_dir.path().to_path_buf(),
+            },
+            Default::default(),
+            &Default::default(),
+        )
+        .await
+        .expect("source repository create");
+    client
+        .snapshot_create(
+            source_dir.path().to_str().unwrap(),
+            &BTreeMap::new(),
+            Some("syncuser@synchost:/data"),
+        )
+        .await
+        .expect("snapshot create");
+
+    // `--parallel 2 --no-times`: the exact flag combo the brief calls out as
+    // smoke-tested against kopia 0.23.1. A wrong flag GRAMMAR (e.g.
+    // `--must-exist=false` instead of `--no-must-exist`) fails here with a
+    // kopia argv-parse error, not a silently-wrong result.
+    client
+        .repository_sync_to(
+            &ConnectSpec::Filesystem {
+                path: dest_repo_dir.path().to_path_buf(),
+            },
+            &SyncToOptions {
+                parallel: Some(2),
+                times: Some(false),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("sync-to with --parallel 2 --no-times should succeed");
+
+    // The destination is now itself a connectable repository with the mirrored
+    // snapshot — proving the copy (not just a successful exit code) happened.
+    let dest_config_dir = config_dir.path().join("dest");
+    std::fs::create_dir_all(&dest_config_dir).unwrap();
+    let dest_client = isolated_client(&dest_config_dir);
+    dest_client
+        .repository_connect(
+            &ConnectSpec::Filesystem {
+                path: dest_repo_dir.path().to_path_buf(),
+            },
+            Default::default(),
+        )
+        .await
+        .expect("connect to the sync-to destination");
+    let list = dest_client
+        .snapshot_list(None)
+        .await
+        .expect("list destination snapshots");
+    assert_eq!(
+        list.len(),
+        1,
+        "the mirrored snapshot must appear at the destination"
     );
 }

--- a/crates/mover/README.md
+++ b/crates/mover/README.md
@@ -70,6 +70,9 @@ let spec = MoverWorkSpec {
         source_path: "/data".into(),
         tags: BTreeMap::new(),
         policy: Default::default(),
+        fail_fast: None,
+        upload_limit_mb: None,
+        description: None,
     }),
     identity: ResolvedIdentity {
         username: "mydb".into(),

--- a/crates/mover/src/jobs.rs
+++ b/crates/mover/src/jobs.rs
@@ -803,6 +803,9 @@ mod tests {
                 source_path: "/data".into(),
                 tags: BTreeMap::new(),
                 policy: Default::default(),
+                fail_fast: None,
+                upload_limit_mb: None,
+                description: None,
             }),
             identity: ResolvedIdentity {
                 username: "db".into(),

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -1357,7 +1357,17 @@ async fn run_verify_flow(
                 error!(class = %err.kopia_class(), "deep verify scratch path not writable");
                 return Err(err);
             }
-            if let Err(e) = client.snapshot_restore(&id, &d.scratch_path).await {
+            if let Err(e) = client
+                .snapshot_restore_with(
+                    &id,
+                    &d.scratch_path,
+                    &kopiur_kopia::RestoreOptions {
+                        parallel: d.parallel,
+                        ..Default::default()
+                    },
+                )
+                .await
+            {
                 patch_verify_status(&spec.target_ref, &verify_failed_body(&e.to_string())).await;
                 error!(class = %e.class(), "deep verify scratch-restore failed");
                 return Err(MoverError::Kopia {

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -401,7 +401,12 @@ async fn run_operation(
                 }
             }
             let result = client
-                .snapshot_create(&op.source_path, &op.tags, Some(&override_source))
+                .snapshot_create_with(
+                    &op.source_path,
+                    &op.tags,
+                    Some(&override_source),
+                    &op.create_options(),
+                )
                 .await
                 .map_err(kopia(KopiaOp::SnapshotCreate))?;
             // kopia exits non-zero (→ a classified `PermissionDenied` failure above) when

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -1518,7 +1518,7 @@ async fn run_replicate_flow(
     let dest_env = credentials::dest_env_overlay(&dest, &raw_env);
 
     if let Err(e) = client
-        .repository_sync_to_with_env(&dest, op.delete_extra, &dest_env)
+        .repository_sync_to_with_env(&dest, &op.sync_options(), &dest_env)
         .await
     {
         patch_replicate_status(&spec.target_ref, &replicate_failed_body(&e.to_string())).await;

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -100,6 +100,33 @@ pub struct SnapshotOp {
     /// (ADR-0005 §13(b)/§13(f), ADR-0004 §4b). Empty ⇒ leave kopia's defaults.
     #[serde(default, skip_serializing_if = "PolicyArgsSpec::is_empty")]
     pub policy: PolicyArgsSpec,
+    /// `snapshot create --[no-]fail-fast` (M4 flag sweep, issue #216 category
+    /// sweep). Resolved from `SnapshotPolicy.spec.errorHandling.failFast`.
+    /// `#[serde(default)]` so old-wire work-spec JSON (stamped before this
+    /// field existed) still decodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fail_fast: Option<bool>,
+    /// `snapshot create --upload-limit-mb` (M4 flag sweep). Resolved from
+    /// `SnapshotPolicy.spec.upload.limitMb`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upload_limit_mb: Option<i64>,
+    /// `snapshot create --description` (M4 flag sweep). Per-invocation, from
+    /// `Snapshot.spec.description` (not the recipe) — scheduled/discovered
+    /// runs never set this.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+impl SnapshotOp {
+    /// Translate the carried `snapshot create` flags into the kopia client's
+    /// options. Pure so the workspec→kopia-client mapping is unit-testable.
+    pub fn create_options(&self) -> kopiur_kopia::SnapshotCreateOptions {
+        kopiur_kopia::SnapshotCreateOptions {
+            fail_fast: self.fail_fast,
+            upload_limit_mb: self.upload_limit_mb,
+            description: self.description.clone(),
+        }
+    }
 }
 
 /// Serializable mirror of [`kopiur_kopia::PolicyArgs`] for the work spec (the kopia
@@ -1102,6 +1129,9 @@ impl Default for MoverOptions {
 ///         source_path: "/data".into(),
 ///         tags: BTreeMap::new(),
 ///         policy: Default::default(),
+///         fail_fast: None,
+///         upload_limit_mb: None,
+///         description: None,
 ///     }),
 ///     identity: ResolvedIdentity {
 ///         username: "mydb".into(),

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -645,6 +645,51 @@ pub struct ReplicateOp {
     /// (additive sync) — safer, so a misconfigured destination is never emptied.
     #[serde(default)]
     pub delete_extra: bool,
+    /// `--parallel`: copy parallelism to the destination (issue #216; kopia
+    /// default `1` — sequential). `#[serde(default)]` so old-wire work-spec JSON
+    /// (stamped before this field existed) still decodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
+    /// `--[no-]must-exist`: fail instead of initializing the destination's
+    /// repository-format blob (kopia default `false`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub must_exist: Option<bool>,
+    /// `--[no-]times`: synchronize blob modification times to the destination
+    /// (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub times: Option<bool>,
+    /// `--[no-]update`: update blobs already present at the destination when the
+    /// source copy is newer (kopia default `true`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub update: Option<bool>,
+    /// `--max-download-speed`: cap read throughput from the source, bytes/sec
+    /// (kopia default: unlimited).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_download_speed_bytes_per_second: Option<i64>,
+    /// `--max-upload-speed`: cap write throughput to the destination, bytes/sec
+    /// (kopia default: unlimited).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_upload_speed_bytes_per_second: Option<i64>,
+}
+
+impl ReplicateOp {
+    /// Project this op's sync-tuning fields into a
+    /// [`SyncToOptions`](kopiur_kopia::SyncToOptions) for
+    /// `KopiaClient::repository_sync_to_with_env`. Pure so the field → option
+    /// mapping is unit-testable without a kopia binary (the regression guard for
+    /// this whole gap class: plumbing that exists but a hardcoded `None` never
+    /// reaches it).
+    pub fn sync_options(&self) -> kopiur_kopia::SyncToOptions {
+        kopiur_kopia::SyncToOptions {
+            parallel: self.parallel,
+            delete_extra: self.delete_extra,
+            must_exist: self.must_exist,
+            times: self.times,
+            update: self.update,
+            max_download_speed_bytes_per_second: self.max_download_speed_bytes_per_second,
+            max_upload_speed_bytes_per_second: self.max_upload_speed_bytes_per_second,
+        }
+    }
 }
 
 /// Payload for a browse-session run (M7a). The session pod connects read-only,

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -370,10 +370,51 @@ pub struct RestoreOp {
     /// use its default.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub write_files_atomically: Option<bool>,
+    /// `--parallel` (M2 flag sweep). `#[serde(default)]` so old-wire work-spec
+    /// JSON (stamped before this field existed) still decodes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
+    /// `--[no-]write-sparse-files` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub write_sparse_files: Option<bool>,
+    /// `--[no-]skip-owners` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_owners: Option<bool>,
+    /// `--[no-]skip-permissions` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_permissions: Option<bool>,
+    /// `--[no-]skip-times` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_times: Option<bool>,
+    /// `--[no-]overwrite-files` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_files: Option<bool>,
+    /// `--[no-]overwrite-directories` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_directories: Option<bool>,
+    /// `--[no-]overwrite-symlinks` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub overwrite_symlinks: Option<bool>,
+    /// `--[no-]ignore-errors` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ignore_errors: Option<bool>,
+    /// `--[no-]skip-existing` (M2 flag sweep).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_existing: Option<bool>,
+    /// `--[no-]delete-extra`: mirrors Restore CRD `options.enableFileDeletion`
+    /// (`false` by default). Fixes the bug where `enableFileDeletion` was
+    /// settable via CRD/CLI/migrate but consumed by nothing — kopia never
+    /// received `--delete-extra`, so an "exact mirror" restore was silently
+    /// additive.
+    #[serde(default)]
+    pub delete_extra: bool,
 }
 
 impl RestoreOp {
     /// Translate the carried restore flags into the kopia client's options.
+    /// Every field is mapped explicitly (no `..Default::default()` swallowing a
+    /// field silently) — this is the regression guard for the M2 gap-sweep bug
+    /// class: plumbing that exists end-to-end but a field never reaches it.
     ///
     /// ```
     /// use kopiur_mover::workspec::{RestoreOp, RestoreSelection};
@@ -384,16 +425,42 @@ impl RestoreOp {
     ///     anchor: Default::default(),
     ///     ignore_permission_errors: Some(false),
     ///     write_files_atomically: Some(true),
+    ///     parallel: Some(4),
+    ///     write_sparse_files: Some(true),
+    ///     skip_owners: Some(true),
+    ///     skip_permissions: Some(false),
+    ///     skip_times: Some(true),
+    ///     overwrite_files: Some(false),
+    ///     overwrite_directories: Some(false),
+    ///     overwrite_symlinks: Some(true),
+    ///     ignore_errors: Some(false),
+    ///     skip_existing: Some(true),
+    ///     delete_extra: true,
     /// };
     /// let opts = op.restore_options();
     /// assert_eq!(opts.ignore_permission_errors, Some(false));
     /// assert_eq!(opts.write_files_atomically, Some(true));
+    /// assert_eq!(opts.parallel, Some(4));
+    /// assert_eq!(opts.delete_extra, Some(true));
     /// ```
     pub fn restore_options(&self) -> kopiur_kopia::RestoreOptions {
         kopiur_kopia::RestoreOptions {
             ignore_permission_errors: self.ignore_permission_errors,
             write_files_atomically: self.write_files_atomically,
-            ..Default::default()
+            parallel: self.parallel,
+            write_sparse_files: self.write_sparse_files,
+            skip_owners: self.skip_owners,
+            skip_permissions: self.skip_permissions,
+            skip_times: self.skip_times,
+            overwrite_files: self.overwrite_files,
+            overwrite_directories: self.overwrite_directories,
+            overwrite_symlinks: self.overwrite_symlinks,
+            ignore_errors: self.ignore_errors,
+            skip_existing: self.skip_existing,
+            // `enableFileDeletion` stays a plain bool at the CRD/work-spec layer
+            // (no tri-state is exposed); `false` omits the flag entirely, exactly
+            // reproducing today's (additive) argv.
+            delete_extra: self.delete_extra.then_some(true),
         }
     }
 }

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -653,6 +653,14 @@ pub struct QuickVerify {
     /// `--parallel`: verification parallelism.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parallel: Option<u32>,
+    /// `--file-parallelism`: parallelism for file verification. `#[serde(default)]`
+    /// so old-wire work specs (predating this field) still decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_parallelism: Option<u32>,
+    /// `--file-queue-length`: queue length for file verification. `#[serde(default)]`
+    /// so old-wire work specs (predating this field) still decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub file_queue_length: Option<u32>,
 }
 
 impl QuickVerify {
@@ -662,6 +670,8 @@ impl QuickVerify {
             verify_files_percent: self.verify_files_percent,
             max_errors: self.max_errors,
             parallel: self.parallel,
+            file_parallelism: self.file_parallelism,
+            file_queue_length: self.file_queue_length,
         }
     }
 }
@@ -680,6 +690,11 @@ pub struct DeepVerify {
     /// the identity); `None` lets the mover resolve the latest itself.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub snapshot_id: Option<String>,
+    /// `restore --parallel`: restore parallelism for the scratch-restore (deep
+    /// verify IS a restore under the hood). `#[serde(default)]` so old-wire work
+    /// specs (predating this field) still decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel: Option<u32>,
 }
 
 /// Payload for a verification run (ADR-0005 §4). Owns its own connect lifecycle

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -900,6 +900,12 @@ fn replicate_roundtrip_and_wire_shape() {
                 ambient_credentials: false,
             },
             delete_extra: true,
+            parallel: Some(8),
+            must_exist: Some(false),
+            times: Some(true),
+            update: Some(false),
+            max_download_speed_bytes_per_second: Some(1_000_000),
+            max_upload_speed_bytes_per_second: Some(500_000),
         }),
         // The source repository the mover connects to.
         identity: ResolvedIdentity {
@@ -928,6 +934,18 @@ fn replicate_roundtrip_and_wire_shape() {
         "mirror"
     );
     assert_eq!(v["operation"]["replicate"]["deleteExtra"], true);
+    assert_eq!(v["operation"]["replicate"]["parallel"], 8);
+    assert_eq!(v["operation"]["replicate"]["mustExist"], false);
+    assert_eq!(v["operation"]["replicate"]["times"], true);
+    assert_eq!(v["operation"]["replicate"]["update"], false);
+    assert_eq!(
+        v["operation"]["replicate"]["maxDownloadSpeedBytesPerSecond"],
+        1_000_000
+    );
+    assert_eq!(
+        v["operation"]["replicate"]["maxUploadSpeedBytesPerSecond"],
+        500_000
+    );
     // The destination converts to the kopia client connect spec.
     if let Operation::Replicate(op) = &spec.operation {
         assert_eq!(
@@ -942,7 +960,49 @@ fn replicate_roundtrip_and_wire_shape() {
                 ambient_credentials: false,
             }
         );
+        // #216 controller-glue guard: every new op field reaches the kopia
+        // client's SyncToOptions — no dormant plumbing.
+        assert_eq!(
+            op.sync_options(),
+            kopiur_kopia::SyncToOptions {
+                parallel: Some(8),
+                delete_extra: true,
+                must_exist: Some(false),
+                times: Some(true),
+                update: Some(false),
+                max_download_speed_bytes_per_second: Some(1_000_000),
+                max_upload_speed_bytes_per_second: Some(500_000),
+            }
+        );
     } else {
         panic!("expected replicate op");
     }
+}
+
+#[test]
+fn replicate_op_old_wire_decodes_with_sync_fields_defaulted() {
+    // #216: a work-spec ConfigMap written before `sync` tuning existed (just
+    // `destination` + `deleteExtra`) must still decode — the mover pairs one
+    // controller+mover image per Job, but old ConfigMaps can persist across a
+    // rolling restart. `#[serde(default)]` on every new field is the guard.
+    let legacy = serde_json::json!({
+        "destination": { "filesystem": { "path": "/mirror" } },
+        "deleteExtra": true,
+    });
+    let op: ReplicateOp = serde_json::from_value(legacy).expect("legacy replicate op decodes");
+    assert!(op.delete_extra);
+    assert_eq!(op.parallel, None);
+    assert_eq!(op.must_exist, None);
+    assert_eq!(op.times, None);
+    assert_eq!(op.update, None);
+    assert_eq!(op.max_download_speed_bytes_per_second, None);
+    assert_eq!(op.max_upload_speed_bytes_per_second, None);
+    // All-None sync fields reproduce today's SyncToOptions exactly.
+    assert_eq!(
+        op.sync_options(),
+        kopiur_kopia::SyncToOptions {
+            delete_extra: true,
+            ..Default::default()
+        }
+    );
 }

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -32,6 +32,9 @@ fn backup_roundtrip() {
             source_path: "/data".into(),
             tags,
             policy: Default::default(),
+            fail_fast: None,
+            upload_limit_mb: None,
+            description: None,
         }),
         identity: sample_identity(),
         repository: RepositoryConnect::Filesystem {
@@ -48,6 +51,56 @@ fn backup_roundtrip() {
     };
     assert_eq!(roundtrip(&spec), spec);
     assert_eq!(spec.operation.kind_str(), "Snapshot");
+}
+
+#[test]
+fn snapshot_op_create_knobs_roundtrip_wire_shape_and_map_to_kopia() {
+    // M4 flag sweep (issue #216 category sweep): failFast/uploadLimitMb/
+    // description round-trip on the wire, serialize under their camelCase
+    // names, and `create_options()` carries them into the kopia client's
+    // `SnapshotCreateOptions` unchanged.
+    let op = SnapshotOp {
+        source_path: "/data".into(),
+        tags: BTreeMap::new(),
+        policy: Default::default(),
+        fail_fast: Some(true),
+        upload_limit_mb: Some(250),
+        description: Some("pre-upgrade snapshot".into()),
+    };
+    let json = serde_json::to_value(&op).unwrap();
+    assert_eq!(json["failFast"], true);
+    assert_eq!(json["uploadLimitMb"], 250);
+    assert_eq!(json["description"], "pre-upgrade snapshot");
+    let reparsed: SnapshotOp = serde_json::from_value(json).unwrap();
+    assert_eq!(reparsed, op);
+    assert_eq!(
+        op.create_options(),
+        kopiur_kopia::SnapshotCreateOptions {
+            fail_fast: Some(true),
+            upload_limit_mb: Some(250),
+            description: Some("pre-upgrade snapshot".into()),
+        }
+    );
+}
+
+#[test]
+fn snapshot_op_old_wire_decodes_with_m4_fields_defaulted() {
+    // A work-spec ConfigMap written before M4 (just sourcePath/tags/policy)
+    // must still decode — `#[serde(default)]` on every new field is the
+    // guard, and the all-None result reproduces the pre-M4 `snapshot create`
+    // argv exactly (SnapshotCreateOptions::default()).
+    let legacy = serde_json::json!({
+        "sourcePath": "/data",
+        "tags": {"app": "mydb"},
+    });
+    let op: SnapshotOp = serde_json::from_value(legacy).expect("legacy snapshot op decodes");
+    assert_eq!(op.fail_fast, None);
+    assert_eq!(op.upload_limit_mb, None);
+    assert_eq!(op.description, None);
+    assert_eq!(
+        op.create_options(),
+        kopiur_kopia::SnapshotCreateOptions::default()
+    );
 }
 
 #[test]
@@ -350,6 +403,9 @@ fn externally_tagged_operation_shape() {
             source_path: "/data".into(),
             tags: BTreeMap::new(),
             policy: Default::default(),
+            fail_fast: None,
+            upload_limit_mb: None,
+            description: None,
         }),
         identity: sample_identity(),
         repository: RepositoryConnect::Filesystem {
@@ -678,10 +734,15 @@ fn policy_args_from_policy_maps_all_flattened_knobs() {
             ignore_file_errors: true,
             ignore_dir_errors: false,
             ignore_unknown_types: true,
+            // M4 flag sweep: `failFast` is a `snapshot create` argv flag, not a
+            // `policy set` knob — it must NOT leak into `PolicyArgsSpec` below.
+            fail_fast: true,
         }),
         upload: Some(Upload {
             max_parallel_snapshots: Some(4),
             max_parallel_file_reads: Some(8),
+            // Same non-leak guard as `fail_fast` above, for `limitMb`.
+            limit_mb: Some(100),
         }),
         verification: None,
         preflight: None,
@@ -703,6 +764,14 @@ fn policy_args_from_policy_maps_all_flattened_knobs() {
     assert_eq!(p.max_parallel_file_reads, Some(8));
     assert_eq!(p.extra_args, vec!["--one-file-system".to_string()]);
     assert!(!p.is_empty());
+    // M4 flag sweep: `errorHandling.failFast`/`upload.limitMb` are `snapshot
+    // create` argv flags (they ride `SnapshotOp`, not `policy set`), so they
+    // must not appear anywhere on the wire `PolicyArgsSpec` produces —
+    // `PolicyArgsSpec` structurally has no such fields, and this proves it at
+    // the JSON boundary too.
+    let policy_json = serde_json::to_value(&p).unwrap();
+    assert!(policy_json.get("failFast").is_none());
+    assert!(policy_json.get("limitMb").is_none());
 
     // The kopia args builder emits the expected flags (end-to-end into argv).
     let args = p.to_kopia();

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -63,6 +63,17 @@ fn restore_roundtrip() {
             },
             ignore_permission_errors: Some(true),
             write_files_atomically: Some(false),
+            parallel: Some(4),
+            write_sparse_files: Some(true),
+            skip_owners: Some(false),
+            skip_permissions: Some(true),
+            skip_times: Some(false),
+            overwrite_files: Some(true),
+            overwrite_directories: Some(false),
+            overwrite_symlinks: Some(true),
+            ignore_errors: Some(false),
+            skip_existing: Some(true),
+            delete_extra: true,
         }),
         identity: sample_identity(),
         repository: RepositoryConnect::S3 {
@@ -91,6 +102,43 @@ fn restore_roundtrip() {
     // The externally-tagged source serializes under its own camelCase key.
     let v = serde_json::to_value(&spec).unwrap();
     assert_eq!(v["operation"]["restore"]["source"]["snapshot"], "abc123");
+    // M2 flag sweep: every new leaf field reaches the wire, camelCased.
+    let restore = &v["operation"]["restore"];
+    assert_eq!(restore["parallel"], 4);
+    assert_eq!(restore["writeSparseFiles"], true);
+    assert_eq!(restore["skipOwners"], false);
+    assert_eq!(restore["skipPermissions"], true);
+    assert_eq!(restore["skipTimes"], false);
+    assert_eq!(restore["overwriteFiles"], true);
+    assert_eq!(restore["overwriteDirectories"], false);
+    assert_eq!(restore["overwriteSymlinks"], true);
+    assert_eq!(restore["ignoreErrors"], false);
+    assert_eq!(restore["skipExisting"], true);
+    assert_eq!(restore["deleteExtra"], true);
+    // Controller-glue guard: every field reaches the kopia client's options —
+    // no dormant plumbing (the M2 gap-sweep bug class).
+    if let Operation::Restore(op) = &spec.operation {
+        assert_eq!(
+            op.restore_options(),
+            kopiur_kopia::RestoreOptions {
+                ignore_permission_errors: Some(true),
+                write_files_atomically: Some(false),
+                parallel: Some(4),
+                write_sparse_files: Some(true),
+                skip_owners: Some(false),
+                skip_permissions: Some(true),
+                skip_times: Some(false),
+                overwrite_files: Some(true),
+                overwrite_directories: Some(false),
+                overwrite_symlinks: Some(true),
+                ignore_errors: Some(false),
+                skip_existing: Some(true),
+                delete_extra: Some(true),
+            }
+        );
+    } else {
+        panic!("expected restore op");
+    }
 }
 
 #[test]
@@ -112,6 +160,17 @@ fn restore_resolve_source_roundtrips_and_wire_shape() {
             anchor: SnapshotAnchor::default(),
             ignore_permission_errors: None,
             write_files_atomically: None,
+            parallel: None,
+            write_sparse_files: None,
+            skip_owners: None,
+            skip_permissions: None,
+            skip_times: None,
+            overwrite_files: None,
+            overwrite_directories: None,
+            overwrite_symlinks: None,
+            ignore_errors: None,
+            skip_existing: None,
+            delete_extra: false,
         }),
         identity: sample_identity(),
         repository: RepositoryConnect::S3 {
@@ -463,10 +522,26 @@ fn restore_op_maps_options_and_defaults_absent() {
         anchor: SnapshotAnchor::default(),
         ignore_permission_errors: Some(false),
         write_files_atomically: Some(true),
+        parallel: Some(2),
+        write_sparse_files: None,
+        skip_owners: None,
+        skip_permissions: None,
+        skip_times: Some(true),
+        overwrite_files: None,
+        overwrite_directories: None,
+        overwrite_symlinks: None,
+        ignore_errors: None,
+        skip_existing: None,
+        delete_extra: true,
     };
     let opts = op.restore_options();
     assert_eq!(opts.ignore_permission_errors, Some(false));
     assert_eq!(opts.write_files_atomically, Some(true));
+    assert_eq!(opts.parallel, Some(2));
+    assert_eq!(opts.skip_times, Some(true));
+    // Regression guard: `enableFileDeletion`/`delete_extra: true` must map to
+    // `Some(true)` — the exact bug this milestone fixes.
+    assert_eq!(opts.delete_extra, Some(true));
 
     // A wire payload with just the source + path still deserializes (option/anchor
     // fields default), mapping to kopia defaults (None/empty).
@@ -475,6 +550,44 @@ fn restore_op_maps_options_and_defaults_absent() {
     assert_eq!(parsed.ignore_permission_errors, None);
     assert_eq!(parsed.restore_options().write_files_atomically, None);
     assert!(parsed.anchor.is_empty());
+    assert!(!parsed.delete_extra);
+    assert_eq!(parsed.restore_options().delete_extra, None);
+}
+
+#[test]
+fn restore_op_old_wire_decodes_with_m2_fields_defaulted() {
+    // M2 flag sweep: a work-spec ConfigMap written before this milestone's
+    // fields existed (just source/targetPath/anchor/the original two options)
+    // must still decode — `#[serde(default)]` on every new field is the guard.
+    let legacy = serde_json::json!({
+        "source": { "snapshot": "s" },
+        "targetPath": "/data",
+        "ignorePermissionErrors": true,
+        "writeFilesAtomically": false,
+    });
+    let op: RestoreOp = serde_json::from_value(legacy).expect("legacy restore op decodes");
+    assert_eq!(op.ignore_permission_errors, Some(true));
+    assert_eq!(op.write_files_atomically, Some(false));
+    assert_eq!(op.parallel, None);
+    assert_eq!(op.write_sparse_files, None);
+    assert_eq!(op.skip_owners, None);
+    assert_eq!(op.skip_permissions, None);
+    assert_eq!(op.skip_times, None);
+    assert_eq!(op.overwrite_files, None);
+    assert_eq!(op.overwrite_directories, None);
+    assert_eq!(op.overwrite_symlinks, None);
+    assert_eq!(op.ignore_errors, None);
+    assert_eq!(op.skip_existing, None);
+    assert!(!op.delete_extra);
+    // All-None/false new fields reproduce today's RestoreOptions exactly.
+    assert_eq!(
+        op.restore_options(),
+        kopiur_kopia::RestoreOptions {
+            ignore_permission_errors: Some(true),
+            write_files_atomically: Some(false),
+            ..Default::default()
+        }
+    );
 }
 
 #[test]

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -906,6 +906,8 @@ fn verify_quick_roundtrip_and_wire_shape() {
                 verify_files_percent: Some(10),
                 max_errors: Some(3),
                 parallel: None,
+                file_parallelism: None,
+                file_queue_length: None,
             }),
             success_expr: Some("stats.files > 0 && stats.errors == 0".into()),
         }),
@@ -963,6 +965,7 @@ fn verify_deep_roundtrip_and_wire_shape() {
             tier: VerifyTier::Deep(DeepVerify {
                 scratch_path: "/scratch".into(),
                 snapshot_id: Some("k99".into()),
+                parallel: None,
             }),
             success_expr: None,
         }),
@@ -994,6 +997,62 @@ fn verify_deep_roundtrip_and_wire_shape() {
     } else {
         panic!("expected verify op");
     }
+}
+
+// --- M3 (issue #216 category sweep): quick tuning knobs + deep restore parallelism ---
+
+#[test]
+fn quick_verify_tuning_knobs_roundtrip_and_map_to_kopia() {
+    let q = QuickVerify {
+        verify_files_percent: Some(10),
+        max_errors: Some(1),
+        parallel: Some(2),
+        file_parallelism: Some(4),
+        file_queue_length: Some(100),
+    };
+    let v: serde_json::Value = serde_json::to_value(&q).unwrap();
+    assert_eq!(v["parallel"], 2);
+    assert_eq!(v["fileParallelism"], 4);
+    assert_eq!(v["fileQueueLength"], 100);
+    let reparsed: QuickVerify = serde_json::from_value(v).unwrap();
+    assert_eq!(reparsed, q);
+
+    let kopia = q.to_kopia();
+    assert_eq!(kopia.parallel, Some(2));
+    assert_eq!(kopia.file_parallelism, Some(4));
+    assert_eq!(kopia.file_queue_length, Some(100));
+}
+
+#[test]
+fn quick_verify_old_wire_json_without_new_knobs_still_decodes() {
+    // Pre-M3 work-spec ConfigMaps only ever carried these three keys. A mover
+    // upgraded ahead of a controller still writing the old shape must not wedge.
+    let old = r#"{"verifyFilesPercent":10,"maxErrors":3}"#;
+    let parsed: QuickVerify = serde_json::from_str(old).unwrap();
+    assert_eq!(parsed.verify_files_percent, Some(10));
+    assert_eq!(parsed.max_errors, Some(3));
+    assert!(parsed.parallel.is_none());
+    assert!(parsed.file_parallelism.is_none());
+    assert!(parsed.file_queue_length.is_none());
+}
+
+#[test]
+fn deep_verify_parallel_roundtrips_and_old_wire_json_still_decodes() {
+    let d = DeepVerify {
+        scratch_path: "/scratch".into(),
+        snapshot_id: Some("k1".into()),
+        parallel: Some(2),
+    };
+    let v: serde_json::Value = serde_json::to_value(&d).unwrap();
+    assert_eq!(v["parallel"], 2);
+    let reparsed: DeepVerify = serde_json::from_value(v).unwrap();
+    assert_eq!(reparsed, d);
+
+    // Pre-M3 work-spec ConfigMaps had no `parallel` key.
+    let old = r#"{"scratchPath":"/scratch","snapshotId":"k1"}"#;
+    let parsed: DeepVerify = serde_json::from_str(old).unwrap();
+    assert_eq!(parsed.scratch_path, "/scratch");
+    assert!(parsed.parallel.is_none());
 }
 
 // --- §13(d) replicate op ---

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -868,6 +868,66 @@ spec:
               suspend:
                 description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
+              sync:
+                description: |-
+                  Tuning knobs for the underlying `kopia repository sync-to` invocation
+                  (issue #216). `None` reproduces today's behavior: sequential copy
+                  (`--parallel` unset), additive sync (no `--delete`), kopia's own
+                  `--must-exist`/`--times`/`--update` defaults, and no throughput cap.
+                nullable: true
+                properties:
+                  deleteExtra:
+                    description: |-
+                      `--delete`: prune destination-only blobs so the mirror is an exact copy
+                      (kopia default `false` — additive sync, never removes destination
+                      content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true`
+                      key on backup-adjacent YAML is dangerously ambiguous at a glance.
+
+                      CAUTION: with this `true`, blobs present at the destination but absent
+                      from the source are deleted on every run.
+                    type: boolean
+                  maxDownloadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-download-speed`: cap read throughput from the source, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  maxUploadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-upload-speed`: cap write throughput to the destination, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  mustExist:
+                    description: |-
+                      `--[no-]must-exist`: fail the sync instead of initializing the
+                      destination's repository-format blob (kopia default `false` — sync-to may
+                      create the destination layout on first run).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: |-
+                      `--parallel`: number of concurrent blob-copy workers (kopia default `1` —
+                      sequential, the root cause of #216's multi-week seed times to R2).
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  times:
+                    description: |-
+                      `--[no-]times`: synchronize blob modification times to the destination,
+                      when the destination backend supports it (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  update:
+                    description: |-
+                      `--[no-]update`: update blobs already present at the destination when the
+                      source copy is newer (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                type: object
             required:
             - destination
             - schedule

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -49,6 +49,15 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              description:
+                description: |-
+                  Free-form text recorded on the kopia snapshot manifest
+                  (`snapshot create --description`). Per-invocation by nature —
+                  scheduled/discovered `Snapshot`s never set this (no templated
+                  descriptions).
+                maxLength: 1024
+                nullable: true
+                type: string
               failurePolicy:
                 description: Mover Job retry and deadline limits for this run.
                 nullable: true

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -6220,6 +6220,14 @@ spec:
                         description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
+                      parallel:
+                        description: |-
+                          `restore --parallel`: restore parallelism for the scratch-restore (deep verify
+                          IS a restore under the hood); absent leaves kopia's default.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
@@ -6252,6 +6260,32 @@ spec:
                       lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
+                      fileParallelism:
+                        description: '`--file-parallelism`: parallelism for file verification (kopia default: unset).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      fileQueueLength:
+                        description: '`--file-queue-length`: queue length for file verification (kopia default: 20000).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxErrors:
+                        description: |-
+                          `--max-errors`: stop after this many errors (kopia default: 0, meaning stop
+                          at the first error).
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      parallel:
+                        description: '`--parallel`: verification parallelism (kopia default: 8).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -7513,14 +7513,66 @@ spec:
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                    description: |-
+                      Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                      Wired to kopia's `--[no-]delete-extra` (previously a silent no-op — see issue #216 gap sweep).
+                    type: boolean
+                  ignoreErrors:
+                    description: '`--[no-]ignore-errors`: ignore all restore errors and continue (kopia default `false`).'
+                    nullable: true
                     type: boolean
                   ignorePermissionErrors:
                     description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
+                  overwriteDirectories:
+                    description: |-
+                      `--[no-]overwrite-directories`: overwrite existing directories in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  overwriteFiles:
+                    description: '`--[no-]overwrite-files`: overwrite existing files in the target (kopia default `true`).'
+                    nullable: true
+                    type: boolean
+                  overwriteSymlinks:
+                    description: |-
+                      `--[no-]overwrite-symlinks`: overwrite existing symlinks in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: '`--parallel`: restore parallelism (kopia default `8`; `1` disables parallelism).'
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  skipExisting:
+                    description: |-
+                      `--[no-]skip-existing`: skip files/symlinks that already exist in the target
+                      (kopia default `false`).
+                    nullable: true
+                    type: boolean
+                  skipOwners:
+                    description: '`--[no-]skip-owners`: skip restoring file owners (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipPermissions:
+                    description: '`--[no-]skip-permissions`: skip restoring file permissions (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipTimes:
+                    description: '`--[no-]skip-times`: skip restoring file modification times (kopia default `false`).'
+                    nullable: true
+                    type: boolean
                   writeFilesAtomically:
                     description: Write files atomically via a temp file + rename (default true).
+                    nullable: true
+                    type: boolean
+                  writeSparseFiles:
+                    description: |-
+                      `--[no-]write-sparse-files`: attempt to write files sparsely, allocating the
+                      minimum disk space needed (kopia default `false`).
                     nullable: true
                     type: boolean
                 type: object

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -9465,6 +9465,66 @@ spec:
               suspend:
                 description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
+              sync:
+                description: |-
+                  Tuning knobs for the underlying `kopia repository sync-to` invocation
+                  (issue #216). `None` reproduces today's behavior: sequential copy
+                  (`--parallel` unset), additive sync (no `--delete`), kopia's own
+                  `--must-exist`/`--times`/`--update` defaults, and no throughput cap.
+                nullable: true
+                properties:
+                  deleteExtra:
+                    description: |-
+                      `--delete`: prune destination-only blobs so the mirror is an exact copy
+                      (kopia default `false` — additive sync, never removes destination
+                      content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true`
+                      key on backup-adjacent YAML is dangerously ambiguous at a glance.
+
+                      CAUTION: with this `true`, blobs present at the destination but absent
+                      from the source are deleted on every run.
+                    type: boolean
+                  maxDownloadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-download-speed`: cap read throughput from the source, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  maxUploadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-upload-speed`: cap write throughput to the destination, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  mustExist:
+                    description: |-
+                      `--[no-]must-exist`: fail the sync instead of initializing the
+                      destination's repository-format blob (kopia default `false` — sync-to may
+                      create the destination layout on first run).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: |-
+                      `--parallel`: number of concurrent blob-copy workers (kopia default `1` —
+                      sequential, the root cause of #216's multi-week seed times to R2).
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  times:
+                    description: |-
+                      `--[no-]times`: synchronize blob modification times to the destination,
+                      when the destination backend supports it (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  update:
+                    description: |-
+                      `--[no-]update`: update blobs already present at the destination when the
+                      source copy is newer (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                type: object
             required:
             - destination
             - schedule

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -5304,6 +5304,13 @@ spec:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
+                  failFast:
+                    description: |-
+                      Abort the snapshot at the first error instead of collecting and
+                      continuing (`snapshot create --fail-fast`; kopia default: false). This
+                      is a `snapshot create` argv flag, not a `policy set` knob, but lives
+                      beside its semantic opposites (`ignore*Errors`) for discoverability.
+                    type: boolean
                   ignoreDirErrors:
                     description: Continue the snapshot when a directory cannot be read (`--ignore-dir-errors`).
                     type: boolean
@@ -6197,6 +6204,16 @@ spec:
                 description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
+                  limitMb:
+                    description: |-
+                      `snapshot create --upload-limit-mb`: abort the snapshot once this many
+                      MB have been uploaded (kopia default: 0 — unlimited). Named `limitMb`
+                      rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter;
+                      like `failFast`, this is a `snapshot create` argv flag, not a `policy
+                      set` knob, but lives here beside its parallelism siblings.
+                    format: int64
+                    nullable: true
+                    type: integer
                   maxParallelFileReads:
                     description: '`--max-parallel-file-reads`: file-read concurrency within a snapshot.'
                     format: int64
@@ -6488,6 +6505,15 @@ spec:
                 - Delete
                 - Retain
                 - Orphan
+                nullable: true
+                type: string
+              description:
+                description: |-
+                  Free-form text recorded on the kopia snapshot manifest
+                  (`snapshot create --description`). Per-invocation by nature —
+                  scheduled/discovered `Snapshot`s never set this (no templated
+                  descriptions).
+                maxLength: 1024
                 nullable: true
                 type: string
               failurePolicy:

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -865,6 +865,66 @@ spec:
               suspend:
                 description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
+              sync:
+                description: |-
+                  Tuning knobs for the underlying `kopia repository sync-to` invocation
+                  (issue #216). `None` reproduces today's behavior: sequential copy
+                  (`--parallel` unset), additive sync (no `--delete`), kopia's own
+                  `--must-exist`/`--times`/`--update` defaults, and no throughput cap.
+                nullable: true
+                properties:
+                  deleteExtra:
+                    description: |-
+                      `--delete`: prune destination-only blobs so the mirror is an exact copy
+                      (kopia default `false` — additive sync, never removes destination
+                      content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true`
+                      key on backup-adjacent YAML is dangerously ambiguous at a glance.
+
+                      CAUTION: with this `true`, blobs present at the destination but absent
+                      from the source are deleted on every run.
+                    type: boolean
+                  maxDownloadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-download-speed`: cap read throughput from the source, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  maxUploadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-upload-speed`: cap write throughput to the destination, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  mustExist:
+                    description: |-
+                      `--[no-]must-exist`: fail the sync instead of initializing the
+                      destination's repository-format blob (kopia default `false` — sync-to may
+                      create the destination layout on first run).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: |-
+                      `--parallel`: number of concurrent blob-copy workers (kopia default `1` —
+                      sequential, the root cause of #216's multi-week seed times to R2).
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  times:
+                    description: |-
+                      `--[no-]times`: synchronize blob modification times to the destination,
+                      when the destination backend supports it (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  update:
+                    description: |-
+                      `--[no-]update`: update blobs already present at the destination when the
+                      source copy is newer (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                type: object
             required:
             - destination
             - schedule

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -443,14 +443,66 @@ spec:
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                    description: |-
+                      Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                      Wired to kopia's `--[no-]delete-extra` (previously a silent no-op — see issue #216 gap sweep).
+                    type: boolean
+                  ignoreErrors:
+                    description: '`--[no-]ignore-errors`: ignore all restore errors and continue (kopia default `false`).'
+                    nullable: true
                     type: boolean
                   ignorePermissionErrors:
                     description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
+                  overwriteDirectories:
+                    description: |-
+                      `--[no-]overwrite-directories`: overwrite existing directories in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  overwriteFiles:
+                    description: '`--[no-]overwrite-files`: overwrite existing files in the target (kopia default `true`).'
+                    nullable: true
+                    type: boolean
+                  overwriteSymlinks:
+                    description: |-
+                      `--[no-]overwrite-symlinks`: overwrite existing symlinks in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: '`--parallel`: restore parallelism (kopia default `8`; `1` disables parallelism).'
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  skipExisting:
+                    description: |-
+                      `--[no-]skip-existing`: skip files/symlinks that already exist in the target
+                      (kopia default `false`).
+                    nullable: true
+                    type: boolean
+                  skipOwners:
+                    description: '`--[no-]skip-owners`: skip restoring file owners (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipPermissions:
+                    description: '`--[no-]skip-permissions`: skip restoring file permissions (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipTimes:
+                    description: '`--[no-]skip-times`: skip restoring file modification times (kopia default `false`).'
+                    nullable: true
+                    type: boolean
                   writeFilesAtomically:
                     description: Write files atomically via a temp file + rename (default true).
+                    nullable: true
+                    type: boolean
+                  writeSparseFiles:
+                    description: |-
+                      `--[no-]write-sparse-files`: attempt to write files sparsely, allocating the
+                      minimum disk space needed (kopia default `false`).
                     nullable: true
                     type: boolean
                 type: object

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -1001,6 +1001,14 @@ spec:
                         description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
+                      parallel:
+                        description: |-
+                          `restore --parallel`: restore parallelism for the scratch-restore (deep verify
+                          IS a restore under the hood); absent leaves kopia's default.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
@@ -1033,6 +1041,32 @@ spec:
                       lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
+                      fileParallelism:
+                        description: '`--file-parallelism`: parallelism for file verification (kopia default: unset).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      fileQueueLength:
+                        description: '`--file-queue-length`: queue length for file verification (kopia default: 20000).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxErrors:
+                        description: |-
+                          `--max-errors`: stop after this many errors (kopia default: 0, meaning stop
+                          at the first error).
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      parallel:
+                        description: '`--parallel`: verification parallelism (kopia default: 8).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -85,6 +85,13 @@ spec:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
+                  failFast:
+                    description: |-
+                      Abort the snapshot at the first error instead of collecting and
+                      continuing (`snapshot create --fail-fast`; kopia default: false). This
+                      is a `snapshot create` argv flag, not a `policy set` knob, but lives
+                      beside its semantic opposites (`ignore*Errors`) for discoverability.
+                    type: boolean
                   ignoreDirErrors:
                     description: Continue the snapshot when a directory cannot be read (`--ignore-dir-errors`).
                     type: boolean
@@ -978,6 +985,16 @@ spec:
                 description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
+                  limitMb:
+                    description: |-
+                      `snapshot create --upload-limit-mb`: abort the snapshot once this many
+                      MB have been uploaded (kopia default: 0 — unlimited). Named `limitMb`
+                      rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter;
+                      like `failFast`, this is a `snapshot create` argv flag, not a `policy
+                      set` knob, but lives here beside its parallelism siblings.
+                    format: int64
+                    nullable: true
+                    type: integer
                   maxParallelFileReads:
                     description: '`--max-parallel-file-reads`: file-read concurrency within a snapshot.'
                     format: int64

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -46,6 +46,15 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              description:
+                description: |-
+                  Free-form text recorded on the kopia snapshot manifest
+                  (`snapshot create --description`). Per-invocation by nature —
+                  scheduled/discovered `Snapshot`s never set this (no templated
+                  descriptions).
+                maxLength: 1024
+                nullable: true
+                type: string
               failurePolicy:
                 description: Mover Job retry and deadline limits for this run.
                 nullable: true

--- a/deploy/examples/06-manual-backup.yaml
+++ b/deploy/examples/06-manual-backup.yaml
@@ -25,6 +25,10 @@ spec:
     name: postgres-data
   tags:
     reason: "pre-schema-migration"
+  # Free-form text recorded on the kopia snapshot manifest itself
+  # (`snapshot create --description`, up to 1024 characters). Per-invocation
+  # by nature — scheduled/discovered Snapshots never set this.
+  description: "pre-upgrade snapshot before the v14→v15 migration"
   # Keep the Snapshot CR even when the next GFS prune runs.
   deletionPolicy: Retain
   # Pin the underlying kopia snapshot so GFS retention NEVER expires it — for a

--- a/deploy/examples/15-restore-in-place-mirror.yaml
+++ b/deploy/examples/15-restore-in-place-mirror.yaml
@@ -2,16 +2,22 @@
 #
 # Restore directly into an EXISTING PVC (`target.pvcRef`) and make it an EXACT mirror
 # of the snapshot with `options.enableFileDeletion: true` — files in the target that
-# aren't in the snapshot are DELETED. This is the faithful "put it back exactly how
-# it was" restore.
+# aren't in the snapshot are DELETED (kopia's `--delete-extra`). This is the faithful
+# "put it back exactly how it was" restore.
 #
 # !! Use deliberately. By default a restore is ADDITIVE (writes the snapshot's files,
 #    leaves everything else). enableFileDeletion makes it destructive — point it at
 #    the wrong PVC and it wipes the extra files. Scale the app DOWN first so nothing
 #    is writing the target during the restore.
 #
+# Also shows `options.parallel` (restore parallelism, kopia default 8) and
+# `options.skipTimes` (skip restoring file modification times) — two of the M2
+# flag-sweep tuning knobs, all of which mirror kopia's own `snapshot restore` flags.
+#
 # Field shapes verified against crates/api: target.pvcRef = { name }; options =
-# { enableFileDeletion, ignorePermissionErrors?, writeFilesAtomically? }.
+# { enableFileDeletion, ignorePermissionErrors?, writeFilesAtomically?, parallel?,
+#   writeSparseFiles?, skipOwners?, skipPermissions?, skipTimes?, overwriteFiles?,
+#   overwriteDirectories?, overwriteSymlinks?, ignoreErrors?, skipExisting? }.
 ---
 apiVersion: kopiur.home-operations.com/v1alpha1
 kind: Restore
@@ -27,9 +33,11 @@ spec:
     pvcRef:
       name: postgres-data
   options:
-    enableFileDeletion: true # EXACT mirror — delete target files not in the snapshot
+    enableFileDeletion: true # EXACT mirror — delete target files not in the snapshot (--delete-extra)
     ignorePermissionErrors: true
     writeFilesAtomically: true
+    parallel: 4 # restore parallelism; kopia default 8
+    skipTimes: true # don't restore file modification times
   # Match the UID/GID that owns the data so the rewritten files land correctly.
   mover:
     securityContext:

--- a/deploy/examples/19-repository-replication.yaml
+++ b/deploy/examples/19-repository-replication.yaml
@@ -62,6 +62,15 @@ spec:
   schedule:
     cron: "0 5 * * *" # nightly, after the 02:xx backups have landed
     jitter: 1h
+  # Tuning for `kopia repository sync-to` (issue #216). Every field is optional;
+  # omitting `sync` (or any field within it) reproduces kopia's own default.
+  # `parallel` is the main knob: sync-to copies blobs one at a time by default,
+  # so a large initial seed to a slow/high-latency destination can otherwise
+  # take days. `deleteExtra` (kopia's `--delete`) prunes destination-only blobs
+  # for a true mirror — left `false` (additive) here since it deletes
+  # destination content; see docs/replication.md#tuning-the-sync.
+  sync:
+    parallel: 8
   # Pause replication without deleting the CR.
   suspend: false
 # --8<-- [end:replication]

--- a/deploy/examples/scenarios/06-verification-drill.yaml
+++ b/deploy/examples/scenarios/06-verification-drill.yaml
@@ -50,6 +50,12 @@ spec:
       schedule:
         cron: "0 4 * * *"
         jitter: 30m
+      # Tuning knobs map directly onto `kopia snapshot verify`'s own flags; all
+      # optional, absent leaves kopia's default.
+      parallel: 8 # --parallel (kopia default: 8)
+      fileParallelism: 4 # --file-parallelism
+      fileQueueLength: 20000 # --file-queue-length (kopia default: 20000)
+      maxErrors: 0 # --max-errors (kopia default: 0, stop at the first error)
     # Deep: scratch-restore the latest snapshot into a throwaway volume, weekly.
     deep:
       schedule:
@@ -60,6 +66,8 @@ spec:
       # emptyDir. storageClassName only applies when capacity is set (omit = default).
       capacity: 100Gi
       storageClassName: fast-ssd
+      # restore --parallel: deep verify IS a restore under the hood.
+      parallel: 4
     # CEL pass/fail over the result — a verify with 0 files or any error FAILS.
     successExpr: "stats.files > 0 && stats.errors == 0"
     verifyFilesPercent: 10 # how much of each file `quick` reads fully

--- a/deploy/helm/kopiur/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/crds/repositoryreplications.yaml
@@ -865,6 +865,66 @@ spec:
               suspend:
                 description: Pause this replication; a suspended replication runs no syncs (default `false`).
                 type: boolean
+              sync:
+                description: |-
+                  Tuning knobs for the underlying `kopia repository sync-to` invocation
+                  (issue #216). `None` reproduces today's behavior: sequential copy
+                  (`--parallel` unset), additive sync (no `--delete`), kopia's own
+                  `--must-exist`/`--times`/`--update` defaults, and no throughput cap.
+                nullable: true
+                properties:
+                  deleteExtra:
+                    description: |-
+                      `--delete`: prune destination-only blobs so the mirror is an exact copy
+                      (kopia default `false` — additive sync, never removes destination
+                      content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true`
+                      key on backup-adjacent YAML is dangerously ambiguous at a glance.
+
+                      CAUTION: with this `true`, blobs present at the destination but absent
+                      from the source are deleted on every run.
+                    type: boolean
+                  maxDownloadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-download-speed`: cap read throughput from the source, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  maxUploadSpeedBytesPerSecond:
+                    description: |-
+                      `--max-upload-speed`: cap write throughput to the destination, in
+                      bytes/sec (kopia default: unlimited).
+                    format: int64
+                    nullable: true
+                    type: integer
+                  mustExist:
+                    description: |-
+                      `--[no-]must-exist`: fail the sync instead of initializing the
+                      destination's repository-format blob (kopia default `false` — sync-to may
+                      create the destination layout on first run).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: |-
+                      `--parallel`: number of concurrent blob-copy workers (kopia default `1` —
+                      sequential, the root cause of #216's multi-week seed times to R2).
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  times:
+                    description: |-
+                      `--[no-]times`: synchronize blob modification times to the destination,
+                      when the destination backend supports it (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  update:
+                    description: |-
+                      `--[no-]update`: update blobs already present at the destination when the
+                      source copy is newer (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                type: object
             required:
             - destination
             - schedule

--- a/deploy/helm/kopiur/crds/restores.yaml
+++ b/deploy/helm/kopiur/crds/restores.yaml
@@ -443,14 +443,66 @@ spec:
                 nullable: true
                 properties:
                   enableFileDeletion:
-                    description: Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                    description: |-
+                      Delete files in the target that are not present in the snapshot (exact mirror); off by default.
+                      Wired to kopia's `--[no-]delete-extra` (previously a silent no-op — see issue #216 gap sweep).
+                    type: boolean
+                  ignoreErrors:
+                    description: '`--[no-]ignore-errors`: ignore all restore errors and continue (kopia default `false`).'
+                    nullable: true
                     type: boolean
                   ignorePermissionErrors:
                     description: Continue past permission errors during restore (default true).
                     nullable: true
                     type: boolean
+                  overwriteDirectories:
+                    description: |-
+                      `--[no-]overwrite-directories`: overwrite existing directories in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  overwriteFiles:
+                    description: '`--[no-]overwrite-files`: overwrite existing files in the target (kopia default `true`).'
+                    nullable: true
+                    type: boolean
+                  overwriteSymlinks:
+                    description: |-
+                      `--[no-]overwrite-symlinks`: overwrite existing symlinks in the target
+                      (kopia default `true`).
+                    nullable: true
+                    type: boolean
+                  parallel:
+                    description: '`--parallel`: restore parallelism (kopia default `8`; `1` disables parallelism).'
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  skipExisting:
+                    description: |-
+                      `--[no-]skip-existing`: skip files/symlinks that already exist in the target
+                      (kopia default `false`).
+                    nullable: true
+                    type: boolean
+                  skipOwners:
+                    description: '`--[no-]skip-owners`: skip restoring file owners (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipPermissions:
+                    description: '`--[no-]skip-permissions`: skip restoring file permissions (kopia default `false`).'
+                    nullable: true
+                    type: boolean
+                  skipTimes:
+                    description: '`--[no-]skip-times`: skip restoring file modification times (kopia default `false`).'
+                    nullable: true
+                    type: boolean
                   writeFilesAtomically:
                     description: Write files atomically via a temp file + rename (default true).
+                    nullable: true
+                    type: boolean
+                  writeSparseFiles:
+                    description: |-
+                      `--[no-]write-sparse-files`: attempt to write files sparsely, allocating the
+                      minimum disk space needed (kopia default `false`).
                     nullable: true
                     type: boolean
                 type: object

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -1001,6 +1001,14 @@ spec:
                         description: Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`.
                         nullable: true
                         type: string
+                      parallel:
+                        description: |-
+                          `restore --parallel`: restore parallelism for the scratch-restore (deep verify
+                          IS a restore under the hood); absent leaves kopia's default.
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter for the deep restore-test (e.g. weekly).
                         properties:
@@ -1033,6 +1041,32 @@ spec:
                       lives under `quick.schedule` (matching `deep.schedule`), see [`QuickVerification`].
                     nullable: true
                     properties:
+                      fileParallelism:
+                        description: '`--file-parallelism`: parallelism for file verification (kopia default: unset).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      fileQueueLength:
+                        description: '`--file-queue-length`: queue length for file verification (kopia default: 20000).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      maxErrors:
+                        description: |-
+                          `--max-errors`: stop after this many errors (kopia default: 0, meaning stop
+                          at the first error).
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      parallel:
+                        description: '`--parallel`: verification parallelism (kopia default: 8).'
+                        format: uint32
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
                       schedule:
                         description: Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled.
                         nullable: true

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -85,6 +85,13 @@ spec:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
                 properties:
+                  failFast:
+                    description: |-
+                      Abort the snapshot at the first error instead of collecting and
+                      continuing (`snapshot create --fail-fast`; kopia default: false). This
+                      is a `snapshot create` argv flag, not a `policy set` knob, but lives
+                      beside its semantic opposites (`ignore*Errors`) for discoverability.
+                    type: boolean
                   ignoreDirErrors:
                     description: Continue the snapshot when a directory cannot be read (`--ignore-dir-errors`).
                     type: boolean
@@ -978,6 +985,16 @@ spec:
                 description: Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`).
                 nullable: true
                 properties:
+                  limitMb:
+                    description: |-
+                      `snapshot create --upload-limit-mb`: abort the snapshot once this many
+                      MB have been uploaded (kopia default: 0 — unlimited). Named `limitMb`
+                      rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter;
+                      like `failFast`, this is a `snapshot create` argv flag, not a `policy
+                      set` knob, but lives here beside its parallelism siblings.
+                    format: int64
+                    nullable: true
+                    type: integer
                   maxParallelFileReads:
                     description: '`--max-parallel-file-reads`: file-read concurrency within a snapshot.'
                     format: int64

--- a/deploy/helm/kopiur/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/crds/snapshots.yaml
@@ -46,6 +46,15 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              description:
+                description: |-
+                  Free-form text recorded on the kopia snapshot manifest
+                  (`snapshot create --description`). Per-invocation by nature —
+                  scheduled/discovered `Snapshot`s never set this (no templated
+                  descriptions).
+                maxLength: 1024
+                nullable: true
+                type: string
               failurePolicy:
                 description: Mover Job retry and deadline limits for this run.
                 nullable: true

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -299,17 +299,23 @@ errorHandling:
     ignoreFileErrors: true # --ignore-file-errors: skip unreadable files
     ignoreDirErrors: false # --ignore-dir-errors: skip unreadable directories
     ignoreUnknownTypes: true # --ignore-unknown-types: skip sockets/devices/...
+    failFast: false # --fail-fast: abort at the FIRST error instead of collecting and continuing
 ```
+
+`failFast` is the opposite kind of knob from its three siblings above — it makes the snapshot _less_ tolerant of errors, not more. It's a `kopia snapshot create` argv flag (not a `policy set` knob), which is why it lives here beside its semantic opposites rather than under `upload`.
 
 ### upload — parallelism
 
-kopia's upload policy; both knobs optional (absent leaves kopia's default):
+kopia's upload policy; every knob is optional (absent leaves kopia's default):
 
 ```yaml
 upload:
     maxParallelSnapshots: 4 # --max-parallel-snapshots: concurrent sources
     maxParallelFileReads: 8 # --max-parallel-file-reads: file-read concurrency
+    limitMb: 500 # --upload-limit-mb: abort the snapshot after this many MB uploaded (kopia default: unlimited)
 ```
+
+`limitMb` is named to avoid the `upload.uploadLimitMb` stutter. Like `failFast`, it's a `snapshot create` argv flag, not a `policy set` knob, but lives here beside its parallelism siblings.
 
 ### verification — prove the snapshots are restorable
 
@@ -529,6 +535,16 @@ Set it per-`Snapshot` (`spec.deletionPolicy`) or set the recipe-wide default wit
 spec:
     policyRef: { name: postgres-data }
     pin: true # GFS retention will skip this snapshot until you clear pin
+```
+
+### `description` — annotate a one-off run
+
+`Snapshot.spec.description` (up to 1024 characters) records free-form text on the kopia snapshot manifest (`snapshot create --description`). It's per-invocation by nature — a `SnapshotSchedule`'s children and `discovered` backups never set it — so use it on a manual `Snapshot` or `kubectl kopiur snapshot now --description` to note *why* this particular run exists:
+
+```yaml
+spec:
+    policyRef: { name: postgres-data }
+    description: pre-upgrade snapshot before the v14→v15 migration
 ```
 
 ### `failurePolicy` — retry & deadline for the mover Job

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -319,13 +319,20 @@ Opt-in. When absent, nothing runs. When set, the operator runs a frequent blob-l
 verification:
     quick: # blob-level `kopia snapshot verify`, often
         schedule: { cron: "0 4 * * *", jitter: 30m }
+        parallel: 8 # --parallel: verification parallelism (kopia default: 8)
+        fileParallelism: 4 # --file-parallelism: parallelism for file verification
+        fileQueueLength: 20000 # --file-queue-length (kopia default: 20000)
+        maxErrors: 0 # --max-errors: stop after this many errors (0 = stop at first)
     deep: # scratch-restore the latest snapshot into a throwaway volume, rarely
         schedule: { cron: "0 5 * * 0", jitter: 1h }
         capacity: 100Gi # size a fresh ephemeral PVC for the restore (omit = emptyDir)
         storageClassName: fast-ssd # StorageClass for that PVC (omit = cluster default)
+        parallel: 4 # restore --parallel: deep verify IS a restore under the hood
     successExpr: "stats.files > 0 && stats.errors == 0" # CEL pass/fail predicate
     verifyFilesPercent: 10 # how much of each file `quick` reads fully
 ```
+
+`quick`'s four tuning knobs (`parallel`, `fileParallelism`, `fileQueueLength`, `maxErrors`) map directly onto `kopia snapshot verify`'s own flags; all are optional and absent leaves kopia's own default. `deep.parallel` maps onto `restore --parallel` — the deep tier restores the snapshot under the hood, so its parallelism knob lives with the rest of the restore-shaped config. `maxErrors: 0` is kopia's own default (stop at the very first error), so it's deliberately unconstrained at admission — unlike the count knobs, which must be `>= 1`.
 
 **Two tiers, because there are two different questions.** `quick` asks _"are the
 repository blobs and indexes intact?"_ — it runs `kopia snapshot verify`, reads

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -1555,6 +1555,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | --- | --- | --- | --- |
 | `schedule` | [object](#snapshotpolicy-spec-verification-deep-schedule) | **required** | Cron + jitter for the deep restore-test (e.g. weekly). |
 | `capacity` | string | — | Size of the ephemeral scratch PVC (e.g. `10Gi`); absent falls back to a node-ephemeral `emptyDir`. |
+| `parallel` | integer | —<br><sub>min 0</sub> | `restore --parallel`: restore parallelism for the scratch-restore (deep verify IS a restore under the hood); absent leaves kopia's default. |
 | `storageClassName` | string | — | StorageClass for the ephemeral scratch PVC; absent uses the cluster default (only with `capacity`). |
 
 ###### `spec.verification.deep.schedule` { #snapshotpolicy-spec-verification-deep-schedule }
@@ -1569,6 +1570,10 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `fileParallelism` | integer | —<br><sub>min 0</sub> | `--file-parallelism`: parallelism for file verification (kopia default: unset). |
+| `fileQueueLength` | integer | —<br><sub>min 0</sub> | `--file-queue-length`: queue length for file verification (kopia default: 20000). |
+| `maxErrors` | integer | —<br><sub>min 0</sub> | `--max-errors`: stop after this many errors (kopia default: 0, meaning stop at the first error). |
+| `parallel` | integer | —<br><sub>min 0</sub> | `--parallel`: verification parallelism (kopia default: 8). |
 | `schedule` | [object](#snapshotpolicy-spec-verification-quick-schedule) | — | Cron + jitter + timezone for the frequent blob-level verify; absent ⇒ quick tier disabled. |
 
 ###### `spec.verification.quick.schedule` { #snapshotpolicy-spec-verification-quick-schedule }

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -2032,9 +2032,19 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `enableFileDeletion` | boolean | — | Delete files in the target that are not present in the snapshot (exact mirror); off by default. |
+| `enableFileDeletion` | boolean | — | Delete files in the target that are not present in the snapshot (exact mirror); off by default. Wired to kopia's `--[no-]delete-extra` (previously a silent no-op — see issue #216 gap sweep). |
+| `ignoreErrors` | boolean | — | `--[no-]ignore-errors`: ignore all restore errors and continue (kopia default `false`). |
 | `ignorePermissionErrors` | boolean | — | Continue past permission errors during restore (default true). |
+| `overwriteDirectories` | boolean | — | `--[no-]overwrite-directories`: overwrite existing directories in the target (kopia default `true`). |
+| `overwriteFiles` | boolean | — | `--[no-]overwrite-files`: overwrite existing files in the target (kopia default `true`). |
+| `overwriteSymlinks` | boolean | — | `--[no-]overwrite-symlinks`: overwrite existing symlinks in the target (kopia default `true`). |
+| `parallel` | integer | —<br><sub>min 0</sub> | `--parallel`: restore parallelism (kopia default `8`; `1` disables parallelism). |
+| `skipExisting` | boolean | — | `--[no-]skip-existing`: skip files/symlinks that already exist in the target (kopia default `false`). |
+| `skipOwners` | boolean | — | `--[no-]skip-owners`: skip restoring file owners (kopia default `false`). |
+| `skipPermissions` | boolean | — | `--[no-]skip-permissions`: skip restoring file permissions (kopia default `false`). |
+| `skipTimes` | boolean | — | `--[no-]skip-times`: skip restoring file modification times (kopia default `false`). |
 | `writeFilesAtomically` | boolean | — | Write files atomically via a temp file + rename (default true). |
+| `writeSparseFiles` | boolean | — | `--[no-]write-sparse-files`: attempt to write files sparsely, allocating the minimum disk space needed (kopia default `false`). |
 
 #### `spec.policy` { #restore-spec-policy }
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -2336,6 +2336,7 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector
 | `sourceRef` | [object](#repositoryreplication-spec-sourceref) | **required** | Reference to the `Repository` or `ClusterRepository` to mirror from. |
 | `mover` | [object](#repositoryreplication-spec-mover) | — | Mover (Job pod) overrides for the replication run. |
 | `suspend` | boolean | — | Pause this replication; a suspended replication runs no syncs (default `false`). |
+| `sync` | [object](#repositoryreplication-spec-sync) | — | Tuning knobs for the underlying `kopia repository sync-to` invocation (issue #216). `None` reproduces today's behavior: sequential copy (`--parallel` unset), additive sync (no `--delete`), kopia's own `--must-exist`/`--times`/`--update` defaults, and no throughput cap. |
 
 #### `spec.destination` { #repositoryreplication-spec-destination }
 
@@ -2637,6 +2638,18 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector
 | --- | --- | --- | --- |
 | `podSelector` | core/v1 LabelSelector | **required** | Label selector matching the workload pod(s) to read context/hooks from. |
 | `container` | string | — | Which container within the matched pod; absent uses the first/only container. |
+
+#### `spec.sync` { #repositoryreplication-spec-sync }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `deleteExtra` | boolean | — | `--delete`: prune destination-only blobs so the mirror is an exact copy (kopia default `false` — additive sync, never removes destination content). Named `deleteExtra`, not kopia's bare `delete`: a `delete: true` key on backup-adjacent YAML is dangerously ambiguous at a glance.<br>CAUTION: with this `true`, blobs present at the destination but absent from the source are deleted on every run. |
+| `maxDownloadSpeedBytesPerSecond` | integer | — | `--max-download-speed`: cap read throughput from the source, in bytes/sec (kopia default: unlimited). |
+| `maxUploadSpeedBytesPerSecond` | integer | — | `--max-upload-speed`: cap write throughput to the destination, in bytes/sec (kopia default: unlimited). |
+| `mustExist` | boolean | — | `--[no-]must-exist`: fail the sync instead of initializing the destination's repository-format blob (kopia default `false` — sync-to may create the destination layout on first run). |
+| `parallel` | integer | —<br><sub>min 0</sub> | `--parallel`: number of concurrent blob-copy workers (kopia default `1` — sequential, the root cause of #216's multi-week seed times to R2). |
+| `times` | boolean | — | `--[no-]times`: synchronize blob modification times to the destination, when the destination backend supports it (kopia default `true`). |
+| `update` | boolean | — | `--[no-]update`: update blobs already present at the destination when the source copy is newer (kopia default `true`). |
 
 ### `status` { #repositoryreplication-status }
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -1317,6 +1317,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `failFast` | boolean | — | Abort the snapshot at the first error instead of collecting and continuing (`snapshot create --fail-fast`; kopia default: false). This is a `snapshot create` argv flag, not a `policy set` knob, but lives beside its semantic opposites (`ignore*Errors`) for discoverability. |
 | `ignoreDirErrors` | boolean | — | Continue the snapshot when a directory cannot be read (`--ignore-dir-errors`). |
 | `ignoreFileErrors` | boolean | — | Continue the snapshot when a file cannot be read (`--ignore-file-errors`). |
 | `ignoreUnknownTypes` | boolean | — | Continue past entries of unknown type (`--ignore-unknown-types`). |
@@ -1537,6 +1538,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `limitMb` | integer | — | `snapshot create --upload-limit-mb`: abort the snapshot once this many MB have been uploaded (kopia default: 0 — unlimited). Named `limitMb` rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter; like `failFast`, this is a `snapshot create` argv flag, not a `policy set` knob, but lives here beside its parallelism siblings. |
 | `maxParallelFileReads` | integer | — | `--max-parallel-file-reads`: file-read concurrency within a snapshot. |
 | `maxParallelSnapshots` | integer | — | `--max-parallel-snapshots`: how many sources snapshot concurrently. |
 
@@ -1647,6 +1649,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `deletionPolicy` | enum: Delete \| Retain \| Orphan | — | Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted. Produced backups default to `Delete`; discovered snapshots are forced to `Retain`. |
+| `description` | string | —<br><sub>maxLength 1024</sub> | Free-form text recorded on the kopia snapshot manifest (`snapshot create --description`). Per-invocation by nature — scheduled/discovered `Snapshot`s never set this (no templated descriptions). |
 | `failurePolicy` | [object](#snapshot-spec-failurepolicy) | — | Mover Job retry and deadline limits for this run. |
 | `pin` | boolean | — | Exempt this snapshot from GFS retention. |
 | `policyRef` | [object](#snapshot-spec-policyref) | — | The `SnapshotPolicy` recipe to run; absent for `discovered` backups. |

--- a/docs/reference/crds/repository-replication.md
+++ b/docs/reference/crds/repository-replication.md
@@ -28,6 +28,22 @@ Mover (Job pod) overrides for the replication run — resources, scheduling, sec
 
 Pause this replication declaratively (default `false`). A suspended `RepositoryReplication` is skipped by its own reconcile — no sync runs — and the state is surfaced via a condition.
 
+### `sync`
+
+Tuning knobs for the underlying `kopia repository sync-to` invocation (issue #216). Every field is optional; an absent `sync` block, or an absent field within it, reproduces kopia's own default for that flag — see [Tuning the sync](../../replication.md#tuning-the-sync).
+
+| Field | kopia flag | Meaning |
+| --- | --- | --- |
+| `parallel` | `--parallel` | Concurrent blob-copy workers (kopia default `1` — sequential; the main knob for a slow initial seed). |
+| `deleteExtra` | `--delete` | Prune destination-only blobs for a true mirror (kopia default `false` — additive sync). **Deletes destination content** — see the safety note in the guide. |
+| `mustExist` | `--[no-]must-exist` | Fail instead of initializing the destination's repository-format blob (kopia default `false`). |
+| `times` | `--[no-]times` | Synchronize blob modification times to the destination, when supported (kopia default `true`). |
+| `update` | `--[no-]update` | Update blobs already present at the destination when the source copy is newer (kopia default `true`). |
+| `maxDownloadSpeedBytesPerSecond` | `--max-download-speed` | Cap read throughput from the source, bytes/sec (kopia default: unlimited). |
+| `maxUploadSpeedBytesPerSecond` | `--max-upload-speed` | Cap write throughput to the destination, bytes/sec (kopia default: unlimited). |
+
+`parallel` and the two speed caps must be `>= 1` when set (admission-webhook enforced).
+
 ## `status`
 
 ### `phase`

--- a/docs/reference/crds/restore.md
+++ b/docs/reference/crds/restore.md
@@ -30,7 +30,9 @@ The repository to read from. Derived from `source` when omitted; **required only
 
 ### `options`
 
-kopia restore-behavior knobs: `enableFileDeletion` (delete files in the target absent from the snapshot, making the target an exact mirror — off by default, so restores are additive and safe), `ignorePermissionErrors` (continue past permission errors, default true), and `writeFilesAtomically` (temp-file + rename, default true).
+kopia restore-behavior knobs; every field's default is kopia's own default (unset ⇒ kopia decides), so an absent `options` block reproduces plain, additive `kopia snapshot restore` behavior. The core three: `enableFileDeletion` (delete files in the target absent from the snapshot, making the target an exact mirror — off by default, so restores are additive and safe; drives kopia's `--delete-extra`), `ignorePermissionErrors` (continue past permission errors, default true), and `writeFilesAtomically` (temp-file + rename, default true).
+
+The rest mirror `kopia snapshot restore`'s own flags one-to-one and are all tri-state (`true`/`false`/absent) booleans except `parallel`: `parallel` (restore parallelism; kopia default `8`), `writeSparseFiles`, `skipOwners`, `skipPermissions`, `skipTimes`, `overwriteFiles`, `overwriteDirectories`, `overwriteSymlinks`, `ignoreErrors`, and `skipExisting`. See the [field reference](../../field-reference.md) for kopia's per-flag default.
 
 ### `policy`
 

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -129,18 +129,26 @@ First-class backup verification that proves snapshots are **restorable**, not ju
 that maintenance ran. Opt-in: when absent, no verification runs. Two tiers, both
 shaped `{ schedule: CronSpec, ... }`:
 
-- `quick` — a `QuickVerification { schedule?: CronSpec }`: the frequent blob-level
-  `kopia snapshot verify`. `quick.schedule` absent means no quick verification.
-  `verifyFilesPercent` (`--verify-files-percent`, a sibling of `quick`/`deep` on
-  `verification` itself) tunes how many files it verifies fully (absent leaves
-  kopia's default).
-- `deep` — a `DeepVerification { schedule: CronSpec, storageClassName?, capacity? }`:
-  the rarer scratch-restore restorability test, which restores the latest snapshot
-  into an ephemeral volume, sanity-checks it, then discards it. `deep.schedule` is
-  its cron+jitter (e.g. weekly); `deep.capacity` sizes the ephemeral scratch PVC
-  (e.g. `10Gi`) — absent falls back to a node-ephemeral `emptyDir`;
-  `deep.storageClassName` picks the scratch PVC's StorageClass (absent uses the
-  cluster default, and only applies when `capacity` is set).
+- `quick` — a `QuickVerification { schedule?: CronSpec, parallel?, fileParallelism?,
+  fileQueueLength?, maxErrors? }`: the frequent blob-level `kopia snapshot verify`.
+  `quick.schedule` absent means no quick verification. `verifyFilesPercent`
+  (`--verify-files-percent`, a sibling of `quick`/`deep` on `verification` itself)
+  tunes how many files it verifies fully (absent leaves kopia's default). The four
+  tuning knobs map directly onto `kopia snapshot verify`'s own flags — `parallel`
+  (`--parallel`, kopia default 8), `fileParallelism` (`--file-parallelism`),
+  `fileQueueLength` (`--file-queue-length`, kopia default 20000), and `maxErrors`
+  (`--max-errors`, kopia default 0 — stop at the first error); all optional, and
+  `maxErrors` is the only one left unconstrained at admission (0 is a meaningful
+  value, not a footgun) — the other three must be `>= 1` when set.
+- `deep` — a `DeepVerification { schedule: CronSpec, storageClassName?, capacity?,
+  parallel? }`: the rarer scratch-restore restorability test, which restores the
+  latest snapshot into an ephemeral volume, sanity-checks it, then discards it.
+  `deep.schedule` is its cron+jitter (e.g. weekly); `deep.capacity` sizes the
+  ephemeral scratch PVC (e.g. `10Gi`) — absent falls back to a node-ephemeral
+  `emptyDir`; `deep.storageClassName` picks the scratch PVC's StorageClass (absent
+  uses the cluster default, and only applies when `capacity` is set); `deep.parallel`
+  maps onto `restore --parallel` — deep verify IS a restore under the hood, so this
+  is the restore's own parallelism knob, not a separate concept.
 - `successExpr` — a CEL pass/fail predicate over the verify result, applied to both
   tiers. The environment exposes `stats{files,bytes,errors}`, `snapshot`, and (deep
   only) `restored{files,checksumMatches}`; returning `false` fails the run, killing

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -116,12 +116,22 @@ failing outright. Each flag defaults `false` (kopia's fail-on-error default):
 `ignoreDirErrors` (`--ignore-dir-errors`) past unreadable directories, and
 `ignoreUnknownTypes` (`--ignore-unknown-types`) past entries of unknown type.
 
+`failFast` (`--fail-fast`, default `false`) is the opposite kind of knob: it
+aborts the snapshot at the *first* error instead of collecting and continuing.
+It rides `kopia snapshot create`'s own argv (not `policy set`), which is why it
+lives here beside its semantic opposites rather than under `upload`.
+
 ### `upload`
 
 Upload parallelism (kopia's upload policy). `maxParallelSnapshots`
 (`--max-parallel-snapshots`) is how many sources snapshot concurrently;
 `maxParallelFileReads` (`--max-parallel-file-reads`) is file-read concurrency
-within a snapshot. Absent knobs leave kopia's default.
+within a snapshot. `limitMb` (`--upload-limit-mb`, kopia default: unlimited)
+aborts the snapshot once this many MB have been uploaded — named `limitMb`
+rather than `uploadLimitMb` to avoid the `upload.uploadLimitMb` stutter. Like
+`failFast`, it is a `snapshot create` argv flag, not a `policy set` knob, but
+lives here beside its parallelism siblings. Absent knobs leave kopia's
+default.
 
 ### `verification`
 

--- a/docs/reference/crds/snapshot.md
+++ b/docs/reference/crds/snapshot.md
@@ -32,6 +32,10 @@ What happens to the underlying kopia snapshot when this CR is deleted. The defau
 
 Exempt this snapshot from GFS retention. When `true` the reconciler applies a kopia snapshot pin and the GFS pruner never selects it for deletion — useful for pre-migration or compliance holds. Clearing it removes the pin. Defaults to `false`.
 
+### `description`
+
+Free-form text recorded on the kopia snapshot manifest (`snapshot create --description`), up to 1024 characters. Per-invocation by nature — a `SnapshotSchedule`'s children and `discovered` backups never set this; use it on a manual `Snapshot` (or `kubectl kopiur snapshot now --description`) to annotate one-off runs, e.g. `pre-upgrade snapshot`.
+
 ## `status`
 
 The status is rich; `discovered` snapshots populate it without any spec.

--- a/docs/replication.md
+++ b/docs/replication.md
@@ -94,6 +94,42 @@ The full apply-ready manifest — including the destination-backend `Secret` —
 | `schedule.cron` / `jitter` | When replication runs (Jenkins-style `H` supported, like a `SnapshotSchedule`). |
 | `mover` | Per-run mover overrides (resources, scheduling, security context). Inherits the source repository's `moverDefaults`. |
 | `suspend` | Pause replication without deleting the CR. |
+| `sync` | Tuning knobs for the underlying `kopia repository sync-to` invocation — see [Tuning the sync](#tuning-the-sync) below. |
+
+## Tuning the sync
+
+By default `sync-to` copies blobs **one at a time**: fine for a small repository, but
+an initial seed of a large one to a slow or high-latency destination (object storage
+in particular) can take days to weeks at roughly one object per second. `spec.sync`
+exposes the kopia flags that speed this up and otherwise tune the copy:
+
+```yaml
+spec:
+  sync:
+    parallel: 8 # concurrent blob-copy workers (kopia default: 1 — sequential)
+    deleteExtra: false # prune destination-only blobs for a true mirror (default: false)
+    mustExist: false # fail instead of initializing the destination (default: false)
+    times: true # sync blob modification times, when supported (default: true)
+    update: true # update blobs already at the destination when newer (default: true)
+    maxDownloadSpeedBytesPerSecond: 50000000 # cap source read throughput
+    maxUploadSpeedBytesPerSecond: 20000000 # cap destination write throughput
+```
+
+Every field is independently optional; omitting `sync` entirely (or any field within
+it) reproduces kopia's own default for that flag — raising `parallel` is the main
+knob most users reach for.
+
+/// warning | `deleteExtra` deletes destination content
+
+`deleteExtra` maps to kopia's `--delete`: with it `true`, every run **deletes** blobs
+present at the destination but no longer present at the source, turning the mirror
+into an exact copy rather than an additive one. This is the correct behavior for a
+true 3-2-1 mirror, but it means a mistaken or emptied source repository will prune the
+destination's copies too on the next scheduled run. It is named `deleteExtra` here
+(not kopia's bare `delete`) precisely so a `deleteExtra: true` reads as deliberate
+rather than being mistaken for a leftover default.
+
+///
 
 ## Destination credentials
 

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -141,6 +141,9 @@ options:
     enableFileDeletion: false # default: additive restore (don't delete extra files in the target)
     ignorePermissionErrors: true # default true
     writeFilesAtomically: true # default true
+    parallel: 4 # restore parallelism; kopia default 8
+    skipTimes: true # skip restoring file modification times
+    overwriteFiles: true # overwrite existing files in the target
 policy:
     onMissingSnapshot: Fail # see table below
     waitTimeout: 5m # how long to wait for the source snapshot to appear
@@ -151,6 +154,8 @@ policy:
 By default a restore is **additive** — it writes the snapshot's files and leaves anything else in the target alone. `enableFileDeletion: true` deletes files in the target that aren't in the snapshot, making it an exact mirror. Use it deliberately.
 
 ///
+
+`options` also exposes the rest of `kopia snapshot restore`'s own tuning flags directly, one field per flag: `writeSparseFiles`, `skipOwners`, `skipPermissions`, `skipTimes`, `overwriteFiles`, `overwriteDirectories`, `overwriteSymlinks`, `ignoreErrors`, and `skipExisting` (all tri-state — `true`/`false`/absent, where absent means "let kopia decide") plus `parallel` (a count). See the [field reference](field-reference.md) for kopia's per-flag default.
 
 ### `onMissingSnapshot` — fail-closed vs proceed
 
@@ -275,9 +280,13 @@ The full `Restore` surface, with the examples that exercise each. `source` is th
 | `target.pvc` | Create a new PVC and restore into it (`{ name, storageClassName?, capacity?, accessModes? }`). | The safe default — restore beside the original, verify, cut over. ([03](examples.md#example-03--restore-by-picking-a-snapshot)) |
 | `target.pvcRef` | Restore into an **existing** PVC (`{ name }`). | In-place restore (scale the app down first). ([15](examples.md#example-15--in-place-mirror-restore)) |
 | `target.populator` | Explicit passive volume-populator source (`populator: {}`). | GitOps deploy-or-restore via a PVC `dataSourceRef`. ([05](examples.md#example-05--deploy-or-restore-gitops)) |
-| `options.enableFileDeletion` | Delete target files not in the snapshot (exact **mirror**). Default `false` (additive). | A faithful in-place restore — destructive, use deliberately. ([15](examples.md#example-15--in-place-mirror-restore)) |
+| `options.enableFileDeletion` | Delete target files not in the snapshot (exact **mirror**); wired to kopia's `--delete-extra`. Default `false` (additive). | A faithful in-place restore — destructive, use deliberately. ([15](examples.md#example-15--in-place-mirror-restore)) |
 | `options.ignorePermissionErrors` | Complete and _report_ permission problems vs. fail hard. Default `true`. | `false` to fail-closed when exact permissions matter. |
 | `options.writeFilesAtomically` | Write via a temp file + rename. Default `true`. | Rarely changed. |
+| `options.parallel` | Restore parallelism (`--parallel`). Kopia default `8`. | Large restores on fast storage/network. |
+| `options.writeSparseFiles` / `skipOwners` / `skipPermissions` / `skipTimes` | Tri-state passthroughs to kopia's `--[no-]write-sparse-files` / `--[no-]skip-owners` / `--[no-]skip-permissions` / `--[no-]skip-times`. Absent ⇒ kopia's own default. | Sparse-file-heavy targets; cross-platform restores where owners/permissions/times don't translate. |
+| `options.overwriteFiles` / `overwriteDirectories` / `overwriteSymlinks` | Tri-state passthroughs to kopia's `--[no-]overwrite-*` (kopia default `true` for all three). | `false` to refuse clobbering an existing target. |
+| `options.ignoreErrors` / `skipExisting` | Tri-state passthroughs to kopia's `--[no-]ignore-errors` / `--[no-]skip-existing`. Kopia default `false` for both. | Best-effort restores; resuming a partially-written target. |
 | `policy.onMissingSnapshot` | `Fail` (explicit sources) vs `Continue` (fromPolicy default). | `Fail` for deliberate recoveries; `Continue` for deploy-or-restore. |
 | `policy.waitTimeout` | How long to wait for the source snapshot to appear. | Sources that may lag behind the Restore being applied. |
 | `mover.securityContext` / `podSecurityContext` | Container UID/GID, and the pod-level `fsGroup` that makes a fresh target volume writable. | Own restored files as the app's UID; populate a fresh PVC as non-root (`fsGroup`). See [Mover, cache & failure policy](#mover-cache--failure-policy). ([12](examples.md#example-12--restore-mover-cache--failure-policy)) |

--- a/docs/scenarios/verification-drills.md
+++ b/docs/scenarios/verification-drills.md
@@ -27,10 +27,13 @@ spec:
     verification:
         quick: # blob-level `kopia snapshot verify`, often
             schedule: { cron: "0 4 * * *", jitter: 30m }
+            parallel: 8 # --parallel: verification parallelism (kopia default: 8)
+            maxErrors: 0 # --max-errors: stop after this many errors (0 = stop at first)
         deep: # scratch-restore the latest snapshot into a throwaway volume, rarely
             schedule: { cron: "0 5 * * 0", jitter: 1h }
             capacity: 100Gi # size a fresh ephemeral PVC for the restore (omit = emptyDir)
             storageClassName: fast-ssd # StorageClass for that PVC (omit = cluster default)
+            parallel: 4 # restore --parallel: deep verify IS a restore under the hood
         successExpr: "stats.files > 0 && stats.errors == 0" # CEL pass/fail predicate
         verifyFilesPercent: 10 # how much of each file `quick` actually reads
 ```
@@ -39,6 +42,10 @@ spec:
   full scratch-restore into a throwaway volume (then discarded). Both tiers nest
   their cron under `schedule:` (`quick.schedule`, `deep.schedule`); `deep` additionally
   carries the scratch-volume knobs below. Schedule each independently.
+- **`quick` tuning** — `parallel`/`fileParallelism`/`fileQueueLength`/`maxErrors` map
+  directly onto `kopia snapshot verify`'s own flags; all optional, absent leaves
+  kopia's default. `deep.parallel` is the analogous knob for the scratch-restore
+  (`restore --parallel`).
 - **Gated until there's something to verify** — a brand-new policy does not spawn a
   verify Job before it has a first successful backup (or, for an adopted repository,
   discovered snapshots already in it). See


### PR DESCRIPTION
## Summary

#216 reported that `RepositoryReplication` runs `kopia repository sync-to` with no `--parallel`, making large initial seeds latency-bound (~1.3 obj/s to R2 ⇒ weeks). An audit against the pinned kopia 0.23.1 confirmed a whole category of unexposed tuning flags — including three cases of **dormant plumbing** (client/workspec supported the flag, the controller hardcoded `None`/`false`) and one **silent no-op bug**. This PR sweeps the category in four milestones:

1. **`RepositoryReplication.spec.sync`** — `parallel` (the #216 fix), `deleteExtra`, `mustExist`, `times`, `update`, `maxDownloadSpeedBytesPerSecond`, `maxUploadSpeedBytesPerSecond` → `kopia repository sync-to`
2. **`Restore.spec.options`** — `parallel`, `writeSparseFiles`, `skipOwners`, `skipPermissions`, `skipTimes`, `overwriteFiles`, `overwriteDirectories`, `overwriteSymlinks`, `ignoreErrors`, `skipExisting`; **bug fix:** `enableFileDeletion` was documented as mirror-delete but consumed by nothing — now wired to `restore --delete-extra` with a behavior-level regression test. CLI (`kubectl kopiur restore`) gains matching flags.
3. **Verification** — `verification.quick.{parallel,fileParallelism,fileQueueLength,maxErrors}` (fixes controller-hardcoded `None`s) and `verification.deep.parallel` (threads into the scratch restore).
4. **Snapshot create** — `SnapshotPolicy.spec.errorHandling.failFast`, `SnapshotPolicy.spec.upload.limitMb`, `Snapshot.spec.description` (per-invocation); `kubectl kopiur snapshot` gains `--description`.

## Compatibility

Every new field is optional; absent = kopia's default = previous behavior (asserted byte-for-byte on each arg builder). Old work-spec wire JSON decodes (hand-written old-wire tests per op); no CRD version bump; no `MoverWorkSpec.version` bump needed.

## Deliberately NOT exposed

- `maintenance run --safety=none` — GC-safety footgun in a data-protection operator
- kopia retention flags — conflict with the locked GFS-only retention design
- `snapshot create --parallel` — redundant with `spec.upload.maxParallel*` (policy path)
- Operator-owned flags (`--json`, `--override-source`, `--tags`, `--pin`, shallow/mode/time overrides, credentials/logging) and `policy set` flags (already covered by `spec.policy` + `extraArgs`)
- No new `extraArgs`-style escape hatches — typed fields only

## Testing

- Per-layer unit tests for every field: serde roundtrips (`from_yaml` path), validators (`require_min`), **controller-glue tests proving each CRD field reaches the workspec op** (the regression class behind the three dormant-plumbing gaps), arg-builder argv tests, old-wire decode tests
- Real-kopia integration suite (kopia 0.23.1): 5/5, including sync-to negated forms, the restore flag sweep with `--delete-extra` actually deleting a stale file, and snapshot-create knobs recording the description
- e2e on kind: replication 3/3, restore 17/17, verification 4/4, policy_knobs 4/4 — new/extended scenarios assert the mover work-spec ConfigMap carries the knobs and the run still succeeds
- `mise run test` / `clippy` / `fmt-check` / `complexity-check` / `gen-check` all green

## Follow-ups (not in this PR)

- `MoverWorkSpec.version` values are inconsistent across builders (verify/replicate say 1, restore says 2, default 2) — harmless, worth a tidy-up
- Optional: map the new restore options in the VolSync migration path (`crates/migrate`)

Closes #216