### PR TITLE
fix: reap mover work-spec ConfigMaps at Job-terminal + orphan sweep

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -101,7 +101,7 @@ set -eu
 # the worst offender — so a NEW overly-complex function fails immediately
 # even while the legacy offenders are still being paid down. Refactored one
 # under the threshold? Lower BUDGET to match (the task reminds you).
-BUDGET=32
+BUDGET=31
 COUNT=$(cargo clippy --workspace --all-targets --all-features --locked -q -- -W clippy::cognitive_complexity 2>&1 \
   | grep -A1 'cognitive complexity of' | grep -oE '[-]{2}> [^ ]+' | sort -u | wc -l)
 echo "==> functions above the cognitive-complexity threshold: $COUNT (budget: $BUDGET)"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -440,42 +440,44 @@ provenance = "github-attestations"
 version = "24.17.0"
 backend = "core:node"
 
-[tools.node.options]
-compile = "true"
-
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:faa0d59ba7fe7045c950ed09b190578fb8eee73e4358686d38fcc99ca58c1480"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:cc54f73a1a4108d9e325eb201d90b25eeab60edc92b2a13240b2877a74c596da"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:f884c958c0652f7cd0ea43fdc39dddd1a98456ea9b1adeca85964847e2e39fb0"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
-install = "source"
+checksum = "sha256:80da552fe037290cb130e9dea590f5eeeb7aa450636f0c89ab41415511c1ec27"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:f2aa33b35b75aca5f3f7b85675a6f6423201053e9381911e64961f3bda2528ab"
 url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-win-x64.zip"
+
+[[tools.node]]
+version = "24.17.0"
+backend = "core:node"
+
+[tools.node.options]
+compile = "true"
+
+[tools.node."platforms.linux-x64"]
+checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
 
 [[tools.oxfmt]]
 version = "0.58.0"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -440,44 +440,42 @@ provenance = "github-attestations"
 version = "24.17.0"
 backend = "core:node"
 
+[tools.node.options]
+compile = "true"
+
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:faa0d59ba7fe7045c950ed09b190578fb8eee73e4358686d38fcc99ca58c1480"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-arm64.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:cc54f73a1a4108d9e325eb201d90b25eeab60edc92b2a13240b2877a74c596da"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-arm64-musl.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:f884c958c0652f7cd0ea43fdc39dddd1a98456ea9b1adeca85964847e2e39fb0"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-x64-musl.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-arm64.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:80da552fe037290cb130e9dea590f5eeeb7aa450636f0c89ab41415511c1ec27"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-x64.tar.gz"
+checksum = "sha256:66a10e05fa7875ff1d7d669de405ea6ce8725f2352bd07550f520dea2f880825"
+url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0.tar.gz"
+install = "source"
 
 [tools.node."platforms.windows-x64"]
 checksum = "sha256:f2aa33b35b75aca5f3f7b85675a6f6423201053e9381911e64961f3bda2528ab"
 url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-win-x64.zip"
-
-[[tools.node]]
-version = "24.17.0"
-backend = "core:node"
-
-[tools.node.options]
-compile = "true"
-
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
 
 [[tools.oxfmt]]
 version = "0.58.0"

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -189,7 +189,7 @@ pub struct BrowseArgs {
 #[derive(clap::Subcommand, Debug)]
 pub enum SessionCommand {
     /// End the warm browse session holding a repository open (deletes its
-    /// Job + work-spec ConfigMap). A no-op when no session exists.
+    /// Job). A no-op when no session exists.
     End(SessionEndArgs),
 }
 

--- a/crates/cli/src/cmd/browse/mod.rs
+++ b/crates/cli/src/cmd/browse/mod.rs
@@ -824,7 +824,7 @@ pub async fn session_end(ctx: &KubeCtx, args: &SessionEndArgs) -> Result<CmdOutp
             let job_name = kube::ResourceExt::name_any(&job);
             session::delete_session(ctx, &ns, &job_name).await?;
             Ok(CmdOutput::ok(format!(
-                "session {job_name} ended (Job + work-spec ConfigMap deleted)\n"
+                "session {job_name} ended (Job deleted)\n"
             )))
         }
         None => Ok(CmdOutput::ok(format!(

--- a/crates/cli/src/cmd/browse/session.rs
+++ b/crates/cli/src/cmd/browse/session.rs
@@ -320,8 +320,8 @@ impl ExecSession {
     }
 }
 
-/// Create the session Job (FIRST, so it can own the ConfigMap) and its
-/// work-spec ConfigMap, returning the Job name.
+/// Create the session Job (the work spec rides its pod env — the session is
+/// one self-cleaning object), returning the Job name.
 async fn create_session_job(
     ctx: &KubeCtx,
     target: &BrowseTarget,
@@ -407,7 +407,12 @@ async fn create_session_job(
         readiness_exec: Some(vec![SESSION_MOVER_BIN.to_string(), "ready".to_string()]),
     };
 
-    let job = jobs::build_job(&inputs);
+    // The session is ONE object: the Job carries the work spec inline in its
+    // pod env, so there is no sidecar ConfigMap to create (or leak — #224).
+    let job = jobs::build_job(&inputs).map_err(|source| CliError::Serialization {
+        what: "browse session work spec",
+        source: Box::new(source),
+    })?;
     let jobs_api: Api<Job> = Api::namespaced(ctx.client.clone(), ns);
     eprintln!(
         "starting browse session {name} (repository {})…",
@@ -415,8 +420,7 @@ async fn create_session_job(
     );
     let created = match jobs_api.create(&PostParams::default(), &job).await {
         Ok(created) => created,
-        // A concurrent CLI won the race: the session exists — reuse it (the
-        // winner also creates the ConfigMap; skip ours).
+        // A concurrent CLI won the race: the session exists — reuse it.
         Err(kube::Error::Api(ae)) if ae.code == 409 => {
             eprintln!("a concurrent command already started this session; joining it");
             return Ok(name);
@@ -432,50 +436,6 @@ async fn create_session_job(
             ));
         }
     };
-
-    // The ConfigMap is owned by the JOB (not the repository) so `session end`
-    // and the Job TTL cascade-delete it.
-    let mut cm = jobs::build_config_map(&inputs).map_err(|source| CliError::Serialization {
-        what: "browse session work spec",
-        source: source.into(),
-    })?;
-    cm.metadata.owner_references = Some(vec![OwnerReference {
-        api_version: "batch/v1".into(),
-        kind: "Job".into(),
-        name: created.name_any(),
-        uid: created.uid().unwrap_or_default(),
-        controller: Some(true),
-        block_owner_deletion: Some(false),
-    }]);
-    let cms: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), ns);
-    match cms.create(&PostParams::default(), &cm).await {
-        Ok(_) => {}
-        // A leftover CM under the deterministic name (e.g. from a session whose
-        // Job the TTL controller already reaped): replace it.
-        Err(kube::Error::Api(ae)) if ae.code == 409 => {
-            let _ = cms.delete(&name, &DeleteParams::default()).await;
-            cms.create(&PostParams::default(), &cm).await.map_err(|e| {
-                classify_kube(
-                    "create",
-                    "ConfigMap",
-                    "configmaps",
-                    Some(ns),
-                    Some(&name),
-                    e,
-                )
-            })?;
-        }
-        Err(e) => {
-            return Err(classify_kube(
-                "create",
-                "ConfigMap",
-                "configmaps",
-                Some(ns),
-                Some(&name),
-                e,
-            ));
-        }
-    }
     Ok(created.name_any())
 }
 
@@ -677,9 +637,10 @@ pub async fn find_session_job(
         .find(|j| j.metadata.name.as_deref() == Some(expected.as_str())))
 }
 
-/// Delete a session Job (background propagation reaps its pod and the
-/// Job-owned ConfigMap; the ConfigMap is deleted explicitly too for
-/// promptness).
+/// Delete a session Job (background propagation reaps its pod). The session's
+/// whole spec rides the Job env, so the Job is the only object. The trailing
+/// best-effort ConfigMap delete cleans up a LEGACY session's work-spec
+/// ConfigMap (CLI versions that mounted the spec) — a 404 no-op otherwise.
 pub async fn delete_session(
     ctx: &KubeCtx,
     namespace: &str,

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -831,9 +831,9 @@ async fn bootstrap_cluster_via_mover(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, &job_ns, &job_name, &cm, &job).await?;
+    let cm = jobs::build_result_config_map(&inputs);
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, &job_ns, &job_name, Some(&cm), &job).await?;
     // Stamp the reverify token (loop guard): this request is now honored. A
     // health-probe re-run keeps the phase `Ready` so backups/replication aren't paused.
     let mut create_status = if keep_ready_on_launch {

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -695,18 +695,7 @@ async fn bootstrap_cluster_via_mover(
                     )
                 {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
-                    job_api
-                        .delete(&job_name, &kube::api::DeleteParams::background())
-                        .await?;
-                    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), &job_ns);
-                    match cm_api
-                        .delete(&job_name, &kube::api::DeleteParams::default())
-                        .await
-                    {
-                        Ok(_) => {}
-                        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-                        Err(e) => return Err(Error::Kube(e)),
-                    }
+                    io::delete_mover_run(&ctx.client, &job_ns, &job_name).await?;
                     return Ok(Action::requeue(Duration::from_secs(5)));
                 }
                 finalize_cluster_bootstrap(
@@ -1194,25 +1183,7 @@ async fn finalize_cluster_probe_failure(
 /// Delete a finished cluster bootstrap Job + its result ConfigMap (in the creds
 /// Secret's namespace), tolerating a 404. Consumes a probe Job exactly once.
 async fn delete_cluster_bootstrap_job(ctx: &Context, job_ns: &str, job_name: &str) -> Result<()> {
-    let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), job_ns);
-    match job_api
-        .delete(job_name, &kube::api::DeleteParams::background())
-        .await
-    {
-        Ok(_) => {}
-        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-        Err(e) => return Err(Error::Kube(e)),
-    }
-    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), job_ns);
-    match cm_api
-        .delete(job_name, &kube::api::DeleteParams::default())
-        .await
-    {
-        Ok(_) => {}
-        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-        Err(e) => return Err(Error::Kube(e)),
-    }
-    Ok(())
+    io::delete_mover_run(&ctx.client, job_ns, job_name).await
 }
 
 /// The steady-state requeue for a `ClusterRepository`, shortened to the

--- a/crates/controller/src/config.rs
+++ b/crates/controller/src/config.rs
@@ -138,6 +138,31 @@ pub const WEBHOOK_MUTATING_CONFIG_ENV: &str = "KOPIUR_WEBHOOK_MUTATING_CONFIG";
 /// chart's `webhook.tls.secretName` default.
 pub const DEFAULT_WEBHOOK_SECRET_NAME: &str = "kopiur-webhook-tls";
 
+/// Cadence (seconds) of the orphaned work-spec ConfigMap sweep
+/// ([`crate::sweep`]): reaps mover work-spec ConfigMaps whose Job is already
+/// gone (TTL-reaped before the reconciler could observe it, or left behind by
+/// operator versions that never deleted them). `0` disables the sweep.
+/// Defaults to [`DEFAULT_WORK_SPEC_SWEEP_INTERVAL_SECS`]. Reachable via the
+/// chart's `controller.extraEnv`.
+pub const WORK_SPEC_SWEEP_INTERVAL_ENV: &str = "KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS";
+
+/// Fallback sweep cadence when [`WORK_SPEC_SWEEP_INTERVAL_ENV`] is unset: 6h.
+/// The transition-time cleanup in the reconcilers handles the steady state;
+/// the sweep is a backstop, so a slow cadence is ample.
+pub const DEFAULT_WORK_SPEC_SWEEP_INTERVAL_SECS: u64 = 6 * 60 * 60;
+
+/// Minimum age (seconds) a work-spec ConfigMap must reach before the sweep may
+/// reap it, closing the ConfigMap-applied-before-Job window (the ConfigMap and
+/// Job are applied in sequence) and any controller-crash-mid-spawn gap.
+/// Defaults to [`DEFAULT_WORK_SPEC_SWEEP_MIN_AGE_SECS`]; lower it only in
+/// tests. Reachable via the chart's `controller.extraEnv`.
+pub const WORK_SPEC_SWEEP_MIN_AGE_ENV: &str = "KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS";
+
+/// Fallback sweep minimum age when [`WORK_SPEC_SWEEP_MIN_AGE_ENV`] is unset: 1h
+/// (a spawned run's Job lands within seconds of its ConfigMap; 1h is a
+/// comfortable margin over any apply/crash window).
+pub const DEFAULT_WORK_SPEC_SWEEP_MIN_AGE_SECS: i64 = 3600;
+
 /// Steady-state cadence for re-checking the webhook cert for rotation and
 /// re-asserting the `caBundle`. The leaf is long-lived and renewed well before
 /// expiry, so a slow cadence is ample once the cert is established.
@@ -260,6 +285,18 @@ pub struct ControllerArgs {
     /// never contend on the same Lease.
     #[arg(long, env = LEASE_NAME_ENV)]
     pub lease_name: Option<String>,
+
+    /// Cadence (seconds) of the orphaned work-spec ConfigMap sweep; 0 disables.
+    #[arg(long, env = WORK_SPEC_SWEEP_INTERVAL_ENV,
+          default_value_t = DEFAULT_WORK_SPEC_SWEEP_INTERVAL_SECS,
+          value_parser = parse_sweep_interval)]
+    pub work_spec_sweep_interval_secs: u64,
+
+    /// Minimum age (seconds) before the sweep may reap a work-spec ConfigMap.
+    #[arg(long, env = WORK_SPEC_SWEEP_MIN_AGE_ENV,
+          default_value_t = DEFAULT_WORK_SPEC_SWEEP_MIN_AGE_SECS,
+          value_parser = parse_sweep_min_age)]
+    pub work_spec_sweep_min_age_secs: i64,
 
     /// Cluster-scoped install: watch every namespace and reconcile
     /// ClusterRepository. The chart stamps it for `installScope: cluster`.
@@ -471,6 +508,10 @@ pub struct ControllerConfig {
     pub watch_scope: WatchScope,
     /// Leader election, when enabled (`--leader-elect`).
     pub leader_election: Option<LeaderElection>,
+    /// Cadence (seconds) of the orphaned work-spec ConfigMap sweep; 0 disables.
+    pub work_spec_sweep_interval_secs: u64,
+    /// Minimum age (seconds) before the sweep may reap a work-spec ConfigMap.
+    pub work_spec_sweep_min_age_secs: i64,
 }
 
 impl ControllerArgs {
@@ -545,6 +586,8 @@ impl ControllerArgs {
             webhook_mutating_config: nonempty(self.webhook_mutating_config),
             watch_scope,
             leader_election,
+            work_spec_sweep_interval_secs: self.work_spec_sweep_interval_secs,
+            work_spec_sweep_min_age_secs: self.work_spec_sweep_min_age_secs.max(0),
         })
     }
 }
@@ -563,6 +606,35 @@ fn parse_http_addr(value: &str) -> Result<SocketAddr, String> {
             "KOPIUR_HTTP_ADDR='{value}' is not a valid socket address; use host:port, e.g. \
              [::]:8081 (IPv6/dual-stack, the default), 0.0.0.0:8081 (IPv4-only, for hosts with \
              IPv6 disabled); unset it to use the default [::]:8081"
+        )
+    })
+}
+
+/// Value parser for [`WORK_SPEC_SWEEP_INTERVAL_ENV`]. An empty value means
+/// "unset" (the chart can render an env var as `""`); `0` disables the sweep.
+fn parse_sweep_interval(value: &str) -> Result<u64, String> {
+    if value.is_empty() {
+        return Ok(DEFAULT_WORK_SPEC_SWEEP_INTERVAL_SECS);
+    }
+    value.parse::<u64>().map_err(|_| {
+        format!(
+            "KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS='{value}' is not a valid interval; use a \
+             number of seconds (0 disables the sweep); unset it to use the default \
+             {DEFAULT_WORK_SPEC_SWEEP_INTERVAL_SECS}"
+        )
+    })
+}
+
+/// Value parser for [`WORK_SPEC_SWEEP_MIN_AGE_ENV`]. An empty value means
+/// "unset"; negative values are clamped to 0 in `resolve()`.
+fn parse_sweep_min_age(value: &str) -> Result<i64, String> {
+    if value.is_empty() {
+        return Ok(DEFAULT_WORK_SPEC_SWEEP_MIN_AGE_SECS);
+    }
+    value.parse::<i64>().map_err(|_| {
+        format!(
+            "KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS='{value}' is not a valid age; use a number of \
+             seconds; unset it to use the default {DEFAULT_WORK_SPEC_SWEEP_MIN_AGE_SECS}"
         )
     })
 }

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -143,6 +143,21 @@ pub const RESTORE_POPULATED_REASON: &str = "RestoreSucceeded";
 /// absent from the workload namespace — `False` carries the actionable message
 /// (which Secret, which namespace, why, and how to fix). ADR §4.12.
 pub const CREDENTIALS_AVAILABLE_CONDITION: &str = "CredentialsAvailable";
+/// `Snapshot` condition tracking kopia-side pin reconciliation (ADR-0005 §13(c)).
+/// `True`/`False` mirrors `status.pinned` once a SnapshotPin mover Job ran;
+/// `Unknown` with reason `PinJobRunning` while one is in flight. Named for the
+/// state (like `Ready`/`LeaseOwned`). Doubles as the durable "a pin mover was
+/// ever spawned" marker that gates the per-reconcile pin-Job lookup — never
+/// remove it once set.
+pub const PINNED_CONDITION: &str = "Pinned";
+/// `reason` for [`PINNED_CONDITION`] = `False`: the SnapshotPin mover Job failed.
+pub const PIN_JOB_FAILED_REASON: &str = "PinJobFailed";
+/// Annotation stamped on a `{name}-pin` mover Job recording the pin state it
+/// was spawned to APPLY (`"true"` = pin, `"false"` = unpin). The reconciler
+/// consumes a terminal pin Job by this direction — never by the currently
+/// desired `spec.pin` — so a stale Job can't satisfy the opposite toggle and a
+/// pin that completed after a mid-flight spec flip is still recorded.
+pub const PIN_TARGET_ANNOTATION: &str = "kopiur.home-operations.com/pin-target";
 /// `reason`/Event reason for [`CREDENTIALS_AVAILABLE_CONDITION`] = `False`.
 pub const MISSING_CREDENTIALS_REASON: &str = "MissingCredentialsSecret";
 /// `reason`/Event reason for [`CREDENTIALS_AVAILABLE_CONDITION`] = `False` when

--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -60,6 +60,13 @@ pub enum Error {
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// The mover Job builder refused ([`kopiur_mover::jobs::BuildJobError`]):
+    /// either the work spec can't be JSON-encoded (structural) or it exceeds
+    /// what a pod env var can carry (a pathological recipe — terminal until the
+    /// spec shrinks, so it maps to Validation semantics via the error message).
+    #[error("mover Job build failed: {0}")]
+    BuildJob(#[from] kopiur_mover::jobs::BuildJobError),
+
     /// A cron expression failed to parse at scheduling time. Structural.
     #[error("invalid schedule: {0}")]
     InvalidSchedule(String),
@@ -154,6 +161,7 @@ impl Error {
             Error::Validation(_)
             | Error::BlockedOnGrant(_)
             | Error::Serialization(_)
+            | Error::BuildJob(_)
             | Error::InvalidSchedule(_)
             | Error::Invariant(_) => ErrorClass::Structural,
         }

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -246,6 +246,14 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
                  field(s) named above and re-apply."
             ),
         ),
+        // Same user contract as Validation: the run cannot start until the
+        // recipe shrinks (or, for the never-in-practice serialize arm, until
+        // the version skew is fixed) — the message carries the what/why/fix.
+        Error::BuildJob(_) => (
+            INVALID_SPEC_REASON,
+            FIX_SPEC_ACTION,
+            format!("{err}. The run will not start until this is corrected."),
+        ),
         Error::MissingDependency(_) => (
             MISSING_DEPENDENCY_REASON,
             CHECK_REFERENCES_ACTION,

--- a/crates/controller/src/io/mover.rs
+++ b/crates/controller/src/io/mover.rs
@@ -20,28 +20,33 @@ use kopiur_api::secctx_compat::{is_managed_by_kopiur, pod_mounts_claim};
 use crate::consts::PRIVILEGED_MOVERS_ANNOTATION;
 use crate::error::{Error, Result};
 
-/// Apply both the work-spec `ConfigMap` and the mover `Job` (server-side).
-/// Both carry the owner reference so GC reaps them with the CR (§4.10).
+/// Apply a mover run's objects (server-side): the `Job` (which carries the
+/// work spec inline in its pod env) and, for bootstrap/probe runs only, the
+/// result `ConfigMap` the mover PATCHes its outcome into. Everything carries
+/// the owner reference so GC reaps it with the CR (§4.10); the Job's
+/// `ttlSecondsAfterFinished` handles the interim.
 pub async fn apply_mover_objects(
     client: &kube::Client,
     namespace: &str,
     name: &str,
-    config_map: &ConfigMap,
+    result_config_map: Option<&ConfigMap>,
     job: &Job,
 ) -> Result<()> {
-    let cm_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
-    apply(&cm_api, name, config_map).await?;
+    if let Some(config_map) = result_config_map {
+        let cm_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+        apply(&cm_api, name, config_map).await?;
+    }
     let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
     apply(&job_api, name, job).await?;
     Ok(())
 }
 
-/// Delete only the work-spec `ConfigMap` of a mover run, tolerating a 404 (owner
-/// GC or an earlier pass may have won). The Job is deliberately left to its
-/// `ttlSecondsAfterFinished` — it carries the pod logs and, for the slot-based
-/// reconcilers, is the durable "slot handled" marker until the TTL reaps it.
-/// Callers must only invoke this once the same-named Job is observed terminal
-/// (no pod will mount the ConfigMap again).
+/// Delete the same-named `ConfigMap` of a mover run, tolerating a 404 (owner
+/// GC or an earlier pass may have won). Today that ConfigMap exists only for
+/// bootstrap/probe runs (the result channel); for every other run kind this is
+/// a no-op 404 in the steady state, and cleans up the LEGACY per-run work-spec
+/// ConfigMap left by operator versions that mounted the spec instead of
+/// embedding it in the Job env.
 pub async fn delete_work_spec_cm(
     client: &kube::Client,
     namespace: &str,
@@ -56,30 +61,14 @@ pub async fn delete_work_spec_cm(
     Ok(())
 }
 
-/// Best-effort [`delete_work_spec_cm`] for the pure-hygiene call sites: a
-/// failed delete is only a DEFERRED cleanup (the periodic orphan sweep is the
-/// backstop), so it must never fail the reconcile that carried it — e.g. an
-/// admission policy denying ConfigMap deletes must not turn every completed
-/// maintenance slot into a reconcile error.
-pub async fn reap_work_spec_cm(client: &kube::Client, namespace: &str, job_name: &str) {
-    if let Err(e) = delete_work_spec_cm(client, namespace, job_name).await {
-        tracing::warn!(
-            configmap = %job_name, namespace = %namespace, error = %e,
-            "work-spec ConfigMap cleanup failed (deferred to the orphan sweep)"
-        );
-    }
-}
-
-/// Delete a mover run being torn down: the Job (background propagation, so its
-/// pods are reaped too) AND its same-named work-spec `ConfigMap`, both tolerating
-/// a 404 (the kube TTL controller may have reaped the Job first). Only for runs
-/// observed terminal or being force-failed (wedged) — never against a run whose
-/// pod may still mount the ConfigMap.
+/// Delete a mover run being consumed: the Job (background propagation, so its
+/// pods are reaped too) AND its same-named `ConfigMap` (the bootstrap result
+/// channel, or a legacy work-spec leftover), both tolerating a 404 (the kube
+/// TTL controller may have reaped the Job first). Only for runs observed
+/// terminal or being force-failed.
 ///
 /// Propagates non-404 errors: the bootstrap/probe consumers rely on the delete
 /// for their consume-exactly-once semantics, so a failure there must requeue.
-/// Wedged-teardown call sites wrap this best-effort instead — aborting a
-/// reconcile mid-teardown would skip the staged-source cleanup that follows.
 pub async fn delete_mover_run(
     client: &kube::Client,
     namespace: &str,

--- a/crates/controller/src/io/mover.rs
+++ b/crates/controller/src/io/mover.rs
@@ -10,7 +10,7 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::api::rbac::v1::{RoleBinding, RoleRef, Subject};
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, OwnerReference};
-use kube::api::{ListParams, PostParams};
+use kube::api::{DeleteParams, ListParams, PostParams};
 use kube::core::ObjectMeta;
 use kube::{Api, ResourceExt};
 
@@ -34,6 +34,64 @@ pub async fn apply_mover_objects(
     let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
     apply(&job_api, name, job).await?;
     Ok(())
+}
+
+/// Delete only the work-spec `ConfigMap` of a mover run, tolerating a 404 (owner
+/// GC or an earlier pass may have won). The Job is deliberately left to its
+/// `ttlSecondsAfterFinished` — it carries the pod logs and, for the slot-based
+/// reconcilers, is the durable "slot handled" marker until the TTL reaps it.
+/// Callers must only invoke this once the same-named Job is observed terminal
+/// (no pod will mount the ConfigMap again).
+pub async fn delete_work_spec_cm(
+    client: &kube::Client,
+    namespace: &str,
+    job_name: &str,
+) -> Result<()> {
+    let cm_api: Api<ConfigMap> = Api::namespaced(client.clone(), namespace);
+    match cm_api.delete(job_name, &DeleteParams::default()).await {
+        Ok(_) => {}
+        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
+        Err(e) => return Err(Error::Kube(e)),
+    }
+    Ok(())
+}
+
+/// Best-effort [`delete_work_spec_cm`] for the pure-hygiene call sites: a
+/// failed delete is only a DEFERRED cleanup (the periodic orphan sweep is the
+/// backstop), so it must never fail the reconcile that carried it — e.g. an
+/// admission policy denying ConfigMap deletes must not turn every completed
+/// maintenance slot into a reconcile error.
+pub async fn reap_work_spec_cm(client: &kube::Client, namespace: &str, job_name: &str) {
+    if let Err(e) = delete_work_spec_cm(client, namespace, job_name).await {
+        tracing::warn!(
+            configmap = %job_name, namespace = %namespace, error = %e,
+            "work-spec ConfigMap cleanup failed (deferred to the orphan sweep)"
+        );
+    }
+}
+
+/// Delete a mover run being torn down: the Job (background propagation, so its
+/// pods are reaped too) AND its same-named work-spec `ConfigMap`, both tolerating
+/// a 404 (the kube TTL controller may have reaped the Job first). Only for runs
+/// observed terminal or being force-failed (wedged) — never against a run whose
+/// pod may still mount the ConfigMap.
+///
+/// Propagates non-404 errors: the bootstrap/probe consumers rely on the delete
+/// for their consume-exactly-once semantics, so a failure there must requeue.
+/// Wedged-teardown call sites wrap this best-effort instead — aborting a
+/// reconcile mid-teardown would skip the staged-source cleanup that follows.
+pub async fn delete_mover_run(
+    client: &kube::Client,
+    namespace: &str,
+    job_name: &str,
+) -> Result<()> {
+    let job_api: Api<Job> = Api::namespaced(client.clone(), namespace);
+    match job_api.delete(job_name, &DeleteParams::background()).await {
+        Ok(_) => {}
+        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
+        Err(e) => return Err(Error::Kube(e)),
+    }
+    delete_work_spec_cm(client, namespace, job_name).await
 }
 
 /// Labels marking the per-namespace mover RBAC objects as kopiur-managed.

--- a/crates/controller/src/lib.rs
+++ b/crates/controller/src/lib.rs
@@ -25,6 +25,7 @@ pub mod snapshot;
 pub mod snapshot_policy;
 pub mod snapshot_schedule;
 mod startup;
+pub mod sweep;
 pub mod verification;
 pub mod watch;
 pub mod webhook_tls;

--- a/crates/controller/src/maintenance/mod.rs
+++ b/crates/controller/src/maintenance/mod.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use k8s_openapi::api::batch::v1::Job;
-use kube::api::ListParams;
+use kube::api::{DeleteParams, ListParams};
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 
@@ -187,12 +187,9 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
             // `status.<mode>.lastHandledSlot` — the Job self-reaps via its TTL,
             // and a yield does not advance `lastRunAt`, so without the durable
             // marker the same slot re-fired after every TTL reap (a yield Job per
-            // hour, forever). The work-spec ConfigMap is only needed while the
-            // pod runs — drop it so per-slot ConfigMaps do not accumulate. Then
-            // sleep until the next slot.
+            // hour, forever). Then sleep until the next slot.
             Some(true) => {
                 record_handled_slot(&api, &name, maint, mode, slot, now).await?;
-                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(cap(next_wakeup(
                     maint,
                     now,
@@ -202,8 +199,7 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
             }
             // Failed: surface the condition once (transition-guarded) and re-check.
             // The failed Job lingers until its TTL (pod logs stay reachable), then
-            // a fresh reconcile re-spawns this slot as a bounded retry. The
-            // work-spec ConfigMap is dropped now — the retry recreates it.
+            // a fresh reconcile re-spawns this slot as a bounded retry.
             Some(false) => {
                 patch_condition_if_changed(
                     &api,
@@ -214,7 +210,6 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
                     "maintenance Job failed; see the Job/pod logs",
                 )
                 .await?;
-                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(REQUEUE_FAILED))
             }
             // Still running — but a mover that can't START (impossible securityContext, bad
@@ -238,12 +233,10 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
                         &crate::snapshot::wedged_pod_message(&reason, &message, grace),
                     )
                     .await?;
-                    // BEST-EFFORT: mirror the wedged teardown elsewhere — an error
-                    // must not turn the surfaced condition into a reconcile error.
-                    if let Err(e) = io::delete_mover_run(&ctx.client, &namespace, &job_name).await {
-                        tracing::warn!(maint = %name, error = %e,
-                            "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
-                    }
+                    // Reap the wedged Job (cascade) so the kubelet stops
+                    // retrying. BEST-EFFORT: an error must not turn the
+                    // surfaced condition into a reconcile error.
+                    let _ = job_api.delete(&job_name, &DeleteParams::background()).await;
                     return Ok(Action::requeue(REQUEUE_FAILED));
                 }
                 Ok(Action::requeue(REQUEUE_RUNNING))
@@ -367,7 +360,6 @@ async fn handle_manual_run(
                     },
                 )
                 .await?;
-                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
                 Ok(None)
             }
             Some(false) => {
@@ -391,7 +383,6 @@ async fn handle_manual_run(
                     "manual maintenance Job failed; see the Job/pod logs",
                 )
                 .await?;
-                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
                 Ok(None)
             }
             None => Ok(Some(Action::requeue(REQUEUE_RUNNING))),
@@ -672,9 +663,8 @@ async fn spawn_maintenance_job(
         readiness_exec: None,
     };
 
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, namespace, job_name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, namespace, job_name, None, &job).await?;
     Ok(())
 }
 

--- a/crates/controller/src/maintenance/mod.rs
+++ b/crates/controller/src/maintenance/mod.rs
@@ -21,8 +21,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::ConfigMap;
-use kube::api::{DeleteParams, ListParams};
+use kube::api::ListParams;
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 
@@ -193,7 +192,7 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
             // sleep until the next slot.
             Some(true) => {
                 record_handled_slot(&api, &name, maint, mode, slot, now).await?;
-                delete_work_spec_cm(ctx, &namespace, &job_name).await;
+                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(cap(next_wakeup(
                     maint,
                     now,
@@ -202,8 +201,9 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
                 ))))
             }
             // Failed: surface the condition once (transition-guarded) and re-check.
-            // The failed Job lingers until its TTL, then a fresh reconcile
-            // re-spawns this slot as a bounded retry.
+            // The failed Job lingers until its TTL (pod logs stay reachable), then
+            // a fresh reconcile re-spawns this slot as a bounded retry. The
+            // work-spec ConfigMap is dropped now — the retry recreates it.
             Some(false) => {
                 patch_condition_if_changed(
                     &api,
@@ -214,6 +214,7 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
                     "maintenance Job failed; see the Job/pod logs",
                 )
                 .await?;
+                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(REQUEUE_FAILED))
             }
             // Still running — but a mover that can't START (impossible securityContext, bad
@@ -237,7 +238,12 @@ async fn reconcile_inner(maint: &Maintenance, ctx: &Context) -> Result<Action> {
                         &crate::snapshot::wedged_pod_message(&reason, &message, grace),
                     )
                     .await?;
-                    let _ = job_api.delete(&job_name, &DeleteParams::background()).await;
+                    // BEST-EFFORT: mirror the wedged teardown elsewhere — an error
+                    // must not turn the surfaced condition into a reconcile error.
+                    if let Err(e) = io::delete_mover_run(&ctx.client, &namespace, &job_name).await {
+                        tracing::warn!(maint = %name, error = %e,
+                            "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
+                    }
                     return Ok(Action::requeue(REQUEUE_FAILED));
                 }
                 Ok(Action::requeue(REQUEUE_RUNNING))
@@ -361,7 +367,7 @@ async fn handle_manual_run(
                     },
                 )
                 .await?;
-                delete_work_spec_cm(ctx, namespace, &job_name).await;
+                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
                 Ok(None)
             }
             Some(false) => {
@@ -385,6 +391,7 @@ async fn handle_manual_run(
                     "manual maintenance Job failed; see the Job/pod logs",
                 )
                 .await?;
+                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
                 Ok(None)
             }
             None => Ok(Some(Action::requeue(REQUEUE_RUNNING))),
@@ -888,14 +895,6 @@ async fn has_active_maintenance_job(job_api: &Api<Job>, cr_name: &str) -> Result
         .list(&ListParams::default().labels(&selector))
         .await?;
     Ok(jobs.items.iter().any(|j| job_terminal_state(j).is_none()))
-}
-
-/// Best-effort delete of a per-slot work-spec ConfigMap once its Job is done.
-async fn delete_work_spec_cm(ctx: &Context, namespace: &str, name: &str) {
-    let api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
-    if let Err(e) = api.delete(name, &DeleteParams::default()).await {
-        tracing::debug!(error = %e, configmap = %name, "work-spec ConfigMap cleanup failed (ignored)");
-    }
 }
 
 /// Patch the single `LeaseOwned` condition only when its status/reason actually

--- a/crates/controller/src/metrics.rs
+++ b/crates/controller/src/metrics.rs
@@ -67,6 +67,7 @@ pub struct Metrics {
     snapshots_completed: Counter<u64>,
     snapshot_deletion_failures: Counter<u64>,
     orphaned_snapshots: Counter<u64>,
+    work_spec_cms_swept: Counter<u64>,
     schedule_backups_created: Counter<u64>,
     secrets_projected: Counter<u64>,
     backups_refused: Counter<u64>,
@@ -160,6 +161,13 @@ impl Metrics {
                 "Total snapshots orphaned (Orphan policy or skip-snapshot-cleanup annotation).",
             )
             .build();
+        let work_spec_cms_swept = m
+            .u64_counter("kopiur_work_spec_cms_swept")
+            .with_description(
+                "Total orphaned mover work-spec ConfigMaps deleted by the periodic sweep \
+                 (ConfigMaps whose mover Job was already TTL-reaped).",
+            )
+            .build();
         let schedule_backups_created = m
             .u64_counter("kopiur_schedule_snapshots_created")
             .with_description("Total Snapshot CRs created by a SnapshotSchedule.")
@@ -231,6 +239,7 @@ impl Metrics {
             snapshots_completed,
             snapshot_deletion_failures,
             orphaned_snapshots,
+            work_spec_cms_swept,
             schedule_backups_created,
             secrets_projected,
             backups_refused,
@@ -582,6 +591,11 @@ impl Metrics {
     pub fn inc_orphaned_snapshot(&self, ns: &str) {
         self.orphaned_snapshots
             .add(1, &[KeyValue::new("namespace", ns.to_string())]);
+    }
+
+    /// Count `n` orphaned work-spec ConfigMaps deleted by one sweep pass.
+    pub fn inc_work_spec_cms_swept(&self, n: u64) {
+        self.work_spec_cms_swept.add(n, &[]);
     }
 
     /// Count a Snapshot CR created by a SnapshotSchedule.

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -18,7 +18,6 @@ use std::time::Duration;
 
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::ConfigMap;
-use kube::api::DeleteParams;
 use kube::runtime::controller::Action;
 use kube::{Api, Resource, ResourceExt};
 
@@ -639,15 +638,7 @@ async fn bootstrap_via_mover(
                     )
                 {
                     tracing::debug!(repo = %name, "recycling finished bootstrap Job for a catalog refresh");
-                    job_api
-                        .delete(&job_name, &DeleteParams::background())
-                        .await?;
-                    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
-                    match cm_api.delete(&job_name, &DeleteParams::default()).await {
-                        Ok(_) => {}
-                        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-                        Err(e) => return Err(Error::Kube(e)),
-                    }
+                    io::delete_mover_run(&ctx.client, namespace, &job_name).await?;
                     return Ok(Action::requeue(Duration::from_secs(5)));
                 }
                 finalize_bootstrap(
@@ -1205,19 +1196,7 @@ async fn finalize_probe_failure(
 /// kube TTL controller may have reaped it first). Used to consume a probe Job
 /// exactly once.
 async fn delete_bootstrap_job(ctx: &Context, namespace: &str, job_name: &str) -> Result<()> {
-    let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
-    match job_api.delete(job_name, &DeleteParams::background()).await {
-        Ok(_) => {}
-        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-        Err(e) => return Err(Error::Kube(e)),
-    }
-    let cm_api: Api<ConfigMap> = Api::namespaced(ctx.client.clone(), namespace);
-    match cm_api.delete(job_name, &DeleteParams::default()).await {
-        Ok(_) => {}
-        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
-        Err(e) => return Err(Error::Kube(e)),
-    }
-    Ok(())
+    io::delete_mover_run(&ctx.client, namespace, job_name).await
 }
 
 /// The steady-state requeue for a `Repository`, shortened to the health-probe

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -813,9 +813,9 @@ async fn bootstrap_via_mover(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, namespace, &job_name, &cm, &job).await?;
+    let cm = jobs::build_result_config_map(&inputs);
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, namespace, &job_name, Some(&cm), &job).await?;
     // Stamp the reverify token (loop guard): this request is now honored.
     // A health-probe re-run of an already-`Ready` repo keeps its phase `Ready`
     // (`keep_ready_on_launch`) so backups/replication are never paused while the

--- a/crates/controller/src/repository_replication.rs
+++ b/crates/controller/src/repository_replication.rs
@@ -134,12 +134,21 @@ async fn reconcile_inner(repl: &RepositoryReplication, ctx: &Context) -> Result<
     match job_api.get_opt(&job_name).await? {
         Some(job) => match job_terminal_state(&job) {
             // Success: the mover stamped status; sleep until the next slot.
-            Some(true) => Ok(Action::requeue(cap(next_wakeup(
-                repl,
-                now,
-                Some(slot),
-                repo_tz,
-            )))),
+            // Drop the per-slot work-spec ConfigMap now — it is owned by the
+            // long-lived RepositoryReplication CR, so left alone one accumulates
+            // per slot, forever. The Job stays until its TTL: it is the
+            // slot-handled marker (deleting it early would re-fire the slot).
+            Some(true) => {
+                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
+                Ok(Action::requeue(cap(next_wakeup(
+                    repl,
+                    now,
+                    Some(slot),
+                    repo_tz,
+                ))))
+            }
+            // Failure: same CM reap. The failed Job lingers to its TTL as the
+            // bounded-retry backoff; the retry re-spawn recreates the ConfigMap.
             Some(false) => {
                 patch_ready_if_changed(
                     &api,
@@ -151,6 +160,7 @@ async fn reconcile_inner(repl: &RepositoryReplication, ctx: &Context) -> Result<
                     Some("Failed"),
                 )
                 .await?;
+                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(REQUEUE_FAILED))
             }
             None => Ok(Action::requeue(REQUEUE_RUNNING)),

--- a/crates/controller/src/repository_replication.rs
+++ b/crates/controller/src/repository_replication.rs
@@ -133,22 +133,17 @@ async fn reconcile_inner(repl: &RepositoryReplication, ctx: &Context) -> Result<
     let job_name = replication_job_name(&name, slot);
     match job_api.get_opt(&job_name).await? {
         Some(job) => match job_terminal_state(&job) {
-            // Success: the mover stamped status; sleep until the next slot.
-            // Drop the per-slot work-spec ConfigMap now — it is owned by the
-            // long-lived RepositoryReplication CR, so left alone one accumulates
-            // per slot, forever. The Job stays until its TTL: it is the
-            // slot-handled marker (deleting it early would re-fire the slot).
-            Some(true) => {
-                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
-                Ok(Action::requeue(cap(next_wakeup(
-                    repl,
-                    now,
-                    Some(slot),
-                    repo_tz,
-                ))))
-            }
-            // Failure: same CM reap. The failed Job lingers to its TTL as the
-            // bounded-retry backoff; the retry re-spawn recreates the ConfigMap.
+            // Success: the mover stamped status; sleep until the next slot. The
+            // terminal Job (its env carries the whole run spec) self-reaps via
+            // its TTL — nothing else to clean up.
+            Some(true) => Ok(Action::requeue(cap(next_wakeup(
+                repl,
+                now,
+                Some(slot),
+                repo_tz,
+            )))),
+            // Failure: the failed Job lingers to its TTL as the bounded-retry
+            // backoff (and keeps the pod logs).
             Some(false) => {
                 patch_ready_if_changed(
                     &api,
@@ -160,7 +155,6 @@ async fn reconcile_inner(repl: &RepositoryReplication, ctx: &Context) -> Result<
                     Some("Failed"),
                 )
                 .await?;
-                io::reap_work_spec_cm(&ctx.client, &namespace, &job_name).await;
                 Ok(Action::requeue(REQUEUE_FAILED))
             }
             None => Ok(Action::requeue(REQUEUE_RUNNING)),
@@ -335,9 +329,8 @@ async fn spawn_replication_job(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, namespace, job_name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, namespace, job_name, None, &job).await?;
     Ok(())
 }
 

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -137,39 +137,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     // is NOT terminal here — see `phase_is_terminal_at_guard`.)
     match restore.status.as_ref().and_then(|s| s.phase) {
         Some(phase) if phase_is_terminal_at_guard(phase, state) => {
-            // The kstatus conditions come from the controller's transition patch
-            // in `drive_direct_restore` — which the MOVER's own terminal `phase`
-            // stamp races past in the common case (its in-cluster PATCH carries
-            // `phase: Completed`/`Failed` + logTail/failure but no conditions;
-            // the Job-completion reconcile then already sees the terminal phase
-            // and lands HERE, never in the Job branch). Heal once: patch ONLY
-            // phase + observedGeneration + conditions (`restore_ready_status`
-            // carries nothing else, so the merge preserves the mover-written
-            // logTail/failure/progress and the pinned resolution). Self-gated by
-            // `kstatus_settled_for`, so a healed Restore never re-patches.
-            if !kstatus_settled_for(restore, phase) {
-                let status = if phase == RestorePhase::Completed {
-                    // The mover wrote `phase: Completed` + `status.resolved` in one
-                    // PATCH, so `resolved` is observed here — distinguish a real
-                    // restore from a deploy-or-restore that came up empty.
-                    restore_success_status(
-                        restore,
-                        restore.status.as_ref().and_then(|s| s.resolved.as_ref()),
-                    )
-                } else {
-                    restore_ready_status(
-                        restore,
-                        phase,
-                        "MoverJobFailed",
-                        "the restore mover reported a terminal failure; see \
-                         status.failure / status.logTail for the cause, fix it, and \
-                         create a NEW Restore — a Failed Restore is terminal and \
-                         never retries",
-                    )
-                };
-                io::patch_status(&api, &name, status).await?;
-            }
-            return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+            return steady_terminal_restore(restore, ctx, &api, &namespace, &name, phase).await;
         }
         _ => {}
     }
@@ -1159,6 +1127,130 @@ enum MoverOutcome {
 /// Idempotent: an existing Job is tracked to terminal, never re-applied. The caller
 /// owns the status/phase writes. `selection` is a concrete id (anchor-healed) or an
 /// in-Job selector the mover resolves.
+/// The steady pass for a Restore already in a terminal phase (the entry guard):
+/// heal the kstatus once, reap the finished run's work-spec ConfigMap, and
+/// settle into the slow heartbeat.
+///
+/// The kstatus conditions come from the controller's transition patch in
+/// `drive_direct_restore` — which the MOVER's own terminal `phase` stamp races
+/// past in the common case (its in-cluster PATCH carries `phase:
+/// Completed`/`Failed` + logTail/failure but no conditions; the Job-completion
+/// reconcile then already sees the terminal phase and lands HERE, never in the
+/// Job branch). Heal once: patch ONLY phase + observedGeneration + conditions
+/// (`restore_ready_status` carries nothing else, so the merge preserves the
+/// mover-written logTail/failure/progress and the pinned resolution).
+/// Self-gated by `kstatus_settled_for`, so a healed Restore never re-patches.
+async fn steady_terminal_restore(
+    restore: &Restore,
+    ctx: &Context,
+    api: &Api<Restore>,
+    namespace: &str,
+    name: &str,
+    phase: RestorePhase,
+) -> Result<Action> {
+    if !kstatus_settled_for(restore, phase) {
+        let status = if phase == RestorePhase::Completed {
+            // The mover wrote `phase: Completed` + `status.resolved` in one
+            // PATCH, so `resolved` is observed here — distinguish a real
+            // restore from a deploy-or-restore that came up empty.
+            restore_success_status(
+                restore,
+                restore.status.as_ref().and_then(|s| s.resolved.as_ref()),
+            )
+        } else {
+            restore_ready_status(
+                restore,
+                phase,
+                "MoverJobFailed",
+                "the restore mover reported a terminal failure; see \
+                 status.failure / status.logTail for the cause, fix it, and \
+                 create a NEW Restore — a Failed Restore is terminal and \
+                 never retries",
+            )
+        };
+        io::patch_status(api, name, status).await?;
+    }
+    // The COMMON terminal path lands here, not in `run_restore_mover`'s
+    // terminal arms: the mover stamps the terminal phase before its pod exits,
+    // and this guard then short-circuits every later reconcile. Reap the
+    // work-spec ConfigMap once the direct-restore mover Job (named after the
+    // Restore) is observed terminal; the Job keeps the pod logs until its TTL.
+    // Gated on the run having finished within the reap lookback — beyond it
+    // the Job is certainly TTL-reaped and the GET would 404 on every heartbeat
+    // for as long as the Restore CR lives (the orphan sweep owns stragglers).
+    // A populator restore has no Job of this name (its `-populate` artifacts
+    // are `finalize_populator`'s) — a one-time absent-Job GET there.
+    let end_time = restore
+        .status
+        .as_ref()
+        .and_then(|s| s.timing.as_ref())
+        .and_then(|t| t.end_time.as_deref());
+    if crate::snapshot::finished_recently(end_time, chrono::Utc::now()) {
+        let job_api: Api<k8s_openapi::api::batch::v1::Job> =
+            Api::namespaced(ctx.client.clone(), namespace);
+        if crate::snapshot::work_spec_reapable(job_api.get_opt(name).await?.as_ref()) {
+            io::reap_work_spec_cm(&ctx.client, namespace, name).await;
+        }
+    }
+    Ok(Action::requeue(std::time::Duration::from_secs(600)))
+}
+
+/// Classify an EXISTING restore mover Job into a [`MoverOutcome`], reaping the
+/// work-spec ConfigMap at terminal (the Job stays until its TTL so pod logs
+/// remain reachable) and tearing down a wedged mover. Split from
+/// [`run_restore_mover`] so both stay under the complexity ratchet.
+async fn observe_restore_mover(
+    ctx: &Context,
+    restore: &Restore,
+    namespace: &str,
+    job_name: &str,
+    job: &k8s_openapi::api::batch::v1::Job,
+) -> Result<MoverOutcome> {
+    Ok(match crate::snapshot::job_terminal_state(job) {
+        // Terminal either way: drop the work-spec ConfigMap now. Idempotent —
+        // the mover usually stamps the terminal phase before the Job goes
+        // terminal, in which case the entry guard short-circuits future
+        // reconciles and the periodic orphan sweep reaps the ConfigMap instead.
+        Some(true) => {
+            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
+            MoverOutcome::Succeeded {
+                duration_secs: restore_job_duration_seconds(job),
+            }
+        }
+        Some(false) => {
+            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
+            MoverOutcome::Failed
+        }
+        // A mover that can't START (impossible securityContext, bad image,
+        // unschedulable) never terminates, so backoffLimit never trips — fail fast
+        // past the pod-startup deadline instead of hanging to the 48h backstop.
+        None => {
+            let grace = kopiur_api::common::pod_startup_deadline_seconds(
+                restore.spec.failure_policy.as_ref(),
+            );
+            if let io::WedgedVerdict::Wedged { reason, message } =
+                io::wedged_pod_verdict(&ctx.client, namespace, job_name, grace).await?
+            {
+                // Reap the wedged Job (cascade) so the kubelet stops retrying,
+                // and its work-spec ConfigMap with it. BEST-EFFORT: an error here
+                // must not abort before `MoverOutcome::Wedged` reaches the caller —
+                // a partial teardown (Job gone, error surfaced) would otherwise
+                // leave the Restore un-Failed and the retry would spawn a fresh
+                // wedged mover, cycling instead of failing fast.
+                if let Err(e) = io::delete_mover_run(&ctx.client, namespace, job_name).await {
+                    tracing::warn!(restore = %job_name, error = %e,
+                        "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
+                }
+                MoverOutcome::Wedged {
+                    message: crate::snapshot::wedged_pod_message(&reason, &message, grace),
+                }
+            } else {
+                MoverOutcome::Running { created: false }
+            }
+        }
+    })
+}
+
 async fn run_restore_mover(
     ctx: &Context,
     restore: &Restore,
@@ -1171,33 +1263,7 @@ async fn run_restore_mover(
     use k8s_openapi::api::batch::v1::Job;
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
     if let Some(job) = job_api.get_opt(job_name).await? {
-        return Ok(match crate::snapshot::job_terminal_state(&job) {
-            Some(true) => MoverOutcome::Succeeded {
-                duration_secs: restore_job_duration_seconds(&job),
-            },
-            Some(false) => MoverOutcome::Failed,
-            // A mover that can't START (impossible securityContext, bad image,
-            // unschedulable) never terminates, so backoffLimit never trips — fail fast
-            // past the pod-startup deadline instead of hanging to the 48h backstop.
-            None => {
-                let grace = kopiur_api::common::pod_startup_deadline_seconds(
-                    restore.spec.failure_policy.as_ref(),
-                );
-                if let io::WedgedVerdict::Wedged { reason, message } =
-                    io::wedged_pod_verdict(&ctx.client, namespace, job_name, grace).await?
-                {
-                    // Reap the wedged Job (cascade) so the kubelet stops retrying.
-                    let _ = job_api
-                        .delete(job_name, &kube::api::DeleteParams::background())
-                        .await;
-                    MoverOutcome::Wedged {
-                        message: crate::snapshot::wedged_pod_message(&reason, &message, grace),
-                    }
-                } else {
-                    MoverOutcome::Running { created: false }
-                }
-            }
-        });
+        return observe_restore_mover(ctx, restore, namespace, job_name, &job).await;
     }
 
     let target_path = "/restore".to_string();

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -137,7 +137,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     // is NOT terminal here — see `phase_is_terminal_at_guard`.)
     match restore.status.as_ref().and_then(|s| s.phase) {
         Some(phase) if phase_is_terminal_at_guard(phase, state) => {
-            return steady_terminal_restore(restore, ctx, &api, &namespace, &name, phase).await;
+            return steady_terminal_restore(restore, &api, &name, phase).await;
         }
         _ => {}
     }
@@ -1142,9 +1142,7 @@ enum MoverOutcome {
 /// Self-gated by `kstatus_settled_for`, so a healed Restore never re-patches.
 async fn steady_terminal_restore(
     restore: &Restore,
-    ctx: &Context,
     api: &Api<Restore>,
-    namespace: &str,
     name: &str,
     phase: RestorePhase,
 ) -> Result<Action> {
@@ -1170,35 +1168,12 @@ async fn steady_terminal_restore(
         };
         io::patch_status(api, name, status).await?;
     }
-    // The COMMON terminal path lands here, not in `run_restore_mover`'s
-    // terminal arms: the mover stamps the terminal phase before its pod exits,
-    // and this guard then short-circuits every later reconcile. Reap the
-    // work-spec ConfigMap once the direct-restore mover Job (named after the
-    // Restore) is observed terminal; the Job keeps the pod logs until its TTL.
-    // Gated on the run having finished within the reap lookback — beyond it
-    // the Job is certainly TTL-reaped and the GET would 404 on every heartbeat
-    // for as long as the Restore CR lives (the orphan sweep owns stragglers).
-    // A populator restore has no Job of this name (its `-populate` artifacts
-    // are `finalize_populator`'s) — a one-time absent-Job GET there.
-    let end_time = restore
-        .status
-        .as_ref()
-        .and_then(|s| s.timing.as_ref())
-        .and_then(|t| t.end_time.as_deref());
-    if crate::snapshot::finished_recently(end_time, chrono::Utc::now()) {
-        let job_api: Api<k8s_openapi::api::batch::v1::Job> =
-            Api::namespaced(ctx.client.clone(), namespace);
-        if crate::snapshot::work_spec_reapable(job_api.get_opt(name).await?.as_ref()) {
-            io::reap_work_spec_cm(&ctx.client, namespace, name).await;
-        }
-    }
     Ok(Action::requeue(std::time::Duration::from_secs(600)))
 }
 
-/// Classify an EXISTING restore mover Job into a [`MoverOutcome`], reaping the
-/// work-spec ConfigMap at terminal (the Job stays until its TTL so pod logs
-/// remain reachable) and tearing down a wedged mover. Split from
-/// [`run_restore_mover`] so both stay under the complexity ratchet.
+/// Classify an EXISTING restore mover Job into a [`MoverOutcome`], tearing
+/// down a wedged mover. Split from [`run_restore_mover`] so both stay under
+/// the complexity ratchet.
 async fn observe_restore_mover(
     ctx: &Context,
     restore: &Restore,
@@ -1207,20 +1182,10 @@ async fn observe_restore_mover(
     job: &k8s_openapi::api::batch::v1::Job,
 ) -> Result<MoverOutcome> {
     Ok(match crate::snapshot::job_terminal_state(job) {
-        // Terminal either way: drop the work-spec ConfigMap now. Idempotent —
-        // the mover usually stamps the terminal phase before the Job goes
-        // terminal, in which case the entry guard short-circuits future
-        // reconciles and the periodic orphan sweep reaps the ConfigMap instead.
-        Some(true) => {
-            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
-            MoverOutcome::Succeeded {
-                duration_secs: restore_job_duration_seconds(job),
-            }
-        }
-        Some(false) => {
-            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
-            MoverOutcome::Failed
-        }
+        Some(true) => MoverOutcome::Succeeded {
+            duration_secs: restore_job_duration_seconds(job),
+        },
+        Some(false) => MoverOutcome::Failed,
         // A mover that can't START (impossible securityContext, bad image,
         // unschedulable) never terminates, so backoffLimit never trips — fail fast
         // past the pod-startup deadline instead of hanging to the 48h backstop.
@@ -1231,16 +1196,16 @@ async fn observe_restore_mover(
             if let io::WedgedVerdict::Wedged { reason, message } =
                 io::wedged_pod_verdict(&ctx.client, namespace, job_name, grace).await?
             {
-                // Reap the wedged Job (cascade) so the kubelet stops retrying,
-                // and its work-spec ConfigMap with it. BEST-EFFORT: an error here
-                // must not abort before `MoverOutcome::Wedged` reaches the caller —
-                // a partial teardown (Job gone, error surfaced) would otherwise
-                // leave the Restore un-Failed and the retry would spawn a fresh
-                // wedged mover, cycling instead of failing fast.
-                if let Err(e) = io::delete_mover_run(&ctx.client, namespace, job_name).await {
-                    tracing::warn!(restore = %job_name, error = %e,
-                        "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
-                }
+                // Reap the wedged Job (cascade) so the kubelet stops retrying.
+                // BEST-EFFORT: an error must not abort before
+                // `MoverOutcome::Wedged` reaches the caller — the Restore would
+                // stay un-Failed and the retry would spawn a fresh wedged
+                // mover, cycling instead of failing fast.
+                let job_api: Api<k8s_openapi::api::batch::v1::Job> =
+                    Api::namespaced(ctx.client.clone(), namespace);
+                let _ = job_api
+                    .delete(job_name, &kube::api::DeleteParams::background())
+                    .await;
                 MoverOutcome::Wedged {
                     message: crate::snapshot::wedged_pod_message(&reason, &message, grace),
                 }
@@ -1646,9 +1611,8 @@ async fn run_restore_mover(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, namespace, job_name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, namespace, job_name, None, &job).await?;
     let source_label = match selection {
         RestoreSelection::Snapshot(id) => format!("snapshot {id}"),
         RestoreSelection::Resolve(sel) => {

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -205,20 +205,41 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             // still Active. Tearing the staged PVC + mover pod down now would
             // strand an unschedulable replacement pod (#103) — gate the reap on
             // the Job being terminal (or already gone).
-            if backup
+            // The Job GET below serves both concerns, but ONLY within the
+            // window where the Job can still exist: while staged objects await
+            // teardown, or within the reap lookback of the run's endTime.
+            // Beyond that (Snapshot CRs live indefinitely) the GET would be a
+            // guaranteed 404 on every 600s heartbeat, forever — the orphan
+            // sweep owns any straggler ConfigMap instead.
+            let staged = backup
                 .status
                 .as_ref()
                 .and_then(|s| s.staged.as_ref())
-                .is_some()
-            {
+                .is_some();
+            let end_time = backup
+                .status
+                .as_ref()
+                .and_then(|s| s.timing.as_ref())
+                .and_then(|t| t.end_time.as_deref());
+            if staged || finished_recently(end_time, chrono::Utc::now()) {
                 let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace);
                 let job = job_api.get_opt(&name).await?;
-                if !staged_teardown_ready(job.as_ref()) {
-                    // The owned-Job watch re-triggers us when the Job reaches
-                    // Complete; the requeue is a backstop for a missed event.
-                    return Ok(Action::requeue(Duration::from_secs(15)));
+                if staged {
+                    if !staged_teardown_ready(job.as_ref()) {
+                        // The owned-Job watch re-triggers us when the Job reaches
+                        // Complete; the requeue is a backstop for a missed event.
+                        return Ok(Action::requeue(Duration::from_secs(15)));
+                    }
+                    io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
                 }
-                io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
+                // The work-spec ConfigMap is only needed while the mover pod
+                // runs; Snapshot CRs are the durable backup record, so a CM
+                // left to owner-ref GC accumulates forever (one per run). Reap
+                // it once the Job is observed terminal; the Job itself is left
+                // to its ttlSecondsAfterFinished (pod logs stay reachable).
+                if work_spec_reapable(job.as_ref()) {
+                    io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
+                }
             }
             // §13(c): spec.pin stays live after the mover Job is gone.
             return reconcile_pin(backup, ctx, &api, &namespace, &name).await;
@@ -277,6 +298,16 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
                 }
             }
+            // The COMMON failure path lands here, not in the `Some(false)` Job
+            // branch below: the mover stamps `phase: Failed` before its pod
+            // exits, so by the time the Job is observed terminal the run
+            // decision is already TerminalFailed. Reap the work-spec ConfigMap
+            // once the Job is terminal (mirrors SucceededSteadyState); the
+            // failed Job itself keeps the pod logs until its TTL.
+            let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace);
+            if work_spec_reapable(job_api.get_opt(&name).await?.as_ref()) {
+                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
+            }
             return Ok(Action::await_change());
         }
         RunDecision::Wait => return Ok(Action::await_change()),
@@ -321,6 +352,9 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 {
                     io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
                 }
+                // The Job is terminal: drop the work-spec ConfigMap now (the Job
+                // stays until its TTL so pod logs remain reachable).
+                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
                 // §13(c): reconcile kopia-side pin state with spec.pin once the
                 // snapshot exists. A no-op when already in the desired state.
                 return reconcile_pin(backup, ctx, &api, &namespace, &name).await;
@@ -392,6 +426,11 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 {
                     io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
                 }
+                // Drop the work-spec ConfigMap for the failed run too — a Failed
+                // Snapshot outside a schedule's failedJobsHistoryLimit (manual or
+                // hook-aborted) is never pruned, so its CM would leak forever.
+                // The failed Job keeps the pod logs until its TTL.
+                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
                 return Ok(Action::requeue(Duration::from_secs(120)));
             }
             None => {
@@ -422,8 +461,15 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                     ctx.metrics
                         .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
                     // Delete the wedged Job *and its pod* (Background cascade) so the
-                    // kubelet stops retrying immediately — don't wait for TTL/ownerRef GC.
-                    let _ = job_api.delete(&name, &DeleteParams::background()).await;
+                    // kubelet stops retrying immediately — don't wait for TTL/ownerRef
+                    // GC — and its work-spec ConfigMap with it. BEST-EFFORT: a delete
+                    // error must not abort this pass — the staged-source cleanup below
+                    // would be skipped and never retried (the follow-up reconciles
+                    // route to TerminalFailed, which reaps neither).
+                    if let Err(e) = io::delete_mover_run(&ctx.client, &namespace, &name).await {
+                        tracing::warn!(backup = %name, error = %e,
+                            "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
+                    }
                     if backup
                         .status
                         .as_ref()
@@ -1797,6 +1843,22 @@ async fn reconcile_pin(
     let observed = backup.status.as_ref().and_then(|s| s.pinned);
     let steady = Action::requeue(Duration::from_secs(600));
     let action = pin_decision(desired, observed);
+    let job_name = format!("{name}-pin");
+
+    // Cost gate: the common never-pinned Snapshot (spec.pin unset, no pin ever
+    // ran) skips the per-pass Job GET entirely. A pin mover may only exist once
+    // one was spawned, and spawning durably marks the CR first (the `Pinned`
+    // condition, upserted BEFORE the Job is applied) — so this gate can never
+    // hide a leftover pin Job, including one from a mid-flight spec toggle
+    // back to `pin: false` before the mover finished.
+    if action == PinAction::NoOp && !pin_job_may_exist(backup) {
+        return Ok(steady);
+    }
+
+    let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
+    if let Some(job) = job_api.get_opt(&job_name).await? {
+        return handle_pin_job(backup, ctx, api, namespace, name, &job_name, &job, action).await;
+    }
     if action == PinAction::NoOp {
         return Ok(steady);
     }
@@ -1810,24 +1872,6 @@ async fn reconcile_pin(
         // Not resolved yet (e.g. object-store mover hasn't PATCHed the id) — retry.
         return Ok(Action::requeue(Duration::from_secs(30)));
     };
-
-    let job_name = format!("{name}-pin");
-    let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
-    if let Some(job) = job_api.get_opt(&job_name).await? {
-        match job_terminal_state(&job) {
-            Some(true) => {
-                // Record the new observed pin state so the next reconcile is a NoOp.
-                io::patch_status(api, name, serde_json::json!({ "pinned": desired })).await?;
-                tracing::info!(backup = %name, %snapshot_id, pin = desired, "snapshot pin reconciled");
-                return Ok(steady);
-            }
-            Some(false) => {
-                tracing::warn!(backup = %name, "snapshot pin Job failed; backing off");
-                return Ok(Action::requeue(Duration::from_secs(120)));
-            }
-            None => return Ok(Action::requeue(Duration::from_secs(15))),
-        }
-    }
 
     // Create the SnapshotPin Job (mirrors the SnapshotDelete one-shot path).
     let (config, repo) = resolve_recipe(ctx, backup, namespace).await?;
@@ -1880,6 +1924,13 @@ async fn reconcile_pin(
         "kopiur.home-operations.com/op".to_string(),
         "snapshot-pin".to_string(),
     );
+    // Stamp the direction the Job APPLIES, so its terminal state is later
+    // reconciled by what it did — not by whatever spec.pin says at that moment.
+    let pin_target = matches!(action, PinAction::Pin);
+    let annotations = BTreeMap::from([(
+        crate::consts::PIN_TARGET_ANNOTATION.to_string(),
+        pin_target.to_string(),
+    )]);
     let repo_volume =
         io::filesystem_repo_mount_source(&repo.backend).map(|source| VolumeMountSpec {
             source,
@@ -1929,16 +1980,199 @@ async fn reconcile_pin(
         result_configmap: None,
         service_account: mover_identity.service_account.as_deref(),
         passthrough_env: ctx.mover_env_passthrough.clone(),
-        annotations: Default::default(),
+        annotations,
         cache_volume: Default::default(),
         scratch_volume: None,
         readiness_exec: None,
     };
     let cm = jobs::build_config_map(&inputs)?;
     let job = jobs::build_job(&inputs);
+    // Durably mark "a pin mover exists" BEFORE the Job lands (the `Pinned`
+    // condition is the gate that decides whether steady passes look for one) —
+    // a crash between the two leaves only a spurious per-pass GET, never an
+    // unobserved Job.
+    let conditions = io::upsert_condition_status(
+        &fresh_conditions(api, name, backup).await,
+        crate::consts::PINNED_CONDITION,
+        "Unknown",
+        "PinJobRunning",
+        "a SnapshotPin mover Job is applying spec.pin",
+        backup.meta().generation,
+    );
+    io::patch_status(api, name, serde_json::json!({ "conditions": conditions })).await?;
     io::apply_mover_objects(&ctx.client, namespace, &job_name, &cm, &job).await?;
     tracing::info!(backup = %name, %snapshot_id, ?action, "created SnapshotPin Job");
     Ok(Action::requeue(Duration::from_secs(15)))
+}
+
+/// Whether a `{name}-pin` mover Job may exist for this Snapshot — the cheap,
+/// cache-only gate for the steady-state pin-Job lookup. True once anything pin
+/// ever happened: `spec.pin` set, `status.pinned` recorded, or the `Pinned`
+/// condition present (upserted BEFORE every pin Job is applied, so a mover
+/// spawned for a since-reverted `spec.pin` is still findable).
+fn pin_job_may_exist(backup: &Snapshot) -> bool {
+    backup.spec.pin
+        || backup.status.as_ref().is_some_and(|s| {
+            s.pinned.is_some()
+                || s.conditions
+                    .iter()
+                    .any(|c| c.type_ == crate::consts::PINNED_CONDITION)
+        })
+}
+
+/// The pin state a `{name}-pin` Job was spawned to apply, from
+/// [`crate::consts::PIN_TARGET_ANNOTATION`]. `None` for a legacy Job from an
+/// operator version that didn't stamp it (its outcome can't be attributed, so
+/// it is consumed without recording).
+fn pin_job_target(job: &Job) -> Option<bool> {
+    job.metadata
+        .annotations
+        .as_ref()?
+        .get(crate::consts::PIN_TARGET_ANNOTATION)?
+        .parse()
+        .ok()
+}
+
+/// The freshest `status.conditions` for `name`, falling back to the cached
+/// copy. The pin paths rewrite the whole conditions array (status writes are
+/// JSON merge patches), so basing the upsert on the live object — not the
+/// reflector cache — shrinks the window where a just-written condition from a
+/// concurrent reconcile pass would be clobbered.
+async fn fresh_conditions(
+    api: &Api<Snapshot>,
+    name: &str,
+    backup: &Snapshot,
+) -> Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition> {
+    match api.get_opt(name).await {
+        Ok(Some(latest)) => latest.status.map(|s| s.conditions).unwrap_or_default(),
+        _ => backup
+            .status
+            .as_ref()
+            .map(|s| s.conditions.clone())
+            .unwrap_or_default(),
+    }
+}
+
+/// Whether a FAILED pin Job's direction is still what the current decision
+/// wants — if not (the spec toggled past it, or nothing is wanted anymore) the
+/// stale Job is consumed instead of kept as a retry-backoff marker. Pure so
+/// the direction-vs-decision matrix is unit-tested.
+fn pin_job_still_wanted(target: Option<bool>, action: PinAction) -> bool {
+    match (target, action) {
+        (Some(t), PinAction::Pin) => t,
+        (Some(t), PinAction::Unpin) => !t,
+        // Legacy direction-less Job: assume it was this action's attempt.
+        (None, PinAction::Pin | PinAction::Unpin) => true,
+        (_, PinAction::NoOp) => false,
+    }
+}
+
+/// The requeue after consuming a leftover pin Job: near-immediate when a pin
+/// action is still pending (the spawn path runs next pass), steady otherwise.
+fn post_pin_consume_action(action: PinAction) -> Action {
+    match action {
+        PinAction::NoOp => Action::requeue(Duration::from_secs(600)),
+        PinAction::Pin | PinAction::Unpin => Action::requeue(Duration::from_secs(5)),
+    }
+}
+
+/// Reconcile an EXISTING `{name}-pin` Job against the desired/observed pin
+/// state. The Job carries the direction it applied ([`pin_job_target`]), so a
+/// terminal Job is consumed by what it DID — never by what `spec.pin` happens
+/// to say now. That closes both silent-divergence shapes: a stale succeeded
+/// Job can't satisfy the opposite toggle, and a pin that completed after a
+/// mid-flight spec flip is still recorded (the next pass then spawns the
+/// corrective mover).
+#[allow(clippy::too_many_arguments)]
+async fn handle_pin_job(
+    backup: &Snapshot,
+    ctx: &Context,
+    api: &Api<Snapshot>,
+    namespace: &str,
+    name: &str,
+    job_name: &str,
+    job: &Job,
+    action: PinAction,
+) -> Result<Action> {
+    let observed = backup.status.as_ref().and_then(|s| s.pinned);
+    let target = pin_job_target(job);
+    match job_terminal_state(job) {
+        // Still running — wait, whatever the current decision is (a mid-flight
+        // toggle is reconciled from the terminal outcome, below).
+        None => Ok(Action::requeue(Duration::from_secs(15))),
+        Some(true) => match target {
+            // The mover applied `t` and status doesn't say so yet: record the
+            // kopia truth (even if spec.pin has since flipped — the next pass
+            // recomputes the decision from the accurate observed state and
+            // spawns the corrective mover). The Job is consumed on a LATER
+            // pass, once this write is visible in the cache — deleting it here
+            // would race the reflector (the deletion event can re-reconcile
+            // against a stale `status.pinned` and respawn a spurious mover).
+            Some(t) if observed != Some(t) => {
+                record_pin_outcome(backup, api, name, t).await?;
+                Ok(Action::requeue(Duration::from_secs(5)))
+            }
+            // Outcome already recorded (or a legacy direction-less Job whose
+            // result can't be attributed): consume it so it can never satisfy
+            // a future toggle, then act on the (now accurate) decision.
+            _ => {
+                io::delete_mover_run(&ctx.client, namespace, job_name).await?;
+                Ok(post_pin_consume_action(action))
+            }
+        },
+        Some(false) => {
+            // The mover failed: kopia's pin state is unchanged (= `observed`).
+            // A failed Job whose direction is still wanted stays until its TTL
+            // — it keeps the pod logs AND is the natural retry backoff (the
+            // TTL reap re-enters the spawn path; deleting it now would respawn
+            // immediately on the deletion event, hot-looping a persistent
+            // failure). A STALE failed Job (direction no longer wanted, or
+            // nothing wanted at all) is consumed instead so it can't block —
+            // or mis-satisfy — a future toggle.
+            if !pin_job_still_wanted(target, action) {
+                io::delete_mover_run(&ctx.client, namespace, job_name).await?;
+                return Ok(post_pin_consume_action(action));
+            }
+            let conditions = io::upsert_condition(
+                &fresh_conditions(api, name, backup).await,
+                crate::consts::PINNED_CONDITION,
+                observed.unwrap_or(false),
+                crate::consts::PIN_JOB_FAILED_REASON,
+                "the SnapshotPin mover Job failed; see the Job/pod logs",
+                backup.meta().generation,
+            );
+            io::patch_status(api, name, serde_json::json!({ "conditions": conditions })).await?;
+            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
+            tracing::warn!(backup = %name, "snapshot pin Job failed; backing off");
+            Ok(Action::requeue(Duration::from_secs(120)))
+        }
+    }
+}
+
+/// Record a pin mover's applied state (`status.pinned` + the `Pinned`
+/// condition) — the kopia truth, independent of the currently-desired spec.
+async fn record_pin_outcome(
+    backup: &Snapshot,
+    api: &Api<Snapshot>,
+    name: &str,
+    pinned: bool,
+) -> Result<()> {
+    let conditions = io::upsert_condition(
+        &fresh_conditions(api, name, backup).await,
+        crate::consts::PINNED_CONDITION,
+        pinned,
+        "PinReconciled",
+        "the SnapshotPin mover Job ran",
+        backup.meta().generation,
+    );
+    io::patch_status(
+        api,
+        name,
+        serde_json::json!({ "pinned": pinned, "conditions": conditions }),
+    )
+    .await?;
+    tracing::info!(backup = %name, pin = pinned, "snapshot pin recorded");
+    Ok(())
 }
 
 /// On a Job's terminal success, pin phase=Succeeded and the resulting kopia
@@ -2257,6 +2491,39 @@ fn staged_teardown_ready(job: Option<&Job>) -> bool {
         None => true,
         Some(j) => job_terminal_state(j).is_some(),
     }
+}
+
+/// Whether a run's work-spec ConfigMap may be reaped: the same-named Job must be
+/// observed terminal (`restartPolicy: Never` + a terminal Job means no pod will
+/// mount the ConfigMap again). An ABSENT Job deliberately returns `false`: the
+/// TTL controller already reaped the run and the periodic orphan sweep owns that
+/// case — reaping here too would re-issue a delete on every steady-state pass,
+/// forever. Shared with the Restore reconciler (same Job/ConfigMap contract).
+pub(crate) fn work_spec_reapable(job: Option<&Job>) -> bool {
+    job.is_some_and(|j| job_terminal_state(j).is_some())
+}
+
+/// How long after a run's `timing.endTime` the steady-state pass keeps looking
+/// for its mover Job (to reap the work-spec ConfigMap). Generously above any
+/// sane `ttlSecondsAfterFinished`; beyond it the Job is certainly gone and the
+/// orphan sweep owns any leftover ConfigMap.
+pub(crate) const REAP_LOOKBACK_SECS: i64 = 24 * 3600;
+
+/// Whether an RFC3339 `timing.endTime` is within [`REAP_LOOKBACK_SECS`] of
+/// `now` — the only window where a terminal CR's steady heartbeat needs a
+/// mover-Job GET to reap the work-spec ConfigMap. Absent/unparseable endTime →
+/// `false`: the orphan sweep is the backstop, and long-lived terminal records
+/// (Snapshot CRs live indefinitely by design) stop paying an apiserver GET on
+/// every heartbeat, forever. Shared with the Restore reconciler.
+pub(crate) fn finished_recently(
+    end_time: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    end_time
+        .and_then(|e| chrono::DateTime::parse_from_rfc3339(e).ok())
+        .is_some_and(|end| {
+            (now - end.with_timezone(&chrono::Utc)).num_seconds() < REAP_LOOKBACK_SECS
+        })
 }
 
 /// `error_policy` for the `Snapshot` controller.

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -205,41 +205,20 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             // still Active. Tearing the staged PVC + mover pod down now would
             // strand an unschedulable replacement pod (#103) — gate the reap on
             // the Job being terminal (or already gone).
-            // The Job GET below serves both concerns, but ONLY within the
-            // window where the Job can still exist: while staged objects await
-            // teardown, or within the reap lookback of the run's endTime.
-            // Beyond that (Snapshot CRs live indefinitely) the GET would be a
-            // guaranteed 404 on every 600s heartbeat, forever — the orphan
-            // sweep owns any straggler ConfigMap instead.
-            let staged = backup
+            if backup
                 .status
                 .as_ref()
                 .and_then(|s| s.staged.as_ref())
-                .is_some();
-            let end_time = backup
-                .status
-                .as_ref()
-                .and_then(|s| s.timing.as_ref())
-                .and_then(|t| t.end_time.as_deref());
-            if staged || finished_recently(end_time, chrono::Utc::now()) {
+                .is_some()
+            {
                 let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace);
                 let job = job_api.get_opt(&name).await?;
-                if staged {
-                    if !staged_teardown_ready(job.as_ref()) {
-                        // The owned-Job watch re-triggers us when the Job reaches
-                        // Complete; the requeue is a backstop for a missed event.
-                        return Ok(Action::requeue(Duration::from_secs(15)));
-                    }
-                    io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
+                if !staged_teardown_ready(job.as_ref()) {
+                    // The owned-Job watch re-triggers us when the Job reaches
+                    // Complete; the requeue is a backstop for a missed event.
+                    return Ok(Action::requeue(Duration::from_secs(15)));
                 }
-                // The work-spec ConfigMap is only needed while the mover pod
-                // runs; Snapshot CRs are the durable backup record, so a CM
-                // left to owner-ref GC accumulates forever (one per run). Reap
-                // it once the Job is observed terminal; the Job itself is left
-                // to its ttlSecondsAfterFinished (pod logs stay reachable).
-                if work_spec_reapable(job.as_ref()) {
-                    io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
-                }
+                io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
             }
             // §13(c): spec.pin stays live after the mover Job is gone.
             return reconcile_pin(backup, ctx, &api, &namespace, &name).await;
@@ -298,16 +277,6 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
                 }
             }
-            // The COMMON failure path lands here, not in the `Some(false)` Job
-            // branch below: the mover stamps `phase: Failed` before its pod
-            // exits, so by the time the Job is observed terminal the run
-            // decision is already TerminalFailed. Reap the work-spec ConfigMap
-            // once the Job is terminal (mirrors SucceededSteadyState); the
-            // failed Job itself keeps the pod logs until its TTL.
-            let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace);
-            if work_spec_reapable(job_api.get_opt(&name).await?.as_ref()) {
-                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
-            }
             return Ok(Action::await_change());
         }
         RunDecision::Wait => return Ok(Action::await_change()),
@@ -352,9 +321,6 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 {
                     io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
                 }
-                // The Job is terminal: drop the work-spec ConfigMap now (the Job
-                // stays until its TTL so pod logs remain reachable).
-                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
                 // §13(c): reconcile kopia-side pin state with spec.pin once the
                 // snapshot exists. A no-op when already in the desired state.
                 return reconcile_pin(backup, ctx, &api, &namespace, &name).await;
@@ -426,11 +392,6 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 {
                     io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
                 }
-                // Drop the work-spec ConfigMap for the failed run too — a Failed
-                // Snapshot outside a schedule's failedJobsHistoryLimit (manual or
-                // hook-aborted) is never pruned, so its CM would leak forever.
-                // The failed Job keeps the pod logs until its TTL.
-                io::reap_work_spec_cm(&ctx.client, &namespace, &name).await;
                 return Ok(Action::requeue(Duration::from_secs(120)));
             }
             None => {
@@ -462,14 +423,10 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
                     // Delete the wedged Job *and its pod* (Background cascade) so the
                     // kubelet stops retrying immediately — don't wait for TTL/ownerRef
-                    // GC — and its work-spec ConfigMap with it. BEST-EFFORT: a delete
-                    // error must not abort this pass — the staged-source cleanup below
-                    // would be skipped and never retried (the follow-up reconciles
-                    // route to TerminalFailed, which reaps neither).
-                    if let Err(e) = io::delete_mover_run(&ctx.client, &namespace, &name).await {
-                        tracing::warn!(backup = %name, error = %e,
-                            "wedged mover teardown failed (Job runs to its deadline; sweep reaps the ConfigMap)");
-                    }
+                    // GC. BEST-EFFORT: a delete error must not abort this pass — the
+                    // staged-source cleanup below would be skipped and never retried
+                    // (the follow-up reconciles route to TerminalFailed).
+                    let _ = job_api.delete(&name, &DeleteParams::background()).await;
                     if backup
                         .status
                         .as_ref()
@@ -1272,9 +1229,8 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, &namespace, &name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, &namespace, &name, None, &job).await?;
 
     io::patch_status(
         &api,
@@ -1818,9 +1774,8 @@ async fn delete_snapshot_via_job(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, job_ns, &job_name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, job_ns, &job_name, None, &job).await?;
     io::patch_status(api, name, serde_json::json!({ "phase": "Deleting" })).await?;
     tracing::info!(backup = %name, %snapshot_id, job_namespace = %job_ns, "created SnapshotDelete Job");
     Ok(Action::requeue(Duration::from_secs(15)))
@@ -1985,8 +1940,7 @@ async fn reconcile_pin(
         scratch_volume: None,
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
+    let job = jobs::build_job(&inputs)?;
     // Durably mark "a pin mover exists" BEFORE the Job lands (the `Pinned`
     // condition is the gate that decides whether steady passes look for one) —
     // a crash between the two leaves only a spurious per-pass GET, never an
@@ -2000,7 +1954,7 @@ async fn reconcile_pin(
         backup.meta().generation,
     );
     io::patch_status(api, name, serde_json::json!({ "conditions": conditions })).await?;
-    io::apply_mover_objects(&ctx.client, namespace, &job_name, &cm, &job).await?;
+    io::apply_mover_objects(&ctx.client, namespace, &job_name, None, &job).await?;
     tracing::info!(backup = %name, %snapshot_id, ?action, "created SnapshotPin Job");
     Ok(Action::requeue(Duration::from_secs(15)))
 }
@@ -2142,7 +2096,6 @@ async fn handle_pin_job(
                 backup.meta().generation,
             );
             io::patch_status(api, name, serde_json::json!({ "conditions": conditions })).await?;
-            io::reap_work_spec_cm(&ctx.client, namespace, job_name).await;
             tracing::warn!(backup = %name, "snapshot pin Job failed; backing off");
             Ok(Action::requeue(Duration::from_secs(120)))
         }
@@ -2491,39 +2444,6 @@ fn staged_teardown_ready(job: Option<&Job>) -> bool {
         None => true,
         Some(j) => job_terminal_state(j).is_some(),
     }
-}
-
-/// Whether a run's work-spec ConfigMap may be reaped: the same-named Job must be
-/// observed terminal (`restartPolicy: Never` + a terminal Job means no pod will
-/// mount the ConfigMap again). An ABSENT Job deliberately returns `false`: the
-/// TTL controller already reaped the run and the periodic orphan sweep owns that
-/// case — reaping here too would re-issue a delete on every steady-state pass,
-/// forever. Shared with the Restore reconciler (same Job/ConfigMap contract).
-pub(crate) fn work_spec_reapable(job: Option<&Job>) -> bool {
-    job.is_some_and(|j| job_terminal_state(j).is_some())
-}
-
-/// How long after a run's `timing.endTime` the steady-state pass keeps looking
-/// for its mover Job (to reap the work-spec ConfigMap). Generously above any
-/// sane `ttlSecondsAfterFinished`; beyond it the Job is certainly gone and the
-/// orphan sweep owns any leftover ConfigMap.
-pub(crate) const REAP_LOOKBACK_SECS: i64 = 24 * 3600;
-
-/// Whether an RFC3339 `timing.endTime` is within [`REAP_LOOKBACK_SECS`] of
-/// `now` — the only window where a terminal CR's steady heartbeat needs a
-/// mover-Job GET to reap the work-spec ConfigMap. Absent/unparseable endTime →
-/// `false`: the orphan sweep is the backstop, and long-lived terminal records
-/// (Snapshot CRs live indefinitely by design) stop paying an apiserver GET on
-/// every heartbeat, forever. Shared with the Restore reconciler.
-pub(crate) fn finished_recently(
-    end_time: Option<&str>,
-    now: chrono::DateTime<chrono::Utc>,
-) -> bool {
-    end_time
-        .and_then(|e| chrono::DateTime::parse_from_rfc3339(e).ok())
-        .is_some_and(|end| {
-            (now - end.with_timezone(&chrono::Utc)).num_seconds() < REAP_LOOKBACK_SECS
-        })
 }
 
 /// `error_policy` for the `Snapshot` controller.

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -933,66 +933,6 @@ fn staged_teardown_proceeds_on_terminal_or_absent_job() {
     assert!(staged_teardown_ready(None), "absent Job → reap");
 }
 
-// The work-spec ConfigMap-leak fix: the ConfigMap is reaped only when the Job
-// is OBSERVED terminal. Note the deliberate contrast with staged teardown on
-// an absent Job: teardown proceeds (nothing left to strand), but the ConfigMap
-// reap does NOT (the orphan sweep owns that case — re-issuing a delete on every
-// steady-state pass would chatter forever).
-#[test]
-fn work_spec_reap_requires_an_observed_terminal_job() {
-    use k8s_openapi::api::batch::v1::JobStatus;
-    let running = job_with_status(Some(JobStatus {
-        active: Some(1),
-        ..Default::default()
-    }));
-    let complete = job_with_status(Some(JobStatus {
-        conditions: Some(vec![job_condition("Complete", "True")]),
-        succeeded: Some(1),
-        ..Default::default()
-    }));
-    let failed = job_with_status(Some(JobStatus {
-        conditions: Some(vec![job_condition("Failed", "True")]),
-        ..Default::default()
-    }));
-    assert!(
-        !work_spec_reapable(Some(&running)),
-        "a running Job's pod still mounts the ConfigMap"
-    );
-    assert!(!work_spec_reapable(Some(&job_with_status(None))));
-    assert!(work_spec_reapable(Some(&complete)), "Complete → reap");
-    assert!(
-        work_spec_reapable(Some(&failed)),
-        "Failed → reap too (manual Failed Snapshots are never pruned; the Job keeps the logs)"
-    );
-    assert!(
-        !work_spec_reapable(None),
-        "absent Job → the sweep's case, not the reconciler's"
-    );
-}
-
-// The steady-state Job GET is gated on the run having finished within the reap
-// lookback: Snapshot CRs live indefinitely, so an ungated GET would 404 on
-// every 600s heartbeat, forever, for every historical backup.
-#[test]
-fn finished_recently_bounds_the_steady_state_job_get() {
-    let now = chrono::Utc::now();
-    let recent = (now - chrono::Duration::hours(1)).to_rfc3339();
-    let ancient = (now - chrono::Duration::days(30)).to_rfc3339();
-    assert!(finished_recently(Some(&recent), now));
-    assert!(
-        !finished_recently(Some(&ancient), now),
-        "a month-old backup's Job is certainly TTL-reaped — no GET"
-    );
-    assert!(
-        !finished_recently(None, now),
-        "no endTime → the orphan sweep owns cleanup, not the heartbeat"
-    );
-    assert!(
-        !finished_recently(Some("not-a-timestamp"), now),
-        "unparseable endTime must not re-enable the forever-GET"
-    );
-}
-
 // The pin-Job lookup gate: never-pinned Snapshots (the overwhelmingly common
 // case) skip the per-heartbeat GET; anything that ever spawned a pin mover —
 // including one whose spec.pin was toggled back mid-flight — stays findable

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -932,3 +932,149 @@ fn staged_teardown_proceeds_on_terminal_or_absent_job() {
     // TTL-reaped, or a discovered Snapshot that never owned a Job.
     assert!(staged_teardown_ready(None), "absent Job → reap");
 }
+
+// The work-spec ConfigMap-leak fix: the ConfigMap is reaped only when the Job
+// is OBSERVED terminal. Note the deliberate contrast with staged teardown on
+// an absent Job: teardown proceeds (nothing left to strand), but the ConfigMap
+// reap does NOT (the orphan sweep owns that case — re-issuing a delete on every
+// steady-state pass would chatter forever).
+#[test]
+fn work_spec_reap_requires_an_observed_terminal_job() {
+    use k8s_openapi::api::batch::v1::JobStatus;
+    let running = job_with_status(Some(JobStatus {
+        active: Some(1),
+        ..Default::default()
+    }));
+    let complete = job_with_status(Some(JobStatus {
+        conditions: Some(vec![job_condition("Complete", "True")]),
+        succeeded: Some(1),
+        ..Default::default()
+    }));
+    let failed = job_with_status(Some(JobStatus {
+        conditions: Some(vec![job_condition("Failed", "True")]),
+        ..Default::default()
+    }));
+    assert!(
+        !work_spec_reapable(Some(&running)),
+        "a running Job's pod still mounts the ConfigMap"
+    );
+    assert!(!work_spec_reapable(Some(&job_with_status(None))));
+    assert!(work_spec_reapable(Some(&complete)), "Complete → reap");
+    assert!(
+        work_spec_reapable(Some(&failed)),
+        "Failed → reap too (manual Failed Snapshots are never pruned; the Job keeps the logs)"
+    );
+    assert!(
+        !work_spec_reapable(None),
+        "absent Job → the sweep's case, not the reconciler's"
+    );
+}
+
+// The steady-state Job GET is gated on the run having finished within the reap
+// lookback: Snapshot CRs live indefinitely, so an ungated GET would 404 on
+// every 600s heartbeat, forever, for every historical backup.
+#[test]
+fn finished_recently_bounds_the_steady_state_job_get() {
+    let now = chrono::Utc::now();
+    let recent = (now - chrono::Duration::hours(1)).to_rfc3339();
+    let ancient = (now - chrono::Duration::days(30)).to_rfc3339();
+    assert!(finished_recently(Some(&recent), now));
+    assert!(
+        !finished_recently(Some(&ancient), now),
+        "a month-old backup's Job is certainly TTL-reaped — no GET"
+    );
+    assert!(
+        !finished_recently(None, now),
+        "no endTime → the orphan sweep owns cleanup, not the heartbeat"
+    );
+    assert!(
+        !finished_recently(Some("not-a-timestamp"), now),
+        "unparseable endTime must not re-enable the forever-GET"
+    );
+}
+
+// The pin-Job lookup gate: never-pinned Snapshots (the overwhelmingly common
+// case) skip the per-heartbeat GET; anything that ever spawned a pin mover —
+// including one whose spec.pin was toggled back mid-flight — stays findable
+// via the `Pinned` condition upserted before every pin Job is applied.
+#[test]
+fn pin_job_may_exist_covers_every_marker() {
+    fn snap(pin: bool, pinned: Option<bool>, with_condition: bool) -> Snapshot {
+        let mut s = dummy_backup();
+        s.spec.pin = pin;
+        let conditions = if with_condition {
+            io::upsert_condition_status(
+                &[],
+                crate::consts::PINNED_CONDITION,
+                "Unknown",
+                "PinJobRunning",
+                "a SnapshotPin mover Job is applying spec.pin",
+                None,
+            )
+        } else {
+            Vec::new()
+        };
+        s.status = Some(kopiur_api::snapshot::SnapshotStatus {
+            pinned,
+            conditions,
+            ..Default::default()
+        });
+        s
+    }
+    assert!(
+        !pin_job_may_exist(&snap(false, None, false)),
+        "never pinned"
+    );
+    assert!(pin_job_may_exist(&snap(true, None, false)), "spec.pin set");
+    assert!(
+        pin_job_may_exist(&snap(false, Some(false), false)),
+        "pin recorded"
+    );
+    assert!(
+        pin_job_may_exist(&snap(false, None, true)),
+        "mid-flight toggle-back: the spawn-time condition keeps the Job findable"
+    );
+}
+
+// A FAILED pin Job is kept (as the TTL-based retry-backoff marker) only while
+// its direction is still what the decision wants; a stale one is consumed so
+// it can't block — or mis-satisfy — a future toggle.
+#[test]
+fn pin_job_still_wanted_matrix() {
+    // Direction matches the pending action → keep as backoff.
+    assert!(pin_job_still_wanted(Some(true), PinAction::Pin));
+    assert!(pin_job_still_wanted(Some(false), PinAction::Unpin));
+    // Direction contradicts the pending action → stale, consume.
+    assert!(!pin_job_still_wanted(Some(false), PinAction::Pin));
+    assert!(!pin_job_still_wanted(Some(true), PinAction::Unpin));
+    // Nothing pending at all → any failed Job is stale.
+    assert!(!pin_job_still_wanted(Some(true), PinAction::NoOp));
+    assert!(!pin_job_still_wanted(None, PinAction::NoOp));
+    // Legacy direction-less Job: assume it was this action's attempt.
+    assert!(pin_job_still_wanted(None, PinAction::Pin));
+    assert!(pin_job_still_wanted(None, PinAction::Unpin));
+}
+
+// A pin Job is consumed by the direction it APPLIED (the annotation), never by
+// the currently-desired spec.pin — a stale Job must not satisfy the opposite
+// toggle.
+#[test]
+fn pin_job_target_reads_the_direction_annotation() {
+    let mut job = Job::default();
+    assert_eq!(pin_job_target(&job), None, "legacy Job: unattributable");
+    job.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        crate::consts::PIN_TARGET_ANNOTATION.to_string(),
+        "true".to_string(),
+    )]));
+    assert_eq!(pin_job_target(&job), Some(true));
+    job.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        crate::consts::PIN_TARGET_ANNOTATION.to_string(),
+        "false".to_string(),
+    )]));
+    assert_eq!(pin_job_target(&job), Some(false));
+    job.metadata.annotations = Some(std::collections::BTreeMap::from([(
+        crate::consts::PIN_TARGET_ANNOTATION.to_string(),
+        "garbage".to_string(),
+    )]));
+    assert_eq!(pin_job_target(&job), None, "unparseable = unattributable");
+}

--- a/crates/controller/src/startup.rs
+++ b/crates/controller/src/startup.rs
@@ -20,6 +20,7 @@ use crate::controllers::{scoped_api, spawn_all};
 use crate::http::serve_http;
 use crate::leader;
 use crate::metrics::Metrics;
+use crate::sweep;
 use crate::webhook_tls;
 
 /// Resolve the effective streaming-list setting against the live apiserver.
@@ -242,6 +243,18 @@ pub async fn run(config: config::ControllerConfig) -> anyhow::Result<()> {
     // resolve it here: on a server that predates WatchList (beta, on by default
     // from 1.32) we force paged lists regardless of config.
     let streaming_lists = effective_streaming_lists(&client, config.streaming_lists).await;
+
+    // Backstop GC for mover work-spec ConfigMaps whose Job is already gone
+    // (TTL-reaped before the reconciler observed it, or left behind by operator
+    // versions that never deleted them). Leader-only, like everything below the
+    // election gate — a single sweeping writer.
+    sweep::spawn_sweep(
+        client.clone(),
+        config.watch_scope.clone(),
+        metrics.clone(),
+        config.work_spec_sweep_interval_secs,
+        config.work_spec_sweep_min_age_secs,
+    );
 
     let controllers = spawn_all(
         client.clone(),

--- a/crates/controller/src/sweep.rs
+++ b/crates/controller/src/sweep.rs
@@ -1,20 +1,17 @@
-//! Periodic sweep for **orphaned mover work-spec ConfigMaps**.
+//! Periodic sweep for **LEGACY per-run work-spec ConfigMaps** (#224).
 //!
-//! Every mover run applies a work-spec `ConfigMap` + `Job` pair
-//! ([`crate::io::apply_mover_objects`]). The Job self-reaps via
-//! `ttlSecondsAfterFinished`, and the reconcilers now delete the ConfigMap as
-//! soon as they observe the Job terminal — but a ConfigMap whose Job is already
-//! gone is invisible to those transition paths: nothing knows its name anymore
-//! (per-slot verify/replication names, or a controller that was down across the
-//! whole Job lifetime), and its owner reference points at a long-lived CR
-//! (`Snapshot`/`SnapshotPolicy`/…) that keeps it alive indefinitely. Clusters
-//! upgraded from operator versions that never deleted work-spec ConfigMaps hold
-//! hundreds of such orphans (one per historical run).
+//! Current operator versions embed the mover work spec in the Job's pod env —
+//! a run is exactly ONE object, cleaned up by its `ttlSecondsAfterFinished`,
+//! and no per-run ConfigMap exists at all. Earlier versions instead mounted
+//! the spec from a sidecar ConfigMap owner-referenced to a long-lived CR
+//! (`Snapshot`/`SnapshotPolicy`/…) with no delete path: the Job self-reaped
+//! via its TTL, the ConfigMap had no TTL mechanism, and one accumulated per
+//! run, forever — clusters held hundreds (one per historical backup).
 //!
-//! This module heals them: a leader-only background task periodically lists the
-//! kopiur-managed ConfigMaps and deletes the stale work-spec ones. The decision
-//! kernel ([`sweep_candidates`]) is pure and conservative — a ConfigMap is only
-//! an orphan when ALL of these hold:
+//! This module heals upgraded clusters: a leader-only background task
+//! periodically lists the kopiur-managed ConfigMaps and deletes the stale
+//! work-spec ones. The decision kernel ([`sweep_candidates`]) is pure and
+//! conservative — a ConfigMap is only an orphan when ALL of these hold:
 //!
 //! 1. labelled `app.kubernetes.io/managed-by=kopiur` (server-side pre-filtered,
 //!    re-checked here),

--- a/crates/controller/src/sweep.rs
+++ b/crates/controller/src/sweep.rs
@@ -1,0 +1,307 @@
+//! Periodic sweep for **orphaned mover work-spec ConfigMaps**.
+//!
+//! Every mover run applies a work-spec `ConfigMap` + `Job` pair
+//! ([`crate::io::apply_mover_objects`]). The Job self-reaps via
+//! `ttlSecondsAfterFinished`, and the reconcilers now delete the ConfigMap as
+//! soon as they observe the Job terminal — but a ConfigMap whose Job is already
+//! gone is invisible to those transition paths: nothing knows its name anymore
+//! (per-slot verify/replication names, or a controller that was down across the
+//! whole Job lifetime), and its owner reference points at a long-lived CR
+//! (`Snapshot`/`SnapshotPolicy`/…) that keeps it alive indefinitely. Clusters
+//! upgraded from operator versions that never deleted work-spec ConfigMaps hold
+//! hundreds of such orphans (one per historical run).
+//!
+//! This module heals them: a leader-only background task periodically lists the
+//! kopiur-managed ConfigMaps and deletes the stale work-spec ones. The decision
+//! kernel ([`sweep_candidates`]) is pure and conservative — a ConfigMap is only
+//! an orphan when ALL of these hold:
+//!
+//! 1. labelled `app.kubernetes.io/managed-by=kopiur` (server-side pre-filtered,
+//!    re-checked here),
+//! 2. its `data` carries the work-spec key ([`crate::jobs::WORK_SPEC_FILE`]) —
+//!    positively identifying a mover work-spec against every other
+//!    kopiur-managed ConfigMap (projected creds, dashboards, …),
+//! 3. its `data` does NOT carry a bootstrap result
+//!    ([`kopiur_mover::bootstrap::RESULT_CONFIGMAP_KEY`]) — the bootstrap/probe
+//!    flow writes `result.json` into its work-spec ConfigMap and consumes it
+//!    after the Job is gone; racing that read could make a completed bootstrap
+//!    look result-less,
+//! 4. no same-named Job exists in its namespace — a pending/running run always
+//!    has its Job (the Job is applied immediately after the ConfigMap), and
+//! 5. it is older than `min_age_secs` — closing the ConfigMap-applied-before-Job
+//!    window and any controller-crash-mid-spawn gap.
+//!
+//! The CLI's browse-session ConfigMap is additionally safe by construction: it
+//! is owned by its session Job, so it either has a live Job (guard 4) or is
+//! already being cascade-deleted with it.
+
+use std::collections::HashSet;
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::api::{DeleteParams, ListParams};
+use kube::{Api, ResourceExt};
+
+use kopiur_mover::bootstrap::RESULT_CONFIGMAP_KEY;
+
+use crate::config;
+use crate::consts::{MANAGED_BY_LABEL, MANAGED_BY_VALUE};
+use crate::controllers::scoped_api;
+use crate::error::Result;
+use crate::jobs::WORK_SPEC_FILE;
+use crate::metrics::Metrics;
+
+/// Select the orphaned work-spec ConfigMaps out of `cms` (see the module doc
+/// for the guard set). `live_jobs` is the `(namespace, name)` set of every
+/// kopiur-managed Job; `now_unix` is the injected decision clock (unix seconds)
+/// so the kernel unit-tests without a wall clock, mirroring
+/// [`crate::io::classify_wedged_pods`].
+pub fn sweep_candidates<'a>(
+    cms: &'a [ConfigMap],
+    live_jobs: &HashSet<(String, String)>,
+    min_age_secs: i64,
+    now_unix: i64,
+) -> Vec<&'a ConfigMap> {
+    cms.iter()
+        .filter(|cm| {
+            let managed = cm.metadata.labels.as_ref().is_some_and(|l| {
+                l.get(MANAGED_BY_LABEL).map(String::as_str) == Some(MANAGED_BY_VALUE)
+            });
+            let Some(data) = cm.data.as_ref() else {
+                return false;
+            };
+            let is_work_spec =
+                data.contains_key(WORK_SPEC_FILE) && !data.contains_key(RESULT_CONFIGMAP_KEY);
+            let key = (cm.namespace().unwrap_or_default(), cm.name_any());
+            let age_secs = cm
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|t| now_unix - t.0.as_second())
+                // No creationTimestamp (only possible for hand-built test
+                // objects; the apiserver always stamps one) → treat as brand
+                // new, never eligible.
+                .unwrap_or(0);
+            managed && is_work_spec && !live_jobs.contains(&key) && age_secs >= min_age_secs
+        })
+        .collect()
+}
+
+/// One sweep pass: list the kopiur-managed ConfigMaps and Jobs within the
+/// install scope, select the orphans, and delete them (404-tolerated;
+/// per-item errors are logged and skipped — degrade, don't crash). Returns the
+/// number deleted.
+///
+/// Two guards close the classify→delete TOCTOU window:
+/// - ConfigMaps are listed BEFORE Jobs: a run spawned between the two lists
+///   shows up only in the Job list (keeping its ConfigMap), never the reverse.
+/// - Each delete carries a `resourceVersion` PRECONDITION pinned to the exact
+///   object version the sweep classified. A run re-spawned during the delete
+///   loop server-side-applies the SAME-NAMED ConfigMap (same UID, same old
+///   creationTimestamp — min-age can't help), but that write bumps the
+///   resourceVersion, so the delete fails 409 and the live run is spared;
+///   the next pass re-evaluates.
+pub async fn run_sweep(
+    client: &kube::Client,
+    scope: &config::WatchScope,
+    min_age_secs: i64,
+) -> Result<usize> {
+    let selector = format!("{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}");
+    let lp = ListParams::default().labels(&selector);
+    let cm_api: Api<ConfigMap> = scoped_api(client, scope);
+    let cms = cm_api.list(&lp).await?.items;
+    let job_api: Api<Job> = scoped_api(client, scope);
+    let live_jobs: HashSet<(String, String)> = job_api
+        .list(&lp)
+        .await?
+        .items
+        .iter()
+        .map(|j| (j.namespace().unwrap_or_default(), j.name_any()))
+        .collect();
+
+    let candidates = sweep_candidates(
+        &cms,
+        &live_jobs,
+        min_age_secs,
+        chrono::Utc::now().timestamp(),
+    );
+    let mut deleted = 0usize;
+    for cm in candidates {
+        let ns = cm.namespace().unwrap_or_default();
+        let name = cm.name_any();
+        let api: Api<ConfigMap> = Api::namespaced(client.clone(), &ns);
+        let dp = DeleteParams {
+            preconditions: Some(kube::api::Preconditions {
+                uid: cm.uid(),
+                resource_version: cm.resource_version(),
+            }),
+            ..DeleteParams::default()
+        };
+        match api.delete(&name, &dp).await {
+            Ok(_) => deleted += 1,
+            // 404: already gone; 409: the object changed since classification
+            // (a re-spawned run reclaimed it) — spare it, re-evaluate next pass.
+            Err(kube::Error::Api(ae)) if ae.code == 404 || ae.code == 409 => {}
+            Err(e) => {
+                tracing::warn!(configmap = %name, namespace = %ns, error = %e,
+                    "orphaned work-spec ConfigMap delete failed (skipped)");
+            }
+        }
+    }
+    Ok(deleted)
+}
+
+/// Spawn the periodic sweep as a background task. Call ONLY after leader
+/// election is won (a single writer — mirroring the reconcilers). The first
+/// pass runs shortly after startup so upgraded clusters heal promptly; later
+/// passes run every `interval_secs`. `interval_secs == 0` disables the sweep
+/// entirely (the config layer documents the knob).
+pub fn spawn_sweep(
+    client: kube::Client,
+    scope: config::WatchScope,
+    metrics: Metrics,
+    interval_secs: u64,
+    min_age_secs: i64,
+) {
+    if interval_secs == 0 {
+        tracing::info!("work-spec ConfigMap sweep disabled (interval 0)");
+        return;
+    }
+    tokio::spawn(async move {
+        // Short initial delay: let the watches/caches warm up and avoid piling
+        // the sweep's LISTs onto the startup burst.
+        let mut delay = std::time::Duration::from_secs(60);
+        loop {
+            tokio::time::sleep(delay).await;
+            delay = std::time::Duration::from_secs(interval_secs);
+            match run_sweep(&client, &scope, min_age_secs).await {
+                Ok(0) => {}
+                Ok(n) => {
+                    metrics.inc_work_spec_cms_swept(n as u64);
+                    tracing::info!(deleted = n, "swept orphaned work-spec ConfigMaps");
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "work-spec ConfigMap sweep failed; will retry next interval");
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+    use kube::core::ObjectMeta;
+    use std::collections::BTreeMap;
+
+    const NOW: i64 = 1_700_000_000;
+    const HOUR: i64 = 3600;
+
+    /// A kopiur-managed ConfigMap in `ns` created `age_secs` ago whose data
+    /// holds exactly `keys`.
+    fn cm(ns: &str, name: &str, age_secs: i64, keys: &[&str], managed: bool) -> ConfigMap {
+        let mut labels = BTreeMap::new();
+        if managed {
+            labels.insert(MANAGED_BY_LABEL.to_string(), MANAGED_BY_VALUE.to_string());
+        }
+        ConfigMap {
+            metadata: ObjectMeta {
+                name: Some(name.to_string()),
+                namespace: Some(ns.to_string()),
+                labels: Some(labels),
+                creation_timestamp: Some(Time(
+                    k8s_openapi::jiff::Timestamp::from_second(NOW - age_secs).unwrap(),
+                )),
+                ..Default::default()
+            },
+            data: Some(
+                keys.iter()
+                    .map(|k| (k.to_string(), "{}".to_string()))
+                    .collect(),
+            ),
+            ..Default::default()
+        }
+    }
+
+    fn names(picked: &[&ConfigMap]) -> Vec<String> {
+        picked.iter().map(|c| c.name_any()).collect()
+    }
+
+    #[test]
+    fn old_orphaned_work_spec_cm_is_selected() {
+        let cms = vec![cm(
+            "media",
+            "qui-20260708155044",
+            2 * HOUR,
+            &[WORK_SPEC_FILE],
+            true,
+        )];
+        let picked = sweep_candidates(&cms, &HashSet::new(), HOUR, NOW);
+        assert_eq!(names(&picked), vec!["qui-20260708155044"]);
+    }
+
+    #[test]
+    fn young_cm_is_skipped_until_min_age() {
+        // Closes the ConfigMap-applied-before-Job window: a freshly-applied
+        // work-spec whose Job hasn't landed yet must never be reaped.
+        let cms = vec![cm("media", "qui-fresh", HOUR - 1, &[WORK_SPEC_FILE], true)];
+        assert!(sweep_candidates(&cms, &HashSet::new(), HOUR, NOW).is_empty());
+    }
+
+    #[test]
+    fn cm_with_live_same_named_job_is_skipped() {
+        let cms = vec![cm(
+            "media",
+            "qui-running",
+            2 * HOUR,
+            &[WORK_SPEC_FILE],
+            true,
+        )];
+        let live: HashSet<_> = [("media".to_string(), "qui-running".to_string())].into();
+        assert!(sweep_candidates(&cms, &live, HOUR, NOW).is_empty());
+    }
+
+    #[test]
+    fn job_in_another_namespace_does_not_shield_a_same_named_cm() {
+        // The live-Job guard keys on (namespace, name) — a Job named like the
+        // ConfigMap but in a different namespace is a different run.
+        let cms = vec![cm("media", "qui-x", 2 * HOUR, &[WORK_SPEC_FILE], true)];
+        let live: HashSet<_> = [("automation".to_string(), "qui-x".to_string())].into();
+        assert_eq!(
+            names(&sweep_candidates(&cms, &live, HOUR, NOW)),
+            vec!["qui-x"]
+        );
+    }
+
+    #[test]
+    fn non_work_spec_managed_cm_is_never_selected() {
+        // kopiur manages other ConfigMaps (dashboards, …) under the same
+        // label; only the work-spec data key marks a sweep target.
+        let cms = vec![cm("media", "other", 2 * HOUR, &["dashboard.json"], true)];
+        assert!(sweep_candidates(&cms, &HashSet::new(), HOUR, NOW).is_empty());
+    }
+
+    #[test]
+    fn bootstrap_result_cm_is_never_selected() {
+        // The bootstrap/probe flow PATCHes result.json INTO its work-spec
+        // ConfigMap and reads it back after the Job is gone — sweeping it
+        // would make a completed bootstrap look result-less.
+        let cms = vec![cm(
+            "kopiur-system",
+            "repo-bootstrap",
+            2 * HOUR,
+            &[WORK_SPEC_FILE, RESULT_CONFIGMAP_KEY],
+            true,
+        )];
+        assert!(sweep_candidates(&cms, &HashSet::new(), HOUR, NOW).is_empty());
+    }
+
+    #[test]
+    fn unmanaged_cm_is_never_selected() {
+        // Defense in depth: the server-side label selector already filters,
+        // but the kernel re-checks so it is safe against an unfiltered list.
+        let cms = vec![cm("media", "user-cm", 2 * HOUR, &[WORK_SPEC_FILE], false)];
+        assert!(sweep_candidates(&cms, &HashSet::new(), HOUR, NOW).is_empty());
+    }
+}

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -354,24 +354,14 @@ pub async fn verify_step(
     match job_api.get_opt(&job_name).await? {
         Some(job) => match job_terminal_state(&job) {
             // Success: the mover stamped lastVerified; sleep until the next slot.
-            // Drop the per-slot work-spec ConfigMap now — it is owned by the
-            // long-lived SnapshotPolicy, so left alone one accumulates per slot,
-            // forever. The Job stays until its TTL: it is the slot-handled
-            // marker (deleting it early would re-fire the slot).
-            Some(true) => {
-                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
-                Ok(Some(
-                    next_verify_wakeup(verification, &seed, Some(now), now, repo_tz)
-                        .min(REQUEUE_CAP),
-                ))
-            }
-            // Failure: same CM reap (per-slot names mean failed slots accumulate
-            // too). The failed Job lingers to its TTL as the bounded-retry
-            // backoff; the retry re-spawn recreates the ConfigMap.
-            Some(false) => {
-                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
-                Ok(Some(REQUEUE_FAILED))
-            }
+            // The terminal Job (its env carries the whole run spec) self-reaps
+            // via its TTL — it is the slot-handled marker until then.
+            Some(true) => Ok(Some(
+                next_verify_wakeup(verification, &seed, Some(now), now, repo_tz).min(REQUEUE_CAP),
+            )),
+            // Failure: the failed Job lingers to its TTL as the bounded-retry
+            // backoff (and keeps the pod logs).
+            Some(false) => Ok(Some(REQUEUE_FAILED)),
             None => Ok(Some(REQUEUE_RUNNING)),
         },
         None => {
@@ -539,9 +529,8 @@ async fn spawn_verify_job(
         },
         readiness_exec: None,
     };
-    let cm = jobs::build_config_map(&inputs)?;
-    let job = jobs::build_job(&inputs);
-    io::apply_mover_objects(&ctx.client, namespace, job_name, &cm, &job).await?;
+    let job = jobs::build_job(&inputs)?;
+    io::apply_mover_objects(&ctx.client, namespace, job_name, None, &job).await?;
     Ok(())
 }
 

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -354,10 +354,24 @@ pub async fn verify_step(
     match job_api.get_opt(&job_name).await? {
         Some(job) => match job_terminal_state(&job) {
             // Success: the mover stamped lastVerified; sleep until the next slot.
-            Some(true) => Ok(Some(
-                next_verify_wakeup(verification, &seed, Some(now), now, repo_tz).min(REQUEUE_CAP),
-            )),
-            Some(false) => Ok(Some(REQUEUE_FAILED)),
+            // Drop the per-slot work-spec ConfigMap now — it is owned by the
+            // long-lived SnapshotPolicy, so left alone one accumulates per slot,
+            // forever. The Job stays until its TTL: it is the slot-handled
+            // marker (deleting it early would re-fire the slot).
+            Some(true) => {
+                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
+                Ok(Some(
+                    next_verify_wakeup(verification, &seed, Some(now), now, repo_tz)
+                        .min(REQUEUE_CAP),
+                ))
+            }
+            // Failure: same CM reap (per-slot names mean failed slots accumulate
+            // too). The failed Job lingers to its TTL as the bounded-retry
+            // backoff; the retry re-spawn recreates the ConfigMap.
+            Some(false) => {
+                io::reap_work_spec_cm(&ctx.client, namespace, &job_name).await;
+                Ok(Some(REQUEUE_FAILED))
+            }
             None => Ok(Some(REQUEUE_RUNNING)),
         },
         None => {

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -296,27 +296,35 @@ pub async fn wait_for_job(jobs: &Api<Job>, name: &str) -> Job {
     .unwrap_or_else(|_| panic!("mover Job {name} should be created"))
 }
 
-/// Wait for a mover run's work-spec `ConfigMap` and return it. The right sync
-/// point for asserting the controller→mover work-spec contract: the ConfigMap
-/// is applied BEFORE its same-named Job and deleted only after the Job is
-/// observed terminal (the ConfigMap-leak fix) — so, unlike syncing on the Job
-/// (which outlives the ConfigMap by its TTL), a poll from run creation observes
-/// it for at least the whole pod lifetime. A sub-second poll makes even an
-/// implausibly fast create→run→reap cycle (pod startup alone takes seconds)
-/// unable to slip between two samples.
+/// The env var carrying a mover run's inline work-spec JSON — the controller↔
+/// mover contract these tests assert at the wire level, so it is a deliberate
+/// LITERAL here (an accidental rename in either crate must fail this suite).
 #[allow(dead_code)] // each test binary compiles `common` separately; not all use it
-pub async fn wait_for_work_spec_cm(
-    cms: &Api<k8s_openapi::api::core::v1::ConfigMap>,
-    name: &str,
-) -> k8s_openapi::api::core::v1::ConfigMap {
-    wait_until(
-        &format!("work-spec ConfigMap {name} created"),
-        default_timeout(),
-        std::time::Duration::from_millis(500),
-        || async { cms.get_opt(name).await },
-    )
-    .await
-    .unwrap_or_else(|_| panic!("work-spec ConfigMap {name} should be created"))
+pub const WORK_SPEC_ENV: &str = "KOPIUR_WORK_SPEC";
+
+/// Extract + parse the inline work-spec JSON from a mover Job's pod env. The
+/// spec rides the Job itself (#224 — no per-run ConfigMap exists), so this
+/// reads the full controller→mover contract from the one run object, which
+/// outlives the run by its `ttlSecondsAfterFinished` — no race with completion.
+#[allow(dead_code)]
+pub fn work_spec_json_from_job(job: &Job) -> serde_json::Value {
+    let raw = job
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.env.as_ref())
+        .and_then(|env| env.iter().find(|e| e.name == WORK_SPEC_ENV))
+        .and_then(|e| e.value.clone())
+        .expect("mover Job carries the inline work-spec env");
+    serde_json::from_str(&raw).expect("work-spec env parses as JSON")
+}
+
+/// Wait for the mover Job named `name` and return its parsed work-spec JSON.
+#[allow(dead_code)]
+pub async fn wait_for_work_spec_json(jobs: &Api<Job>, name: &str) -> serde_json::Value {
+    let job = wait_for_job(jobs, name).await;
+    work_spec_json_from_job(&job)
 }
 
 /// The mover container's container-level `securityContext` from a Job's pod template.

--- a/crates/e2e/tests/common/mod.rs
+++ b/crates/e2e/tests/common/mod.rs
@@ -296,6 +296,29 @@ pub async fn wait_for_job(jobs: &Api<Job>, name: &str) -> Job {
     .unwrap_or_else(|_| panic!("mover Job {name} should be created"))
 }
 
+/// Wait for a mover run's work-spec `ConfigMap` and return it. The right sync
+/// point for asserting the controller→mover work-spec contract: the ConfigMap
+/// is applied BEFORE its same-named Job and deleted only after the Job is
+/// observed terminal (the ConfigMap-leak fix) — so, unlike syncing on the Job
+/// (which outlives the ConfigMap by its TTL), a poll from run creation observes
+/// it for at least the whole pod lifetime. A sub-second poll makes even an
+/// implausibly fast create→run→reap cycle (pod startup alone takes seconds)
+/// unable to slip between two samples.
+#[allow(dead_code)] // each test binary compiles `common` separately; not all use it
+pub async fn wait_for_work_spec_cm(
+    cms: &Api<k8s_openapi::api::core::v1::ConfigMap>,
+    name: &str,
+) -> k8s_openapi::api::core::v1::ConfigMap {
+    wait_until(
+        &format!("work-spec ConfigMap {name} created"),
+        default_timeout(),
+        std::time::Duration::from_millis(500),
+        || async { cms.get_opt(name).await },
+    )
+    .await
+    .unwrap_or_else(|_| panic!("work-spec ConfigMap {name} should be created"))
+}
+
 /// The mover container's container-level `securityContext` from a Job's pod template.
 pub fn job_container_sc(job: &Job) -> Option<k8s_openapi::api::core::v1::SecurityContext> {
     job.spec

--- a/crates/e2e/tests/leak_cleanup.rs
+++ b/crates/e2e/tests/leak_cleanup.rs
@@ -1,17 +1,18 @@
-//! e2e regression guards for the **work-spec ConfigMap leak** (the "605
-//! ConfigMaps" report): every mover run applies a work-spec `ConfigMap` + `Job`
-//! pair, owner-referenced to a long-lived CR. The Job self-reaps via
+//! e2e regression guards for the **work-spec ConfigMap leak** (#224, the "605
+//! ConfigMaps" report): mover runs used to apply a work-spec `ConfigMap` +
+//! `Job` pair, owner-referenced to a long-lived CR. The Job self-reaped via
 //! `ttlSecondsAfterFinished`, but nothing ever deleted the ConfigMap — it lived
 //! as long as its owner (a `Snapshot` CR is the durable backup record, a
 //! `SnapshotPolicy`/`RepositoryReplication` is permanent), so one ConfigMap
 //! accumulated per run, forever.
 //!
-//! The fix has two halves, each guarded here:
-//! 1. **Transition reap** — a reconciler deletes the ConfigMap as soon as it
-//!    observes the Job terminal (the Job stays until its TTL: pod logs).
-//! 2. **Orphan sweep** — a leader-only periodic pass reaps work-spec ConfigMaps
-//!    whose Job is already gone (pre-fix leftovers, reap-before-observe). The
-//!    harness values (`deploy/e2e/values.yaml`) run it on a fast cadence.
+//! The fix is structural, and both halves are guarded here:
+//! 1. **No per-run ConfigMap exists at all** — the work spec rides the mover
+//!    Job's own pod env, so a run is exactly ONE object whose TTL cleans up
+//!    everything.
+//! 2. **Orphan sweep** — a leader-only periodic pass reaps the LEGACY
+//!    work-spec ConfigMaps left by pre-fix operator versions. The harness
+//!    values (`deploy/e2e/values.yaml`) run it on a fast cadence.
 //!
 //! Plus the pin-consumption bug the audit surfaced: a stale terminal
 //! `{name}-pin` Job satisfied the next pin toggle's "Job succeeded" check, so
@@ -140,43 +141,37 @@ async fn create_snapshot(
     backups
 }
 
-/// Wait until the work-spec ConfigMap named `name` is gone.
-async fn wait_cm_reaped(cms: &Api<ConfigMap>, name: &str) {
-    wait_until(
-        &format!("work-spec ConfigMap {name} reaped"),
-        default_timeout(),
-        poll_interval(),
-        || async { Ok(cms.get_opt(name).await?.is_none().then_some(())) },
-    )
-    .await
-    .expect("the controller should delete the work-spec ConfigMap at Job-terminal");
+/// Assert the run named `name` has NO same-named ConfigMap — the work spec
+/// rides the Job env, so a per-run ConfigMap existing at any point is the
+/// leak regression.
+async fn assert_no_work_spec_cm(cms: &Api<ConfigMap>, name: &str, when: &str) {
+    assert!(
+        cms.get_opt(name).await.expect("get ConfigMap").is_none(),
+        "run {name} has a per-run work-spec ConfigMap ({when}) — the spec must ride the Job env"
+    );
 }
 
-/// Assert the ConfigMap named `name` does not reappear during [`QUIET_WINDOW`].
+/// Assert no ConfigMap named `name` appears during [`QUIET_WINDOW`].
 async fn assert_cm_stays_gone(cms: &Api<ConfigMap>, name: &str, while_doing: &str) {
     let deadline = tokio::time::Instant::now() + QUIET_WINDOW;
     while tokio::time::Instant::now() < deadline {
-        if cms.get_opt(name).await.expect("get ConfigMap").is_some() {
-            panic!(
-                "work-spec ConfigMap {name} was re-created while {while_doing} — a reconcile \
-                 is re-applying mover objects for a terminal run"
-            );
-        }
+        assert_no_work_spec_cm(cms, name, while_doing).await;
         tokio::time::sleep(Duration::from_secs(3)).await;
     }
 }
 
 // ---------------------------------------------------------------------------
-// 1. Succeeded backup: ConfigMap reaped at Job-terminal, Job left to its TTL.
+// 1. Succeeded backup: no per-run ConfigMap exists at any point; the Job (its
+//    env carries the whole spec) is left to its TTL.
 // ---------------------------------------------------------------------------
 
 /// THE leak report: one work-spec ConfigMap per (hourly) backup, forever. The
-/// fixed controller deletes the ConfigMap once it observes the mover Job
-/// terminal — while the Job (default 1h TTL) is still present, proving the reap
-/// is the controller's transition-time delete rather than TTL or owner GC.
+/// fix is structural — the spec rides the mover Job's pod env, so no per-run
+/// ConfigMap is ever created, while the Job (default 1h TTL) still carries the
+/// full controller→mover contract and the pod logs.
 #[tokio::test]
 #[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
-async fn succeeded_backup_reaps_work_spec_cm_and_keeps_job() {
+async fn succeeded_backup_creates_no_work_spec_cm_and_keeps_job() {
     let Some(world) = World::connect().await else {
         return;
     };
@@ -206,21 +201,28 @@ async fn succeeded_backup_reaps_work_spec_cm_and_keeps_job() {
         .await
         .expect("Snapshot should reach Succeeded");
 
-    // The controller reaps the ConfigMap once it observes the Job terminal.
-    wait_cm_reaped(&cms, "e2e-leak-ok").await;
-
-    // The Job must still be there (default 1h TTL): pod logs stay reachable,
-    // user-set TTLs are honored — the leak fix must not eat the Job.
+    // No per-run ConfigMap was created; the Job (default 1h TTL) is present
+    // and carries the work spec inline.
+    assert_no_work_spec_cm(&cms, "e2e-leak-ok", "after Succeeded").await;
+    let job = jobs
+        .get_opt("e2e-leak-ok")
+        .await
+        .expect("get mover Job")
+        .expect("the succeeded mover Job must persist to its TTL");
+    let has_spec_env = job
+        .spec
+        .as_ref()
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.env.as_ref())
+        .is_some_and(|env| env.iter().any(|e| e.name == "KOPIUR_WORK_SPEC"));
     assert!(
-        jobs.get_opt("e2e-leak-ok")
-            .await
-            .expect("get mover Job")
-            .is_some(),
-        "the succeeded mover Job must outlive the ConfigMap reap (it self-reaps via its TTL)"
+        has_spec_env,
+        "the mover Job must carry the inline work-spec env"
     );
 
-    // Poke the Snapshot (any watch event re-reconciles it — it owns the CM, so
-    // the deletion event already did once): the ConfigMap must STAY gone.
+    // Poke the Snapshot (any watch event re-reconciles it): no ConfigMap may
+    // appear — a terminal run must not re-apply mover objects.
     let poke = serde_json::json!({
         "metadata": { "annotations": { "kopiur-e2e/leak-poke": "1" } }
     });
@@ -244,13 +246,13 @@ async fn succeeded_backup_reaps_work_spec_cm_and_keeps_job() {
 }
 
 // ---------------------------------------------------------------------------
-// 2. Failed backup: ConfigMap reaped too (manual Failed Snapshots are never
-//    pruned, so their ConfigMaps would leak unbounded); Job kept for logs.
+// 2. Failed backup: no per-run ConfigMap either (manual Failed Snapshots are
+//    never pruned, so a ConfigMap would leak unbounded); Job kept for logs.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
-async fn failed_backup_reaps_work_spec_cm_and_keeps_job() {
+async fn failed_backup_creates_no_work_spec_cm_and_keeps_job() {
     let Some(world) = World::connect().await else {
         return;
     };
@@ -281,7 +283,7 @@ async fn failed_backup_reaps_work_spec_cm_and_keeps_job() {
         .await
         .expect("poisoned Snapshot should end Failed");
 
-    wait_cm_reaped(&cms, "e2e-leak-fail").await;
+    assert_no_work_spec_cm(&cms, "e2e-leak-fail", "after Failed").await;
     assert!(
         jobs.get_opt("e2e-leak-fail")
             .await
@@ -292,7 +294,7 @@ async fn failed_backup_reaps_work_spec_cm_and_keeps_job() {
     assert_cm_stays_gone(
         &cms,
         "e2e-leak-fail",
-        "waiting after a Failed Snapshot's CM reap",
+        "waiting after a Failed Snapshot went terminal",
     )
     .await;
 }
@@ -360,9 +362,9 @@ async fn pin_toggle_after_success_runs_a_fresh_pin_job() {
     .await
     .expect("the pin mover must record status.pinned = true");
 
-    // Regression assert #1: the terminal pin Job (and its ConfigMap) is
-    // CONSUMED once its result is recorded. On the buggy code both linger for
-    // the Job's TTL (1h) — this wait times out.
+    // Regression assert #1: the terminal pin Job is CONSUMED once its result
+    // is recorded. On the buggy code it lingers for its TTL (1h) — this wait
+    // times out.
     wait_until(
         "terminal pin Job consumed",
         default_timeout(),
@@ -377,7 +379,7 @@ async fn pin_toggle_after_success_runs_a_fresh_pin_job() {
     )
     .await
     .expect("the succeeded pin Job must be consumed after status.pinned is recorded");
-    wait_cm_reaped(&cms, "e2e-leak-pin-pin").await;
+    assert_no_work_spec_cm(&cms, "e2e-leak-pin-pin", "after pin-Job consumption").await;
 
     // Unpin — and require a FRESH pin Job to appear while the flip completes.
     // On the buggy code (stale Job satisfying the success check) the flip
@@ -429,13 +431,12 @@ async fn pin_toggle_after_success_runs_a_fresh_pin_job() {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Restore: same contract as backups — ConfigMap reaped at Job-terminal
-//    (via the terminal entry guard: the mover stamps `Completed` first).
+// 4. Restore: same contract as backups — no per-run ConfigMap; Job to its TTL.
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
 #[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
-async fn completed_restore_reaps_work_spec_cm_and_keeps_job() {
+async fn completed_restore_creates_no_work_spec_cm_and_keeps_job() {
     let Some(world) = World::connect().await else {
         return;
     };
@@ -508,20 +509,19 @@ async fn completed_restore_reaps_work_spec_cm_and_keeps_job() {
         .await
         .expect("Restore should reach Completed");
 
-    // The terminal guard reaps the ConfigMap once the restore Job is observed
-    // terminal; the Job (default 1h TTL) must survive it.
-    wait_cm_reaped(&cms, "e2e-leak-restore").await;
+    // No per-run ConfigMap was created; the Job (default 1h TTL) persists.
+    assert_no_work_spec_cm(&cms, "e2e-leak-restore", "after Completed").await;
     assert!(
         jobs.get_opt("e2e-leak-restore")
             .await
             .expect("get restore Job")
             .is_some(),
-        "the completed restore Job must outlive the ConfigMap reap (it self-reaps via its TTL)"
+        "the completed restore Job must persist to its TTL"
     );
     assert_cm_stays_gone(
         &cms,
         "e2e-leak-restore",
-        "waiting after a Completed Restore's CM reap",
+        "waiting after a Completed Restore",
     )
     .await;
 }

--- a/crates/e2e/tests/leak_cleanup.rs
+++ b/crates/e2e/tests/leak_cleanup.rs
@@ -1,0 +1,619 @@
+//! e2e regression guards for the **work-spec ConfigMap leak** (the "605
+//! ConfigMaps" report): every mover run applies a work-spec `ConfigMap` + `Job`
+//! pair, owner-referenced to a long-lived CR. The Job self-reaps via
+//! `ttlSecondsAfterFinished`, but nothing ever deleted the ConfigMap — it lived
+//! as long as its owner (a `Snapshot` CR is the durable backup record, a
+//! `SnapshotPolicy`/`RepositoryReplication` is permanent), so one ConfigMap
+//! accumulated per run, forever.
+//!
+//! The fix has two halves, each guarded here:
+//! 1. **Transition reap** — a reconciler deletes the ConfigMap as soon as it
+//!    observes the Job terminal (the Job stays until its TTL: pod logs).
+//! 2. **Orphan sweep** — a leader-only periodic pass reaps work-spec ConfigMaps
+//!    whose Job is already gone (pre-fix leftovers, reap-before-observe). The
+//!    harness values (`deploy/e2e/values.yaml`) run it on a fast cadence.
+//!
+//! Plus the pin-consumption bug the audit surfaced: a stale terminal
+//! `{name}-pin` Job satisfied the next pin toggle's "Job succeeded" check, so
+//! the controller recorded `status.pinned = desired` WITHOUT running a mover —
+//! kopia's real pin state silently diverged.
+//!
+//! Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; driven by
+//! `mise run //crates/e2e:test`. Skips gracefully without a cluster.
+
+#![cfg(all(unix, feature = "e2e"))]
+
+mod common;
+
+use std::time::Duration;
+
+use common::{cr, wait_phase};
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::ConfigMap;
+use kube::Api;
+use kube::api::{DeleteParams, Patch, PatchParams, PostParams};
+
+use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
+use kopiur_e2e::{E2E_NAMESPACE, Need, World, consts, default_timeout, poll_interval, wait_until};
+
+/// The repository password Secret the chart-installed operator reads.
+const CREDS_SECRET: &str = "kopia-creds";
+
+/// How long a reaped ConfigMap must STAY gone under reconcile pokes. The
+/// regression shape is a requeue/watch-event loop re-creating it, which fires
+/// within seconds.
+const QUIET_WINDOW: Duration = Duration::from_secs(30);
+
+/// Provision the shared filesystem repo + a policy for `policy_name`, and wait
+/// the Repository Ready. `extra_policy` is merged into the SnapshotPolicy spec.
+async fn ensure_repo_and_policy(
+    client: &kube::Client,
+    repo_name: &str,
+    policy_name: &str,
+    extra_policy: serde_json::Value,
+) {
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let repo = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Repository",
+        "metadata": { "name": repo_name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "backend": { "filesystem": { "path": "/repo", "volume": { "pvc": { "name": "kopiur-e2e-repo" } } } },
+            "encryption": { "passwordSecretRef": { "name": CREDS_SECRET, "key": "KOPIA_PASSWORD" } },
+            "create": { "enabled": true }
+        }
+    });
+    let _ = repos.create(&PostParams::default(), &cr(repo)).await;
+    wait_phase(&repos, repo_name, "Ready")
+        .await
+        .expect("repository should reach Ready");
+
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let mut spec = serde_json::json!({
+        "repository": { "kind": "Repository", "name": repo_name },
+        "sources": [ { "pvc": { "name": "e2e-src" } } ],
+        // e2e-src is a statically-provisioned (non-CSI) hostPath PVC; copyMethod
+        // defaults to Snapshot, which would fail preflight against it.
+        "copyMethod": "Direct"
+        // NO mover.ttlSecondsAfterFinished: the DEFAULT 1h TTL applies, so the
+        // finished Job outlives the whole test — proving the ConfigMap reap is
+        // the controller's own transition-time delete, not TTL/owner GC.
+    });
+    if let Some(extra) = extra_policy.as_object() {
+        for (k, v) in extra {
+            spec[k] = v.clone();
+        }
+    }
+    let policy = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotPolicy",
+        "metadata": { "name": policy_name, "namespace": E2E_NAMESPACE },
+        "spec": spec
+    });
+    let _ = policies.create(&PostParams::default(), &cr(policy)).await;
+}
+
+/// Create a Snapshot (deleting any leftover of the same name first) and return
+/// its Api handle.
+async fn create_snapshot(
+    client: &kube::Client,
+    name: &str,
+    policy_name: &str,
+    extra_spec: serde_json::Value,
+) -> Api<Snapshot> {
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if backups
+        .get_opt(name)
+        .await
+        .expect("query leftover Snapshot")
+        .is_some()
+    {
+        let _ = backups.delete(name, &DeleteParams::default()).await;
+        wait_until(
+            &format!("leftover {name} is gone"),
+            default_timeout(),
+            poll_interval(),
+            || async { Ok(backups.get_opt(name).await?.is_none().then_some(())) },
+        )
+        .await
+        .expect("leftover Snapshot should delete (finalizer included)");
+    }
+    let mut spec = serde_json::json!({
+        "policyRef": { "name": policy_name },
+        "deletionPolicy": "Retain"
+    });
+    if let Some(extra) = extra_spec.as_object() {
+        for (k, v) in extra {
+            spec[k] = v.clone();
+        }
+    }
+    let backup = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Snapshot",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": spec
+    });
+    backups
+        .create(&PostParams::default(), &cr(backup))
+        .await
+        .expect("create Snapshot");
+    backups
+}
+
+/// Wait until the work-spec ConfigMap named `name` is gone.
+async fn wait_cm_reaped(cms: &Api<ConfigMap>, name: &str) {
+    wait_until(
+        &format!("work-spec ConfigMap {name} reaped"),
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(cms.get_opt(name).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("the controller should delete the work-spec ConfigMap at Job-terminal");
+}
+
+/// Assert the ConfigMap named `name` does not reappear during [`QUIET_WINDOW`].
+async fn assert_cm_stays_gone(cms: &Api<ConfigMap>, name: &str, while_doing: &str) {
+    let deadline = tokio::time::Instant::now() + QUIET_WINDOW;
+    while tokio::time::Instant::now() < deadline {
+        if cms.get_opt(name).await.expect("get ConfigMap").is_some() {
+            panic!(
+                "work-spec ConfigMap {name} was re-created while {while_doing} — a reconcile \
+                 is re-applying mover objects for a terminal run"
+            );
+        }
+        tokio::time::sleep(Duration::from_secs(3)).await;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 1. Succeeded backup: ConfigMap reaped at Job-terminal, Job left to its TTL.
+// ---------------------------------------------------------------------------
+
+/// THE leak report: one work-spec ConfigMap per (hourly) backup, forever. The
+/// fixed controller deletes the ConfigMap once it observes the mover Job
+/// terminal — while the Job (default 1h TTL) is still present, proving the reap
+/// is the controller's transition-time delete rather than TTL or owner GC.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn succeeded_backup_reaps_work_spec_cm_and_keeps_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client = world.client().clone();
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    ensure_repo_and_policy(
+        &client,
+        "e2e-leak-repo",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    let backups = create_snapshot(
+        &client,
+        "e2e-leak-ok",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    wait_phase(&backups, "e2e-leak-ok", "Succeeded")
+        .await
+        .expect("Snapshot should reach Succeeded");
+
+    // The controller reaps the ConfigMap once it observes the Job terminal.
+    wait_cm_reaped(&cms, "e2e-leak-ok").await;
+
+    // The Job must still be there (default 1h TTL): pod logs stay reachable,
+    // user-set TTLs are honored — the leak fix must not eat the Job.
+    assert!(
+        jobs.get_opt("e2e-leak-ok")
+            .await
+            .expect("get mover Job")
+            .is_some(),
+        "the succeeded mover Job must outlive the ConfigMap reap (it self-reaps via its TTL)"
+    );
+
+    // Poke the Snapshot (any watch event re-reconciles it — it owns the CM, so
+    // the deletion event already did once): the ConfigMap must STAY gone.
+    let poke = serde_json::json!({
+        "metadata": { "annotations": { "kopiur-e2e/leak-poke": "1" } }
+    });
+    backups
+        .patch("e2e-leak-ok", &PatchParams::default(), &Patch::Merge(&poke))
+        .await
+        .expect("poke Snapshot");
+    assert_cm_stays_gone(&cms, "e2e-leak-ok", "poking a Succeeded Snapshot").await;
+
+    // And the phase is untouched (no accidental re-run).
+    let after = backups
+        .get_opt("e2e-leak-ok")
+        .await
+        .expect("get Snapshot")
+        .expect("Snapshot exists");
+    let phase = serde_json::to_value(&after).ok().and_then(|v| {
+        v.pointer("/status/phase")
+            .and_then(|p| p.as_str().map(String::from))
+    });
+    assert_eq!(phase.as_deref(), Some("Succeeded"));
+}
+
+// ---------------------------------------------------------------------------
+// 2. Failed backup: ConfigMap reaped too (manual Failed Snapshots are never
+//    pruned, so their ConfigMaps would leak unbounded); Job kept for logs.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn failed_backup_reaps_work_spec_cm_and_keeps_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client = world.client().clone();
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // Deterministic mover failure: an unknown kopia flag, one attempt only.
+    ensure_repo_and_policy(
+        &client,
+        "e2e-leak-fail-repo",
+        "e2e-leak-fail-cfg",
+        serde_json::json!({ "extraArgs": ["--kopiur-e2e-bogus-flag"] }),
+    )
+    .await;
+    let backups = create_snapshot(
+        &client,
+        "e2e-leak-fail",
+        "e2e-leak-fail-cfg",
+        serde_json::json!({ "failurePolicy": { "backoffLimit": 0 } }),
+    )
+    .await;
+    wait_phase(&backups, "e2e-leak-fail", "Failed")
+        .await
+        .expect("poisoned Snapshot should end Failed");
+
+    wait_cm_reaped(&cms, "e2e-leak-fail").await;
+    assert!(
+        jobs.get_opt("e2e-leak-fail")
+            .await
+            .expect("get mover Job")
+            .is_some(),
+        "the FAILED mover Job must be kept (debugging contract: pod logs until its TTL)"
+    );
+    assert_cm_stays_gone(
+        &cms,
+        "e2e-leak-fail",
+        "waiting after a Failed Snapshot's CM reap",
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Pin toggle: a consumed pin Job means the next toggle runs a FRESH mover.
+// ---------------------------------------------------------------------------
+
+/// The silent-divergence bug: the `{name}-pin` Job was never deleted, so a
+/// pin→unpin toggle found the stale SUCCEEDED Job, matched "Job succeeded", and
+/// recorded `status.pinned = desired` without running a mover — kopia stayed
+/// pinned while the CR said otherwise. The fixed controller consumes the
+/// terminal pin Job (+ ConfigMap) once its result is recorded, so a toggle must
+/// observably spawn a NEW pin Job.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn pin_toggle_after_success_runs_a_fresh_pin_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client = world.client().clone();
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    ensure_repo_and_policy(
+        &client,
+        "e2e-leak-repo",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    let backups = create_snapshot(
+        &client,
+        "e2e-leak-pin",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    wait_phase(&backups, "e2e-leak-pin", "Succeeded")
+        .await
+        .expect("Snapshot should reach Succeeded");
+
+    // Pin it.
+    let pin = serde_json::json!({ "spec": { "pin": true } });
+    backups
+        .patch("e2e-leak-pin", &PatchParams::default(), &Patch::Merge(&pin))
+        .await
+        .expect("patch spec.pin = true");
+    wait_until(
+        "status.pinned == true",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let obj = backups.get_opt("e2e-leak-pin").await?;
+            let pinned = obj
+                .and_then(|o| serde_json::to_value(&o).ok())
+                .and_then(|v| v.pointer("/status/pinned").and_then(|p| p.as_bool()));
+            Ok((pinned == Some(true)).then_some(()))
+        },
+    )
+    .await
+    .expect("the pin mover must record status.pinned = true");
+
+    // Regression assert #1: the terminal pin Job (and its ConfigMap) is
+    // CONSUMED once its result is recorded. On the buggy code both linger for
+    // the Job's TTL (1h) — this wait times out.
+    wait_until(
+        "terminal pin Job consumed",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(jobs
+                .get_opt("e2e-leak-pin-pin")
+                .await?
+                .is_none()
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("the succeeded pin Job must be consumed after status.pinned is recorded");
+    wait_cm_reaped(&cms, "e2e-leak-pin-pin").await;
+
+    // Unpin — and require a FRESH pin Job to appear while the flip completes.
+    // On the buggy code (stale Job satisfying the success check) the flip
+    // happens with NO Job ever created; here the stale Job is gone, so a
+    // recorded flip without a new Job is impossible — but observe it anyway so
+    // the failure mode is named, not inferred.
+    let unpin = serde_json::json!({ "spec": { "pin": false } });
+    backups
+        .patch(
+            "e2e-leak-pin",
+            &PatchParams::default(),
+            &Patch::Merge(&unpin),
+        )
+        .await
+        .expect("patch spec.pin = false");
+    let deadline = tokio::time::Instant::now() + default_timeout();
+    let mut saw_fresh_pin_job = false;
+    loop {
+        if tokio::time::Instant::now() > deadline {
+            panic!("status.pinned never flipped to false after unpin");
+        }
+        if !saw_fresh_pin_job
+            && jobs
+                .get_opt("e2e-leak-pin-pin")
+                .await
+                .ok()
+                .flatten()
+                .is_some()
+        {
+            saw_fresh_pin_job = true;
+        }
+        let pinned = backups
+            .get_opt("e2e-leak-pin")
+            .await
+            .ok()
+            .flatten()
+            .and_then(|o| serde_json::to_value(&o).ok())
+            .and_then(|v| v.pointer("/status/pinned").and_then(|p| p.as_bool()));
+        if pinned == Some(false) {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+    assert!(
+        saw_fresh_pin_job,
+        "pin divergence regression: status.pinned flipped to false without a fresh pin mover \
+         Job — the controller recorded a pin state kopia never applied"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Restore: same contract as backups — ConfigMap reaped at Job-terminal
+//    (via the terminal entry guard: the mover stamps `Completed` first).
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn completed_restore_reaps_work_spec_cm_and_keeps_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client = world.client().clone();
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    ensure_repo_and_policy(
+        &client,
+        "e2e-leak-repo",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    let backups = create_snapshot(
+        &client,
+        "e2e-leak-restore-src",
+        "e2e-leak-cfg",
+        serde_json::json!({}),
+    )
+    .await;
+    wait_phase(&backups, "e2e-leak-restore-src", "Succeeded")
+        .await
+        .expect("source Snapshot should reach Succeeded");
+
+    let restores: Api<kopiur_api::Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    if restores
+        .get_opt("e2e-leak-restore")
+        .await
+        .expect("query leftover Restore")
+        .is_some()
+    {
+        let _ = restores
+            .delete("e2e-leak-restore", &DeleteParams::default())
+            .await;
+        wait_until(
+            "leftover e2e-leak-restore is gone",
+            default_timeout(),
+            poll_interval(),
+            || async {
+                Ok(restores
+                    .get_opt("e2e-leak-restore")
+                    .await?
+                    .is_none()
+                    .then_some(()))
+            },
+        )
+        .await
+        .expect("leftover Restore should delete");
+    }
+    let restore = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": "e2e-leak-restore", "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": "e2e-leak-repo" },
+            "source": { "snapshotRef": { "name": "e2e-leak-restore-src" } },
+            "target": { "pvcRef": { "name": "e2e-dst" } }
+        }
+    });
+    restores
+        .create(&PostParams::default(), &cr(restore))
+        .await
+        .expect("create Restore");
+    wait_phase(&restores, "e2e-leak-restore", "Completed")
+        .await
+        .expect("Restore should reach Completed");
+
+    // The terminal guard reaps the ConfigMap once the restore Job is observed
+    // terminal; the Job (default 1h TTL) must survive it.
+    wait_cm_reaped(&cms, "e2e-leak-restore").await;
+    assert!(
+        jobs.get_opt("e2e-leak-restore")
+            .await
+            .expect("get restore Job")
+            .is_some(),
+        "the completed restore Job must outlive the ConfigMap reap (it self-reaps via its TTL)"
+    );
+    assert_cm_stays_gone(
+        &cms,
+        "e2e-leak-restore",
+        "waiting after a Completed Restore's CM reap",
+    )
+    .await;
+}
+
+// ---------------------------------------------------------------------------
+// 5. Orphan sweep: a work-spec ConfigMap with no Job is reaped; one with a
+//    live Job survives.
+// ---------------------------------------------------------------------------
+
+/// The upgrade/backfill path: ConfigMaps left behind by pre-fix operator
+/// versions (their Jobs long TTL-reaped) are invisible to the transition reap —
+/// the periodic sweep must delete them, and ONLY them. The harness runs the
+/// sweep fast (`KOPIUR_WORK_SPEC_SWEEP_*` in deploy/e2e/values.yaml).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn sweep_reaps_orphaned_work_spec_cm_but_not_a_live_runs() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    let client = world.client().clone();
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    let managed = serde_json::json!({ "app.kubernetes.io/managed-by": "kopiur" });
+
+    // The orphan: kopiur-managed, work-spec-keyed, NO same-named Job — exactly
+    // what a pre-fix operator left behind after the Job's TTL.
+    let orphan = serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": { "name": "e2e-sweep-orphan", "namespace": E2E_NAMESPACE, "labels": managed },
+        "data": { "work-spec.json": "{}" }
+    });
+    let _ = cms.create(&PostParams::default(), &cr(orphan)).await;
+
+    // The control: same shape but with a live same-named Job — a "running
+    // mover" the sweep must never touch.
+    let control_cm = serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "ConfigMap",
+        "metadata": { "name": "e2e-sweep-live", "namespace": E2E_NAMESPACE, "labels": managed },
+        "data": { "work-spec.json": "{}" }
+    });
+    let _ = cms.create(&PostParams::default(), &cr(control_cm)).await;
+    let control_job = serde_json::json!({
+        "apiVersion": "batch/v1",
+        "kind": "Job",
+        "metadata": { "name": "e2e-sweep-live", "namespace": E2E_NAMESPACE, "labels": managed },
+        "spec": {
+            "template": {
+                "spec": {
+                    "restartPolicy": "Never",
+                    "containers": [{
+                        "name": "sleep",
+                        "image": consts::BUSYBOX_IMAGE,
+                        "command": ["sh", "-c", "sleep 600"]
+                    }]
+                }
+            }
+        }
+    });
+    let _ = jobs.create(&PostParams::default(), &cr(control_job)).await;
+
+    // The sweep (fast harness cadence) reaps the orphan once it ages past the
+    // harness min-age.
+    wait_until(
+        "orphaned work-spec ConfigMap swept",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(cms
+                .get_opt("e2e-sweep-orphan")
+                .await?
+                .is_none()
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("the sweep must delete an aged work-spec ConfigMap with no Job");
+
+    // The control survived that same sweep pass (it was as old as the orphan).
+    assert!(
+        cms.get_opt("e2e-sweep-live")
+            .await
+            .expect("get control ConfigMap")
+            .is_some(),
+        "the sweep deleted a work-spec ConfigMap whose Job is still live"
+    );
+
+    // Cleanup.
+    let _ = jobs
+        .delete("e2e-sweep-live", &DeleteParams::background())
+        .await;
+    let _ = cms.delete("e2e-sweep-live", &DeleteParams::default()).await;
+}

--- a/crates/e2e/tests/lifecycle.rs
+++ b/crates/e2e/tests/lifecycle.rs
@@ -1194,6 +1194,26 @@ async fn wedged_mover_pod_fails_fast_instead_of_hanging() {
     .await
     .expect("the wedged Job must be deleted (cascade) so no orphaned pod survives");
 
+    // Leak guard (the "605 ConfigMaps" fix): the wedged teardown deletes the
+    // work-spec ConfigMap along with the Job — a bare Job delete used to
+    // orphan it until the Snapshot CR was deleted.
+    let cms: Api<k8s_openapi::api::core::v1::ConfigMap> =
+        Api::namespaced(client.clone(), E2E_NAMESPACE);
+    wait_until(
+        "wedged mover's work-spec ConfigMap reaped",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(cms
+                .get_opt("e2e-wedge-backup")
+                .await?
+                .is_none()
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("the wedged run's work-spec ConfigMap must be deleted with its Job");
+
     // Cleanup.
     let _ = repos
         .delete("e2e-wedge-repo", &DeleteParams::default())

--- a/crates/e2e/tests/policy_knobs.rs
+++ b/crates/e2e/tests/policy_knobs.rs
@@ -13,12 +13,11 @@ mod common;
 
 use common::{
     cr, ensure_repo, observed_snapshot_count, repository_json, snapshot_json, snapshot_policy_json,
-    wait_for_job, wait_phase,
+    wait_for_work_spec_cm, wait_phase,
 };
 use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
 
-use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{ConfigMap, Pod};
 
 use kopiur_api::{Repository, Restore, Snapshot, SnapshotPolicy};
@@ -168,10 +167,11 @@ async fn compression_and_upload_knobs_reach_the_mover_contract() {
         .await;
 
     // The work-spec ConfigMap (same name as the mover Job) carries the knobs.
-    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let _ = wait_for_job(&jobs, "e2e-knobs").await;
+    // Sync on the ConfigMap itself, not the Job: the ConfigMap is applied
+    // BEFORE the Job and deleted only after the Job is observed terminal (the
+    // ConfigMap-leak fix), so this read can never race the reap.
     let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cm = cms.get("e2e-knobs").await.expect("work-spec ConfigMap");
+    let cm = wait_for_work_spec_cm(&cms, "e2e-knobs").await;
     let spec_json = cm
         .data
         .as_ref()
@@ -259,13 +259,8 @@ async fn snapshot_create_knobs_reach_the_mover_contract() {
     // The work-spec ConfigMap (same name as the mover Job) carries all three
     // knobs directly on `operation.snapshot` — NOT under `.policy` (the
     // `policy set` args), proving the recipe/invocation split holds end to end.
-    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let _ = wait_for_job(&jobs, "e2e-create-knobs").await;
     let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cm = cms
-        .get("e2e-create-knobs")
-        .await
-        .expect("work-spec ConfigMap");
+    let cm = wait_for_work_spec_cm(&cms, "e2e-create-knobs").await;
     let spec_json = cm
         .data
         .as_ref()

--- a/crates/e2e/tests/policy_knobs.rs
+++ b/crates/e2e/tests/policy_knobs.rs
@@ -13,12 +13,13 @@ mod common;
 
 use common::{
     cr, ensure_repo, observed_snapshot_count, repository_json, snapshot_json, snapshot_policy_json,
-    wait_for_work_spec_cm, wait_phase,
+    wait_for_work_spec_json, wait_phase,
 };
 use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
 
-use k8s_openapi::api::core::v1::{ConfigMap, Pod};
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::Pod;
 
 use kopiur_api::{Repository, Restore, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{E2E_NAMESPACE, Need, World, builders, consts, wait};
@@ -124,8 +125,8 @@ async fn ignore_file_errors_lets_snapshot_complete() {
     );
 }
 
-/// `compression` + `upload` knobs reach the controller→mover work-spec ConfigMap
-/// (the contract the mover's `kopia policy set` consumes — its flag construction
+/// `compression` + `upload` knobs reach the controller→mover work-spec (the
+/// Job-embedded contract the mover's `kopia policy set` consumes — its flag
 /// is unit-tested in `crates/kopia`), and kopia accepts them (`Succeeded`: a bad
 /// compressor would fail the mover's policy-set step).
 #[tokio::test]
@@ -166,19 +167,11 @@ async fn compression_and_upload_knobs_reach_the_mover_contract() {
         )
         .await;
 
-    // The work-spec ConfigMap (same name as the mover Job) carries the knobs.
-    // Sync on the ConfigMap itself, not the Job: the ConfigMap is applied
-    // BEFORE the Job and deleted only after the Job is observed terminal (the
-    // ConfigMap-leak fix), so this read can never race the reap.
-    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cm = wait_for_work_spec_cm(&cms, "e2e-knobs").await;
-    let spec_json = cm
-        .data
-        .as_ref()
-        .and_then(|d| d.get("work-spec.json"))
-        .expect("work-spec.json key");
-    let spec: serde_json::Value =
-        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+    // The mover Job's inline work-spec env carries the knobs (#224: the spec
+    // rides the Job itself — no per-run ConfigMap). The Job outlives the run
+    // by its TTL, so this read never races completion.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let spec = wait_for_work_spec_json(&jobs, "e2e-knobs").await;
     let policy = spec
         .pointer("/operation/snapshot/policy")
         .unwrap_or(&serde_json::Value::Null);
@@ -259,15 +252,8 @@ async fn snapshot_create_knobs_reach_the_mover_contract() {
     // The work-spec ConfigMap (same name as the mover Job) carries all three
     // knobs directly on `operation.snapshot` — NOT under `.policy` (the
     // `policy set` args), proving the recipe/invocation split holds end to end.
-    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cm = wait_for_work_spec_cm(&cms, "e2e-create-knobs").await;
-    let spec_json = cm
-        .data
-        .as_ref()
-        .and_then(|d| d.get("work-spec.json"))
-        .expect("work-spec.json key");
-    let spec: serde_json::Value =
-        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let spec = wait_for_work_spec_json(&jobs, "e2e-create-knobs").await;
     let snapshot_op = spec
         .pointer("/operation/snapshot")
         .unwrap_or(&serde_json::Value::Null);

--- a/crates/e2e/tests/replication.rs
+++ b/crates/e2e/tests/replication.rs
@@ -86,21 +86,32 @@ async fn repository_replication_mirrors_to_second_filesystem_repo() {
     let selector = format!(
         "app.kubernetes.io/component=replication,kopiur.home-operations.com/replication={name}"
     );
-    let job_name = wait_until(
-        "a replication mover Job is created",
+    // The controller deletes a slot's work-spec ConfigMap once it observes the
+    // Job terminal (the ConfigMap-leak fix), so wait for a (Job, ConfigMap)
+    // PAIR: a pending/running slot always has both, and the every-minute cron
+    // keeps spawning fresh pairs.
+    let cm = wait_until(
+        "a replication mover Job with a live work-spec ConfigMap",
         default_timeout(),
         poll_interval(),
         || async {
-            let list = jobs.list(&ListParams::default().labels(&selector)).await?;
-            Ok(list.items.into_iter().find_map(|j| j.metadata.name))
+            for job in jobs
+                .list(&ListParams::default().labels(&selector))
+                .await?
+                .items
+            {
+                let Some(job_name) = job.metadata.name else {
+                    continue;
+                };
+                if let Some(cm) = cms.get_opt(&job_name).await? {
+                    return Ok(Some(cm));
+                }
+            }
+            Ok(None)
         },
     )
     .await
-    .expect("a replication mover Job should be created");
-    let cm = cms
-        .get(&job_name)
-        .await
-        .expect("replication work-spec ConfigMap");
+    .expect("a replication mover Job should be created with its work-spec ConfigMap");
     let spec_json = cm
         .data
         .as_ref()
@@ -155,6 +166,37 @@ async fn repository_replication_mirrors_to_second_filesystem_repo() {
         count >= 1,
         "the destination repository must hold the mirrored snapshot, got {count}"
     );
+
+    // Leak guard (the "605 ConfigMaps" fix): a finished slot's work-spec
+    // ConfigMap is reaped once the controller observes its Job terminal — the
+    // per-slot names would otherwise accumulate one ConfigMap per slot on the
+    // long-lived RepositoryReplication CR, forever. The Job lingers to its TTL.
+    wait_until(
+        "a terminal replication Job with its work-spec ConfigMap reaped",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            for job in jobs
+                .list(&ListParams::default().labels(&selector))
+                .await?
+                .items
+            {
+                let terminal = job
+                    .status
+                    .as_ref()
+                    .is_some_and(|s| s.succeeded.unwrap_or(0) >= 1);
+                let Some(job_name) = job.metadata.name else {
+                    continue;
+                };
+                if terminal && cms.get_opt(&job_name).await?.is_none() {
+                    return Ok(Some(()));
+                }
+            }
+            Ok(None)
+        },
+    )
+    .await
+    .expect("a finished replication slot's work-spec ConfigMap must be reaped (leak guard)");
 
     let _ = repls.delete(name, &DeleteParams::default()).await;
 }

--- a/crates/e2e/tests/replication.rs
+++ b/crates/e2e/tests/replication.rs
@@ -78,47 +78,36 @@ async fn repository_replication_mirrors_to_second_filesystem_repo() {
         .await
         .expect("create RepositoryReplication to a second filesystem repo");
 
-    // The work-spec ConfigMap (same name as the per-slot mover Job) carries the
-    // #216 sync knobs — the controller→mover contract, mirroring the
-    // `policy_knobs` compression/upload-knobs pattern.
+    // The per-slot mover Job's inline work-spec env carries the #216 sync
+    // knobs — the controller→mover contract, mirroring the `policy_knobs`
+    // compression/upload-knobs pattern. The spec rides the Job itself (#224 —
+    // no per-run ConfigMap), and the Job outlives the slot by its TTL.
     let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let selector = format!(
         "app.kubernetes.io/component=replication,kopiur.home-operations.com/replication={name}"
     );
-    // The controller deletes a slot's work-spec ConfigMap once it observes the
-    // Job terminal (the ConfigMap-leak fix), so wait for a (Job, ConfigMap)
-    // PAIR: a pending/running slot always has both, and the every-minute cron
-    // keeps spawning fresh pairs.
-    let cm = wait_until(
-        "a replication mover Job with a live work-spec ConfigMap",
+    let job = wait_until(
+        "a replication mover Job is created",
         default_timeout(),
         poll_interval(),
         || async {
-            for job in jobs
-                .list(&ListParams::default().labels(&selector))
-                .await?
-                .items
-            {
-                let Some(job_name) = job.metadata.name else {
-                    continue;
-                };
-                if let Some(cm) = cms.get_opt(&job_name).await? {
-                    return Ok(Some(cm));
-                }
-            }
-            Ok(None)
+            let list = jobs.list(&ListParams::default().labels(&selector)).await?;
+            Ok(list.items.into_iter().next())
         },
     )
     .await
-    .expect("a replication mover Job should be created with its work-spec ConfigMap");
-    let spec_json = cm
-        .data
+    .expect("a replication mover Job should be created");
+    let raw = job
+        .spec
         .as_ref()
-        .and_then(|d| d.get("work-spec.json"))
-        .expect("work-spec.json key");
-    let spec: serde_json::Value =
-        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.env.as_ref())
+        .and_then(|env| env.iter().find(|e| e.name == "KOPIUR_WORK_SPEC"))
+        .and_then(|e| e.value.clone())
+        .expect("replication Job carries the inline work-spec env");
+    let spec: serde_json::Value = serde_json::from_str(&raw).expect("work-spec env parses as JSON");
     let replicate = spec
         .pointer("/operation/replicate")
         .unwrap_or(&serde_json::Value::Null);
@@ -167,36 +156,27 @@ async fn repository_replication_mirrors_to_second_filesystem_repo() {
         "the destination repository must hold the mirrored snapshot, got {count}"
     );
 
-    // Leak guard (the "605 ConfigMaps" fix): a finished slot's work-spec
-    // ConfigMap is reaped once the controller observes its Job terminal — the
-    // per-slot names would otherwise accumulate one ConfigMap per slot on the
-    // long-lived RepositoryReplication CR, forever. The Job lingers to its TTL.
-    wait_until(
-        "a terminal replication Job with its work-spec ConfigMap reaped",
-        default_timeout(),
-        poll_interval(),
-        || async {
-            for job in jobs
-                .list(&ListParams::default().labels(&selector))
-                .await?
-                .items
-            {
-                let terminal = job
-                    .status
-                    .as_ref()
-                    .is_some_and(|s| s.succeeded.unwrap_or(0) >= 1);
-                let Some(job_name) = job.metadata.name else {
-                    continue;
-                };
-                if terminal && cms.get_opt(&job_name).await?.is_none() {
-                    return Ok(Some(()));
-                }
-            }
-            Ok(None)
-        },
-    )
-    .await
-    .expect("a finished replication slot's work-spec ConfigMap must be reaped (leak guard)");
+    // Leak guard (the "605 ConfigMaps" fix, #224): a replication slot creates
+    // NO per-run ConfigMap at all — the spec rides the Job env. Per-slot names
+    // used to accumulate one ConfigMap per slot on the long-lived
+    // RepositoryReplication CR, forever.
+    for job in jobs
+        .list(&ListParams::default().labels(&selector))
+        .await
+        .expect("list replication Jobs")
+        .items
+    {
+        let Some(job_name) = job.metadata.name else {
+            continue;
+        };
+        assert!(
+            cms.get_opt(&job_name)
+                .await
+                .expect("query ConfigMap")
+                .is_none(),
+            "replication slot {job_name} must not create a per-run work-spec ConfigMap"
+        );
+    }
 
     let _ = repls.delete(name, &DeleteParams::default()).await;
 }

--- a/crates/e2e/tests/restore.rs
+++ b/crates/e2e/tests/restore.rs
@@ -20,7 +20,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use k8s_openapi::api::batch::v1::Job;
-use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolumeClaim, Pod};
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
 
 use kopiur_api::{ClusterRepository, Repository, Restore, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{
@@ -1199,7 +1199,7 @@ async fn restore_options_flag_sweep_reaches_work_spec_and_completes() {
     let client = world.client().clone();
     ensure_seed_backup(&client).await;
     let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
 
     let name = "e2e-r-flags";
     cleanup_restore(&restores, name).await;
@@ -1216,23 +1216,19 @@ async fn restore_options_flag_sweep_reaches_work_spec_and_completes() {
         .await
         .expect("create Restore with an options flag sweep");
 
-    // The work-spec ConfigMap shares the mover Job's name, which for a
-    // pvc-create target (restore_json's default) equals the Restore's own name.
-    let cm = wait_until(
-        "restore work-spec ConfigMap is created",
-        default_timeout(),
-        poll_interval(),
-        || async { cms.get_opt(name).await },
-    )
-    .await
-    .expect("restore work-spec ConfigMap should be created");
-    let spec_json = cm
-        .data
+    // The mover Job (named after the Restore for a pvc-create target) carries
+    // the work spec inline in its pod env (#224 — no per-run ConfigMap).
+    let job = wait_for_job(&jobs, name).await;
+    let raw = job
+        .spec
         .as_ref()
-        .and_then(|d| d.get("work-spec.json"))
-        .expect("work-spec.json key");
-    let spec: serde_json::Value =
-        serde_json::from_str(spec_json).expect("work-spec parses as JSON");
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.env.as_ref())
+        .and_then(|env| env.iter().find(|e| e.name == "KOPIUR_WORK_SPEC"))
+        .and_then(|e| e.value.clone())
+        .expect("restore Job carries the inline work-spec env");
+    let spec: serde_json::Value = serde_json::from_str(&raw).expect("work-spec env parses as JSON");
     let restore_op = spec
         .pointer("/operation/restore")
         .unwrap_or(&serde_json::Value::Null);

--- a/crates/e2e/tests/ttl_rerun.rs
+++ b/crates/e2e/tests/ttl_rerun.rs
@@ -607,6 +607,27 @@ async fn yielded_maintenance_slot_is_not_respawned_after_its_job_is_ttl_reaped()
     .await
     .expect("yielded slots must durably record lastHandledAt");
 
+    // Leak guard (the "605 ConfigMaps" fix): a handled slot's work-spec
+    // ConfigMap is deleted when the slot is recorded — the per-slot Jobs may
+    // still be waiting on their TTL, but no ConfigMap may remain.
+    let cms: Api<k8s_openapi::api::core::v1::ConfigMap> =
+        Api::namespaced(client.clone(), E2E_NAMESPACE);
+    wait_until(
+        "handled maintenance slots' work-spec ConfigMaps reaped",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let list = cms.list(&Default::default()).await?;
+            Ok(list
+                .items
+                .iter()
+                .all(|c| !c.name_any().starts_with("e2e-ttl-yield-"))
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("handled maintenance slots must not leave work-spec ConfigMaps behind");
+
     // The mover recorded the yield, and the controller surfaces it as a real
     // health signal: maintenance is NOT running (GC/compaction is not
     // happening) — Ready=False / MaintenanceYielding with the remediation.

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -39,23 +39,31 @@ use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wai
 /// name as the Job — `io::apply_mover_objects`) rather than a name built here.
 async fn verify_work_spec_json(client: &kube::Client, selector: &str) -> serde_json::Value {
     let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let job = wait_until(
-        "verify mover Job created",
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    // The controller deletes a slot's work-spec ConfigMap once it observes the
+    // Job terminal (the ConfigMap-leak fix), so a finished slot's Job may
+    // linger (TTL) with no ConfigMap — wait for a (Job, ConfigMap) PAIR: a
+    // pending/running slot always has both, and the every-minute cron keeps
+    // spawning fresh pairs.
+    let cm = wait_until(
+        "verify mover Job with a live work-spec ConfigMap",
         default_timeout(),
         poll_interval(),
         || async {
             let lp = ListParams::default().labels(selector);
-            Ok(jobs.list(&lp).await?.items.into_iter().next())
+            for job in jobs.list(&lp).await?.items {
+                let Some(job_name) = job.metadata.name else {
+                    continue;
+                };
+                if let Some(cm) = cms.get_opt(&job_name).await? {
+                    return Ok(Some(cm));
+                }
+            }
+            Ok(None)
         },
     )
     .await
-    .expect("a verify Job should be spawned");
-    let job_name = job.metadata.name.expect("Job has a name");
-    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cm = cms
-        .get(&job_name)
-        .await
-        .unwrap_or_else(|_| panic!("work-spec ConfigMap {job_name}"));
+    .expect("a verify Job should be spawned with its work-spec ConfigMap");
     let spec_json = cm
         .data
         .as_ref()
@@ -160,6 +168,39 @@ async fn verification_quick_with_success_expr_stamps_last_verified() {
         Some(1),
         "verification.quick.maxErrors must reach the mover contract; quick: {quick}"
     );
+
+    // Leak guard (the "605 ConfigMaps" fix): a finished slot's work-spec
+    // ConfigMap is reaped once the controller observes its Job terminal — the
+    // per-slot names would otherwise accumulate one ConfigMap per slot on the
+    // long-lived SnapshotPolicy, forever. The Job itself lingers to its TTL.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    wait_until(
+        "a terminal verify Job with its work-spec ConfigMap reaped",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let lp = ListParams::default().labels(
+                "app.kubernetes.io/component=verify,\
+                 kopiur.home-operations.com/verify=e2e-verify-policy",
+            );
+            for job in jobs.list(&lp).await?.items {
+                let terminal = job
+                    .status
+                    .as_ref()
+                    .is_some_and(|s| s.succeeded.unwrap_or(0) >= 1);
+                let Some(job_name) = job.metadata.name else {
+                    continue;
+                };
+                if terminal && cms.get_opt(&job_name).await?.is_none() {
+                    return Ok(Some(()));
+                }
+            }
+            Ok(None)
+        },
+    )
+    .await
+    .expect("a finished verify slot's work-spec ConfigMap must be reaped (leak guard)");
 }
 
 /// Deep verification (ADR-0005 §4): a `SnapshotPolicy.spec.verification.deep` drives

--- a/crates/e2e/tests/verification.rs
+++ b/crates/e2e/tests/verification.rs
@@ -31,45 +31,36 @@ use k8s_openapi::api::core::v1::ConfigMap;
 use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
 use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wait_until};
 
-/// Wait for a verify Job matching `selector`, then return its work-spec
-/// ConfigMap's `work-spec.json`, parsed. Verify Job names are per-slot
+/// Wait for a verify Job matching `selector`, then return its inline work-spec
+/// env (`KOPIUR_WORK_SPEC`), parsed. Verify Job names are per-slot
 /// (`<policy>-vfy-<q|d>-<unix_slot>`, [`crate::verify_job_name`] in the
-/// controller), not deterministic like other mover Jobs, so the CM is looked up
-/// by the FOUND Job's own name (the controller applies the CM under the same
-/// name as the Job — `io::apply_mover_objects`) rather than a name built here.
+/// controller), not deterministic like other mover Jobs, so the spec is read
+/// from the FOUND Job. The spec rides the Job itself (#224 — no per-run
+/// ConfigMap), and the Job outlives the slot by its TTL, so this never races
+/// completion.
 async fn verify_work_spec_json(client: &kube::Client, selector: &str) -> serde_json::Value {
     let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    // The controller deletes a slot's work-spec ConfigMap once it observes the
-    // Job terminal (the ConfigMap-leak fix), so a finished slot's Job may
-    // linger (TTL) with no ConfigMap — wait for a (Job, ConfigMap) PAIR: a
-    // pending/running slot always has both, and the every-minute cron keeps
-    // spawning fresh pairs.
-    let cm = wait_until(
-        "verify mover Job with a live work-spec ConfigMap",
+    let job = wait_until(
+        "verify mover Job created",
         default_timeout(),
         poll_interval(),
         || async {
             let lp = ListParams::default().labels(selector);
-            for job in jobs.list(&lp).await?.items {
-                let Some(job_name) = job.metadata.name else {
-                    continue;
-                };
-                if let Some(cm) = cms.get_opt(&job_name).await? {
-                    return Ok(Some(cm));
-                }
-            }
-            Ok(None)
+            Ok(jobs.list(&lp).await?.items.into_iter().next())
         },
     )
     .await
-    .expect("a verify Job should be spawned with its work-spec ConfigMap");
-    let spec_json = cm
-        .data
+    .expect("a verify Job should be spawned");
+    let raw = job
+        .spec
         .as_ref()
-        .and_then(|d| d.get("work-spec.json"))
-        .expect("work-spec.json key");
-    serde_json::from_str(spec_json).expect("work-spec parses as JSON")
+        .and_then(|s| s.template.spec.as_ref())
+        .and_then(|p| p.containers.first())
+        .and_then(|c| c.env.as_ref())
+        .and_then(|env| env.iter().find(|e| e.name == "KOPIUR_WORK_SPEC"))
+        .and_then(|e| e.value.clone())
+        .expect("verify Job carries the inline work-spec env");
+    serde_json::from_str(&raw).expect("work-spec env parses as JSON")
 }
 
 /// Verification (ADR-0005 §4): a `SnapshotPolicy.spec.verification.quick` with an
@@ -169,38 +160,28 @@ async fn verification_quick_with_success_expr_stamps_last_verified() {
         "verification.quick.maxErrors must reach the mover contract; quick: {quick}"
     );
 
-    // Leak guard (the "605 ConfigMaps" fix): a finished slot's work-spec
-    // ConfigMap is reaped once the controller observes its Job terminal — the
-    // per-slot names would otherwise accumulate one ConfigMap per slot on the
-    // long-lived SnapshotPolicy, forever. The Job itself lingers to its TTL.
+    // Leak guard (the "605 ConfigMaps" fix, #224): a verify slot creates NO
+    // per-run ConfigMap at all — the spec rides the Job env. Per-slot names
+    // used to accumulate one ConfigMap per slot on the long-lived
+    // SnapshotPolicy, forever.
     let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let cms: Api<ConfigMap> = Api::namespaced(client.clone(), E2E_NAMESPACE);
-    wait_until(
-        "a terminal verify Job with its work-spec ConfigMap reaped",
-        default_timeout(),
-        poll_interval(),
-        || async {
-            let lp = ListParams::default().labels(
-                "app.kubernetes.io/component=verify,\
-                 kopiur.home-operations.com/verify=e2e-verify-policy",
-            );
-            for job in jobs.list(&lp).await?.items {
-                let terminal = job
-                    .status
-                    .as_ref()
-                    .is_some_and(|s| s.succeeded.unwrap_or(0) >= 1);
-                let Some(job_name) = job.metadata.name else {
-                    continue;
-                };
-                if terminal && cms.get_opt(&job_name).await?.is_none() {
-                    return Ok(Some(()));
-                }
-            }
-            Ok(None)
-        },
-    )
-    .await
-    .expect("a finished verify slot's work-spec ConfigMap must be reaped (leak guard)");
+    let lp = ListParams::default().labels(
+        "app.kubernetes.io/component=verify,\
+         kopiur.home-operations.com/verify=e2e-verify-policy",
+    );
+    for job in jobs.list(&lp).await.expect("list verify Jobs").items {
+        let Some(job_name) = job.metadata.name else {
+            continue;
+        };
+        assert!(
+            cms.get_opt(&job_name)
+                .await
+                .expect("query ConfigMap")
+                .is_none(),
+            "verify slot {job_name} must not create a per-run work-spec ConfigMap (leak guard)"
+        );
+    }
 }
 
 /// Deep verification (ADR-0005 §4): a `SnapshotPolicy.spec.verification.deep` drives

--- a/crates/e2e/tests/workload_identity.rs
+++ b/crates/e2e/tests/workload_identity.rs
@@ -227,6 +227,21 @@ async fn workload_identity_s3_full_pipeline_without_static_keys() {
         )
         .await
         .expect("create Snapshot");
+    // Capture the work-spec ConfigMap BEFORE waiting for Succeeded: the
+    // controller deletes it as soon as it observes the mover Job terminal (the
+    // ConfigMap-leak fix), so reading it after the phase gate races the reap.
+    // The ConfigMap is applied before the Job, so polling from creation always
+    // observes it.
+    let cms: Api<k8s_openapi::api::core::v1::ConfigMap> =
+        Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let work_spec_cm = wait_until(
+        "work-spec ConfigMap e2e-wi-backup created",
+        default_timeout(),
+        poll_interval(),
+        || async { cms.get_opt("e2e-wi-backup").await },
+    )
+    .await
+    .expect("work-spec ConfigMap should be created");
     wait_phase(&backups, "e2e-wi-backup", "Succeeded")
         .await
         .expect("workload-identity Snapshot should reach Succeeded");
@@ -258,12 +273,6 @@ async fn workload_identity_s3_full_pipeline_without_static_keys() {
         vec![WI_SECRET.to_string()],
         "envFrom must carry ONLY the password Secret — no backend keys"
     );
-    let cms: Api<k8s_openapi::api::core::v1::ConfigMap> =
-        Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let work_spec_cm = cms
-        .get("e2e-wi-backup")
-        .await
-        .expect("work-spec ConfigMap exists");
     let work_spec = work_spec_cm
         .data
         .as_ref()

--- a/crates/e2e/tests/workload_identity.rs
+++ b/crates/e2e/tests/workload_identity.rs
@@ -227,21 +227,6 @@ async fn workload_identity_s3_full_pipeline_without_static_keys() {
         )
         .await
         .expect("create Snapshot");
-    // Capture the work-spec ConfigMap BEFORE waiting for Succeeded: the
-    // controller deletes it as soon as it observes the mover Job terminal (the
-    // ConfigMap-leak fix), so reading it after the phase gate races the reap.
-    // The ConfigMap is applied before the Job, so polling from creation always
-    // observes it.
-    let cms: Api<k8s_openapi::api::core::v1::ConfigMap> =
-        Api::namespaced(client.clone(), E2E_NAMESPACE);
-    let work_spec_cm = wait_until(
-        "work-spec ConfigMap e2e-wi-backup created",
-        default_timeout(),
-        poll_interval(),
-        || async { cms.get_opt("e2e-wi-backup").await },
-    )
-    .await
-    .expect("work-spec ConfigMap should be created");
     wait_phase(&backups, "e2e-wi-backup", "Succeeded")
         .await
         .expect("workload-identity Snapshot should reach Succeeded");
@@ -273,10 +258,15 @@ async fn workload_identity_s3_full_pipeline_without_static_keys() {
         vec![WI_SECRET.to_string()],
         "envFrom must carry ONLY the password Secret — no backend keys"
     );
-    let work_spec = work_spec_cm
-        .data
-        .as_ref()
-        .and_then(|d| d.values().next().cloned())
+    // The work spec rides the Job's own env (#224 — no per-run ConfigMap), so
+    // the ambient-credential flag is asserted on the same object.
+    let work_spec = pod_spec.containers[0]
+        .env
+        .as_deref()
+        .unwrap_or_default()
+        .iter()
+        .find(|e| e.name == "KOPIUR_WORK_SPEC")
+        .and_then(|e| e.value.clone())
         .unwrap_or_default();
     assert!(
         work_spec.contains("ambientCredentials"),

--- a/crates/mover/src/env.rs
+++ b/crates/mover/src/env.rs
@@ -16,8 +16,18 @@
 //! assert!(env::READY_MARKER.starts_with(kopiur_kopia::env::DEFAULT_CACHE_DIR));
 //! ```
 
-/// Path to the mounted work-spec JSON (the controller↔mover contract). The
-/// controller sets this on the Job; the mover reads it (falling back to `argv[1]`).
+/// The work-spec JSON itself, inline (the controller↔mover contract). The
+/// controller embeds the serialized [`crate::workspec::MoverWorkSpec`] directly
+/// in the Job's pod env — the run needs exactly ONE Kubernetes object, whose
+/// `ttlSecondsAfterFinished` cleans up everything (the per-run work-spec
+/// ConfigMap this replaces had no TTL mechanism and leaked one per run,
+/// forever). Takes precedence over [`WORK_SPEC_PATH`].
+pub const WORK_SPEC: &str = "KOPIUR_WORK_SPEC";
+
+/// Path to a work-spec JSON file — the fallback for [`WORK_SPEC`]: manual
+/// `kopiur-mover <path>` invocations, and Jobs created by operator versions
+/// that mounted the work spec as a ConfigMap. The mover reads it when
+/// [`WORK_SPEC`] is unset (falling back further to `argv[1]`).
 pub const WORK_SPEC_PATH: &str = "KOPIUR_WORK_SPEC_PATH";
 
 /// Optional override for the `kopia` binary path (defaults to `kopia` on PATH).

--- a/crates/mover/src/error.rs
+++ b/crates/mover/src/error.rs
@@ -114,19 +114,21 @@ pub enum MoverError {
         message: String,
     },
 
-    /// No work-spec path was provided at all.
+    /// No work spec was provided at all.
     #[error(
-        "no work spec path: pass it as the first arg or set {}",
+        "no work spec: pass a path as the first arg, or set {} (inline JSON, how the \
+         controller passes it) or {} (a file path)",
+        crate::env::WORK_SPEC,
         crate::env::WORK_SPEC_PATH
     )]
     WorkSpecPathMissing,
 
     /// The work-spec file could not be read.
     #[error(
-        "failed to read the work spec at {}: {source}. The controller mounts it via the \
-         work-spec ConfigMap — check the Job's volume mount and {}",
+        "failed to read the work spec at {}: {source} — check the path (for a \
+         controller-created Job the spec is inline in the {} env instead)",
         .path.display(),
-        crate::env::WORK_SPEC_PATH
+        crate::env::WORK_SPEC
     )]
     WorkSpecRead {
         /// The path that could not be read.
@@ -533,7 +535,9 @@ mod tests {
         };
         let msg = read.to_string();
         assert!(msg.contains("/spec/work.json"), "{msg}");
-        assert!(msg.contains("work-spec ConfigMap"), "{msg}");
+        // The fix points at the inline-env contract (the controller no longer
+        // mounts a work-spec ConfigMap).
+        assert!(msg.contains("KOPIUR_WORK_SPEC"), "{msg}");
     }
 
     #[test]

--- a/crates/mover/src/jobs.rs
+++ b/crates/mover/src/jobs.rs
@@ -19,12 +19,11 @@ use std::collections::BTreeMap;
 use crate::workspec::MoverWorkSpec;
 use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
-    Affinity, ConfigMap, ConfigMapVolumeSource, Container, EmptyDirVolumeSource, EnvFromSource,
-    EphemeralVolumeSource, NFSVolumeSource, NodeAffinity, NodeSelector, NodeSelectorRequirement,
-    NodeSelectorTerm, PersistentVolumeClaimSpec, PersistentVolumeClaimTemplate,
-    PersistentVolumeClaimVolumeSource, PodSecurityContext, PodSpec, PodTemplateSpec,
-    ResourceRequirements, SecretEnvSource, SecurityContext, Toleration, Volume, VolumeMount,
-    VolumeResourceRequirements,
+    Affinity, ConfigMap, Container, EmptyDirVolumeSource, EnvFromSource, EphemeralVolumeSource,
+    NFSVolumeSource, NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm,
+    PersistentVolumeClaimSpec, PersistentVolumeClaimTemplate, PersistentVolumeClaimVolumeSource,
+    PodSecurityContext, PodSpec, PodTemplateSpec, ResourceRequirements, SecretEnvSource,
+    SecurityContext, Toleration, Volume, VolumeMount, VolumeResourceRequirements,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{ObjectMeta, OwnerReference};
@@ -35,21 +34,51 @@ use kopiur_api::consts::API_VERSION;
 /// `:latest` is deliberately avoided (G15) — callers should pin a digest/tag.
 pub const DEFAULT_MOVER_IMAGE: &str = "ghcr.io/home-operations/kopiur-mover:v0.1.0";
 
-/// Path inside the mover pod where the work-spec ConfigMap is mounted.
-pub const WORK_SPEC_MOUNT: &str = "/etc/kopiur";
 /// Path inside the deep-verify mover pod the scratch-restore writes into. Part of
 /// the controller↔mover contract: the work-spec `scratch_path`, the Job's scratch
 /// `VolumeMount`, and the mover's writability preflight + restore target all
 /// reference this single constant so they can never drift (centralize-config).
 pub const DEEP_SCRATCH_PATH: &str = "/scratch";
-/// File name of the work spec within the mount.
+/// Data key the LEGACY per-run work-spec ConfigMaps carried (operator versions
+/// that mounted the spec instead of embedding it in the Job env). Still
+/// referenced by the controller's orphan sweep, which reaps those leftovers.
 pub const WORK_SPEC_FILE: &str = "work-spec.json";
-/// Env var the mover reads for the work-spec path. Sourced from the mover
-/// crate's single definition so the controller↔mover contract can't drift.
-pub const WORK_SPEC_ENV: &str = crate::env::WORK_SPEC_PATH;
+/// Env var carrying the inline work-spec JSON. Sourced from the mover crate's
+/// single definition so the controller↔mover contract can't drift.
+pub const WORK_SPEC_ENV: &str = crate::env::WORK_SPEC;
 /// Env var naming the ConfigMap the mover writes a bootstrap result into (set
 /// only for `BootstrapRepository` Jobs). Single definition shared with the mover.
 pub const RESULT_CONFIGMAP_ENV: &str = crate::env::RESULT_CONFIGMAP;
+
+/// Upper bound on the serialized work spec [`build_job`] will embed in the pod
+/// env. Linux caps a single `execve` string ("NAME=value") at `MAX_ARG_STRLEN`
+/// (128 KiB) — an env var over that makes the container fail at exec time with
+/// an inscrutable runtime error, so the builder refuses eagerly with an
+/// actionable one instead. Real work specs are ~1 KiB; only a pathological
+/// recipe (hundreds of KiB of ignore rules / hooks) can approach this.
+pub const MAX_WORK_SPEC_BYTES: usize = 100 * 1024;
+
+/// Why [`build_job`] refused to build. Closed enum with what/why/fix messages
+/// so every caller (controller reconcilers, the CLI browse spawner) surfaces
+/// the same actionable text.
+#[derive(Debug, thiserror::Error)]
+pub enum BuildJobError {
+    /// The work spec could not be JSON-encoded (never, for the closed types —
+    /// but propagated rather than panicked).
+    #[error("the work spec could not be JSON-encoded: {0}")]
+    Serialize(#[from] serde_json::Error),
+    /// The serialized work spec exceeds what a pod env var can carry.
+    #[error(
+        "the serialized work spec is {bytes} bytes, over the {MAX_WORK_SPEC_BYTES}-byte limit \
+         a pod environment variable can carry (Linux MAX_ARG_STRLEN is 128 KiB). The recipe \
+         is pathologically large — trim the policy (ignore rules, hooks, extra args) or split \
+         the source across policies"
+    )]
+    TooLarge {
+        /// Size of the serialized work spec.
+        bytes: usize,
+    },
+}
 
 /// Built-in `Job.spec.activeDeadlineSeconds` applied by [`build_job`] when a
 /// recipe's `failurePolicy.activeDeadlineSeconds` is unset. A generous 48h
@@ -350,14 +379,15 @@ fn managed_labels(inputs: &MoverJobInputs<'_>) -> BTreeMap<String, String> {
     labels
 }
 
-/// Build the `ConfigMap` carrying the serialized work spec. Returns a
-/// serialization error only if the work spec can't be JSON-encoded (never, for
-/// the closed types — but propagated rather than panicked).
-pub fn build_config_map(inputs: &MoverJobInputs<'_>) -> Result<ConfigMap, serde_json::Error> {
-    let json = serde_json::to_string_pretty(inputs.work_spec)?;
-    let mut data = BTreeMap::new();
-    data.insert(WORK_SPEC_FILE.to_string(), json);
-    Ok(ConfigMap {
+/// Build the RESULT `ConfigMap` for a bootstrap/probe run — the out-of-band
+/// channel the mover PATCHes `result.json` into (see
+/// [`crate::bootstrap::RESULT_CONFIGMAP_KEY`]) and the controller reads back
+/// AFTER the Job may already be TTL-reaped. Created empty: the work spec
+/// itself rides the Job env ([`WORK_SPEC_ENV`]), so this exists only for the
+/// flows that need data to OUTLIVE the Job. Deliberately carries no
+/// `work-spec.json` key — that key is what the orphan sweep targets.
+pub fn build_result_config_map(inputs: &MoverJobInputs<'_>) -> ConfigMap {
+    ConfigMap {
         metadata: ObjectMeta {
             name: Some(inputs.name.to_string()),
             namespace: Some(inputs.namespace.to_string()),
@@ -365,9 +395,9 @@ pub fn build_config_map(inputs: &MoverJobInputs<'_>) -> Result<ConfigMap, serde_
             owner_references: Some(vec![inputs.owner.clone()]),
             ..Default::default()
         },
-        data: Some(data),
+        data: None,
         ..Default::default()
-    })
+    }
 }
 
 /// The `Volume` source (the `name` is set by the caller) for the mover's kopia
@@ -412,29 +442,32 @@ fn cache_volume_source(cache: &CacheVolume) -> Volume {
     }
 }
 
-/// Build the mover `Job` that mounts the work-spec ConfigMap and runs the
-/// kopiur-mover image. `restartPolicy: Never`; backoff/deadline from limits.
-pub fn build_job(inputs: &MoverJobInputs<'_>) -> Job {
+/// Build the mover `Job` that carries the serialized work spec INLINE in its
+/// pod env ([`WORK_SPEC_ENV`]) and runs the kopiur-mover image.
+/// `restartPolicy: Never`; backoff/deadline from limits.
+///
+/// Embedding the spec in the Job — instead of a sidecar ConfigMap — means a
+/// run is exactly ONE Kubernetes object whose `ttlSecondsAfterFinished` cleans
+/// up everything, structurally eliminating the per-run ConfigMap leak (#224);
+/// it is also immutable after spawn (pod templates can't be edited) and shows
+/// the full controller→mover contract in one `kubectl get job -o yaml`.
+/// Refuses a spec over [`MAX_WORK_SPEC_BYTES`] with an actionable error.
+pub fn build_job(inputs: &MoverJobInputs<'_>) -> Result<Job, BuildJobError> {
+    let work_spec_json = serde_json::to_string(inputs.work_spec)?;
+    if work_spec_json.len() > MAX_WORK_SPEC_BYTES {
+        return Err(BuildJobError::TooLarge {
+            bytes: work_spec_json.len(),
+        });
+    }
+
     // The container security context is fully resolved upstream (hardened ⊂
     // moverDefaults ⊂ recipe, ADR-0004 §2); apply it verbatim.
     let sec_ctx = inputs.security_context.clone();
 
-    // Volumes + mounts: always the work-spec ConfigMap; plus the source PVC
-    // (read-only, for Snapshot) and the repo PVC (read-write, filesystem backend).
-    let mut volumes = vec![Volume {
-        name: "work-spec".to_string(),
-        config_map: Some(ConfigMapVolumeSource {
-            name: inputs.name.to_string(),
-            ..Default::default()
-        }),
-        ..Default::default()
-    }];
-    let mut volume_mounts = vec![VolumeMount {
-        name: "work-spec".to_string(),
-        mount_path: WORK_SPEC_MOUNT.to_string(),
-        read_only: Some(true),
-        ..Default::default()
-    }];
+    // Volumes + mounts: the source PVC (read-only, for Snapshot) and the repo
+    // PVC (read-write, filesystem backend); the work spec needs none (env).
+    let mut volumes = vec![];
+    let mut volume_mounts = vec![];
 
     // Writable cache/logs/config for kopia. kopia defaults these under $HOME,
     // which is /nonexistent on distroless:nonroot; without this volume (and the
@@ -501,14 +534,14 @@ pub fn build_job(inputs: &MoverJobInputs<'_>) -> Job {
         )
     };
 
-    // Work-spec path env, plus any passthrough (OTLP + RUST_LOG/KOPIUR_LOG_FORMAT)
+    // Inline work-spec env, plus any passthrough (OTLP + RUST_LOG/KOPIUR_LOG_FORMAT)
     // so the mover exports to the same collector and logs at the same level/format
     // as the controller.
     let base = kopiur_kopia::env::DEFAULT_CACHE_DIR;
     let mut env = vec![
         k8s_openapi::api::core::v1::EnvVar {
             name: WORK_SPEC_ENV.to_string(),
-            value: Some(format!("{WORK_SPEC_MOUNT}/{WORK_SPEC_FILE}")),
+            value: Some(work_spec_json),
             value_from: None,
         },
         // Redirect kopia's cache/logs/config onto the writable emptyDir mounted
@@ -592,7 +625,7 @@ pub fn build_job(inputs: &MoverJobInputs<'_>) -> Job {
         ..Default::default()
     };
 
-    Job {
+    Ok(Job {
         metadata: ObjectMeta {
             name: Some(inputs.name.to_string()),
             namespace: Some(inputs.namespace.to_string()),
@@ -622,7 +655,7 @@ pub fn build_job(inputs: &MoverJobInputs<'_>) -> Job {
             ..Default::default()
         }),
         status: None,
-    }
+    })
 }
 
 /// The well-known node label carrying a node's hostname — the topology key a
@@ -868,7 +901,7 @@ mod tests {
     fn readiness_exec_renders_a_probe_only_when_set() {
         // Default (every operator mover): no probe — a batch Job is "done", not "ready".
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         assert!(
             job.spec.unwrap().template.spec.unwrap().containers[0]
                 .readiness_probe
@@ -882,7 +915,7 @@ mod tests {
             "/usr/local/bin/kopiur-mover".to_string(),
             "ready".to_string(),
         ]);
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let probe = job.spec.unwrap().template.spec.unwrap().containers[0]
             .readiness_probe
             .clone()
@@ -900,7 +933,7 @@ mod tests {
         // The mover PATCHes the owning CR's status, so the pod must run as the
         // operator SA, not the namespace `default` SA.
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let sa = job
             .spec
             .unwrap()
@@ -912,19 +945,46 @@ mod tests {
     }
 
     #[test]
-    fn config_map_carries_serialized_work_spec() {
+    fn job_env_carries_serialized_work_spec() {
         let ws = sample_work_spec();
-        let cm = build_config_map(&inputs(&ws, JobLimits::default())).unwrap();
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        let env = &pod.containers[0].env.as_ref().unwrap()[0];
+        assert_eq!(env.name, WORK_SPEC_ENV);
+        // The serialized spec round-trips back to the same MoverWorkSpec.
+        let parsed: MoverWorkSpec = serde_json::from_str(env.value.as_deref().unwrap()).unwrap();
+        assert_eq!(parsed, ws);
+    }
+
+    #[test]
+    fn result_config_map_is_result_only_and_cr_owned() {
+        let ws = sample_work_spec();
+        let cm = build_result_config_map(&inputs(&ws, JobLimits::default()));
         assert_eq!(cm.metadata.name.as_deref(), Some("db-1"));
         assert_eq!(cm.metadata.namespace.as_deref(), Some("prod"));
-        let body = &cm.data.as_ref().unwrap()[WORK_SPEC_FILE];
-        // The serialized spec round-trips back to the same MoverWorkSpec.
-        let parsed: MoverWorkSpec = serde_json::from_str(body).unwrap();
-        assert_eq!(parsed, ws);
+        // No work-spec payload: the spec rides the Job env, and the absent
+        // `work-spec.json` key keeps the orphan sweep from ever matching it.
+        assert!(cm.data.is_none());
         // Owner reference present so GC reaps it with the CR.
         assert_eq!(
             cm.metadata.owner_references.as_ref().unwrap()[0].uid,
             "uid-123"
+        );
+    }
+
+    #[test]
+    fn build_job_refuses_an_oversized_work_spec() {
+        let mut ws = sample_work_spec();
+        // Inflate past MAX_WORK_SPEC_BYTES via a pathological ignore list.
+        if let Operation::Snapshot(op) = &mut ws.operation {
+            op.policy.ignore = vec!["x".repeat(1024); MAX_WORK_SPEC_BYTES / 1024 + 8];
+        }
+        let err = build_job(&inputs(&ws, JobLimits::default())).unwrap_err();
+        let msg = err.to_string();
+        assert!(matches!(err, BuildJobError::TooLarge { .. }), "{msg}");
+        assert!(
+            msg.contains("MAX_ARG_STRLEN") || msg.contains("128 KiB"),
+            "{msg}"
         );
     }
 
@@ -936,7 +996,7 @@ mod tests {
             active_deadline_seconds: Some(7200),
             ttl_seconds_after_finished: Some(3600),
         };
-        let job = build_job(&inputs(&ws, limits));
+        let job = build_job(&inputs(&ws, limits)).unwrap();
         let spec = job.spec.as_ref().unwrap();
         assert_eq!(spec.backoff_limit, Some(5));
         assert_eq!(spec.active_deadline_seconds, Some(7200));
@@ -953,7 +1013,7 @@ mod tests {
         // A default-limits Job must not set ttlSecondsAfterFinished (owner-ref GC
         // reaps one-Job-per-CR runs; no regression for backup/restore).
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         assert_eq!(
             job.spec.unwrap().ttl_seconds_after_finished,
             None,
@@ -969,20 +1029,20 @@ mod tests {
             "kopiur.home-operations.com/maintenance-slot".to_string(),
             "2026-06-06T03:00:00+00:00".to_string(),
         )]);
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         assert_eq!(
             job.metadata.annotations.unwrap()["kopiur.home-operations.com/maintenance-slot"],
             "2026-06-06T03:00:00+00:00"
         );
         // Empty annotations must leave the field unset (no churn for other runs).
-        let bare = build_job(&inputs(&ws, JobLimits::default()));
+        let bare = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         assert!(bare.metadata.annotations.is_none());
     }
 
     #[test]
     fn job_uses_hardened_security_context_by_default() {
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let sc = job.spec.unwrap().template.spec.unwrap().containers[0]
             .security_context
             .clone()
@@ -1009,7 +1069,7 @@ mod tests {
             run_as_non_root: Some(true),
             ..Default::default()
         };
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let sc = job.spec.unwrap().template.spec.unwrap().containers[0]
             .security_context
             .clone()
@@ -1033,7 +1093,7 @@ mod tests {
             fs_group_change_policy: Some("OnRootMismatch".to_string()),
             ..Default::default()
         });
-        let pod = build_job(&i).spec.unwrap().template.spec.unwrap();
+        let pod = build_job(&i).unwrap().spec.unwrap().template.spec.unwrap();
         assert_eq!(
             pod.containers[0]
                 .security_context
@@ -1064,7 +1124,7 @@ mod tests {
         // must still carry the built-in wall-clock cap so it can never linger
         // Active forever.
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         assert_eq!(
             job.spec.unwrap().active_deadline_seconds,
             Some(DEFAULT_JOB_ACTIVE_DEADLINE_SECONDS),
@@ -1081,7 +1141,7 @@ mod tests {
         i.creds_secrets = vec![CredsEnvFrom::plain("kopia-creds")];
         i.image_pull_policy = Some("IfNotPresent");
 
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
         let vols = pod.volumes.as_ref().unwrap();
 
@@ -1138,7 +1198,7 @@ mod tests {
             false,
         ));
 
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
         let vols = pod.volumes.as_ref().unwrap();
 
@@ -1182,7 +1242,7 @@ mod tests {
         ];
         i.result_configmap = Some("repo-bootstrap");
 
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let container = &job.spec.unwrap().template.spec.unwrap().containers[0];
 
         let env_from = container.env_from.as_ref().expect("envFrom present");
@@ -1211,7 +1271,7 @@ mod tests {
             CredsEnvFrom::prefixed("dest-creds", "KOPIUR_DEST_"),
         ];
 
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let container = &job.spec.unwrap().template.spec.unwrap().containers[0];
         let env_from = container.env_from.as_ref().expect("envFrom present");
 
@@ -1229,14 +1289,15 @@ mod tests {
     }
 
     #[test]
-    fn job_without_pvcs_or_secret_has_only_work_spec_and_cache_volumes() {
+    fn job_without_pvcs_or_secret_has_only_the_cache_volume() {
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
         let vols = pod.volumes.as_ref().unwrap();
-        // work-spec ConfigMap + the always-present writable kopia cache emptyDir.
+        // Only the always-present writable kopia cache emptyDir — the work
+        // spec rides the pod env, not a mounted ConfigMap (#224).
         let names: Vec<&str> = vols.iter().map(|v| v.name.as_str()).collect();
-        assert_eq!(names, vec!["work-spec", "kopia-cache"]);
+        assert_eq!(names, vec!["kopia-cache"]);
         assert!(pod.containers[0].env_from.is_none());
     }
 
@@ -1247,7 +1308,7 @@ mod tests {
     #[test]
     fn job_mounts_writable_kopia_cache_volume_and_env() {
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
 
         // emptyDir volume present.
@@ -1300,7 +1361,7 @@ mod tests {
     fn job_without_scratch_volume_mounts_no_scratch() {
         // Default inputs (every non-deep-verify run): no scratch volume/mount.
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
         assert!(
             !pod.volumes
@@ -1326,7 +1387,7 @@ mod tests {
         let ws = sample_work_spec();
         let mut i = inputs(&ws, JobLimits::default());
         i.scratch_volume = Some(CacheVolume::EmptyDir);
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
 
         // An emptyDir scratch volume is present...
@@ -1368,7 +1429,7 @@ mod tests {
             capacity: "50Gi".into(),
             storage_class: Some("fast-ssd".into()),
         });
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
         let vol = pod
             .volumes
@@ -1401,7 +1462,7 @@ mod tests {
     fn pod_security_context_flows_to_the_mover_pod() {
         // Default: no pod-level securityContext on the mover pod (minimal spec).
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         assert!(
             job.spec
                 .as_ref()
@@ -1417,7 +1478,7 @@ mod tests {
             fs_group: Some(1000),
             ..Default::default()
         });
-        let job = build_job(&i);
+        let job = build_job(&i).unwrap();
         let psc = job
             .spec
             .unwrap()
@@ -1449,7 +1510,7 @@ mod tests {
             node_affinity: Some(NodeAffinity::default()),
             ..Default::default()
         });
-        let pod = build_job(&i).spec.unwrap().template.spec.unwrap();
+        let pod = build_job(&i).unwrap().spec.unwrap().template.spec.unwrap();
         assert_eq!(pod.node_selector.unwrap()["disktype"], "ssd");
         assert_eq!(
             pod.tolerations.unwrap()[0].key.as_deref(),
@@ -1459,6 +1520,7 @@ mod tests {
 
         // Unset → pod placement fields stay None (no churn for the common case).
         let bare = build_job(&inputs(&ws, JobLimits::default()))
+            .unwrap()
             .spec
             .unwrap()
             .template
@@ -1505,17 +1567,19 @@ mod tests {
     }
 
     #[test]
-    fn job_mounts_work_spec_configmap_with_matching_env() {
+    fn job_needs_no_work_spec_volume() {
+        // The run is exactly ONE Kubernetes object: no sidecar ConfigMap, no
+        // work-spec mount — the spec rides the pod env (#224).
         let ws = sample_work_spec();
-        let job = build_job(&inputs(&ws, JobLimits::default()));
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
         let pod = job.spec.unwrap().template.spec.unwrap();
-        let vol = &pod.volumes.as_ref().unwrap()[0];
-        assert_eq!(vol.config_map.as_ref().unwrap().name, "db-1");
-        let env = &pod.containers[0].env.as_ref().unwrap()[0];
-        assert_eq!(env.name, WORK_SPEC_ENV);
-        assert_eq!(
-            env.value.as_deref(),
-            Some(format!("{WORK_SPEC_MOUNT}/{WORK_SPEC_FILE}").as_str())
-        );
+        let names: Vec<_> = pod
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .map(|v| v.name.as_str())
+            .collect();
+        assert!(!names.contains(&"work-spec"), "volumes: {names:?}");
     }
 }

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -199,8 +199,7 @@ async fn run(cli: &MoverCli) -> Result<()> {
     // client (the rustls-tls backend panics without it). Idempotent.
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let spec_path = work_spec_path(cli.work_spec.clone())?;
-    let spec = load_work_spec(&spec_path)?;
+    let spec = resolve_work_spec(cli.work_spec.clone())?;
     let operation = spec.operation.kind_str().to_string();
     info!(
         operation = %operation,
@@ -1712,15 +1711,26 @@ impl MoverMetrics {
     }
 }
 
-/// Locate the run-once work spec: positional arg, else [`env::WORK_SPEC_PATH`].
-/// The env fallback is deliberately manual (not clap `#[arg(env)]`) — see
+/// Load the run-once work spec. Resolution order:
+/// 1. a positional path arg (manual/debug invocations),
+/// 2. the INLINE JSON in [`env::WORK_SPEC`] (how the controller passes it —
+///    embedded in the Job env so the run is one self-cleaning object, #224),
+/// 3. a file at [`env::WORK_SPEC_PATH`] (legacy ConfigMap-mounting Jobs).
+///
+/// The env fallbacks are deliberately manual (not clap `#[arg(env)]`) — see
 /// [`kopiur_mover::cli`].
-fn work_spec_path(arg: Option<PathBuf>) -> Result<PathBuf> {
+fn resolve_work_spec(arg: Option<PathBuf>) -> Result<MoverWorkSpec> {
     if let Some(arg) = arg {
-        return Ok(arg);
+        return load_work_spec(&arg);
+    }
+    if let Ok(inline) = std::env::var(kopiur_mover::env::WORK_SPEC) {
+        return serde_json::from_str(&inline).map_err(|source| MoverError::WorkSpecParse {
+            path: PathBuf::from(format!("${}", kopiur_mover::env::WORK_SPEC)),
+            source,
+        });
     }
     if let Ok(env) = std::env::var(WORK_SPEC_PATH) {
-        return Ok(PathBuf::from(env));
+        return load_work_spec(&PathBuf::from(env));
     }
     Err(MoverError::WorkSpecPathMissing)
 }

--- a/crates/xtask/src/rbac.rs
+++ b/crates/xtask/src/rbac.rs
@@ -162,10 +162,10 @@ fn kopia_crd_rules(include_cluster_crds: bool) -> Vec<PolicyRule> {
 fn workload_rules() -> Vec<PolicyRule> {
     vec![
         // Mover pods + exec for pre/post hooks; PVCs for snapshot/restore I/O;
-        // events for surfacing reconcile outcomes; configmaps carry the mover
-        // work spec AND (for repository bootstrap) receive the mover's result
-        // patch — the mover runs as this SA, so its result write reuses these
-        // configmaps verbs (no separate rule needed).
+        // events for surfacing reconcile outcomes; configmaps carry the
+        // repository-bootstrap result channel (and the sweep reaps LEGACY
+        // per-run work-spec ConfigMaps) — the mover runs as this SA, so its
+        // result write reuses these configmaps verbs (no separate rule needed).
         rule(
             &[""],
             &[
@@ -317,9 +317,9 @@ fn webhook_cert_secret_rules() -> Vec<PolicyRule> {
 /// The minimal RBAC a mover Job actually uses, verified against `crates/mover/src/`:
 /// it PATCHes the owning CR's `.status` subresource (the target kind is dynamic —
 /// `backups`, `restores`, `repositories`, `clusterrepositories`, `maintenances`)
-/// and PATCHes the work-spec `ConfigMap` to write the repository-bootstrap result.
+/// and PATCHes the result `ConfigMap` to write the repository-bootstrap result.
 /// Nothing else — credentials are env-mounted (no `secrets` access) and the work
-/// spec is a mounted volume (no `configmaps` get for it). This is deliberately a
+/// spec rides the Job's own pod env (no `configmaps` get for it). This is deliberately a
 /// tiny subset of [`workload_rules`]; the mover runs as its own least-privilege SA.
 ///
 /// `cluster` decides whether `clusterrepositories/status` is included. The

--- a/deploy/e2e/values.yaml
+++ b/deploy/e2e/values.yaml
@@ -81,6 +81,15 @@ extraVolumeMounts:
   - name: ro-repo
     mountPath: /ro-repo
 
+# Run the orphaned work-spec ConfigMap sweep on a fast cadence so crates/e2e
+# tests/leak_cleanup.rs can observe it in-test (production defaults: 6h
+# interval, 1h min-age). Root extraEnv = controller env (chart flatten, #203).
+extraEnv:
+  - name: KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS
+    value: "15"
+  - name: KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS
+    value: "30"
+
 # Exercise the probe passthrough: a retuned readiness probe (faster first check)
 # proves values-driven probes render and the pod still goes Ready.
 readinessProbe:

--- a/deploy/helm/kopiur/templates/browse-clusterrole.tpl
+++ b/deploy/helm/kopiur/templates/browse-clusterrole.tpl
@@ -41,11 +41,12 @@ rules:
     resources:
       - jobs
     verbs: [create, get, list, delete]
-  # The session's work-spec ConfigMap (owned by the Job; created/deleted with it).
+  # `session end` best-effort-deletes a LEGACY session's work-spec ConfigMap
+  # (CLI versions that mounted the spec; today the spec rides the Job env).
   - apiGroups: [""]
     resources:
       - configmaps
-    verbs: [create, get, delete]
+    verbs: [delete]
   # Wait for the session pod to become Ready; surface its logs on failure.
   - apiGroups: [""]
     resources:

--- a/deploy/helm/kopiur/tests/browse-clusterrole_test.yaml
+++ b/deploy/helm/kopiur/tests/browse-clusterrole_test.yaml
@@ -45,12 +45,14 @@ tests:
             apiGroups: [batch]
             resources: [jobs]
             verbs: [create, get, list, delete]
+      # `session end` only best-effort-deletes a LEGACY session's work-spec
+      # ConfigMap (the session spec rides the Job env today, #224).
       - contains:
           path: rules
           content:
             apiGroups: [""]
             resources: [configmaps]
-            verbs: [create, get, delete]
+            verbs: [delete]
       - contains:
           path: rules
           content:

--- a/docs/cli/browse.md
+++ b/docs/cli/browse.md
@@ -124,10 +124,10 @@ End a warm browse session early (it expires by TTL anyway):
 ```console
 $ kubectl kopiur session end nightly-20260611-030012 -n media   # via a snapshot in that repo
 $ kubectl kopiur session end --repository nas -n media          # or the repository directly
-session kopiur-browse-nas-1a2b3c4d ended (Job + work-spec ConfigMap deleted)
+session kopiur-browse-nas-1a2b3c4d ended (Job deleted)
 ```
 
-Deletes the session Job and its work-spec ConfigMap. When no session is open
+Deletes the session Job (the session's whole spec rides the Job). When no session is open
 it says so and exits 0 — safe to run from cleanup scripts. Sessions are also
 labeled (`kopiur.home-operations.com/session=browse`) so a plain
 `kubectl delete job -l kopiur.home-operations.com/session=browse` works too.
@@ -208,7 +208,7 @@ kopiur:/config> quit
 
 ```console
 $ kubectl kopiur session end nightly-manual-20260611030012 -n media
-session kopiur-browse-nas-1a2b3c4d ended (Job + work-spec ConfigMap deleted)
+session kopiur-browse-nas-1a2b3c4d ended (Job deleted)
 ```
 
 /// note | Illustrative output

--- a/docs/dev/watch-and-reconcile.md
+++ b/docs/dev/watch-and-reconcile.md
@@ -130,7 +130,7 @@ The controller is cluster-scoped and watches several core/v1 kinds across every
 namespace, so its RSS is dominated by what it lists/watches and how the allocator
 and runtime are sized. The levers, all in `spawn_all`/`main.rs`/`config.rs`:
 
-- **Scoped owned watches.** Owned children (mover `Job`s, work-spec `ConfigMap`s)
+- **Scoped owned watches.** Owned children (mover `Job`s, bootstrap-result `ConfigMap`s)
   ALWAYS carry `app.kubernetes.io/managed-by=kopiur` (`io::finalizer::child_labels`),
   so they are watched via `owns_with` + a server-side label selector (`owned_cfg`):
   the controller lists/watches only *kopiur's* Jobs/ConfigMaps, not every one in the

--- a/docs/movers.md
+++ b/docs/movers.md
@@ -302,6 +302,32 @@ $ kubectl -n media get snapshot <new-name> \
 
 Re-add the annotation (re-apply the bundle's `namespace` section, or `kubectl annotate … =true`) and the blocked Snapshot proceeds within seconds — no re-apply needed.
 
+## Run artifacts & cleanup
+
+Every mover run consists of exactly two Kubernetes objects, applied together and cleaned up on different clocks:
+
+- **The mover `Job`** (and its pod) lives until its `ttlSecondsAfterFinished` — 1 hour by default, tunable per recipe (`spec.mover.ttlSecondsAfterFinished`) or repository-wide (`spec.moverDefaults.ttlSecondsAfterFinished`). Kopiur never deletes a finished Job early: the pod logs are your debugging record, and `kubectl kopiur logs` resolves them through the Job for as long as the TTL keeps it around.
+- **The work-spec `ConfigMap`** (same name as the Job, one key `work-spec.json` — the controller→mover contract) is needed only while the pod runs. The controller **deletes it as soon as it observes the Job terminal**, succeeded or failed. Its contents are derived from your CRs, so nothing debuggable is lost — the spec that produced a run can always be reconstructed from the `SnapshotPolicy`/`Snapshot`.
+
+Without that delete the ConfigMaps accumulated forever: they are owner-referenced to long-lived CRs (a `Snapshot` is the durable record of a backup; a `SnapshotPolicy` or `RepositoryReplication` never goes away), so Kubernetes GC alone never reaped them — an hourly backup leaked one ConfigMap per hour, per app.
+
+### The orphan sweep
+
+A ConfigMap whose Job is *already gone* (reaped by its TTL while the operator was down, or left behind by operator versions before the fix) is invisible to the transition-time cleanup. A leader-only background sweep heals those: every 6 hours it lists Kopiur-managed ConfigMaps and deletes work-spec ones that have **no same-named Job** and are **older than 1 hour**. Bootstrap result ConfigMaps (`result.json`) and anything a live run still mounts are never touched. On upgrade, clusters that accumulated historical work-spec ConfigMaps converge automatically — no `kubectl` cleanup needed.
+
+Two environment variables tune it (set via the chart's controller `extraEnv`):
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS` | `21600` (6h) | Sweep cadence; `0` disables the sweep entirely. |
+| `KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS` | `3600` (1h) | Minimum ConfigMap age before it may be reaped. |
+
+Each pass increments the `kopiur_work_spec_cms_swept_total` counter on `/metrics`, so you can watch a backlog drain after an upgrade.
+
+/// note | "Where did the ConfigMap go?"
+If you previously inspected `work-spec.json` after a run finished, do it while the run is in flight — or read the equivalent fields from the CR spec/status. The Job (and pod logs) remain available until the TTL either way.
+///
+
 ## Troubleshooting
 
 The mover preconditions surface on the `Snapshot`/`Restore` status as conditions **and** as `Warning` Events (visible in `kubectl describe`), so you never have to read controller logs to find out why a backup didn't start.

--- a/docs/movers.md
+++ b/docs/movers.md
@@ -304,16 +304,20 @@ Re-add the annotation (re-apply the bundle's `namespace` section, or `kubectl an
 
 ## Run artifacts & cleanup
 
-Every mover run consists of exactly two Kubernetes objects, applied together and cleaned up on different clocks:
+A mover run is exactly **one Kubernetes object: the `Job`**. The controller embeds the run's instructions (the *work spec*, serialized JSON) directly in the Job's pod environment as `KOPIUR_WORK_SPEC` — there is no per-run ConfigMap, Secret, or other sidecar object. That means:
 
-- **The mover `Job`** (and its pod) lives until its `ttlSecondsAfterFinished` — 1 hour by default, tunable per recipe (`spec.mover.ttlSecondsAfterFinished`) or repository-wide (`spec.moverDefaults.ttlSecondsAfterFinished`). Kopiur never deletes a finished Job early: the pod logs are your debugging record, and `kubectl kopiur logs` resolves them through the Job for as long as the TTL keeps it around.
-- **The work-spec `ConfigMap`** (same name as the Job, one key `work-spec.json` — the controller→mover contract) is needed only while the pod runs. The controller **deletes it as soon as it observes the Job terminal**, succeeded or failed. Its contents are derived from your CRs, so nothing debuggable is lost — the spec that produced a run can always be reconstructed from the `SnapshotPolicy`/`Snapshot`.
+- **One clock cleans up everything.** The Job (and its pod) lives until its `ttlSecondsAfterFinished` — 1 hour by default, tunable per recipe (`spec.mover.ttlSecondsAfterFinished`) or repository-wide (`spec.moverDefaults.ttlSecondsAfterFinished`). Kopiur never deletes a finished Job early: the pod logs are your debugging record, and `kubectl kopiur logs` resolves them through the Job for as long as the TTL keeps it around.
+- **The full controller→mover contract is inspectable in one place**: `kubectl get job <name> -o yaml` shows the pod template *and* the exact work spec the mover ran, for the Job's whole lifetime. The work spec never contains credentials — those reach the mover via `envFrom` Secret references.
 
-Without that delete the ConfigMaps accumulated forever: they are owner-referenced to long-lived CRs (a `Snapshot` is the durable record of a backup; a `SnapshotPolicy` or `RepositoryReplication` never goes away), so Kubernetes GC alone never reaped them — an hourly backup leaked one ConfigMap per hour, per app.
+The one exception is repository **bootstrap/probe** runs, which additionally create a small result `ConfigMap` (same name as the Job) the mover writes its outcome into — needed because the controller may read the result after the Job is already gone. It is one fixed-name object per repository, consumed and deleted by the controller; it cannot accumulate.
 
-### The orphan sweep
+/// note | Why not a ConfigMap?
+Operator versions up to 0.7.0 mounted the work spec from a per-run ConfigMap. The Job self-reaped via its TTL, but ConfigMaps have no TTL mechanism and were owner-referenced to long-lived CRs (a `Snapshot` is the durable record of a backup; a `SnapshotPolicy` never goes away) — so one ConfigMap leaked per run, forever (issue #224: 605 in one reported cluster). Embedding the spec in the Job removes the second object, and with it the entire leak class.
+///
 
-A ConfigMap whose Job is *already gone* (reaped by its TTL while the operator was down, or left behind by operator versions before the fix) is invisible to the transition-time cleanup. A leader-only background sweep heals those: every 6 hours it lists Kopiur-managed ConfigMaps and deletes work-spec ones that have **no same-named Job** and are **older than 1 hour**. Bootstrap result ConfigMaps (`result.json`) and anything a live run still mounts are never touched. On upgrade, clusters that accumulated historical work-spec ConfigMaps converge automatically — no `kubectl` cleanup needed.
+### The legacy-ConfigMap sweep
+
+Clusters upgraded from versions that created per-run work-spec ConfigMaps still hold the historical leftovers. A leader-only background sweep heals them: every 6 hours it lists Kopiur-managed ConfigMaps and deletes work-spec ones (data key `work-spec.json`) that have **no same-named Job** and are **older than 1 hour**. Bootstrap result ConfigMaps and anything a live legacy run still mounts are never touched. On upgrade, the backlog drains automatically — no `kubectl` cleanup needed.
 
 Two environment variables tune it (set via the chart's controller `extraEnv`):
 
@@ -322,11 +326,7 @@ Two environment variables tune it (set via the chart's controller `extraEnv`):
 | `KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS` | `21600` (6h) | Sweep cadence; `0` disables the sweep entirely. |
 | `KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS` | `3600` (1h) | Minimum ConfigMap age before it may be reaped. |
 
-Each pass increments the `kopiur_work_spec_cms_swept_total` counter on `/metrics`, so you can watch a backlog drain after an upgrade.
-
-/// note | "Where did the ConfigMap go?"
-If you previously inspected `work-spec.json` after a run finished, do it while the run is in flight — or read the equivalent fields from the CR spec/status. The Job (and pod logs) remain available until the TTL either way.
-///
+Each pass increments the `kopiur_work_spec_cms_swept_total` counter on `/metrics`, so you can watch the backlog drain after an upgrade.
 
 ## Troubleshooting
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -26,7 +26,7 @@ What each rule is **for**, grouped by purpose:
 | --- | --- | --- |
 | `kopiur.home-operations.com` → all 8 CRDs (`repositories`, `snapshotpolicies`, `snapshots`, `snapshotschedules`, `restores`, `maintenances`, `repositoryreplications`, `clusterrepositories`†) | get, list, watch, create, update, patch, delete | Reconcile every kind; schedules **create** `Snapshot` CRs; repositories **create** owned `Maintenance` CRs; retention **deletes** pruned `Snapshot` CRs. |
 | same group → each CRD's `/status` and `/finalizers` | get, update, patch | Status is written via server-side apply (**a PATCH — `patch` is required, not just `update`**); finalizers gate snapshot deletion. |
-| core → `pods`, `persistentvolumeclaims`, `configmaps` | get, list, watch, create, update, patch, delete | Resolve workload pods for `inheritSecurityContextFrom` and hooks; create restore-target / cache PVCs; write the mover work-spec ConfigMap. |
+| core → `pods`, `persistentvolumeclaims`, `configmaps` | get, list, watch, create, update, patch, delete | Resolve workload pods for `inheritSecurityContextFrom` and hooks; create restore-target / cache PVCs; write the bootstrap result ConfigMap and sweep legacy work-spec ConfigMaps. |
 | core → `pods/exec` | create, get | Run `hooks.beforeSnapshot/afterSnapshot` `workloadExec` commands inside the workload pod (quiesce/resume). |
 | core → `events` **and** `events.k8s.io` → `events` | create, patch | The kube `Recorder` writes `events.k8s.io/v1` Events; **both** groups are needed (a common gotcha — without `events.k8s.io` every event write 403s). |
 | core → `secrets` | get, list, watch, create, patch | Read repository credential Secrets (and re-reconcile when they change); **create/patch** is the credential-projection feature (copying a repo's Secret into a consumer namespace) and the self-managed webhook TLS Secret. |
@@ -50,7 +50,7 @@ The mover is deliberately tiny — it can **only** report its result:
 | API group → resources | Verbs | Why |
 | --- | --- | --- |
 | `kopiur.home-operations.com` → every CRD's `/status` | get, patch | Patch progress and the terminal result (snapshot id, stats, timing, `logTail`, `failure`) onto the CR that owns the Job. |
-| core → `configmaps` | get, patch | Read its work-spec; write bootstrap results back to the result ConfigMap. |
+| core → `configmaps` | get, patch | Write bootstrap results back to the result ConfigMap (the work spec itself rides the Job env). |
 
 It cannot read Secrets (credentials arrive via `envFrom` on the Job), cannot
 create or delete anything, and cannot touch other namespaces.
@@ -96,7 +96,7 @@ user to browsing snapshots in that one namespace):
 | `kopiur.home-operations.com` → `clusterrepositories` | get | Same chain for cluster-scoped repositories. |
 | `apps` → `deployments` | get, list | Resolve the mover image from the controller Deployment (sessions run exactly what the operator runs). |
 | `batch` → `jobs` | create, get, list, delete | Find-or-create the read-only session Job; `session end`. |
-| core → `configmaps` | create, get, delete | The session's work-spec ConfigMap (owned by the Job). |
+| core → `configmaps` | delete | `session end` cleans up a legacy session's work-spec ConfigMap (the spec rides the Job env today). |
 | core → `pods` | get, list, watch | Wait for the session pod to become Ready. |
 | core → `pods/log` | get | Surface the pod's logs when the session fails to start. |
 | core → `pods/exec` | create | The read path: exec the closed kopia read-command set. |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,6 +171,10 @@ same `logTail`/`failure` fields appear on a failed `Restore`.
 
 Common causes: the source PVC's `VolumeSnapshotClass` is wrong/missing (for `copyMethod: Snapshot`), a `beforeSnapshot` hook failed (it aborts the backup unless `continueOnFailure: true`), or the repository became unreachable mid-run.
 
+/// note | The Job stays, the ConfigMap doesn't
+A finished run's mover **Job** (and its pod logs, as above) sticks around until its `ttlSecondsAfterFinished` (default 1h). The run's **work-spec ConfigMap** is deleted as soon as the run finishes — it only carried the instructions the controller handed the mover, which are derived from your CRs, so there is nothing in it to debug. If you don't see per-run ConfigMaps anymore: that's the fix for the leak where one accumulated per run, forever. See [Movers → Run artifacts & cleanup](movers.md#run-artifacts--cleanup).
+///
+
 ## Backup `Succeeded` but is **incomplete** (`filesFailed > 0`)
 
 By default an unreadable file is **fatal** — the backup fails loudly with `PermissionDenied` (above), so nothing is silent. But if you set an `errorHandling.ignoreFileErrors`/`ignoreDirErrors` policy, kopia **completes** the snapshot while *skipping* the files it couldn't read. Kopiur surfaces that so it isn't silent: the excluded count rides on `status.stats.filesFailed`, and the controller sets `SecurityContextCompatible=False` + a Warning Event.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,8 +171,8 @@ same `logTail`/`failure` fields appear on a failed `Restore`.
 
 Common causes: the source PVC's `VolumeSnapshotClass` is wrong/missing (for `copyMethod: Snapshot`), a `beforeSnapshot` hook failed (it aborts the backup unless `continueOnFailure: true`), or the repository became unreachable mid-run.
 
-/// note | The Job stays, the ConfigMap doesn't
-A finished run's mover **Job** (and its pod logs, as above) sticks around until its `ttlSecondsAfterFinished` (default 1h). The run's **work-spec ConfigMap** is deleted as soon as the run finishes — it only carried the instructions the controller handed the mover, which are derived from your CRs, so there is nothing in it to debug. If you don't see per-run ConfigMaps anymore: that's the fix for the leak where one accumulated per run, forever. See [Movers → Run artifacts & cleanup](movers.md#run-artifacts--cleanup).
+/// note | The run is one object — the Job
+A finished run's mover **Job** (and its pod logs, as above) sticks around until its `ttlSecondsAfterFinished` (default 1h). The instructions the controller handed the mover ride the Job itself — `kubectl get job <name> -o yaml` shows them in the pod env as `KOPIUR_WORK_SPEC`. If you don't see per-run work-spec ConfigMaps anymore: they no longer exist — that's the fix for the leak where one accumulated per run, forever (#224). See [Movers → Run artifacts & cleanup](movers.md#run-artifacts--cleanup).
 ///
 
 ## Backup `Succeeded` but is **incomplete** (`filesFailed > 0`)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -6,6 +6,28 @@ the Deployments, done. The one exception so far is **0.5.x → 0.6.0**, which mo
 the CRDs between two Helm mechanisms and needs one deliberate step to avoid data
 loss. Read that section before you cross it.
 
+## After 0.7.0: per-run work-spec ConfigMaps are cleaned up (no action needed)
+
+Versions after 0.7.0 fix a resource leak: every mover run (backup, restore,
+verify, replication, maintenance, pin) left its `work-spec.json` ConfigMap
+behind forever — clusters with hourly schedules accumulated hundreds. Two
+behavior changes land together, both automatic:
+
+- The controller now **deletes a run's work-spec ConfigMap as soon as its mover
+  Job finishes** (succeeded or failed). The Job itself still lingers to its
+  `ttlSecondsAfterFinished` (default 1h) — pod logs and `kubectl kopiur logs`
+  are unaffected.
+- A periodic **orphan sweep** (default: every 6h, ConfigMaps older than 1h with
+  no matching Job) deletes the ConfigMaps accumulated by earlier versions, so
+  existing clusters converge on their own after the upgrade — no `kubectl`
+  cleanup required. Watch the backlog drain via the
+  `kopiur_work_spec_cms_swept_total` counter.
+
+If any tooling of yours read the per-run ConfigMaps after a run completed, read
+them while the run is in flight instead, or reconstruct the values from the CR
+spec/status. Details and tuning knobs:
+[Movers → Run artifacts & cleanup](movers.md#run-artifacts--cleanup).
+
 ## Upgrading 0.5.x → 0.6.0 (one-time CRD migration)
 
 /// danger | 0.5.x → 0.6.0 is a breaking upgrade — read this first

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -6,26 +6,28 @@ the Deployments, done. The one exception so far is **0.5.x → 0.6.0**, which mo
 the CRDs between two Helm mechanisms and needs one deliberate step to avoid data
 loss. Read that section before you cross it.
 
-## After 0.7.0: per-run work-spec ConfigMaps are cleaned up (no action needed)
+## After 0.7.0: per-run work-spec ConfigMaps no longer exist (no action needed)
 
 Versions after 0.7.0 fix a resource leak: every mover run (backup, restore,
 verify, replication, maintenance, pin) left its `work-spec.json` ConfigMap
-behind forever — clusters with hourly schedules accumulated hundreds. Two
-behavior changes land together, both automatic:
+behind forever — clusters with hourly schedules accumulated hundreds. The fix
+is structural, and both halves are automatic:
 
-- The controller now **deletes a run's work-spec ConfigMap as soon as its mover
-  Job finishes** (succeeded or failed). The Job itself still lingers to its
-  `ttlSecondsAfterFinished` (default 1h) — pod logs and `kubectl kopiur logs`
-  are unaffected.
-- A periodic **orphan sweep** (default: every 6h, ConfigMaps older than 1h with
-  no matching Job) deletes the ConfigMaps accumulated by earlier versions, so
-  existing clusters converge on their own after the upgrade — no `kubectl`
-  cleanup required. Watch the backlog drain via the
+- The controller now **embeds the work spec in the mover Job's pod env**
+  (`KOPIUR_WORK_SPEC`) — a run is one object, and no per-run ConfigMap is
+  created at all. The Job still lingers to its `ttlSecondsAfterFinished`
+  (default 1h) — pod logs and `kubectl kopiur logs` are unaffected, and
+  `kubectl get job <name> -o yaml` now shows the full run spec in one place.
+  (Repository bootstrap/probe keeps one fixed-name result ConfigMap per
+  repository, consumed and deleted by the controller.)
+- A periodic **legacy sweep** (default: every 6h, ConfigMaps older than 1h with
+  no matching Job) deletes the work-spec ConfigMaps accumulated by earlier
+  versions, so existing clusters converge on their own after the upgrade — no
+  `kubectl` cleanup required. Watch the backlog drain via the
   `kopiur_work_spec_cms_swept_total` counter.
 
-If any tooling of yours read the per-run ConfigMaps after a run completed, read
-them while the run is in flight instead, or reconstruct the values from the CR
-spec/status. Details and tuning knobs:
+If any tooling of yours read the per-run ConfigMaps, read the Job's
+`KOPIUR_WORK_SPEC` env instead. Details and tuning knobs:
 [Movers → Run artifacts & cleanup](movers.md#run-artifacts--cleanup).
 
 ## Upgrading 0.5.x → 0.6.0 (one-time CRD migration)


### PR DESCRIPTION
Closes #224.

## The problem

Every mover run (backup, restore, verify, replication, maintenance, pin, delete) applied a work-spec `ConfigMap` + `Job` pair. One `ConfigMap` leaked per run, forever: a reported cluster held **605** of them, one per hourly snapshot per app — while nobody saw 605 Jobs.

### Anatomy of the leak: two objects, two clocks

1. The controller applied the work-spec `ConfigMap`, then the mover `Job`. **Both** carried an `ownerReference` to the same long-lived CR — the `Snapshot` CR for backups, the `SnapshotPolicy` for verify slots, the `RepositoryReplication` CR for replication slots.
2. **The Job disappeared ~1h later — but not because Kopiur cleaned it up.** Every mover Job is stamped with `ttlSecondsAfterFinished` (`resolve_mover` always sets it; default 3600), and Kubernetes' built-in TTL-after-finished controller deletes finished Jobs, cascading to their pods.
3. **The ConfigMap had no equivalent mechanism.** Kubernetes has no TTL for ConfigMaps; its only reaper was owner-reference GC, which fires when the *owner* is deleted — and these owners essentially never are (a `Snapshot` CR is the durable record of the backup; `SnapshotPolicy` / `RepositoryReplication` are permanent).

So the pair was born with the same owner, but the Job had a *second, shorter* clock while the ConfigMap only had the owner's clock — "years." The ConfigMaps were never orphaned in the Kubernetes sense; they were fully-owned children of an owner that never dies.

## The fix — remove the ConfigMap entirely

Asking the obvious follow-up ("do we even need that ConfigMap?") turned the fix structural: **the work spec now rides the mover Job's own pod env** (`KOPIUR_WORK_SPEC`). A run is exactly **one Kubernetes object**, whose `ttlSecondsAfterFinished` cleans up everything. There is nothing left to leak, and no reap choreography to get right:

- The work spec was always a fit for env transport: secret-free by design (credentials flow via `envFrom` Secret refs — it previously lived in a world-readable ConfigMap), read exactly once at mover startup, and derived entirely from the CRs.
- **Strictly better properties**: the pod template is immutable after spawn (a mounted ConfigMap could be mutated mid-run); `kubectl get job <name> -o yaml` shows the pod shape *and* the exact controller→mover contract in one object for the Job's whole TTL; and the object count per run halves.
- **The one real constraint is guarded**: Linux caps a single env string at 128 KiB (`MAX_ARG_STRLEN`), so `build_job` refuses a serialized spec over 100 KiB with an actionable what/why/fix error (`BuildJobError`, surfaced as a `Structural` reconcile failure + Warning Event). Real work specs are ~1 KiB; only a pathological recipe approaches the limit.
- **Rollout-safe**: the mover resolves the spec env-first, falling back to the legacy `KOPIUR_WORK_SPEC_PATH` file for manually-invoked movers and in-flight Jobs from older controllers (whose pinned older image reads the file anyway).

**The one legitimate ConfigMap consumer keeps one.** Repository bootstrap/probe runs need a channel that *outlives the Job* (the controller reads the mover's `result.json` after the Job may be TTL-reaped), so they create a **result-only** ConfigMap — no work-spec payload, one fixed name per repository, consumed and deleted by the controller. It cannot accumulate. The CLI browse session also drops its ConfigMap (one-object sessions); its ClusterRole shrinks to `configmaps: [delete]` for legacy cleanup only.

### The legacy sweep (upgrade backfill)

Clusters upgraded from ConfigMap-mounting versions still hold the historical leftovers (the 605). A **leader-only periodic sweep** (`crates/controller/src/sweep.rs`) heals them: every 6h it lists kopiur-managed ConfigMaps within the install scope (`scoped_api`, Role-RBAC-safe) and deletes work-spec ones (data key `work-spec.json`, never `result.json`) with **no same-named Job**, **older than a minimum age**, using **UID + resourceVersion delete preconditions** so any concurrent write spares the object. Config: `KOPIUR_WORK_SPEC_SWEEP_INTERVAL_SECS` (21600 default; `0` disables) and `KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS` (3600 default) via the chart's controller `extraEnv`; each pass increments `kopiur_work_spec_cms_swept_total`.

## Bonus correctness fix: pin-Job consumption (silent kopia divergence)

The audit surfaced a real bug adjacent to the leak: the `{name}-pin` Job was never consumed, so a pin→unpin toggle found the *stale succeeded* Job, matched "Job succeeded", and recorded `status.pinned = desired` **without running a mover** — kopia's real pin state silently diverged (a snapshot the user believes unpinned stays exempt from retention, or vice versa).

Pin Jobs now carry a `kopiur.home-operations.com/pin-target` annotation recording the state they apply, and a terminal pin Job is reconciled by **what it did**, never by what `spec.pin` currently says: an unrecorded success writes `status.pinned` to the *applied* state (even after a mid-flight spec flip — the next pass spawns the corrective mover); a recorded or legacy direction-less Job is consumed so it can never satisfy a future toggle; a failed Job stays as the TTL-based retry-backoff only while its direction is still wanted. A new `Pinned` condition tracks state (`Unknown`/`PinJobRunning` in flight) and doubles as the durable marker gating the steady-state Job lookup — never-pinned Snapshots pay zero extra API calls.

## Robustness decisions (from a 22-agent adversarial review)

- Wedged-mover teardowns are best-effort Job deletes — a transient error can't skip the staged-PVC cleanup that follows (Snapshot) or leave a Restore un-Failed and respawning wedged movers.
- Bootstrap/probe result-ConfigMap deletes keep propagate-on-error semantics (consume-exactly-once).
- Sweep deletes are resourceVersion-preconditioned (TOCTOU-safe against re-spawned runs).

## Tests

**Unit** (69 suites green; the cognitive-complexity ratchet *tightened* 32 → 31): Job-env round-trip, oversized-spec refusal, result-only ConfigMap shape, no-work-spec-volume guard, sweep candidate matrix, pin direction/gate matrices.

**e2e** — `crates/e2e/tests/leak_cleanup.rs`:
1. Succeeded backup → **no per-run ConfigMap exists at any point** (stronger than the earlier reap-after-terminal design); the Job persists to its TTL and carries the inline spec; poking the terminal Snapshot never materializes a ConfigMap.
2. Failed backup → same, Job kept for logs.
3. Pin toggle → succeeded pin Job consumed after `status.pinned` lands; unpin observably spawns a **fresh** pin Job (regression test for the divergence bug).
4. Completed Restore → same one-object contract.
5. Sweep → a synthetic aged legacy ConfigMap is deleted while a same-shaped one with a live Job survives.

The work-spec *contract* tests (`policy_knobs`, `verification`, `replication`, `restore`, `workload_identity`) now assert the knobs on the Job's `KOPIUR_WORK_SPEC` env — race-free by construction, since the Job outlives the run by its TTL.

## Docs

`docs/movers.md` ("Run artifacts & cleanup": one-object runs, why-not-a-ConfigMap admonition, legacy sweep + knobs), `docs/troubleshooting.md`, `docs/upgrade.md` (behavior-change note), `docs/rbac.md` + browse ClusterRole (shrunk grant), `docs/cli/browse.md`.

## Verification

`mise run test` (69 suites), `clippy` (0 findings), `complexity-check` (31/31, ratchet lowered), `fmt-check`, `gen-check` (no drift), `mise run docs` (strict) — all green. A full targeted e2e pass (`leak_cleanup`, `ttl_rerun`, `verification`, `replication`, `policy_knobs`, `restore`, `workload_identity`, wedged `lifecycle`) runs against a fresh kind cluster; results will be posted on this PR.