### PR TITLE
feat: staged-PVC storageClass/accessModes overrides + bind race fix (closes #223)

### DIFF
--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -343,6 +343,121 @@ pub struct ObjectRef {
     pub namespace: Option<String>,
 }
 
+/// A PersistentVolumeClaim access mode as a closed set — `ReadWriteOnce`,
+/// `ReadOnlyMany`, `ReadWriteMany`, `ReadWriteOncePod` — so a typo is rejected by
+/// the CRD schema itself instead of surfacing as a provisioner error at the first
+/// backup or restore run.
+///
+/// Deliberately **no `Default`** (unlike other unit enums here): everywhere this
+/// type appears, an absent/empty list means "inherit from context" — the source
+/// PVC's modes for a staged PVC, `ReadWriteOnce` for a restore-created PVC — so
+/// there is no context-free default value to name.
+///
+/// The extra [`PvcAccessMode::Unknown`] variant exists ONLY so values persisted
+/// before this field was schema-enforced still **deserialize** instead of erroring
+/// the typed watch stream for the whole Kind (one legacy CR must never wedge every
+/// other CR's reconciliation). It is hidden from the CRD schema — the apiserver
+/// rejects non-canonical strings on every new write — and
+/// [`crate::validate::validate_access_modes`] rejects it loudly per-CR with the
+/// offending value quoted.
+///
+/// ```
+/// use kopiur_api::common::PvcAccessMode;
+///
+/// // Canonical values round-trip as bare k8s strings.
+/// assert_eq!(serde_json::to_value(PvcAccessMode::ReadOnlyMany).unwrap(), "ReadOnlyMany");
+/// let m: PvcAccessMode = serde_json::from_value(serde_json::json!("ReadWriteOnce")).unwrap();
+/// assert_eq!(m, PvcAccessMode::ReadWriteOnce);
+///
+/// // A legacy/bogus stored string decodes (never a watcher-poisoning error) into
+/// // `Unknown`, preserving the value verbatim for the rejection message — and it
+/// // re-serializes to the same string, so a read-modify-write never mutates it.
+/// let m: PvcAccessMode = serde_json::from_value(serde_json::json!("ReadWriteOnze")).unwrap();
+/// assert_eq!(m, PvcAccessMode::Unknown("ReadWriteOnze".into()));
+/// assert_eq!(serde_json::to_value(&m).unwrap(), "ReadWriteOnze");
+/// ```
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PvcAccessMode {
+    /// Mounted read-write by a single node (`RWO`).
+    ReadWriteOnce,
+    /// Mounted read-only by many nodes (`ROX`) — e.g. a CephFS `backingSnapshot`
+    /// shallow-clone staged PVC.
+    ReadOnlyMany,
+    /// Mounted read-write by many nodes (`RWX`).
+    ReadWriteMany,
+    /// Mounted read-write by a single **pod** (`RWOP`); the apiserver requires it
+    /// to be the sole mode on a PVC.
+    ReadWriteOncePod,
+    /// A non-canonical stored value (pre-schema-enforcement legacy data). Never
+    /// admissible on a new write (not in the CRD schema); consumers reject it via
+    /// [`crate::validate::validate_access_modes`] with the value quoted, instead
+    /// of a serde error that would poison the typed watcher.
+    Unknown(String),
+}
+
+impl PvcAccessMode {
+    /// The four canonical Kubernetes access-mode strings — the CRD schema `enum`
+    /// and the "valid values" list in rejection messages, from one source.
+    pub const CANONICAL: [&'static str; 4] = [
+        "ReadWriteOnce",
+        "ReadOnlyMany",
+        "ReadWriteMany",
+        "ReadWriteOncePod",
+    ];
+
+    /// The k8s wire string (exhaustive; `Unknown` echoes the stored value verbatim).
+    pub fn mode_str(&self) -> &str {
+        match self {
+            PvcAccessMode::ReadWriteOnce => "ReadWriteOnce",
+            PvcAccessMode::ReadOnlyMany => "ReadOnlyMany",
+            PvcAccessMode::ReadWriteMany => "ReadWriteMany",
+            PvcAccessMode::ReadWriteOncePod => "ReadWriteOncePod",
+            PvcAccessMode::Unknown(s) => s,
+        }
+    }
+
+    /// Parse a **canonical** k8s access-mode string; `None` for anything else.
+    /// The migrate tool uses this to refuse a non-canonical VolSync value up
+    /// front instead of passing it through to a doomed `kubectl apply`.
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "ReadWriteOnce" => Some(PvcAccessMode::ReadWriteOnce),
+            "ReadOnlyMany" => Some(PvcAccessMode::ReadOnlyMany),
+            "ReadWriteMany" => Some(PvcAccessMode::ReadWriteMany),
+            "ReadWriteOncePod" => Some(PvcAccessMode::ReadWriteOncePod),
+            _ => None,
+        }
+    }
+}
+
+impl Serialize for PvcAccessMode {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(self.mode_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for PvcAccessMode {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Ok(PvcAccessMode::parse(&s).unwrap_or(PvcAccessMode::Unknown(s)))
+    }
+}
+
+impl JsonSchema for PvcAccessMode {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "PvcAccessMode".into()
+    }
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        // Only the canonical values: `Unknown` is a decode-compat artifact for
+        // legacy stored data, never an admissible write.
+        schemars::json_schema!({
+            "type": "string",
+            "description": "A Kubernetes PersistentVolumeClaim access mode.",
+            "enum": PvcAccessMode::CANONICAL,
+        })
+    }
+}
+
 /// Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted.
 /// Produced backups default to `Delete`; discovered snapshots are forced to `Retain`.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]

--- a/crates/api/src/common/tests.rs
+++ b/crates/api/src/common/tests.rs
@@ -907,3 +907,47 @@ fn effective_timezone_unset_invalid_default_falls_back_to_utc() {
     assert_eq!(tz, chrono_tz::Tz::UTC);
     assert!(amb.is_none());
 }
+
+// --- PvcAccessMode: closed schema, graceful legacy decode ---
+
+#[test]
+fn pvc_access_mode_schema_lists_only_canonical_values() {
+    // `Unknown` is a decode-compat artifact for legacy stored data and must NEVER
+    // be admissible: the schema enum is exactly the four canonical k8s strings.
+    let schema = schemars::schema_for!(PvcAccessMode);
+    let json = serde_json::to_value(&schema).unwrap();
+    assert_eq!(
+        json["enum"],
+        serde_json::json!([
+            "ReadWriteOnce",
+            "ReadOnlyMany",
+            "ReadWriteMany",
+            "ReadWriteOncePod"
+        ]),
+        "schema enum must be exactly the canonical set; got {json}"
+    );
+    assert_eq!(json["type"], "string", "got {json}");
+}
+
+#[test]
+fn pvc_access_mode_parse_and_mode_str_are_inverse_on_canonical() {
+    for s in PvcAccessMode::CANONICAL {
+        let parsed = PvcAccessMode::parse(s).expect("canonical value must parse");
+        assert!(!matches!(parsed, PvcAccessMode::Unknown(_)));
+        assert_eq!(parsed.mode_str(), s);
+    }
+    // Case matters (k8s wire strings are exact) — shorthand/typos don't parse.
+    assert_eq!(PvcAccessMode::parse("rwo"), None);
+    assert_eq!(PvcAccessMode::parse("readwriteonce"), None);
+}
+
+#[test]
+fn pvc_access_mode_legacy_value_decodes_to_unknown_and_roundtrips() {
+    // The load-bearing property: a bogus stored string must DECODE (a serde error
+    // here would poison the typed watch stream for the whole Kind) and must
+    // re-serialize unchanged, so a read-modify-write never mutates legacy data.
+    let m: PvcAccessMode = serde_json::from_value(serde_json::json!("ReadWriteOnze")).unwrap();
+    assert_eq!(m, PvcAccessMode::Unknown("ReadWriteOnze".into()));
+    assert_eq!(m.mode_str(), "ReadWriteOnze");
+    assert_eq!(serde_json::to_value(&m).unwrap(), "ReadWriteOnze");
+}

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -2,7 +2,8 @@
 //! populator source. ADR-0001 §3.6, ADR-0003 §4.6.
 
 use crate::common::{
-    CredentialProjection, FailurePolicy, MoverSpec, ObjectRef, RepositoryRef, ResolvedIdentity,
+    CredentialProjection, FailurePolicy, MoverSpec, ObjectRef, PvcAccessMode, RepositoryRef,
+    ResolvedIdentity,
 };
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
@@ -199,9 +200,13 @@ pub struct PvcTemplate {
     /// Requested size of the new PVC (e.g. `100Gi`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub capacity: Option<String>,
-    /// Access modes for the new PVC (e.g. `["ReadWriteOnce"]`).
+    /// Access modes for the new PVC; empty defaults to `[ReadWriteOnce]`. Closed
+    /// enum in the schema; a non-canonical value persisted before enforcement
+    /// decodes as [`PvcAccessMode::Unknown`] and is rejected per-CR with the
+    /// value quoted (webhook + reconciler, via `validate_access_modes`) instead
+    /// of poisoning the typed watcher.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub access_modes: Vec<String>,
+    pub access_modes: Vec<PvcAccessMode>,
 }
 
 /// kopia restore behavior knobs (M2 flag sweep). Every `Option` field's `None`
@@ -518,7 +523,7 @@ policy:
         match target {
             RestoreTarget::Pvc(t) => {
                 assert_eq!(t.name, "postgres-data-restored");
-                assert_eq!(t.access_modes, vec!["ReadWriteOnce".to_string()]);
+                assert_eq!(t.access_modes, vec![PvcAccessMode::ReadWriteOnce]);
             }
             other => panic!("expected Pvc, got {}", other.kind_str()),
         }
@@ -530,6 +535,56 @@ policy:
         let json = serde_json::to_value(&spec).expect("serialize");
         let reparsed: RestoreSpec = serde_json::from_value(json).expect("reparse");
         assert_eq!(spec, reparsed);
+    }
+
+    #[test]
+    fn restore_pvc_access_modes_render_a_closed_enum_in_the_crd_schema() {
+        // The Vec<String> → Vec<PvcAccessMode> migration must surface in the CRD:
+        // items are a closed string enum (apiserver rejects typos on new writes),
+        // and the legacy-decode `Unknown` variant never appears.
+        let crd = Restore::crd();
+        let json = serde_json::to_value(&crd).expect("serialize CRD");
+        let items = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["target"]["properties"]["pvc"]["properties"]["accessModes"]["items"];
+        assert_eq!(
+            items["type"], "string",
+            "items must be strings; got {items}"
+        );
+        assert_eq!(
+            items["enum"],
+            serde_json::json!([
+                "ReadWriteOnce",
+                "ReadOnlyMany",
+                "ReadWriteMany",
+                "ReadWriteOncePod"
+            ]),
+            "items enum must be exactly the canonical modes; got {items}"
+        );
+    }
+
+    #[test]
+    fn restore_legacy_access_mode_decodes_to_unknown_not_an_error() {
+        // A pre-enforcement stored Restore with a bogus mode must still
+        // deserialize (a serde error would poison the typed watch stream for the
+        // whole Kind) — the value lands in `Unknown`, verbatim, and the shared
+        // validator rejects it per-CR with the value quoted.
+        let spec: RestoreSpec = from_yaml(
+            "source: { snapshotRef: { name: b } }\n\
+             target: { pvc: { name: restored, capacity: 10Gi, accessModes: [ReadWriteOnze] } }\n",
+        );
+        match &spec.target {
+            RestoreTarget::Pvc(t) => assert_eq!(
+                t.access_modes,
+                vec![PvcAccessMode::Unknown("ReadWriteOnze".into())]
+            ),
+            other => panic!("expected Pvc, got {}", other.kind_str()),
+        }
+        // And it re-serializes unchanged (read-modify-write never mutates it).
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(
+            json["target"]["pvc"]["accessModes"],
+            serde_json::json!(["ReadWriteOnze"])
+        );
     }
 
     #[test]

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -193,6 +193,17 @@ pub struct StagedSources {
     /// `true` once the stage is ready for the mover.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub ready: Option<bool>,
+    /// StorageClass of the staged PVC — `spec.staging.storageClassName` when set,
+    /// else the source PVC's class. Pinned for observability (e.g. confirming a
+    /// CephFS shallow-clone class actually took effect).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_class_name: Option<String>,
+    /// The resolved `spec.staging.timeout` (seconds) pinned when the stage was
+    /// stamped, so the running-Job staged-PVC bind watchdog never re-resolves a
+    /// policy that may have been edited or deleted mid-run. `0` = wait
+    /// indefinitely.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub staging_timeout_seconds: Option<i64>,
 }
 
 /// When each hook list completed.

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -4,7 +4,7 @@
 use crate::backend::NfsVolume;
 use crate::common::{
     CredentialProjection, CronSpec, DeletionPolicy, Identity, MoverSpec, PodSelector,
-    RepositoryRef, ResolvedIdentity, Retention,
+    PvcAccessMode, RepositoryRef, ResolvedIdentity, Retention,
 };
 use k8s_openapi::api::batch::v1::JobSpec;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{Condition, LabelSelector};
@@ -241,15 +241,34 @@ pub enum CopyMethod {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct StagingSpec {
-    /// How long the staged `VolumeSnapshot` may take to become `readyToUse`
-    /// (measured from its creation) before the backup is failed (Go-style
-    /// duration like `10m` or `1h`; default `10m`). A transient CSI/
-    /// snapshot-controller error during the wait is retried, never fatal on its
-    /// own — only this deadline fails staging. A zero duration (`0`/`0s`) waits
-    /// indefinitely. Raise this for backends whose snapshots take long to become
-    /// ready (e.g. cloud snapshots of large volumes).
+    /// How long each staging phase may take before the backup is failed (Go-style
+    /// duration like `10m` or `1h`; default `10m`): first the staged
+    /// `VolumeSnapshot` becoming `readyToUse` (measured from its creation), then —
+    /// on an `Immediate`-binding StorageClass — the staged PVC binding (a fresh
+    /// budget measured from the PVC's creation, covering the CSI restore/clone).
+    /// A transient CSI/snapshot-controller error during either wait is retried,
+    /// never fatal on its own — only this deadline fails staging. A zero duration
+    /// (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots or
+    /// clones take long (e.g. cloud snapshots of large volumes, CephFS full clones
+    /// of small-file-heavy volumes).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timeout: Option<String>,
+    /// StorageClass for the **staged PVC** — the temporary PVC restored from the
+    /// CSI `VolumeSnapshot` (`copyMethod: Snapshot`) or cloned from the source
+    /// (`copyMethod: Clone`). Absent ⇒ the staged PVC copies the source PVC's
+    /// class. Must belong to the **same CSI driver** as the source (staging fails
+    /// fast on a mismatch). Flagship use: a rook-ceph CephFS class with
+    /// `backingSnapshot: "true"`, which mounts the snapshot shallowly
+    /// (metadata-only, near-instant, read-only) instead of running a full
+    /// subvolume clone that can take many minutes on small-file-heavy volumes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub storage_class_name: Option<String>,
+    /// Access modes for the staged PVC. Empty ⇒ copy the source PVC's modes.
+    /// `[ReadOnlyMany]` pairs with snapshot-backed read-only classes (e.g. CephFS
+    /// `backingSnapshot`); the mover always mounts the staged PVC read-only
+    /// regardless of the mode.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub access_modes: Vec<PvcAccessMode>,
 }
 
 /// Multi-PVC grouping strategy. Defaults to a consistent group snapshot across
@@ -666,11 +685,83 @@ mod tests {
         assert_eq!(
             spec.staging,
             Some(StagingSpec {
-                timeout: Some("30m".to_string())
+                timeout: Some("30m".to_string()),
+                ..Default::default()
             })
         );
         let json = serde_json::to_value(&spec).unwrap();
         assert_eq!(json["staging"]["timeout"], "30m");
+    }
+
+    #[test]
+    fn staging_overrides_round_trip_and_are_elided_when_absent() {
+        // The staged-PVC override pair (storageClassName + accessModes) round-trips
+        // through the cluster's parse path; absent fields are skip-elided so
+        // "inherit from the source PVC" stays representable as absence.
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             staging: { timeout: 30m, storageClassName: cephfs-shallow, accessModes: [ReadOnlyMany] }\n",
+        );
+        let st = spec.staging.as_ref().unwrap();
+        assert_eq!(st.storage_class_name.as_deref(), Some("cephfs-shallow"));
+        assert_eq!(st.access_modes, vec![PvcAccessMode::ReadOnlyMany]);
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json["staging"]["storageClassName"], "cephfs-shallow");
+        assert_eq!(
+            json["staging"]["accessModes"],
+            serde_json::json!(["ReadOnlyMany"])
+        );
+
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             staging: { timeout: 30m }\n",
+        );
+        let json = serde_json::to_value(&spec).unwrap();
+        assert!(json["staging"].get("storageClassName").is_none());
+        assert!(json["staging"].get("accessModes").is_none());
+    }
+
+    #[test]
+    fn staging_access_modes_legacy_value_decodes_to_unknown_not_an_error() {
+        // Graceful-decode contract: a non-canonical stored mode deserializes into
+        // `Unknown` (rejected later by the shared validator, per-CR) instead of a
+        // serde error that would wedge the typed watcher for every SnapshotPolicy.
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             staging: { accessModes: [ReadWriteOnze] }\n",
+        );
+        assert_eq!(
+            spec.staging.unwrap().access_modes,
+            vec![PvcAccessMode::Unknown("ReadWriteOnze".into())]
+        );
+    }
+
+    #[test]
+    fn staging_access_modes_render_a_closed_enum_in_the_crd_schema() {
+        // First `Vec<unit-enum>` in the API crate: pin that the generated CRD
+        // schema is `items: {type: string, enum: [...]}` with exactly the four
+        // canonical modes — and does NOT leak the legacy-decode `Unknown` variant.
+        let crd = SnapshotPolicy::crd();
+        let json = serde_json::to_value(&crd).expect("serialize CRD");
+        let items = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["staging"]["properties"]["accessModes"]["items"];
+        assert_eq!(
+            items["type"], "string",
+            "items must be strings; got {items}"
+        );
+        assert_eq!(
+            items["enum"],
+            serde_json::json!([
+                "ReadWriteOnce",
+                "ReadOnlyMany",
+                "ReadWriteMany",
+                "ReadWriteOncePod"
+            ]),
+            "items enum must be exactly the canonical modes; got {items}"
+        );
     }
 
     #[test]

--- a/crates/api/src/validate/mod.rs
+++ b/crates/api/src/validate/mod.rs
@@ -15,7 +15,7 @@
 //! An empty vec means valid.
 
 use crate::backend::NfsVolume;
-use crate::common::{FailurePolicy, MoverSpec, RepositoryMode};
+use crate::common::{FailurePolicy, MoverSpec, PvcAccessMode, RepositoryMode};
 use crate::error::{ValidationError, ValidationResult};
 use crate::server::{ServerAuth, ServerSpec};
 use crate::snapshot_policy::Source;
@@ -84,6 +84,63 @@ pub fn validate_nfs_volume(nfs: &NfsVolume, context: &str) -> ValidationResult {
         });
     }
     Ok(())
+}
+
+/// Validate a PVC access-modes list wherever one appears (`spec.staging.accessModes`,
+/// `restore.target.pvc.accessModes`). Three rules, one place, both callers (webhook
+/// at admission, controller defensively):
+///
+///   * every entry must be canonical — an [`PvcAccessMode::Unknown`] value is either
+///     a legacy stored string from before schema enforcement or a typo, and no PVC
+///     could ever be provisioned from it;
+///   * no duplicates;
+///   * `ReadWriteOncePod` must be the **sole** mode — the apiserver rejects the
+///     combination at PVC-create time, so catching it here fails at admission with
+///     the reason instead of wedging the first run in a create-retry loop.
+///
+/// `field` names the exact path for the message. Accumulates so every bad entry is
+/// reported in one apply.
+pub fn validate_access_modes(field: &str, modes: &[PvcAccessMode]) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    let mut seen = std::collections::BTreeSet::new();
+    for (i, mode) in modes.iter().enumerate() {
+        if let PvcAccessMode::Unknown(value) = mode {
+            errs.push(ValidationError::InvalidFieldValue {
+                field: format!("{field}[{i}]"),
+                reason: format!(
+                    "{value:?} is not a Kubernetes access mode (valid: {}). No PVC can be \
+                     provisioned from it — if this value was stored before kopiur enforced \
+                     the schema, it was already broken then; edit the resource to one of the \
+                     valid modes.",
+                    PvcAccessMode::CANONICAL.join(", ")
+                ),
+            });
+        }
+        if !seen.insert(mode.mode_str().to_string()) {
+            errs.push(ValidationError::InvalidFieldValue {
+                field: format!("{field}[{i}]"),
+                reason: format!(
+                    "duplicate access mode {:?}; list each mode at most once",
+                    mode.mode_str()
+                ),
+            });
+        }
+    }
+    if modes.len() > 1
+        && modes
+            .iter()
+            .any(|m| matches!(m, PvcAccessMode::ReadWriteOncePod))
+    {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: field.to_string(),
+            reason: "ReadWriteOncePod may not be combined with other access modes — the \
+                     apiserver rejects such a PVC at create time, so the run would wedge in \
+                     a retry loop instead of failing here. Use ReadWriteOncePod alone, or \
+                     drop it."
+                .to_string(),
+        });
+    }
+    errs
 }
 
 /// A numeric knob must be at least `min` — the shared one-liner behind every

--- a/crates/api/src/validate/restore.rs
+++ b/crates/api/src/validate/restore.rs
@@ -115,6 +115,19 @@ pub fn validate_restore(spec: &RestoreSpec) -> ValidationResult {
         }
         RestoreTarget::Pvc(_) | RestoreTarget::PvcRef(_) => {}
     }
+    // Access modes on a create-target PVC: canonical/unique/RWOP-sole. Fail-fast on
+    // the first problem (this validator's contract); the accumulate wrapper reports
+    // the rest. A legacy stored value decodes as `PvcAccessMode::Unknown` (never a
+    // watcher-poisoning serde error) and is rejected HERE, per-CR, with the value
+    // quoted — the controller calls this defensively on every reconcile, so the
+    // rejection reaches the user as a Warning Event + structural backoff.
+    if let RestoreTarget::Pvc(t) = &spec.target
+        && let Some(e) = validate_access_modes("restore.target.pvc.accessModes", &t.access_modes)
+            .into_iter()
+            .next()
+    {
+        return Err(e);
+    }
     // `pvcConsumer` derives the workload from a *backup source* PVC; a restore has no such
     // source (it writes a target whose consumer may not exist yet), so it is backup-only.
     if let Some(m) = &spec.mover {

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::error::{ValidationError, ValidationResult};
 use crate::snapshot::{Origin, SnapshotSpec};
-use crate::snapshot_policy::{Hook, SnapshotPolicySpec};
+use crate::snapshot_policy::{CopyMethod, Hook, SnapshotPolicySpec};
 use crate::snapshot_schedule::SnapshotScheduleSpec;
 
 /// Validate a `SnapshotPolicy` spec, accumulating all problems.
@@ -180,20 +180,7 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
             errs.push(e);
         }
     }
-    // Staging: the timeout must parse — rejected at admission rather than silently
-    // falling back to the default at the first backup run.
-    if let Some(st) = &spec.staging
-        && let Some(t) = &st.timeout
-        && crate::duration::parse_go_duration(t).is_none()
-    {
-        errs.push(ValidationError::InvalidFieldValue {
-            field: "spec.staging.timeout".to_string(),
-            reason: format!(
-                "{t:?} is not a valid duration. Use a Go-style duration like 10m or 1h; omit \
-                 for the default (10m), or 0 to wait for the VolumeSnapshot indefinitely"
-            ),
-        });
-    }
+    errs.extend(validate_staging(spec));
     // Preflight: the timeout must parse, check names must be unique + non-blank, and
     // each check expression must compile + trial-evaluate to a bool with no
     // out-of-scope variable — rejected at admission rather than at the first run.
@@ -243,6 +230,83 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
                 }
             }
         }
+    }
+    errs
+}
+
+/// Validate `spec.staging` (+ its interplay with `copyMethod` and the sources):
+///
+///   * `timeout` must parse — rejected at admission rather than silently falling
+///     back to the default at the first backup run.
+///   * `accessModes` entries must be canonical/unique, and `ReadWriteOncePod`
+///     sole ([`validate_access_modes`]).
+///   * The staged-PVC override fields (`storageClassName`/`accessModes`) must have
+///     a staged PVC to act on — rejected for `copyMethod: Direct` (no staged PVC
+///     at all), an NFS source (never staged), and `pvcSelector` sources (staging
+///     is skipped for selector expansion). The pre-existing `timeout` and
+///     `volumeSnapshotClassName` stay deliberately lenient in those combinations —
+///     tightening them now would reject already-persisted objects on re-apply.
+fn validate_staging(spec: &SnapshotPolicySpec) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    let Some(st) = &spec.staging else {
+        return errs;
+    };
+    if let Some(t) = &st.timeout
+        && crate::duration::parse_go_duration(t).is_none()
+    {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: "spec.staging.timeout".to_string(),
+            reason: format!(
+                "{t:?} is not a valid duration. Use a Go-style duration like 10m or 1h; omit \
+                 for the default (10m), or 0 to wait for the VolumeSnapshot indefinitely"
+            ),
+        });
+    }
+    errs.extend(validate_access_modes(
+        "spec.staging.accessModes",
+        &st.access_modes,
+    ));
+    let overrides: Vec<&str> = [
+        (
+            "spec.staging.storageClassName",
+            st.storage_class_name.is_some(),
+        ),
+        ("spec.staging.accessModes", !st.access_modes.is_empty()),
+    ]
+    .into_iter()
+    .filter_map(|(name, present)| present.then_some(name))
+    .collect();
+    if overrides.is_empty() {
+        return errs;
+    }
+    let overrides = overrides.join(" / ");
+    match spec.copy_method {
+        CopyMethod::Direct => errs.push(ValidationError::InvalidFieldValue {
+            field: overrides.clone(),
+            reason: "copyMethod: Direct mounts the live source PVC — there is no staged PVC \
+                     to override. Remove the staged-PVC override(s), or use copyMethod: \
+                     Snapshot/Clone."
+                .to_string(),
+        }),
+        CopyMethod::Snapshot | CopyMethod::Clone => {}
+    }
+    if spec.sources.iter().any(|s| s.nfs.is_some()) {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: overrides.clone(),
+            reason: "an NFS source is read directly and never staged, so a staged-PVC \
+                     override is meaningless with it; remove the override(s) or use a PVC \
+                     source for copyMethod: Snapshot/Clone"
+                .to_string(),
+        });
+    }
+    if spec.sources.iter().any(|s| s.pvc_selector.is_some()) {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: overrides,
+            reason: "pvcSelector sources are not CSI-staged (staging applies to single-PVC \
+                     sources only), so a staged-PVC override would be silently ignored; \
+                     remove the override(s) or use a `pvc:` source"
+                .to_string(),
+        });
     }
     errs
 }

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -3147,3 +3147,195 @@ fn source_path_fork_matches_by_pvc_name() {
     // Same effective path (both default) → allowed.
     assert!(detect_source_path_fork(&mk(None), &mk(None), true, false).is_none());
 }
+
+// --- validate_access_modes (shared: staging + restore target) ---
+
+#[test]
+fn access_modes_accept_canonical_unique_lists() {
+    use crate::common::PvcAccessMode as M;
+    assert!(validate_access_modes("f", &[]).is_empty());
+    assert!(validate_access_modes("f", &[M::ReadOnlyMany]).is_empty());
+    assert!(validate_access_modes("f", &[M::ReadWriteOnce, M::ReadWriteMany]).is_empty());
+    // RWOP alone is exactly what the apiserver allows.
+    assert!(validate_access_modes("f", &[M::ReadWriteOncePod]).is_empty());
+}
+
+#[test]
+fn access_modes_reject_unknown_with_the_value_and_valid_set_quoted() {
+    use crate::common::PvcAccessMode as M;
+    let errs = validate_access_modes(
+        "spec.staging.accessModes",
+        &[M::Unknown("ReadWriteOnze".into())],
+    );
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    let msg = errs[0].to_string();
+    assert!(msg.contains("spec.staging.accessModes[0]"), "{msg}");
+    assert!(
+        msg.contains("ReadWriteOnze"),
+        "the bad value must be quoted: {msg}"
+    );
+    assert!(
+        msg.contains("ReadWriteOnce") && msg.contains("ReadWriteOncePod"),
+        "the valid set must be listed: {msg}"
+    );
+}
+
+#[test]
+fn access_modes_reject_duplicates_and_rwop_combinations() {
+    use crate::common::PvcAccessMode as M;
+    let errs = validate_access_modes("f", &[M::ReadWriteOnce, M::ReadWriteOnce]);
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].to_string().contains("duplicate"), "{errs:?}");
+
+    // The apiserver invariant: RWOP must be the sole mode — caught at admission
+    // instead of wedging the first run in a PVC-create retry loop.
+    let errs = validate_access_modes("f", &[M::ReadWriteOncePod, M::ReadOnlyMany]);
+    assert_eq!(errs.len(), 1, "{errs:?}");
+    assert!(errs[0].to_string().contains("ReadWriteOncePod"), "{errs:?}");
+}
+
+// --- validate_staging: staged-PVC overrides need a staged PVC to act on ---
+
+#[test]
+fn staging_overrides_accepted_for_snapshot_and_clone_pvc_sources() {
+    for method in ["Snapshot", "Clone"] {
+        let spec: SnapshotPolicySpec = crate::testutil::from_yaml(&format!(
+            "repository: {{ kind: Repository, name: r }}\n\
+             copyMethod: {method}\n\
+             sources: [ {{ pvc: {{ name: data }} }} ]\n\
+             staging: {{ storageClassName: cephfs-shallow, accessModes: [ReadOnlyMany] }}\n"
+        ));
+        assert!(
+            validate_backup_config(&spec).is_empty(),
+            "{method} + overrides must be valid"
+        );
+    }
+}
+
+#[test]
+fn staging_overrides_rejected_for_direct_copy_method() {
+    let spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         copyMethod: Direct\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         staging: { storageClassName: cephfs-shallow }\n",
+    );
+    let errs = validate_backup_config(&spec);
+    let msg = errs
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(msg.contains("spec.staging.storageClassName"), "{msg}");
+    assert!(msg.contains("Direct"), "{msg}");
+    assert!(
+        msg.contains("Snapshot/Clone"),
+        "the fix must be named: {msg}"
+    );
+
+    // Direct + a bare staging.timeout stays admitted (pre-existing leniency:
+    // tightening it would reject persisted objects on re-apply).
+    let spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         copyMethod: Direct\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         staging: { timeout: 5m }\n",
+    );
+    assert!(validate_backup_config(&spec).is_empty());
+}
+
+#[test]
+fn staging_overrides_rejected_for_nfs_and_pvc_selector_sources() {
+    // NFS is read directly, never staged.
+    let spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { nfs: { server: nas.lan, path: /export/data } } ]\n\
+         staging: { accessModes: [ReadOnlyMany] }\n",
+    );
+    let errs = validate_backup_config(&spec);
+    let msg = errs
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(msg.contains("spec.staging.accessModes"), "{msg}");
+    assert!(msg.contains("NFS"), "{msg}");
+
+    // pvcSelector expansion skips staging, so an override would be silently inert.
+    let spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvcSelector: { labelSelector: { matchLabels: { app: pg } } } } ]\n\
+         staging: { storageClassName: cephfs-shallow }\n",
+    );
+    let errs = validate_backup_config(&spec);
+    let msg = errs
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(msg.contains("pvcSelector"), "{msg}");
+}
+
+#[test]
+fn staging_unknown_access_mode_rejected_via_backup_config() {
+    // The legacy-decode `Unknown` value is rejected by the SHARED validator, so the
+    // webhook (admission) and controller (defensive) both refuse it identically.
+    let spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n\
+         staging: { accessModes: [ReadWriteOnze] }\n",
+    );
+    let errs = validate_backup_config(&spec);
+    let msg = errs
+        .iter()
+        .map(|e| e.to_string())
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(msg.contains("ReadWriteOnze"), "{msg}");
+}
+
+#[test]
+fn restore_pvc_target_rejects_unknown_and_rwop_combo_access_modes() {
+    use crate::common::{ObjectRef, PvcAccessMode as M};
+    use crate::restore::PvcTemplate;
+    let mut spec = restore_with(
+        RestoreSource::SnapshotRef(ObjectRef {
+            name: "b".into(),
+            namespace: None,
+        }),
+        None,
+    );
+    // A legacy stored (or force-applied) bogus mode: rejected per-CR with the
+    // value quoted — this is the graceful path for pre-enforcement data.
+    spec.target = RestoreTarget::Pvc(PvcTemplate {
+        name: "restored".into(),
+        storage_class_name: None,
+        capacity: Some("10Gi".into()),
+        access_modes: vec![M::Unknown("ReadWriteOnze".into())],
+    });
+    let err = validate_restore(&spec).unwrap_err();
+    assert!(err.to_string().contains("ReadWriteOnze"), "{err}");
+    assert!(
+        err.to_string().contains("restore.target.pvc.accessModes"),
+        "{err}"
+    );
+
+    // RWOP combined with another mode: the apiserver would reject the PVC.
+    spec.target = RestoreTarget::Pvc(PvcTemplate {
+        name: "restored".into(),
+        storage_class_name: None,
+        capacity: Some("10Gi".into()),
+        access_modes: vec![M::ReadWriteOncePod, M::ReadWriteOnce],
+    });
+    let err = validate_restore(&spec).unwrap_err();
+    assert!(err.to_string().contains("ReadWriteOncePod"), "{err}");
+
+    // A canonical single mode passes.
+    spec.target = RestoreTarget::Pvc(PvcTemplate {
+        name: "restored".into(),
+        storage_class_name: None,
+        capacity: Some("10Gi".into()),
+        access_modes: vec![M::ReadOnlyMany],
+    });
+    assert!(validate_restore(&spec).is_ok());
+}

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -478,8 +478,13 @@ pub struct RestoreArgs {
     pub storage_class: Option<String>,
 
     /// Access mode of the created PVC, repeatable (e.g. ReadWriteOnce).
-    #[arg(long = "access-mode", value_name = "MODE", requires = "create_pvc")]
-    pub access_modes: Vec<String>,
+    #[arg(
+        long = "access-mode",
+        value_name = "MODE",
+        requires = "create_pvc",
+        value_parser = parse_access_mode
+    )]
+    pub access_modes: Vec<kopiur_api::common::PvcAccessMode>,
 
     // --- kopia restore options ---
     /// Delete files in the target that are not in the snapshot (exact mirror;
@@ -862,6 +867,20 @@ impl OriginFilter {
     pub fn label_value(self) -> &'static str {
         kopiur_api::Origin::from(self).label_value()
     }
+}
+
+/// clap value parser for `--access-mode`: only the four canonical Kubernetes
+/// access modes are accepted, so a typo fails AT THE CLI with the valid set in
+/// the message instead of surviving until the apiserver (or a provisioner)
+/// rejects it. `PvcAccessMode::Unknown` exists solely for decoding legacy
+/// stored data — it is never a valid input here.
+fn parse_access_mode(s: &str) -> Result<kopiur_api::common::PvcAccessMode, String> {
+    kopiur_api::common::PvcAccessMode::parse(s).ok_or_else(|| {
+        format!(
+            "{s:?} is not a Kubernetes access mode; use one of {}",
+            kopiur_api::common::PvcAccessMode::CANONICAL.join(", ")
+        )
+    })
 }
 
 /// `--repository-kind` values; mirrors `kopiur_api::common::RepositoryKind`.

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -209,6 +209,11 @@ pub const SOURCE_STAGED_REASON: &str = "SourceStaged";
 /// `reason` for [`SOURCE_STAGED_CONDITION`] = `False` while the VolumeSnapshot is
 /// still becoming `readyToUse` (a transient, requeued wait — not a failure).
 pub const STAGING_WAITING_REASON: &str = "WaitingForVolumeSnapshot";
+/// `reason` for [`SOURCE_STAGED_CONDITION`] = `False` while the staged PVC (on an
+/// `Immediate`-binding StorageClass) is still binding — the CSI restore/clone from
+/// the source is provisioning. A transient, requeued wait bounded by the staging
+/// deadline; the terminal counterpart is `io::staging::REASON_STAGED_PVC_BIND_TIMEOUT`.
+pub const STAGED_PVC_BINDING_REASON: &str = "WaitingForStagedPvcBind";
 /// Event `action` (remediation hint) for a staging preflight failure: install the
 /// CSI snapshot stack / VolumeSnapshotClass, or set `copyMethod: Direct`.
 pub const FIX_SNAPSHOT_STACK_ACTION: &str = "InstallSnapshotStackOrUseDirect";

--- a/crates/controller/src/io/staging.rs
+++ b/crates/controller/src/io/staging.rs
@@ -35,7 +35,7 @@ use kube::api::{DeleteParams, ListParams, Patch, PatchParams};
 use kube::core::{ApiResource, DynamicObject, GroupVersionKind, ObjectMeta};
 use kube::{Api, ResourceExt};
 
-use kopiur_api::{CopyMethod, SnapshotPolicy};
+use kopiur_api::{CopyMethod, SnapshotPolicy, StagingSpec};
 
 use super::apply::{FIELD_MANAGER, apply};
 use super::child_labels;
@@ -79,6 +79,14 @@ pub struct StagedSource {
     pub volume_snapshot_name: Option<String>,
     /// The resolved capture method (`Snapshot`/`Clone`) — recorded to status.
     pub copy_method: &'static str,
+    /// StorageClass actually written to the staged PVC's spec — the
+    /// `spec.staging.storageClassName` override when set, else the source PVC's
+    /// class. Recorded to status so a shallow-clone setup is observable.
+    pub storage_class_name: Option<String>,
+    /// The resolved staging timeout in seconds (`0` = wait indefinitely), pinned
+    /// to status so the running-Job staged-PVC bind watchdog never re-resolves a
+    /// policy that may have been edited or deleted mid-run.
+    pub staging_timeout_seconds: i64,
 }
 
 /// What [`resolve_staging`] decided. The reconciler maps this to status/conditions/
@@ -89,12 +97,22 @@ pub enum StagingOutcome {
     NotApplicable,
     /// The stage is provisioned and ready; mount [`StagedSource::pvc_name`].
     Ready(StagedSource),
-    /// The VolumeSnapshot is not `readyToUse` yet — requeue (transient). The message is
-    /// for a `SourceStaged=False` / `Pending` condition. A `status.error` on the
-    /// VolumeSnapshot lands HERE (not `Failed`) while the staging deadline has not
-    /// passed: external-snapshotter sets it transiently (e.g. a benign 409-conflict
-    /// retry) and clears it on the next successful sync, so first sight is never fatal.
-    Waiting(String),
+    /// The stage is not usable yet — requeue (transient). Two waits share this
+    /// variant, distinguished by `reason` (both `SourceStaged=False` / `Pending`):
+    /// the VolumeSnapshot becoming `readyToUse`
+    /// ([`crate::consts::STAGING_WAITING_REASON`]) and the staged PVC binding on an
+    /// `Immediate` StorageClass ([`crate::consts::STAGED_PVC_BINDING_REASON`]). A
+    /// `status.error` on the VolumeSnapshot lands HERE (not `Failed`) while the
+    /// staging deadline has not passed: external-snapshotter sets it transiently
+    /// (e.g. a benign 409-conflict retry) and clears it on the next successful
+    /// sync, so first sight is never fatal.
+    Waiting {
+        /// kstatus condition reason (a stable PascalCase token) naming WHICH wait.
+        reason: &'static str,
+        /// Deterministic-per-object message (embeds the fixed deadline, never
+        /// `now()`), so steady-state reconciles don't churn status.
+        message: String,
+    },
     /// The stage cannot be produced (no snapshot stack / no class / source not
     /// CSI-provisioned / the VolumeSnapshot missed the staging deadline). The reconciler
     /// fails the Snapshot with this `reason` + actionable `message`. **Terminal** for
@@ -125,6 +143,26 @@ pub const REASON_STAGING_TIMEOUT: &str = "StagingTimedOut";
 /// Condition reason: the source PVC isn't CSI-provisioned (no StorageClass), so it
 /// can't be snapshotted/cloned.
 pub const REASON_SOURCE_NOT_CSI: &str = "SourceNotCSIProvisioned";
+/// Condition reason: `spec.staging.storageClassName` names a StorageClass that does
+/// not exist.
+pub const REASON_STAGED_CLASS_NOT_FOUND: &str = "StagedClassNotFound";
+/// Condition reason: `spec.staging.storageClassName` names a StorageClass whose
+/// provisioner differs from the source PVC's CSI driver — a VolumeSnapshot restore /
+/// volume clone can only be provisioned by the source's own driver, so the staged
+/// PVC would never bind. Caught up front instead of as an opaque bind timeout.
+pub const REASON_STAGED_CLASS_MISMATCH: &str = "StagedClassMismatch";
+/// Condition reason: the staged PVC did not reach `Bound` within the staging
+/// deadline (`spec.staging.timeout`) — the CSI restore/clone from the source is
+/// still provisioning (e.g. a CephFS full subvolume clone of a small-file-heavy
+/// volume) or the class cannot provision it at all. Pre-fix, this window fell
+/// under the generic 300 s wedged-pod deadline, whose cleanup deleted the
+/// VolumeSnapshot while the restore was still consuming it (the forgejo/CephFS
+/// hourly hard-fail).
+pub const REASON_STAGED_PVC_BIND_TIMEOUT: &str = "StagedPvcBindTimeout";
+/// Condition reason: the staged PVC reports phase `Lost` — its bound
+/// PersistentVolume disappeared. Terminal immediately (no point waiting out the
+/// bind deadline; the stage can never become usable).
+pub const REASON_STAGED_PVC_LOST: &str = "StagedPvcLost";
 
 /// Appended to every `StagingOutcome::Failed` message whose fix is "set copyMethod:
 /// Direct" — since `copyMethod` now *defaults* to `Snapshot` (as of this release), a user
@@ -400,8 +438,10 @@ pub fn staged_pvc_size(restore_size: Option<&str>, source_request: Option<&str>)
     }
 }
 
-/// Build the staged PVC: copies the source PVC's `accessModes`/`storageClassName`/
-/// `volumeMode`, sets `dataSource`, requests `max(restoreSize, source)` storage, and is
+/// Build the staged PVC: `accessModes`/`storageClassName` come from the
+/// `spec.staging` overrides when set, else are copied from the source PVC;
+/// `volumeMode` is always copied (the mover reads files — no override exists).
+/// Sets `dataSource`, requests `max(restoreSize, source)` storage, and is
 /// owner-referenced + managed-by labelled.
 pub fn build_staged_pvc(
     name: &str,
@@ -409,6 +449,7 @@ pub fn build_staged_pvc(
     source_pvc: &PersistentVolumeClaim,
     data_source: TypedLocalObjectReference,
     restore_size: Option<&str>,
+    staging: Option<&StagingSpec>,
     owner: k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference,
 ) -> PersistentVolumeClaim {
     let src = source_pvc.spec.clone().unwrap_or_default();
@@ -423,6 +464,18 @@ pub fn build_staged_pvc(
         requests: Some(BTreeMap::from([("storage".to_string(), Quantity(s))])),
         limits: None,
     });
+    let access_modes = staging
+        .filter(|s| !s.access_modes.is_empty())
+        .map(|s| {
+            s.access_modes
+                .iter()
+                .map(|m| m.mode_str().to_string())
+                .collect()
+        })
+        .or(src.access_modes);
+    let storage_class_name = staging
+        .and_then(|s| s.storage_class_name.clone())
+        .or(src.storage_class_name);
     PersistentVolumeClaim {
         metadata: ObjectMeta {
             name: Some(name.to_string()),
@@ -435,14 +488,55 @@ pub fn build_staged_pvc(
             ..Default::default()
         },
         spec: Some(PersistentVolumeClaimSpec {
-            access_modes: src.access_modes,
-            storage_class_name: src.storage_class_name,
+            access_modes,
+            storage_class_name,
             volume_mode: src.volume_mode,
             data_source: Some(data_source),
             resources,
             ..Default::default()
         }),
         status: None,
+    }
+}
+
+/// Preflight `spec.staging.storageClassName` against the source's CSI driver.
+/// **Pure** (the StorageClass read is the caller's): `override_provisioner` is the
+/// override class's `provisioner` (`None` = the class does not exist);
+/// `source_provisioner` is the source PVC's (`None` = unknown — e.g. a `Clone`
+/// source without a class — so the mismatch check is skipped). Without this, a
+/// wrong-driver override presents as an opaque bind timeout many minutes later:
+/// the override class's provisioner ignores a foreign VolumeSnapshotContent/PVC
+/// forever.
+pub(crate) fn staged_class_preflight(
+    override_class: &str,
+    override_provisioner: Option<&str>,
+    source_provisioner: Option<&str>,
+) -> Option<(&'static str, String)> {
+    let Some(op) = override_provisioner else {
+        return Some((
+            REASON_STAGED_CLASS_NOT_FOUND,
+            format!(
+                "spec.staging.storageClassName `{override_class}` does not exist; create it, \
+                 point the override at an existing StorageClass of the source's CSI driver, \
+                 or remove the override to stage on the source PVC's own class. This \
+                 Snapshot is terminal — the next scheduled run (or a new Snapshot) retries"
+            ),
+        ));
+    };
+    match source_provisioner {
+        Some(sp) if op != sp => Some((
+            REASON_STAGED_CLASS_MISMATCH,
+            format!(
+                "spec.staging.storageClassName `{override_class}` is provisioned by `{op}`, \
+                 but the source PVC's CSI driver is `{sp}` — a VolumeSnapshot restore or \
+                 volume clone can only be provisioned by the source's own driver, so the \
+                 staged PVC would never bind. Point the override at a class of driver \
+                 `{sp}` (e.g. a CephFS `backingSnapshot: \"true\"` class of the same \
+                 driver), or remove the override. This Snapshot is terminal — the next \
+                 scheduled run (or a new Snapshot) retries"
+            ),
+        )),
+        _ => None,
     }
 }
 
@@ -680,6 +774,229 @@ pub(crate) fn vs_wait_outcome(
     }
 }
 
+/// `StorageClass.volumeBindingMode` as staging cares about it. Unset ⇒ `Immediate`
+/// (the Kubernetes API default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum BindingMode {
+    /// The PVC binds (and the CSI restore/clone runs) at provision time — the bind
+    /// gate must wait for `Bound` before minting the mover Job.
+    Immediate,
+    /// Binding happens when the first consuming pod schedules — the pre-Job gate
+    /// skips the wait (the running-Job watchdog covers a hung bind instead).
+    WaitForFirstConsumer,
+}
+
+/// Classify a `StorageClass.volumeBindingMode` string; unset ⇒ `Immediate`.
+pub(crate) fn effective_binding_mode(volume_binding_mode: Option<&str>) -> BindingMode {
+    match volume_binding_mode {
+        Some("WaitForFirstConsumer") => BindingMode::WaitForFirstConsumer,
+        _ => BindingMode::Immediate,
+    }
+}
+
+/// One observation of the staged PVC's state, as read from the cluster. Plain data
+/// so [`pvc_bind_outcome`] — the decision over it — stays pure (mirrors
+/// [`VsObservation`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct StagedPvcObservation {
+    /// `status.phase` (`Pending`/`Bound`/`Lost`).
+    pub phase: Option<String>,
+    /// `metadata.creationTimestamp` — the bind-deadline anchor. Stable across the
+    /// idempotent SSA re-applies each reconcile performs.
+    pub created_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Extract a [`StagedPvcObservation`] from a read PVC (pure — shared by the
+/// pre-Job bind gate and the running-Job watchdog in the snapshot reconciler).
+pub(crate) fn staged_pvc_observation(pvc: &PersistentVolumeClaim) -> StagedPvcObservation {
+    StagedPvcObservation {
+        phase: pvc.status.as_ref().and_then(|s| s.phase.clone()),
+        created_at: pvc
+            .metadata
+            .creation_timestamp
+            .as_ref()
+            .and_then(|t| chrono::DateTime::<chrono::Utc>::from_timestamp(t.0.as_second(), 0)),
+    }
+}
+
+/// What [`pvc_bind_outcome`] decided about an observed staged PVC.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PvcBindWait {
+    /// `Bound` — the stage is usable. Overrides the deadline: an operator restart
+    /// after a slow-but-successful bind must not terminally fail a good stage.
+    Bound,
+    /// Still binding, deadline not passed — hold `Pending` and requeue.
+    Waiting(String),
+    /// Bind deadline passed (or the PVC is `Lost`) — terminal for this Snapshot CR.
+    Failed {
+        reason: &'static str,
+        message: String,
+    },
+}
+
+/// Render the class portion of a bind message: the known class name, or a neutral
+/// phrase when the staged PVC rides the source's/cluster-default class.
+fn bind_class_phrase(class: Option<&str>) -> String {
+    match class {
+        Some(c) => format!("StorageClass `{c}`"),
+        None => "its StorageClass".to_string(),
+    }
+}
+
+/// Decide the bind-wait outcome for one staged-PVC observation. Pure /
+/// clock-injected, mirroring [`vs_wait_outcome`] exactly: `Bound` is checked FIRST
+/// (ready wins over deadline), a missing `creationTimestamp` is never expired, the
+/// deadline is `created_at + timeout` (`timeout == None` ⇒ indefinite), and the
+/// Waiting message embeds the fixed RFC3339 deadline — deterministic per PVC, so
+/// `patch_status_if_changed` doesn't churn. `Lost` is terminal immediately: the
+/// bound PV vanished and no amount of waiting brings the stage back.
+pub(crate) fn pvc_bind_outcome(
+    obs: &StagedPvcObservation,
+    ns: &str,
+    pvc_name: &str,
+    class: Option<&str>,
+    timeout: Option<std::time::Duration>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> PvcBindWait {
+    match obs.phase.as_deref() {
+        Some("Bound") => return PvcBindWait::Bound,
+        Some("Lost") => {
+            return PvcBindWait::Failed {
+                reason: REASON_STAGED_PVC_LOST,
+                message: format!(
+                    "staged PVC `{ns}/{pvc_name}` reports phase Lost — its bound \
+                     PersistentVolume disappeared, so the stage can never become usable; \
+                     check the CSI driver / PV lifecycle. This Snapshot is terminal — the \
+                     next scheduled run (or a new Snapshot) retries"
+                ),
+            };
+        }
+        _ => {}
+    }
+    let deadline = match (timeout, obs.created_at) {
+        (Some(t), Some(created)) => chrono::Duration::from_std(t).ok().map(|d| created + d),
+        _ => None,
+    };
+    let expired = deadline.is_some_and(|d| now >= d);
+    if !expired {
+        let mut msg = format!(
+            "waiting for staged PVC `{ns}/{pvc_name}` ({}) to bind; the CSI restore/clone \
+             from the source is provisioning",
+            bind_class_phrase(class)
+        );
+        match deadline {
+            // Deterministic per-PVC (creationTimestamp + timeout are fixed), so the
+            // condition message doesn't churn status on every reconcile.
+            Some(d) => msg.push_str(&format!(
+                "; staging fails at {} if still unbound",
+                d.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
+            )),
+            None => msg.push_str("; waiting indefinitely (spec.staging.timeout: 0)"),
+        }
+        return PvcBindWait::Waiting(msg);
+    }
+    let waited = fmt_go_duration(timeout.expect("expired implies a timeout"));
+    PvcBindWait::Failed {
+        reason: REASON_STAGED_PVC_BIND_TIMEOUT,
+        message: format!(
+            "staged PVC `{ns}/{pvc_name}` did not reach Bound within {waited} \
+             (spec.staging.timeout; default 10m) — the CSI restore/clone from the source \
+             is still provisioning, or {} cannot provision it; check `kubectl describe \
+             pvc -n {ns} {pvc_name}` and the CSI provisioner logs, raise \
+             spec.staging.timeout if the copy is just slow, or (CephFS) stage on a \
+             `backingSnapshot: \"true\"` class via spec.staging.storageClassName for a \
+             near-instant shallow mount instead of a full clone. This Snapshot is \
+             terminal — the next scheduled run (or a new Snapshot) retries",
+            bind_class_phrase(class)
+        ),
+    }
+}
+
+/// The staged PVC's *effective* StorageClass name: what its spec pins, else the
+/// cluster's default-annotated class (what the PV controller will use), else
+/// `None` (nothing to look up — the bind gate then skips, preserving pre-gate
+/// behavior for classless setups).
+async fn effective_staged_class(
+    client: &kube::Client,
+    staged: &PersistentVolumeClaim,
+) -> Result<Option<String>> {
+    if let Some(c) = staged_class_of(staged) {
+        return Ok(Some(c));
+    }
+    let sc_api: Api<StorageClass> = Api::all(client.clone());
+    let classes = sc_api.list(&ListParams::default()).await?;
+    Ok(classes
+        .items
+        .into_iter()
+        .find(|sc| {
+            sc.metadata
+                .annotations
+                .as_ref()
+                .and_then(|a| a.get("storageclass.kubernetes.io/is-default-class"))
+                .is_some_and(|v| v == "true")
+        })
+        .and_then(|sc| sc.metadata.name))
+}
+
+/// Gate `Ready` on the staged PVC actually binding when its StorageClass binds
+/// `Immediate` (the CSI restore/clone runs at provision time — a mover Job minted
+/// now would sit Unschedulable on the unbound claim until the wedged-pod deadline
+/// killed the run *and the VolumeSnapshot under the in-flight restore*).
+/// `WaitForFirstConsumer` classes return immediately: their bind happens at pod
+/// schedule, and the running-Job watchdog covers a hang there. Returns `None` when
+/// the gate passes (mint the Job) or `Some(outcome)` to surface instead. A class
+/// that has vanished mid-flight is treated as `Immediate` (the API default), so a
+/// never-binding PVC becomes a bounded, actionable failure rather than a wedge.
+async fn staged_pvc_bind_gate(
+    client: &kube::Client,
+    pvc_api: &Api<PersistentVolumeClaim>,
+    ns: &str,
+    staged: &PersistentVolumeClaim,
+    pvc_name: &str,
+    timeout: Option<std::time::Duration>,
+) -> Result<Option<StagingOutcome>> {
+    let Some(class) = effective_staged_class(client, staged).await? else {
+        return Ok(None);
+    };
+    let sc_api: Api<StorageClass> = Api::all(client.clone());
+    let binding = sc_api
+        .get_opt(&class)
+        .await?
+        .map(|sc| effective_binding_mode(sc.volume_binding_mode.as_deref()))
+        .unwrap_or(BindingMode::Immediate);
+    match binding {
+        BindingMode::WaitForFirstConsumer => Ok(None),
+        BindingMode::Immediate => {
+            let outcome = match pvc_api.get_opt(pvc_name).await? {
+                // SSA create still propagating → requeue.
+                None => PvcBindWait::Waiting(format!(
+                    "waiting for staged PVC `{ns}/{pvc_name}` ({}) to bind; the CSI \
+                     restore/clone from the source is provisioning",
+                    bind_class_phrase(Some(&class))
+                )),
+                Some(pvc) => pvc_bind_outcome(
+                    &staged_pvc_observation(&pvc),
+                    ns,
+                    pvc_name,
+                    Some(&class),
+                    timeout,
+                    chrono::Utc::now(),
+                ),
+            };
+            Ok(match outcome {
+                PvcBindWait::Bound => None,
+                PvcBindWait::Waiting(message) => Some(StagingOutcome::Waiting {
+                    reason: crate::consts::STAGED_PVC_BINDING_REASON,
+                    message,
+                }),
+                PvcBindWait::Failed { reason, message } => {
+                    Some(StagingOutcome::Failed { reason, message })
+                }
+            })
+        }
+    }
+}
+
 /// Resolve staging for a backup. Performs the cluster IO (preflight, create
 /// VolumeSnapshot, wait `readyToUse`, create staged PVC) and returns a [`StagingOutcome`]
 /// — **no** status side effects (the reconciler maps the outcome). Idempotent: every
@@ -731,12 +1048,44 @@ pub async fn resolve_staging(
 
     let staged_pvc = staged_pvc_name(snapshot_cr);
     let vs_name = volume_snapshot_name(snapshot_cr);
+    let staging = policy.spec.staging.as_ref();
+
+    // The staging deadline budget — bounds the VolumeSnapshot readyToUse wait and
+    // the staged-PVC bind wait (each phase gets a fresh budget anchored at its
+    // object's creation), and is pinned to status for the running-Job watchdog.
+    let timeout = kopiur_api::resolve_timeout(
+        staging.and_then(|s| s.timeout.as_deref()),
+        crate::consts::DEFAULT_STAGING_TIMEOUT,
+    );
+    let staging_timeout_seconds = timeout.map(|d| d.as_secs() as i64).unwrap_or(0);
+
+    // Source provisioner (CSI driver): required for `Snapshot` class selection, and
+    // the reference for the staged-class preflight (both methods).
+    let provisioner = source_provisioner(client, &source_pvc).await?;
+
+    // Fail fast on a bad `spec.staging.storageClassName` — missing, or on a
+    // different driver than the source — instead of letting the staged PVC sit
+    // Pending until the bind deadline with no explanation.
+    if let Some(override_class) = staging.and_then(|s| s.storage_class_name.as_deref()) {
+        let sc_api: Api<StorageClass> = Api::all(client.clone());
+        let override_provisioner = sc_api
+            .get_opt(override_class)
+            .await?
+            .map(|sc| sc.provisioner);
+        if let Some((reason, message)) = staged_class_preflight(
+            override_class,
+            override_provisioner.as_deref(),
+            provisioner.as_deref(),
+        ) {
+            return Ok(StagingOutcome::Failed { reason, message });
+        }
+    }
 
     // `Snapshot` needs a VolumeSnapshotClass + a ready VolumeSnapshot; `Clone` stages
     // straight from the source PVC.
     if copy_method != CopyMethod::Clone {
         // Provisioner (CSI driver) of the source — required to match a class.
-        let Some(provisioner) = source_provisioner(client, &source_pvc).await? else {
+        let Some(provisioner) = provisioner else {
             return Ok(StagingOutcome::Failed {
                 reason: REASON_SOURCE_NOT_CSI,
                 message: source_not_csi_message(ns, source_name),
@@ -786,25 +1135,25 @@ pub async fn resolve_staging(
         // Wait for readyToUse, bounded by the staging deadline (issue #198): a
         // `status.error` alone is never fatal — external-snapshotter sets it during
         // benign retry loops — only the deadline fails staging.
-        let timeout = kopiur_api::resolve_timeout(
-            policy
-                .spec
-                .staging
-                .as_ref()
-                .and_then(|s| s.timeout.as_deref()),
-            crate::consts::DEFAULT_STAGING_TIMEOUT,
-        );
         let restore_size = match read_volume_snapshot(client, ns, &vs_name).await? {
             // Not visible yet (SSA create still propagating) → requeue.
             None => {
-                return Ok(StagingOutcome::Waiting(format!(
-                    "waiting for VolumeSnapshot `{ns}/{vs_name}` to become readyToUse"
-                )));
+                return Ok(StagingOutcome::Waiting {
+                    reason: crate::consts::STAGING_WAITING_REASON,
+                    message: format!(
+                        "waiting for VolumeSnapshot `{ns}/{vs_name}` to become readyToUse"
+                    ),
+                });
             }
             Some(obs) => {
                 match vs_wait_outcome(&obs, ns, &vs_name, &class, timeout, chrono::Utc::now()) {
                     VsWait::Ready { restore_size } => restore_size,
-                    VsWait::Waiting(msg) => return Ok(StagingOutcome::Waiting(msg)),
+                    VsWait::Waiting(message) => {
+                        return Ok(StagingOutcome::Waiting {
+                            reason: crate::consts::STAGING_WAITING_REASON,
+                            message,
+                        });
+                    }
                     VsWait::Failed { reason, message } => {
                         return Ok(StagingOutcome::Failed { reason, message });
                     }
@@ -819,13 +1168,23 @@ pub async fn resolve_staging(
             &source_pvc,
             data_source,
             restore_size.as_deref(),
+            staging,
             owner.clone(),
         );
         apply(&pvc_api, &staged_pvc, &staged).await?;
+        // Gate on the bind for Immediate classes: minting the Job while the CSI
+        // restore is in flight is exactly the wedge-then-delete-the-VS race.
+        if let Some(outcome) =
+            staged_pvc_bind_gate(client, &pvc_api, ns, &staged, &staged_pvc, timeout).await?
+        {
+            return Ok(outcome);
+        }
         return Ok(StagingOutcome::Ready(StagedSource {
+            storage_class_name: staged_class_of(&staged),
             pvc_name: staged_pvc,
             volume_snapshot_name: Some(vs_name),
             copy_method: "Snapshot",
+            staging_timeout_seconds,
         }));
     }
 
@@ -837,14 +1196,34 @@ pub async fn resolve_staging(
         &source_pvc,
         data_source,
         None,
+        staging,
         owner.clone(),
     );
     apply(&pvc_api, &staged_pvc, &staged).await?;
+    // Same bind gate as the Snapshot tail — a CSI full clone is the SLOWEST staging
+    // method there is, so skipping the gate here would reproduce the original bug
+    // verbatim for `copyMethod: Clone`.
+    if let Some(outcome) =
+        staged_pvc_bind_gate(client, &pvc_api, ns, &staged, &staged_pvc, timeout).await?
+    {
+        return Ok(outcome);
+    }
     Ok(StagingOutcome::Ready(StagedSource {
+        storage_class_name: staged_class_of(&staged),
         pvc_name: staged_pvc,
         volume_snapshot_name: None,
         copy_method: "Clone",
+        staging_timeout_seconds,
     }))
+}
+
+/// The `storageClassName` actually written to a built staged PVC's spec — the single
+/// source for what `status.staged.storageClassName` records.
+fn staged_class_of(staged: &PersistentVolumeClaim) -> Option<String> {
+    staged
+        .spec
+        .as_ref()
+        .and_then(|s| s.storage_class_name.clone())
 }
 
 /// Reap the staged objects a backup created (idempotent; 404-tolerant). Deletes the
@@ -1076,7 +1455,8 @@ mod tests {
         };
         let ds = data_source_for(CopyMethod::Snapshot, "src", "vs");
         let owner = k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference::default();
-        let staged = build_staged_pvc("db-src", "ns", &source, ds, Some("0"), owner);
+        // Regression pin: no staging overrides ⇒ the source's shape is copied verbatim.
+        let staged = build_staged_pvc("db-src", "ns", &source, ds, Some("0"), None, owner);
         let spec = staged.spec.unwrap();
         assert_eq!(
             spec.access_modes.as_deref(),
@@ -1098,6 +1478,137 @@ mod tests {
         let ds = spec.data_source.unwrap();
         assert_eq!(ds.kind, "VolumeSnapshot");
         assert_eq!(ds.name, "vs");
+    }
+
+    /// A source PVC with the common `fast`/RWO/Filesystem shape, for the override tests.
+    fn override_test_source() -> PersistentVolumeClaim {
+        PersistentVolumeClaim {
+            spec: Some(PersistentVolumeClaimSpec {
+                access_modes: Some(vec!["ReadWriteOnce".into()]),
+                storage_class_name: Some("fast".into()),
+                volume_mode: Some("Filesystem".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn staged_pvc_honors_staging_overrides() {
+        use kopiur_api::common::PvcAccessMode;
+        let owner = k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference::default();
+        let source = override_test_source();
+
+        // Both overrides set — the CephFS shallow-clone recipe.
+        let staging = StagingSpec {
+            storage_class_name: Some("cephfs-shallow".into()),
+            access_modes: vec![PvcAccessMode::ReadOnlyMany],
+            ..Default::default()
+        };
+        let ds = data_source_for(CopyMethod::Snapshot, "src", "vs");
+        let staged = build_staged_pvc("db-src", "ns", &source, ds, None, Some(&staging), owner);
+        let spec = staged.spec.as_ref().unwrap();
+        assert_eq!(spec.storage_class_name.as_deref(), Some("cephfs-shallow"));
+        assert_eq!(
+            spec.access_modes.as_deref(),
+            Some(["ReadOnlyMany".to_string()].as_slice())
+        );
+        // volumeMode has no override — always copied from the source.
+        assert_eq!(spec.volume_mode.as_deref(), Some("Filesystem"));
+        // `staged_class_of` (the status.staged.storageClassName source) sees the override.
+        assert_eq!(staged_class_of(&staged).as_deref(), Some("cephfs-shallow"));
+    }
+
+    #[test]
+    fn staged_pvc_overrides_are_independent_and_empty_modes_inherit() {
+        use kopiur_api::common::PvcAccessMode;
+        let owner = k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference::default();
+        let source = override_test_source();
+
+        // Class-only override: modes still inherited.
+        let staging = StagingSpec {
+            storage_class_name: Some("cephfs-shallow".into()),
+            ..Default::default()
+        };
+        let ds = data_source_for(CopyMethod::Clone, "src", "vs");
+        let staged = build_staged_pvc(
+            "db-src",
+            "ns",
+            &source,
+            ds,
+            None,
+            Some(&staging),
+            owner.clone(),
+        );
+        let spec = staged.spec.as_ref().unwrap();
+        assert_eq!(spec.storage_class_name.as_deref(), Some("cephfs-shallow"));
+        assert_eq!(
+            spec.access_modes.as_deref(),
+            Some(["ReadWriteOnce".to_string()].as_slice()),
+            "unset accessModes must inherit the source's"
+        );
+
+        // Modes-only override: class still inherited. An empty modes vec = no override.
+        let staging = StagingSpec {
+            access_modes: vec![PvcAccessMode::ReadOnlyMany],
+            ..Default::default()
+        };
+        let ds = data_source_for(CopyMethod::Clone, "src", "vs");
+        let staged = build_staged_pvc("db-src", "ns", &source, ds, None, Some(&staging), owner);
+        let spec = staged.spec.as_ref().unwrap();
+        assert_eq!(
+            spec.storage_class_name.as_deref(),
+            Some("fast"),
+            "unset storageClassName must inherit the source's"
+        );
+        assert_eq!(
+            spec.access_modes.as_deref(),
+            Some(["ReadOnlyMany".to_string()].as_slice())
+        );
+    }
+
+    // --- staged_class_preflight: fail fast on a missing / wrong-driver override ---
+
+    #[test]
+    fn staged_class_preflight_passes_matching_and_unknown_source_driver() {
+        // Same driver → no complaint.
+        assert_eq!(
+            staged_class_preflight(
+                "cephfs-shallow",
+                Some("cephfs.csi.ceph.com"),
+                Some("cephfs.csi.ceph.com")
+            ),
+            None
+        );
+        // Unknown source driver (e.g. Clone from a classless PVC) → can't compare,
+        // don't block; a real mismatch then surfaces at the bind deadline.
+        assert_eq!(
+            staged_class_preflight("cephfs-shallow", Some("cephfs.csi.ceph.com"), None),
+            None
+        );
+    }
+
+    #[test]
+    fn staged_class_preflight_rejects_missing_class_and_wrong_driver() {
+        let (reason, msg) =
+            staged_class_preflight("nope", None, Some("cephfs.csi.ceph.com")).unwrap();
+        assert_eq!(reason, REASON_STAGED_CLASS_NOT_FOUND);
+        assert!(msg.contains("`nope`"), "{msg}");
+        assert!(msg.contains("does not exist"), "{msg}");
+
+        let (reason, msg) = staged_class_preflight(
+            "ebs-class",
+            Some("ebs.csi.aws.com"),
+            Some("cephfs.csi.ceph.com"),
+        )
+        .unwrap();
+        assert_eq!(reason, REASON_STAGED_CLASS_MISMATCH);
+        assert!(msg.contains("ebs.csi.aws.com"), "{msg}");
+        assert!(msg.contains("cephfs.csi.ceph.com"), "{msg}");
+        assert!(
+            msg.contains("would never bind"),
+            "the why must be spelled out: {msg}"
+        );
     }
 
     // --- cleanup_plan ---
@@ -1345,5 +1856,152 @@ mod tests {
         let owner = k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference::default();
         let vs2 = build_volume_snapshot("db-snap", "ns", "db", None, owner);
         assert!(vs2.data["spec"].get("volumeSnapshotClassName").is_none());
+    }
+
+    // --- effective_binding_mode: unset ⇒ Immediate (the k8s API default) ---
+
+    #[test]
+    fn binding_mode_defaults_to_immediate() {
+        assert_eq!(effective_binding_mode(None), BindingMode::Immediate);
+        assert_eq!(
+            effective_binding_mode(Some("Immediate")),
+            BindingMode::Immediate
+        );
+        assert_eq!(
+            effective_binding_mode(Some("WaitForFirstConsumer")),
+            BindingMode::WaitForFirstConsumer
+        );
+    }
+
+    // --- pvc_bind_outcome: mirrors the vs_wait_outcome decision matrix ---
+
+    fn pvc_obs(phase: Option<&str>, age: Option<std::time::Duration>) -> StagedPvcObservation {
+        StagedPvcObservation {
+            phase: phase.map(str::to_string),
+            created_at: age.map(|a| t0() - chrono::Duration::from_std(a).unwrap()),
+        }
+    }
+
+    fn bind_decide(o: &StagedPvcObservation, timeout: Option<std::time::Duration>) -> PvcBindWait {
+        pvc_bind_outcome(
+            o,
+            "selfhosted",
+            "forgejo-src",
+            Some("cephfs"),
+            timeout,
+            t0(),
+        )
+    }
+
+    #[test]
+    fn bound_wins_even_past_the_deadline() {
+        // Operator down while a slow bind completed: a Bound PVC is a usable stage,
+        // never a terminal failure (mirrors vs_wait_outcome's ready-first rule).
+        let o = pvc_obs(Some("Bound"), Some(std::time::Duration::from_secs(3600)));
+        assert_eq!(bind_decide(&o, TEN_MIN), PvcBindWait::Bound);
+    }
+
+    #[test]
+    fn pending_within_deadline_waits_with_the_fixed_deadline_named() {
+        let o = pvc_obs(Some("Pending"), Some(std::time::Duration::from_secs(1)));
+        match bind_decide(&o, TEN_MIN) {
+            PvcBindWait::Waiting(msg) => {
+                assert!(msg.contains("selfhosted/forgejo-src"), "{msg}");
+                assert!(msg.contains("StorageClass `cephfs`"), "{msg}");
+                assert!(
+                    msg.contains("staging fails at 2026-07-04T18:39:59Z"),
+                    "deterministic deadline (no now()) so status doesn't churn: {msg}"
+                );
+            }
+            other => panic!("a fresh Pending PVC must be Waiting, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pending_past_deadline_fails_with_the_knob_and_the_shallow_clone_fix() {
+        // THE forgejo/CephFS scenario: an 8.5-minute full subvolume clone with a
+        // bounded budget must become an actionable terminal failure — not a
+        // MoverPodWedged that deletes the VolumeSnapshot mid-restore.
+        let o = pvc_obs(Some("Pending"), Some(std::time::Duration::from_secs(600)));
+        match bind_decide(&o, TEN_MIN) {
+            PvcBindWait::Failed { reason, message } => {
+                assert_eq!(reason, REASON_STAGED_PVC_BIND_TIMEOUT);
+                assert!(message.contains("within 10m"), "{message}");
+                assert!(message.contains("spec.staging.timeout"), "{message}");
+                assert!(
+                    message.contains("backingSnapshot") && message.contains("storageClassName"),
+                    "the CephFS shallow-clone fix must be named: {message}"
+                );
+                assert!(
+                    message.contains("next scheduled run (or a new Snapshot) retries"),
+                    "{message}"
+                );
+            }
+            other => panic!("expected Failed at the deadline, got {other:?}"),
+        }
+        // One second earlier: still waiting.
+        let o = pvc_obs(Some("Pending"), Some(std::time::Duration::from_secs(599)));
+        assert!(matches!(bind_decide(&o, TEN_MIN), PvcBindWait::Waiting(_)));
+    }
+
+    #[test]
+    fn lost_pvc_is_terminal_immediately() {
+        // No point waiting out the deadline: the bound PV vanished, the stage can
+        // never recover.
+        let o = pvc_obs(Some("Lost"), Some(std::time::Duration::from_secs(1)));
+        match bind_decide(&o, TEN_MIN) {
+            PvcBindWait::Failed { reason, message } => {
+                assert_eq!(reason, REASON_STAGED_PVC_LOST);
+                assert!(message.contains("Lost"), "{message}");
+            }
+            other => panic!("Lost must be terminal on sight, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_creation_timestamp_and_zero_timeout_never_expire() {
+        // Just-created / not-yet-persisted read: no anchor, not expired.
+        let o = pvc_obs(Some("Pending"), None);
+        assert!(matches!(bind_decide(&o, TEN_MIN), PvcBindWait::Waiting(_)));
+        // spec.staging.timeout: 0 → indefinite, message says so.
+        let o = pvc_obs(
+            Some("Pending"),
+            Some(std::time::Duration::from_secs(86_400)),
+        );
+        match bind_decide(&o, None) {
+            PvcBindWait::Waiting(msg) => {
+                assert!(msg.contains("waiting indefinitely"), "{msg}");
+            }
+            other => panic!("no timeout must wait forever, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn bind_message_without_a_known_class_stays_readable() {
+        let o = pvc_obs(Some("Pending"), Some(std::time::Duration::from_secs(1)));
+        match pvc_bind_outcome(&o, "ns", "db-src", None, TEN_MIN, t0()) {
+            PvcBindWait::Waiting(msg) => {
+                assert!(msg.contains("its StorageClass"), "{msg}");
+            }
+            other => panic!("expected Waiting, got {other:?}"),
+        }
+    }
+
+    // --- staged_pvc_observation extraction ---
+
+    #[test]
+    fn staged_pvc_observation_reads_phase_and_creation() {
+        use k8s_openapi::api::core::v1::PersistentVolumeClaimStatus;
+        let pvc = PersistentVolumeClaim {
+            status: Some(PersistentVolumeClaimStatus {
+                phase: Some("Pending".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let obs = staged_pvc_observation(&pvc);
+        assert_eq!(obs.phase.as_deref(), Some("Pending"));
+        // No creationTimestamp on a fresh object → no deadline anchor.
+        assert_eq!(obs.created_at, None);
     }
 }

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -1792,10 +1792,16 @@ async fn ensure_restore_target_pvc(
             template.name
         ))
     })?;
-    let access_modes = if template.access_modes.is_empty() {
+    // `Unknown` (legacy stored) modes never reach here: `validate_restore` runs at
+    // reconcile entry and rejects them per-CR with the value quoted.
+    let access_modes: Vec<String> = if template.access_modes.is_empty() {
         vec!["ReadWriteOnce".to_string()]
     } else {
-        template.access_modes.clone()
+        template
+            .access_modes
+            .iter()
+            .map(|m| m.mode_str().to_string())
+            .collect()
     };
     let pvc: PersistentVolumeClaim = serde_json::from_value(serde_json::json!({
         "apiVersion": "v1",

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -39,7 +39,7 @@ use crate::consts::{
     HOOKS_SUCCEEDED_CONDITION, MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION, ORIGIN_LABEL,
     PRIVILEGED_MOVER_NOT_PERMITTED_REASON, SECURITY_CONTEXT_COMPATIBLE_CONDITION,
     SECURITY_CONTEXT_COMPATIBLE_REASON, SNAPSHOT_CLEANUP_FINALIZER, SNAPSHOT_INCOMPLETE_REASON,
-    SOURCE_STAGED_CONDITION, SOURCE_STAGED_REASON, STAGING_WAITING_REASON,
+    SOURCE_STAGED_CONDITION, SOURCE_STAGED_REASON,
 };
 use crate::context::Context;
 use crate::error::{Error, Result, error_policy_for};
@@ -277,6 +277,29 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
                 }
             }
+            // Reap any CSI staging objects the run created. The primary reap runs
+            // at the Failed transition itself (the wedge / staging-failure /
+            // Job-failed arms), but a transient API error there — or a crash
+            // between the phase patch and the cleanup — would otherwise leak the
+            // VolumeSnapshot (holding a backend snapshot) until the CR is deleted,
+            // because nothing else re-enters cleanup for a Failed Snapshot. This
+            // mirrors the Succeeded steady-state reap: gated on the Job being
+            // terminal-or-gone (#103 — reaping under an Active Job strands an
+            // unschedulable replacement pod), idempotent no-op once the objects
+            // are gone.
+            if backup
+                .status
+                .as_ref()
+                .and_then(|s| s.staged.as_ref())
+                .is_some()
+            {
+                let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &namespace);
+                let job = job_api.get_opt(&name).await?;
+                if !staged_teardown_ready(job.as_ref()) {
+                    return Ok(Action::requeue(Duration::from_secs(15)));
+                }
+                io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
+            }
             return Ok(Action::await_change());
         }
         RunDecision::Wait => return Ok(Action::await_change()),
@@ -395,6 +418,38 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 return Ok(Action::requeue(Duration::from_secs(120)));
             }
             None => {
+                // Staged-PVC bind watchdog, FIRST: on a WaitForFirstConsumer class the
+                // CSI restore/clone only starts when the mover pod schedules, so a slow
+                // or hung bind leaves the pod Pending on a Pending claim. While the PVC
+                // is provisioning the pod cannot be "wedged" — judging it so at the
+                // 300 s pod-startup deadline and reaping the VolumeSnapshot mid-restore
+                // was the forgejo/CephFS hourly hard-fail. Bound by the staging budget
+                // PINNED at stamp time (the policy may be edited/deleted mid-run), it
+                // fails with the same actionable reason as the pre-Job bind gate.
+                match staged_pvc_watchdog(backup, ctx, &namespace).await? {
+                    StagedPvcWatch::Provisioning => {
+                        return Ok(Action::requeue(Duration::from_secs(30)));
+                    }
+                    StagedPvcWatch::Expired { reason, message } => {
+                        io::patch_status(
+                            &api,
+                            &name,
+                            snapshot_ready_status(backup, SnapshotPhase::Failed, reason, &message),
+                        )
+                        .await?;
+                        ctx.metrics.inc_snapshot_completed(
+                            "failed",
+                            &namespace,
+                            backup_policy(backup),
+                        );
+                        // Stop the kubelet's retry loop, then reap the staged objects
+                        // (PVC before VS — the delete order that is safe mid-restore).
+                        let _ = job_api.delete(&name, &DeleteParams::background()).await;
+                        io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
+                        return Ok(Action::requeue(Duration::from_secs(120)));
+                    }
+                    StagedPvcWatch::Clear => {}
+                }
                 // A wedged pod (impossible securityContext, missing image, Unschedulable)
                 // never reaches a terminal phase, so `backoffLimit` never trips and only
                 // the long `activeDeadlineSeconds` backstop would ever stop it — meanwhile
@@ -1060,17 +1115,26 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                         "volumeSnapshotName": staged.volume_snapshot_name,
                         "pvcName": staged.pvc_name,
                         "ready": true,
+                        "storageClassName": staged.storage_class_name,
+                        "stagingTimeoutSeconds": staged.staging_timeout_seconds,
                     },
                 }),
             )
             .await?;
             Some(staged.pvc_name)
         }
-        io::StagingOutcome::Waiting(msg) => {
-            // The VolumeSnapshot isn't readyToUse yet — a normal, transient wait.
-            // The message may carry the VolumeSnapshot's (possibly transient)
-            // `status.error` as diagnostic context; that is NOT a failure — see
-            // `StagingOutcome::Failed` for the deadline that is (issue #198).
+        io::StagingOutcome::Waiting {
+            reason,
+            message: msg,
+        } => {
+            // The stage isn't usable yet — a normal, transient wait. Two flavors,
+            // named by the carried `reason`: the VolumeSnapshot becoming readyToUse
+            // (`WaitingForVolumeSnapshot`) and the staged PVC binding on an
+            // Immediate class (`WaitingForStagedPvcBind` — the CSI restore/clone is
+            // provisioning). The message may carry the VolumeSnapshot's (possibly
+            // transient) `status.error` as diagnostic context; that is NOT a
+            // failure — see `StagingOutcome::Failed` for the deadline that is
+            // (issue #198).
             let existing = backup
                 .status
                 .as_ref()
@@ -1080,7 +1144,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 &existing,
                 SOURCE_STAGED_CONDITION,
                 false,
-                STAGING_WAITING_REASON,
+                reason,
                 &msg,
                 backup.meta().generation,
             );
@@ -1107,7 +1171,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             // `Ok(await_change)` — deliberately NOT an `Error::Validation`, whose
             // generic `InvalidSpec` event would tell the user to fix a spec that
             // isn't broken.
-            let status = snapshot_ready_status_with_condition(
+            let mut status = snapshot_ready_status_with_condition(
                 backup,
                 SnapshotPhase::Failed,
                 reason,
@@ -1115,6 +1179,31 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 SOURCE_STAGED_CONDITION,
                 false,
             );
+            // Stamp the staged block (deterministic names, `ready: false`) even on
+            // failure: every cleanup site is gated on `status.staged.is_some()`,
+            // and without this stamp a staging-phase failure left an
+            // already-created VolumeSnapshot (applied BEFORE the readyToUse
+            // deadline is evaluated) holding a backend snapshot until CR deletion.
+            let staging_timeout_seconds = kopiur_api::resolve_timeout(
+                config
+                    .spec
+                    .staging
+                    .as_ref()
+                    .and_then(|s| s.timeout.as_deref()),
+                crate::consts::DEFAULT_STAGING_TIMEOUT,
+            )
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+            status["staged"] = serde_json::json!({
+                "copyMethod": format!("{:?}", config.spec.copy_method),
+                // Clone never creates a VolumeSnapshot — don't record a name that
+                // could never exist.
+                "volumeSnapshotName": (config.spec.copy_method != kopiur_api::CopyMethod::Clone)
+                    .then(|| io::volume_snapshot_name(&name)),
+                "pvcName": io::staged_pvc_name(&name),
+                "ready": false,
+                "stagingTimeoutSeconds": staging_timeout_seconds,
+            });
             let current = serde_json::to_value(&backup.status).ok();
             let wrote = io::patch_status_if_changed(&api, &name, current.as_ref(), status).await?;
             if wrote {
@@ -1137,6 +1226,12 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
                 ctx.metrics
                     .inc_snapshot_completed("failed", &namespace, backup_policy(backup));
             }
+            // Reap whatever staging already created, NOW (idempotent, 404-tolerant,
+            // PVC-before-VS — the snapshot-controller's as-source-protection
+            // finalizer drains an in-flight restore safely). The stamped `staged`
+            // block also lets the terminal-path gates re-issue this on any later
+            // reconcile, covering a crash between the patch above and this call.
+            io::cleanup_staged_source(&ctx.client, &namespace, &name).await?;
             return Ok(Action::await_change());
         }
     };
@@ -2443,6 +2538,78 @@ fn staged_teardown_ready(job: Option<&Job>) -> bool {
     match job {
         None => true,
         Some(j) => job_terminal_state(j).is_some(),
+    }
+}
+
+/// What the running-Job staged-PVC bind watchdog observed.
+enum StagedPvcWatch {
+    /// No staged source, or the staged PVC is Bound/absent — proceed to the
+    /// normal wedged-pod check.
+    Clear,
+    /// The staged PVC is still Pending within the pinned staging budget — the
+    /// mover pod cannot start yet and is NOT wedged; just requeue.
+    Provisioning,
+    /// The staged PVC is unbound past the pinned budget (or `Lost`) — terminal,
+    /// with the same reason/message family as the pre-Job bind gate.
+    Expired {
+        reason: &'static str,
+        message: String,
+    },
+}
+
+/// IO half of the staged-PVC bind watchdog: read the staged PVC named in
+/// `status.staged` and run it through the same pure [`io::pvc_bind_outcome`]
+/// decision the pre-Job gate uses — the PVC's own `status.phase` is ground truth,
+/// version-independent, where scheduler `Unschedulable`/`SchedulerError` message
+/// text is not. The budget is `status.staged.stagingTimeoutSeconds` (pinned at
+/// stamp time — never re-resolved from a policy that may have been edited or
+/// deleted mid-run); a legacy stamp without the field gets the default budget
+/// rather than an indefinite wait.
+async fn staged_pvc_watchdog(
+    backup: &Snapshot,
+    ctx: &Context,
+    namespace: &str,
+) -> Result<StagedPvcWatch> {
+    let Some(staged) = backup.status.as_ref().and_then(|s| s.staged.as_ref()) else {
+        return Ok(StagedPvcWatch::Clear);
+    };
+    let Some(pvc_name) = staged.pvc_name.as_deref() else {
+        return Ok(StagedPvcWatch::Clear);
+    };
+    let pvc_api: Api<k8s_openapi::api::core::v1::PersistentVolumeClaim> =
+        Api::namespaced(ctx.client.clone(), namespace);
+    // A missing staged PVC is not this watchdog's problem (already reaped, or a
+    // race with cleanup) — the wedge check / terminal paths handle the rest.
+    let Some(pvc) = pvc_api.get_opt(pvc_name).await? else {
+        return Ok(StagedPvcWatch::Clear);
+    };
+    let timeout = staged_watchdog_budget(staged.staging_timeout_seconds);
+    Ok(
+        match io::pvc_bind_outcome(
+            &io::staged_pvc_observation(&pvc),
+            namespace,
+            pvc_name,
+            staged.storage_class_name.as_deref(),
+            timeout,
+            chrono::Utc::now(),
+        ) {
+            io::PvcBindWait::Bound => StagedPvcWatch::Clear,
+            io::PvcBindWait::Waiting(_) => StagedPvcWatch::Provisioning,
+            io::PvcBindWait::Failed { reason, message } => {
+                StagedPvcWatch::Expired { reason, message }
+            }
+        },
+    )
+}
+
+/// The watchdog's bind budget from the pinned `status.staged.stagingTimeoutSeconds`:
+/// `0` = the user's explicit "wait indefinitely"; absent (a stamp from before the
+/// field existed) = the default staging budget, never an accidental infinite wait.
+fn staged_watchdog_budget(pinned_seconds: Option<i64>) -> Option<std::time::Duration> {
+    match pinned_seconds {
+        Some(0) => None,
+        Some(s) if s > 0 => Some(std::time::Duration::from_secs(s as u64)),
+        _ => Some(crate::consts::DEFAULT_STAGING_TIMEOUT),
     }
 }
 

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -1018,3 +1018,26 @@ fn pin_job_target_reads_the_direction_annotation() {
     )]));
     assert_eq!(pin_job_target(&job), None, "unparseable = unattributable");
 }
+
+// --- staged_watchdog_budget: the pinned bind budget's three states ---
+
+#[test]
+fn staged_watchdog_budget_pins_zero_absent_and_positive() {
+    // Explicit 0 = the user's "wait indefinitely".
+    assert_eq!(staged_watchdog_budget(Some(0)), None);
+    // A positive pin is used verbatim.
+    assert_eq!(
+        staged_watchdog_budget(Some(90)),
+        Some(std::time::Duration::from_secs(90))
+    );
+    // A legacy stamp without the field (or a nonsense negative) gets the default
+    // budget — never an accidental infinite wait.
+    assert_eq!(
+        staged_watchdog_budget(None),
+        Some(crate::consts::DEFAULT_STAGING_TIMEOUT)
+    );
+    assert_eq!(
+        staged_watchdog_budget(Some(-5)),
+        Some(crate::consts::DEFAULT_STAGING_TIMEOUT)
+    );
+}

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth staging-recover staging-timeout; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth staging-recover staging-timeout staging-override staging-mismatch; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -80,6 +80,8 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "idxhealth",
     "staging-recover",
     "staging-timeout",
+    "staging-override",
+    "staging-mismatch",
 ];
 /// The in-pod mount path for an isolated per-scenario repo: the PVC root is mounted
 /// here and `kopia --path` points here, so the kopia repo IS this dir (one repo per

--- a/crates/e2e/tests/staging_deadline.rs
+++ b/crates/e2e/tests/staging_deadline.rs
@@ -512,5 +512,30 @@ async fn timeout_body(client: &kube::Client, prefix: &str) -> anyhow::Result<()>
              ({invalid_spec} found) — there is no spec problem to fix"
         );
     }
+
+    // Leak regression: a staging-phase failure must REAP the VolumeSnapshot it
+    // already created (the VS is applied BEFORE the readyToUse deadline is
+    // evaluated). Pre-fix code never stamped `status.staged` on a staging failure,
+    // so every `status.staged.is_some()` cleanup gate skipped and the VS held a
+    // backend snapshot until the CR itself was deleted.
+    wait_until(
+        "failed staging's VolumeSnapshot reaped",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(vs_api.get_opt(&vs_name).await?.is_none().then_some(())) },
+    )
+    .await
+    .context("the VolumeSnapshot of a staging-failed backup must be cleaned up")?;
+    // And `status.staged` records the failed stage (`ready: false`) — the gate the
+    // terminal-path cleanups key on.
+    let staged = status_json(&backups, prefix)
+        .await
+        .get("staged")
+        .cloned()
+        .unwrap_or_default();
+    ensure!(
+        staged.get("ready").and_then(|v| v.as_bool()) == Some(false),
+        "status.staged must be stamped (ready: false) on a staging failure: {staged}"
+    );
     Ok(())
 }

--- a/crates/e2e/tests/staging_overrides.rs
+++ b/crates/e2e/tests/staging_overrides.rs
@@ -1,0 +1,456 @@
+//! e2e: staged-PVC overrides (`spec.staging.storageClassName` / `accessModes`) and
+//! the staging safeguards around them (the CephFS-shallow-clone feature, GitHub
+//! issue: forgejo hourly hard-fail).
+//!
+//! 1. **Override happy path + Immediate bind gate**: a policy pointing staging at a
+//!    runtime-created StorageClass (same provisioner as `csi-hostpath-sc`, but
+//!    `volumeBindingMode: Immediate`) must produce a staged PVC carrying BOTH
+//!    overrides, wait for it to bind (the new pre-Job bind gate — pre-fix code
+//!    minted the mover Job against the unbound claim), back up successfully with a
+//!    real `kopiaSnapshotID`, record the class in `status.staged`, and reap the
+//!    stage. In kind this is the closest analogue to a real CephFS
+//!    `backingSnapshot: "true"` setup, which needs rook-ceph and is not locally
+//!    testable — the unit tests on `build_staged_pvc`/`pvc_bind_outcome` plus this
+//!    scenario cover the mechanism.
+//! 2. **Same-driver preflight fast fail**: an override class on a different
+//!    (nonexistent) provisioner must fail the Snapshot terminally with
+//!    `StagedClassMismatch` BEFORE creating any VolumeSnapshot, staged PVC, or
+//!    mover Job — pre-fix shape of this misconfig was a mover pod judged
+//!    `MoverPodWedged` at 300 s whose cleanup deleted the VolumeSnapshot while the
+//!    CSI restore still consumed it.
+//!
+//! Requires the CSI snapshot stack (`mise run //crates/e2e:snapshot-stack`) like
+//! `copy_methods.rs`. Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; skips
+//! gracefully without a cluster.
+
+#![cfg(all(unix, feature = "e2e"))]
+
+mod common;
+use common::*;
+
+use kube::Api;
+use kube::api::{DeleteParams, PostParams};
+use kube::core::{ApiResource, DynamicObject, GroupVersionKind, ObjectMeta};
+
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
+use k8s_openapi::api::storage::v1::StorageClass;
+use kopiur_api::{Repository, Snapshot, SnapshotPolicy};
+use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wait_until};
+
+/// The storage class the `snapshot-stack` mise task installs (WaitForFirstConsumer).
+const CSI_STORAGE_CLASS: &str = "csi-hostpath-sc";
+/// Runtime-created override class: hostpath provisioner, but Immediate binding —
+/// exercises the pre-Job bind gate's Bound→Ready path.
+const IMMEDIATE_SC: &str = "e2e-ovr-immediate";
+/// Runtime-created wrong-driver class for the preflight fast-fail scenario.
+const ALIEN_SC: &str = "e2e-ovr-alien";
+const ALIEN_PROVISIONER: &str = "example.com/no-such-driver";
+
+fn volume_snapshots(client: &kube::Client) -> Api<DynamicObject> {
+    let ar = ApiResource::from_gvk_with_plural(
+        &GroupVersionKind::gvk("snapshot.storage.k8s.io", "v1", "VolumeSnapshot"),
+        "volumesnapshots",
+    );
+    Api::namespaced_with(client.clone(), E2E_NAMESPACE, &ar)
+}
+
+/// The snapshot stack must be installed (hard requirement, mirrors
+/// `copy_methods.rs`); returns the hostpath driver's provisioner for building the
+/// Immediate override class.
+async fn require_snapshot_stack(client: &kube::Client) -> String {
+    let scs: Api<StorageClass> = Api::all(client.clone());
+    let base = scs
+        .get_opt(CSI_STORAGE_CLASS)
+        .await
+        .expect("list storageclasses");
+    let Some(base) = base else {
+        panic!(
+            "storageclass {CSI_STORAGE_CLASS} not found — run `mise run \
+             //crates/e2e:snapshot-stack` (or set KOPIUR_E2E_SKIP_SNAPSHOT_STACK=1 only \
+             for shards excluding this file)"
+        );
+    };
+    base.provisioner
+}
+
+/// Create a StorageClass idempotently (409 = a previous run left it; fine — the
+/// spec is deterministic).
+async fn ensure_storage_class(
+    client: &kube::Client,
+    name: &str,
+    provisioner: &str,
+    binding_mode: &str,
+) {
+    let scs: Api<StorageClass> = Api::all(client.clone());
+    let sc = StorageClass {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            ..Default::default()
+        },
+        provisioner: provisioner.to_string(),
+        reclaim_policy: Some("Delete".to_string()),
+        volume_binding_mode: Some(binding_mode.to_string()),
+        ..Default::default()
+    };
+    match scs.create(&PostParams::default(), &sc).await {
+        Ok(_) => {}
+        Err(kube::Error::Api(e)) if e.code == 409 => {}
+        Err(e) => panic!("create StorageClass {name}: {e}"),
+    }
+}
+
+/// OVERRIDE HAPPY PATH: the staged PVC carries `spec.staging.storageClassName` +
+/// `accessModes`, the Immediate bind gate waits for it to bind, the backup reads
+/// the stage and Succeeds with a real kopia snapshot, `status.staged` records the
+/// effective class, and the stage is reaped.
+#[tokio::test]
+#[ignore = "requires the e2e harness + the CSI snapshot stack (mise run //crates/e2e:test)"]
+async fn staging_overrides_stage_on_an_immediate_class_and_succeed() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+    let provisioner = require_snapshot_stack(&client).await;
+    ensure_storage_class(&client, IMMEDIATE_SC, &provisioner, "Immediate").await;
+    ensure_repo(&client, "staging-override").await;
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // A CSI-provisioned source PVC with real content (the VS restore must have
+    // something to provision from), bound by a one-shot seed pod.
+    let src = "e2e-ovr-src-pvc";
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1", "kind": "PersistentVolumeClaim",
+            "metadata": { "name": src, "namespace": E2E_NAMESPACE },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": CSI_STORAGE_CLASS,
+                "resources": { "requests": { "storage": "64Mi" } },
+            },
+        })),
+    )
+    .await
+    .expect("create CSI source PVC");
+    pods.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": { "name": "e2e-ovr-seed", "namespace": E2E_NAMESPACE },
+            "spec": {
+                "restartPolicy": "Never",
+                "containers": [{
+                    "name": "seed", "image": kopiur_e2e::consts::BUSYBOX_IMAGE,
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["sh", "-c", "echo kopiur-override > /data/marker.txt"],
+                    "volumeMounts": [{ "name": "d", "mountPath": "/data" }],
+                }],
+                "volumes": [{ "name": "d", "persistentVolumeClaim": { "claimName": src } }],
+            },
+        })),
+    )
+    .await
+    .expect("create seed pod");
+    wait_until(
+        "CSI source PVC Bound",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let bound = pvcs
+                .get_opt(src)
+                .await?
+                .and_then(|p| p.status.and_then(|s| s.phase))
+                .as_deref()
+                == Some("Bound");
+            Ok(bound.then_some(()))
+        },
+    )
+    .await
+    .expect("source PVC should bind");
+
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                "e2e-ovr-repo",
+                "staging-override",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                "e2e-ovr-policy",
+                "Repository",
+                "e2e-ovr-repo",
+                serde_json::json!({
+                    "copyMethod": "Snapshot",
+                    "sources": [ { "pvc": { "name": src } } ],
+                    "staging": {
+                        "storageClassName": IMMEDIATE_SC,
+                        "accessModes": ["ReadWriteOnce"],
+                    },
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy with staging overrides");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-ovr-backup",
+                "e2e-ovr-policy",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+
+    // The staged PVC exists mid-run and carries BOTH overrides — captured before
+    // the post-success reap. Pre-override code copied the source's class verbatim.
+    let staged_pvc_name = "e2e-ovr-backup-src";
+    let staged_spec = wait_until(
+        "staged PVC exists with the override shape",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(pvcs
+                .get_opt(staged_pvc_name)
+                .await?
+                .and_then(|p| p.spec)
+                .map(Box::new))
+        },
+    )
+    .await
+    .expect("staged PVC should be created");
+    assert_eq!(
+        staged_spec.storage_class_name.as_deref(),
+        Some(IMMEDIATE_SC),
+        "the staged PVC must use spec.staging.storageClassName, not the source's class"
+    );
+    assert_eq!(
+        staged_spec.access_modes.as_deref(),
+        Some(["ReadWriteOnce".to_string()].as_slice()),
+        "the staged PVC must use spec.staging.accessModes"
+    );
+
+    // The backup succeeds reading the override-staged PVC (the bind gate held the
+    // Job until the Immediate-class claim was Bound).
+    wait_phase(&backups, "e2e-ovr-backup", "Succeeded")
+        .await
+        .expect("Snapshot over the override-staged source should Succeed");
+    let status = status_json(&backups, "e2e-ovr-backup").await;
+    assert!(
+        status
+            .pointer("/snapshot/kopiaSnapshotID")
+            .and_then(|v| v.as_str())
+            .is_some_and(|id| !id.is_empty()),
+        "a real kopia snapshot must have been produced: {status}"
+    );
+    let staged = status.get("staged").cloned().unwrap_or_default();
+    assert_eq!(
+        staged.get("storageClassName").and_then(|v| v.as_str()),
+        Some(IMMEDIATE_SC),
+        "status.staged must record the effective (override) class: {status}"
+    );
+    assert!(
+        staged
+            .get("stagingTimeoutSeconds")
+            .and_then(|v| v.as_i64())
+            .is_some_and(|s| s > 0),
+        "status.staged must pin the resolved staging budget: {status}"
+    );
+
+    // The stage is reaped after success.
+    wait_until(
+        "staged PVC reaped",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(pvcs.get_opt(staged_pvc_name).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("staged PVC should be cleaned up after the backup succeeds");
+
+    // Cleanup (tests run --test-threads=1; the SC is ours to remove).
+    let _ = backups
+        .delete("e2e-ovr-backup", &DeleteParams::default())
+        .await;
+    let _ = policies
+        .delete("e2e-ovr-policy", &DeleteParams::default())
+        .await;
+    let _ = repos.delete("e2e-ovr-repo", &DeleteParams::default()).await;
+    let _ = pods.delete("e2e-ovr-seed", &DeleteParams::default()).await;
+    let _ = pvcs.delete(src, &DeleteParams::default()).await;
+    let scs: Api<StorageClass> = Api::all(client.clone());
+    let _ = scs.delete(IMMEDIATE_SC, &DeleteParams::default()).await;
+}
+
+/// PREFLIGHT FAST FAIL: an override class on a foreign driver fails the Snapshot
+/// terminally with `StagedClassMismatch` — naming both provisioners — before ANY
+/// staging object or mover Job exists. This is the regression trip-wire for the
+/// original bug shape: pre-fix, a never-binding staged PVC surfaced as
+/// `MoverPodWedged` after 300 s and the cleanup deleted the VolumeSnapshot while
+/// the CSI restore still consumed it.
+#[tokio::test]
+#[ignore = "requires the e2e harness + the CSI snapshot stack (mise run //crates/e2e:test)"]
+async fn staging_override_on_a_foreign_driver_fails_fast_with_class_mismatch() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+    let source_provisioner = require_snapshot_stack(&client).await;
+    ensure_storage_class(&client, ALIEN_SC, ALIEN_PROVISIONER, "Immediate").await;
+    ensure_repo(&client, "staging-mismatch").await;
+
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // The source PVC only needs to EXIST with a CSI class (the preflight reads its
+    // provisioner; binding is irrelevant — no seed pod).
+    let src = "e2e-mis-src-pvc";
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1", "kind": "PersistentVolumeClaim",
+            "metadata": { "name": src, "namespace": E2E_NAMESPACE },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": CSI_STORAGE_CLASS,
+                "resources": { "requests": { "storage": "64Mi" } },
+            },
+        })),
+    )
+    .await
+    .expect("create CSI source PVC");
+
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                "e2e-mis-repo",
+                "staging-mismatch",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                "e2e-mis-policy",
+                "Repository",
+                "e2e-mis-repo",
+                serde_json::json!({
+                    "copyMethod": "Snapshot",
+                    "sources": [ { "pvc": { "name": src } } ],
+                    "staging": { "storageClassName": ALIEN_SC },
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy with a wrong-driver override");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-mis-backup",
+                "e2e-mis-policy",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+
+    // Terminal fast fail with the specific reason; the message names BOTH drivers
+    // so the user knows exactly which class to fix.
+    let cond = wait_condition(&backups, "e2e-mis-backup", "SourceStaged", "False")
+        .await
+        .expect("SourceStaged=False condition");
+    assert_eq!(
+        cond.get("reason").and_then(|r| r.as_str()),
+        Some("StagedClassMismatch"),
+        "expected the same-driver preflight reason; condition was {cond:?}"
+    );
+    let msg = cond
+        .get("message")
+        .and_then(|m| m.as_str())
+        .unwrap_or_default();
+    assert!(
+        msg.contains(ALIEN_PROVISIONER) && msg.contains(&source_provisioner),
+        "the message must name both provisioners: {msg}"
+    );
+    wait_phase(&backups, "e2e-mis-backup", "Failed")
+        .await
+        .expect("Snapshot reaches Failed");
+    let status = status_json(&backups, "e2e-mis-backup").await;
+    let stalled = status
+        .get("conditions")
+        .and_then(|c| c.as_array())
+        .and_then(|a| {
+            a.iter()
+                .find(|c| c.get("type").and_then(|t| t.as_str()) == Some("Stalled"))
+        })
+        .and_then(|c| c.get("status"))
+        .and_then(|s| s.as_str());
+    assert_eq!(
+        stalled,
+        Some("True"),
+        "terminal failure must be Stalled=True"
+    );
+
+    // Nothing was ever created: no mover Job, no VolumeSnapshot, no staged PVC.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    assert!(
+        jobs.get_opt("e2e-mis-backup")
+            .await
+            .expect("get job")
+            .is_none(),
+        "no mover Job may exist for a preflight-failed backup"
+    );
+    assert!(
+        volume_snapshots(&client)
+            .get_opt("e2e-mis-backup-snap")
+            .await
+            .expect("get VS")
+            .is_none(),
+        "the preflight must fail BEFORE creating a VolumeSnapshot"
+    );
+    assert!(
+        pvcs.get_opt("e2e-mis-backup-src")
+            .await
+            .expect("get staged pvc")
+            .is_none(),
+        "the preflight must fail BEFORE creating a staged PVC"
+    );
+
+    // Cleanup.
+    let _ = backups
+        .delete("e2e-mis-backup", &DeleteParams::default())
+        .await;
+    let _ = policies
+        .delete("e2e-mis-policy", &DeleteParams::default())
+        .await;
+    let _ = repos.delete("e2e-mis-repo", &DeleteParams::default()).await;
+    let _ = pvcs.delete(src, &DeleteParams::default()).await;
+    let scs: Api<StorageClass> = Api::all(client.clone());
+    let _ = scs.delete(ALIEN_SC, &DeleteParams::default()).await;
+}

--- a/crates/migrate/src/kopia.rs
+++ b/crates/migrate/src/kopia.rs
@@ -1385,10 +1385,11 @@ pub fn translate_destination(
             });
             t.mapped("spec.kopia.capacity", "Restore.spec.target.pvc.capacity");
             if let Some(modes) = &kopia.access_modes {
-                pvc["accessModes"] = serde_json::json!(modes);
-                t.mapped(
+                crate::translate::map_access_modes(
+                    &mut t,
+                    &mut pvc,
                     "spec.kopia.accessModes",
-                    "Restore.spec.target.pvc.accessModes",
+                    modes,
                 );
             }
             if let Some(class) = &kopia.storage_class_name {

--- a/crates/migrate/src/translate.rs
+++ b/crates/migrate/src/translate.rs
@@ -77,6 +77,40 @@ impl Translation {
     }
 }
 
+/// Map a VolSync `accessModes` list onto `target.pvc.accessModes`, refusing any
+/// non-canonical mode up front: kopiur's CRD schema is a closed enum
+/// ([`kopiur_api::common::PvcAccessMode`]), so passing a bogus value through would
+/// only fail later, at `kubectl apply`. A refused list is recorded `Unmappable`
+/// (drives `--strict`) and the emitted Restore omits `accessModes` entirely — the
+/// created PVC then defaults to `ReadWriteOnce`.
+pub(crate) fn map_access_modes(
+    t: &mut Translation,
+    pvc: &mut serde_json::Value,
+    field: &str,
+    modes: &[String],
+) {
+    let bad: Vec<&str> = modes
+        .iter()
+        .filter(|m| kopiur_api::common::PvcAccessMode::parse(m).is_none())
+        .map(String::as_str)
+        .collect();
+    if bad.is_empty() {
+        pvc["accessModes"] = serde_json::json!(modes);
+        t.mapped(field, "Restore.spec.target.pvc.accessModes");
+    } else {
+        t.unmappable(
+            field,
+            &format!(
+                "{bad:?} is not a Kubernetes access mode (valid: {}); kopiur's CRD schema \
+                 would reject it at apply time, so it is not carried over. The emitted \
+                 Restore omits accessModes (the created PVC defaults to ReadWriteOnce) — \
+                 fix the VolSync value and re-run, or set target.pvc.accessModes by hand.",
+                kopiur_api::common::PvcAccessMode::CANONICAL.join(", ")
+            ),
+        );
+    }
+}
+
 /// Translate one restic ReplicationSource into a SnapshotPolicy (+ optional
 /// SnapshotSchedule). `repository_ref` is the kopiur repository the policy
 /// should point at (an existing one via `--repository`, or the one
@@ -372,11 +406,7 @@ pub fn translate_destination(
             });
             t.mapped("spec.restic.capacity", "Restore.spec.target.pvc.capacity");
             if let Some(modes) = &restic.access_modes {
-                pvc["accessModes"] = serde_json::json!(modes);
-                t.mapped(
-                    "spec.restic.accessModes",
-                    "Restore.spec.target.pvc.accessModes",
-                );
+                map_access_modes(&mut t, &mut pvc, "spec.restic.accessModes", modes);
             }
             if let Some(class) = &restic.storage_class_name {
                 pvc["storageClassName"] = serde_json::json!(class);
@@ -879,5 +909,41 @@ mod tests {
         }));
         // GCS: no carry (file PATH vs JSON CONTENT mismatch — caller notes it).
         assert!(cred_plan(BackendScheme::Gcs).is_empty());
+    }
+
+    #[test]
+    fn map_access_modes_refuses_non_canonical_values() {
+        // kopiur's CRD schema is a closed enum: passing a bogus VolSync mode
+        // through would only fail later, at `kubectl apply` — refuse it up front
+        // as Unmappable (drives --strict) and omit accessModes entirely.
+        let mut t = Translation::default();
+        let mut pvc = serde_json::json!({ "name": "x" });
+        map_access_modes(
+            &mut t,
+            &mut pvc,
+            "spec.restic.accessModes",
+            &["ReadWriteOnce".into(), "ReadWriteOnze".into()],
+        );
+        assert!(pvc.get("accessModes").is_none(), "{pvc}");
+        assert!(t.has_unmappable);
+        let note = t
+            .notes
+            .iter()
+            .find(|n| n.field == "spec.restic.accessModes")
+            .expect("a note for the refused field");
+        let rendered = serde_json::to_string(note).unwrap();
+        assert!(rendered.contains("ReadWriteOnze"), "{rendered}");
+        assert!(rendered.contains("ReadWriteOncePod"), "{rendered}");
+
+        // A canonical list passes straight through.
+        let mut t = Translation::default();
+        map_access_modes(
+            &mut t,
+            &mut pvc,
+            "spec.restic.accessModes",
+            &["ReadOnlyMany".into()],
+        );
+        assert_eq!(pvc["accessModes"], serde_json::json!(["ReadOnlyMany"]));
+        assert!(!t.has_unmappable);
     }
 }

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -325,6 +325,22 @@ spec:
                     description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
+                  stagingTimeoutSeconds:
+                    description: |-
+                      The resolved `spec.staging.timeout` (seconds) pinned when the stage was
+                      stamped, so the running-Job staged-PVC bind watchdog never re-resolves a
+                      policy that may have been edited or deleted mid-run. `0` = wait
+                      indefinitely.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  storageClassName:
+                    description: |-
+                      StorageClass of the staged PVC — `spec.staging.storageClassName` when set,
+                      else the source PVC's class. Pinned for observability (e.g. confirming a
+                      CephFS shallow-clone class actually took effect).
+                    nullable: true
+                    type: string
                   volumeSnapshotName:
                     description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -6185,15 +6185,45 @@ spec:
                   the CSI capture to become ready before failing the backup).
                 nullable: true
                 properties:
+                  accessModes:
+                    description: |-
+                      Access modes for the staged PVC. Empty ⇒ copy the source PVC's modes.
+                      `[ReadOnlyMany]` pairs with snapshot-backed read-only classes (e.g. CephFS
+                      `backingSnapshot`); the mover always mounts the staged PVC read-only
+                      regardless of the mode.
+                    items:
+                      description: A Kubernetes PersistentVolumeClaim access mode.
+                      enum:
+                      - ReadWriteOnce
+                      - ReadOnlyMany
+                      - ReadWriteMany
+                      - ReadWriteOncePod
+                      type: string
+                    type: array
+                  storageClassName:
+                    description: |-
+                      StorageClass for the **staged PVC** — the temporary PVC restored from the
+                      CSI `VolumeSnapshot` (`copyMethod: Snapshot`) or cloned from the source
+                      (`copyMethod: Clone`). Absent ⇒ the staged PVC copies the source PVC's
+                      class. Must belong to the **same CSI driver** as the source (staging fails
+                      fast on a mismatch). Flagship use: a rook-ceph CephFS class with
+                      `backingSnapshot: "true"`, which mounts the snapshot shallowly
+                      (metadata-only, near-instant, read-only) instead of running a full
+                      subvolume clone that can take many minutes on small-file-heavy volumes.
+                    nullable: true
+                    type: string
                   timeout:
                     description: |-
-                      How long the staged `VolumeSnapshot` may take to become `readyToUse`
-                      (measured from its creation) before the backup is failed (Go-style
-                      duration like `10m` or `1h`; default `10m`). A transient CSI/
-                      snapshot-controller error during the wait is retried, never fatal on its
-                      own — only this deadline fails staging. A zero duration (`0`/`0s`) waits
-                      indefinitely. Raise this for backends whose snapshots take long to become
-                      ready (e.g. cloud snapshots of large volumes).
+                      How long each staging phase may take before the backup is failed (Go-style
+                      duration like `10m` or `1h`; default `10m`): first the staged
+                      `VolumeSnapshot` becoming `readyToUse` (measured from its creation), then —
+                      on an `Immediate`-binding StorageClass — the staged PVC binding (a fresh
+                      budget measured from the PVC's creation, covering the CSI restore/clone).
+                      A transient CSI/snapshot-controller error during either wait is retried,
+                      never fatal on its own — only this deadline fails staging. A zero duration
+                      (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots or
+                      clones take long (e.g. cloud snapshots of large volumes, CephFS full clones
+                      of small-file-heavy volumes).
                     nullable: true
                     type: string
                 type: object
@@ -6783,6 +6813,22 @@ spec:
                     description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
+                  stagingTimeoutSeconds:
+                    description: |-
+                      The resolved `spec.staging.timeout` (seconds) pinned when the stage was
+                      stamped, so the running-Job staged-PVC bind watchdog never re-resolves a
+                      policy that may have been edited or deleted mid-run. `0` = wait
+                      indefinitely.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  storageClassName:
+                    description: |-
+                      StorageClass of the staged PVC — `spec.staging.storageClassName` when set,
+                      else the source PVC's class. Pinned for observability (e.g. confirming a
+                      CephFS shallow-clone class actually took effect).
+                    nullable: true
+                    type: string
                   volumeSnapshotName:
                     description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true
@@ -7769,8 +7815,19 @@ spec:
                     description: Operator creates the PVC.
                     properties:
                       accessModes:
-                        description: Access modes for the new PVC (e.g. `["ReadWriteOnce"]`).
+                        description: |-
+                          Access modes for the new PVC; empty defaults to `[ReadWriteOnce]`. Closed
+                          enum in the schema; a non-canonical value persisted before enforcement
+                          decodes as [`PvcAccessMode::Unknown`] and is rejected per-CR with the
+                          value quoted (webhook + reconciler, via `validate_access_modes`) instead
+                          of poisoning the typed watcher.
                         items:
+                          description: A Kubernetes PersistentVolumeClaim access mode.
+                          enum:
+                          - ReadWriteOnce
+                          - ReadOnlyMany
+                          - ReadWriteMany
+                          - ReadWriteOncePod
                           type: string
                         type: array
                       capacity:

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -639,8 +639,19 @@ spec:
                     description: Operator creates the PVC.
                     properties:
                       accessModes:
-                        description: Access modes for the new PVC (e.g. `["ReadWriteOnce"]`).
+                        description: |-
+                          Access modes for the new PVC; empty defaults to `[ReadWriteOnce]`. Closed
+                          enum in the schema; a non-canonical value persisted before enforcement
+                          decodes as [`PvcAccessMode::Unknown`] and is rejected per-CR with the
+                          value quoted (webhook + reconciler, via `validate_access_modes`) instead
+                          of poisoning the typed watcher.
                         items:
+                          description: A Kubernetes PersistentVolumeClaim access mode.
+                          enum:
+                          - ReadWriteOnce
+                          - ReadOnlyMany
+                          - ReadWriteMany
+                          - ReadWriteOncePod
                           type: string
                         type: array
                       capacity:

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -966,15 +966,45 @@ spec:
                   the CSI capture to become ready before failing the backup).
                 nullable: true
                 properties:
+                  accessModes:
+                    description: |-
+                      Access modes for the staged PVC. Empty ⇒ copy the source PVC's modes.
+                      `[ReadOnlyMany]` pairs with snapshot-backed read-only classes (e.g. CephFS
+                      `backingSnapshot`); the mover always mounts the staged PVC read-only
+                      regardless of the mode.
+                    items:
+                      description: A Kubernetes PersistentVolumeClaim access mode.
+                      enum:
+                      - ReadWriteOnce
+                      - ReadOnlyMany
+                      - ReadWriteMany
+                      - ReadWriteOncePod
+                      type: string
+                    type: array
+                  storageClassName:
+                    description: |-
+                      StorageClass for the **staged PVC** — the temporary PVC restored from the
+                      CSI `VolumeSnapshot` (`copyMethod: Snapshot`) or cloned from the source
+                      (`copyMethod: Clone`). Absent ⇒ the staged PVC copies the source PVC's
+                      class. Must belong to the **same CSI driver** as the source (staging fails
+                      fast on a mismatch). Flagship use: a rook-ceph CephFS class with
+                      `backingSnapshot: "true"`, which mounts the snapshot shallowly
+                      (metadata-only, near-instant, read-only) instead of running a full
+                      subvolume clone that can take many minutes on small-file-heavy volumes.
+                    nullable: true
+                    type: string
                   timeout:
                     description: |-
-                      How long the staged `VolumeSnapshot` may take to become `readyToUse`
-                      (measured from its creation) before the backup is failed (Go-style
-                      duration like `10m` or `1h`; default `10m`). A transient CSI/
-                      snapshot-controller error during the wait is retried, never fatal on its
-                      own — only this deadline fails staging. A zero duration (`0`/`0s`) waits
-                      indefinitely. Raise this for backends whose snapshots take long to become
-                      ready (e.g. cloud snapshots of large volumes).
+                      How long each staging phase may take before the backup is failed (Go-style
+                      duration like `10m` or `1h`; default `10m`): first the staged
+                      `VolumeSnapshot` becoming `readyToUse` (measured from its creation), then —
+                      on an `Immediate`-binding StorageClass — the staged PVC binding (a fresh
+                      budget measured from the PVC's creation, covering the CSI restore/clone).
+                      A transient CSI/snapshot-controller error during either wait is retried,
+                      never fatal on its own — only this deadline fails staging. A zero duration
+                      (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots or
+                      clones take long (e.g. cloud snapshots of large volumes, CephFS full clones
+                      of small-file-heavy volumes).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -322,6 +322,22 @@ spec:
                     description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
+                  stagingTimeoutSeconds:
+                    description: |-
+                      The resolved `spec.staging.timeout` (seconds) pinned when the stage was
+                      stamped, so the running-Job staged-PVC bind watchdog never re-resolves a
+                      policy that may have been edited or deleted mid-run. `0` = wait
+                      indefinitely.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  storageClassName:
+                    description: |-
+                      StorageClass of the staged PVC — `spec.staging.storageClassName` when set,
+                      else the source PVC's class. Pinned for observability (e.g. confirming a
+                      CephFS shallow-clone class actually took effect).
+                    nullable: true
+                    type: string
                   volumeSnapshotName:
                     description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true

--- a/deploy/examples/21-copy-method-snapshot.yaml
+++ b/deploy/examples/21-copy-method-snapshot.yaml
@@ -26,11 +26,13 @@ spec:
     name: primary
   copyMethod: Snapshot
   volumeSnapshotClassName: csi-rbd-snapclass # optional; omit to use the driver default
-  # Optional: how long the VolumeSnapshot may take to become readyToUse before the
-  # backup fails (default 10m; "0" waits indefinitely). Transient CSI/snapshot-
-  # controller errors during the wait are retried — only this deadline fails staging.
-  # Raise it for backends whose snapshots are slow to become ready (e.g. cloud
-  # snapshots of large volumes).
+  # Optional: the staging deadline budget (default 10m; "0" waits indefinitely).
+  # Bounds the VolumeSnapshot becoming readyToUse AND (a fresh budget) the staged
+  # PVC's bind — the CSI restore window. Transient CSI/snapshot-controller errors
+  # during the wait are retried — only this deadline fails staging. Raise it for
+  # backends whose snapshots or restores are slow (e.g. cloud snapshots of large
+  # volumes). `staging` also takes storageClassName/accessModes overrides for the
+  # staged PVC — see example 30 (CephFS backingSnapshot shallow staging).
   staging:
     timeout: 10m
   sources:

--- a/deploy/examples/30-cephfs-shallow-snapshot.yaml
+++ b/deploy/examples/30-cephfs-shallow-snapshot.yaml
@@ -1,0 +1,72 @@
+# Example 30 — CephFS shallow snapshot staging (spec.staging.storageClassName)
+#
+# copyMethod: Snapshot normally restores the CSI VolumeSnapshot into a staged PVC
+# on the SOURCE's StorageClass. On CephFS that restore is a FULL subvolume clone —
+# metadata-bound, so a volume with many small files (git servers, maildirs,
+# node_modules-shaped data) can take many minutes to clone even at ~100 MB, and a
+# slow clone burns the whole staging budget doing setup instead of backup.
+#
+# The fix: point the STAGED PVC (and only it — your app's PVC is untouched) at a
+# rook-ceph StorageClass with `backingSnapshot: "true"`. ceph-csi then mounts the
+# snapshot SHALLOWLY — a metadata-only, read-only view, ready in seconds — instead
+# of copying every file. Shallow volumes are read-only by design, hence
+# `accessModes: [ReadOnlyMany]`; the kopia mover always mounts the staged source
+# read-only anyway, so nothing else changes.
+#
+# Maps to SnapshotPolicy.spec.staging.{storageClassName,accessModes}
+# (crates/api/src/snapshot_policy.rs::StagingSpec). Both fields apply to
+# copyMethod Snapshot AND Clone; absent they inherit from the source PVC.
+# The override class MUST belong to the same CSI driver as the source — kopiur
+# fails fast with `StagedClassMismatch` if it doesn't.
+#
+# Requires: rook-ceph / ceph-csi with CephFS (shallow volumes need ceph-csi >= 3.7)
+# and the CSI snapshot stack. Adjust clusterID/fsName/secret names to your rook
+# install (these are the rook-ceph defaults).
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: cephfs-backingsnapshot
+provisioner: rook-ceph.cephfs.csi.ceph.com # SAME driver as your source PVC's class
+parameters:
+  clusterID: rook-ceph
+  fsName: ceph-filesystem
+  # The load-bearing line: restore-from-snapshot mounts the snapshot shallowly
+  # (metadata-only, read-only, near-instant) instead of a full subvolume clone.
+  backingSnapshot: "true"
+  csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/provisioner-secret-namespace: rook-ceph
+  csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+  csi.storage.k8s.io/controller-expand-secret-namespace: rook-ceph
+  csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+  csi.storage.k8s.io/node-stage-secret-namespace: rook-ceph
+reclaimPolicy: Delete
+allowVolumeExpansion: false
+volumeBindingMode: Immediate
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: forgejo
+  namespace: forgejo
+spec:
+  repository:
+    name: primary # an existing Repository/ClusterRepository (see examples 01-03)
+  copyMethod: Snapshot
+  staging:
+    # Stage on the shallow class above instead of the source's own class.
+    storageClassName: cephfs-backingsnapshot
+    # Shallow CephFS volumes are read-only; request them as ReadOnlyMany.
+    accessModes: [ReadOnlyMany]
+    # With a shallow mount the stage is ready in seconds, so the default 10m
+    # budget is generous. Without the override, a CephFS full clone of a
+    # small-file-heavy volume can need MORE than 10m — if you must full-clone,
+    # raise this instead (it bounds both the VolumeSnapshot readyToUse wait and
+    # the staged PVC's bind).
+    timeout: 10m
+  sources:
+    - pvc:
+        name: forgejo-data
+  retention:
+    keepDaily: 14
+    keepWeekly: 8

--- a/deploy/helm/kopiur/crds/restores.yaml
+++ b/deploy/helm/kopiur/crds/restores.yaml
@@ -639,8 +639,19 @@ spec:
                     description: Operator creates the PVC.
                     properties:
                       accessModes:
-                        description: Access modes for the new PVC (e.g. `["ReadWriteOnce"]`).
+                        description: |-
+                          Access modes for the new PVC; empty defaults to `[ReadWriteOnce]`. Closed
+                          enum in the schema; a non-canonical value persisted before enforcement
+                          decodes as [`PvcAccessMode::Unknown`] and is rejected per-CR with the
+                          value quoted (webhook + reconciler, via `validate_access_modes`) instead
+                          of poisoning the typed watcher.
                         items:
+                          description: A Kubernetes PersistentVolumeClaim access mode.
+                          enum:
+                          - ReadWriteOnce
+                          - ReadOnlyMany
+                          - ReadWriteMany
+                          - ReadWriteOncePod
                           type: string
                         type: array
                       capacity:

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -966,15 +966,45 @@ spec:
                   the CSI capture to become ready before failing the backup).
                 nullable: true
                 properties:
+                  accessModes:
+                    description: |-
+                      Access modes for the staged PVC. Empty ⇒ copy the source PVC's modes.
+                      `[ReadOnlyMany]` pairs with snapshot-backed read-only classes (e.g. CephFS
+                      `backingSnapshot`); the mover always mounts the staged PVC read-only
+                      regardless of the mode.
+                    items:
+                      description: A Kubernetes PersistentVolumeClaim access mode.
+                      enum:
+                      - ReadWriteOnce
+                      - ReadOnlyMany
+                      - ReadWriteMany
+                      - ReadWriteOncePod
+                      type: string
+                    type: array
+                  storageClassName:
+                    description: |-
+                      StorageClass for the **staged PVC** — the temporary PVC restored from the
+                      CSI `VolumeSnapshot` (`copyMethod: Snapshot`) or cloned from the source
+                      (`copyMethod: Clone`). Absent ⇒ the staged PVC copies the source PVC's
+                      class. Must belong to the **same CSI driver** as the source (staging fails
+                      fast on a mismatch). Flagship use: a rook-ceph CephFS class with
+                      `backingSnapshot: "true"`, which mounts the snapshot shallowly
+                      (metadata-only, near-instant, read-only) instead of running a full
+                      subvolume clone that can take many minutes on small-file-heavy volumes.
+                    nullable: true
+                    type: string
                   timeout:
                     description: |-
-                      How long the staged `VolumeSnapshot` may take to become `readyToUse`
-                      (measured from its creation) before the backup is failed (Go-style
-                      duration like `10m` or `1h`; default `10m`). A transient CSI/
-                      snapshot-controller error during the wait is retried, never fatal on its
-                      own — only this deadline fails staging. A zero duration (`0`/`0s`) waits
-                      indefinitely. Raise this for backends whose snapshots take long to become
-                      ready (e.g. cloud snapshots of large volumes).
+                      How long each staging phase may take before the backup is failed (Go-style
+                      duration like `10m` or `1h`; default `10m`): first the staged
+                      `VolumeSnapshot` becoming `readyToUse` (measured from its creation), then —
+                      on an `Immediate`-binding StorageClass — the staged PVC binding (a fresh
+                      budget measured from the PVC's creation, covering the CSI restore/clone).
+                      A transient CSI/snapshot-controller error during either wait is retried,
+                      never fatal on its own — only this deadline fails staging. A zero duration
+                      (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots or
+                      clones take long (e.g. cloud snapshots of large volumes, CephFS full clones
+                      of small-file-heavy volumes).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/helm/kopiur/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/crds/snapshots.yaml
@@ -322,6 +322,22 @@ spec:
                     description: '`true` once the stage is ready for the mover.'
                     nullable: true
                     type: boolean
+                  stagingTimeoutSeconds:
+                    description: |-
+                      The resolved `spec.staging.timeout` (seconds) pinned when the stage was
+                      stamped, so the running-Job staged-PVC bind watchdog never re-resolves a
+                      policy that may have been edited or deleted mid-run. `0` = wait
+                      indefinitely.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  storageClassName:
+                    description: |-
+                      StorageClass of the staged PVC — `spec.staging.storageClassName` when set,
+                      else the source PVC's class. Pinned for observability (e.g. confirming a
+                      CephFS shallow-clone class actually took effect).
+                    nullable: true
+                    type: string
                   volumeSnapshotName:
                     description: 'Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only).'
                     nullable: true

--- a/docs/access-modes.md
+++ b/docs/access-modes.md
@@ -94,7 +94,7 @@ What Kopiur does about it, per situation:
 
 ### Backing up an RWOP volume with `Snapshot` or `Clone` — no downtime (recommended)
 
-With [`copyMethod: Snapshot` (or `Clone`)](copy-methods.md), the mover **never mounts your live volume**. Kopiur takes a CSI VolumeSnapshot (or CSI clone) of the source — a storage-layer operation that the RWOP mount exclusivity does not restrict — provisions a temporary staged PVC from it, and runs kopia against that stage. The staged PVC inherits your source's access modes, RWOP included, but the mover is its **only** pod, so the exclusivity is satisfied. Your app keeps running, untouched.
+With [`copyMethod: Snapshot` (or `Clone`)](copy-methods.md), the mover **never mounts your live volume**. Kopiur takes a CSI VolumeSnapshot (or CSI clone) of the source — a storage-layer operation that the RWOP mount exclusivity does not restrict — provisions a temporary staged PVC from it, and runs kopia against that stage. By default the staged PVC inherits your source's access modes, RWOP included, but the mover is its **only** pod, so the exclusivity is satisfied. Your app keeps running, untouched. (`spec.staging.accessModes` can override the staged PVC's modes — e.g. `[ReadOnlyMany]` for a snapshot-backed read-only class like CephFS `backingSnapshot`; see [Copy methods → staging overrides](copy-methods.md#staging-overrides).)
 
 This is the recommended way to back up RWOP volumes, and you almost certainly already have what it needs: RWOP itself requires a CSI driver, and most CSI drivers that ship RWOP support also ship snapshots.
 

--- a/docs/copy-methods.md
+++ b/docs/copy-methods.md
@@ -77,10 +77,10 @@ $ kubectl -n kopiur-tryit wait --for=jsonpath='{.status.phase}'=Succeeded \
     snapshot/app-data-snapshot --timeout=5m
 $ kubectl -n kopiur-tryit get snapshot app-data-snapshot \
     -o jsonpath='{.status.staged}'
-{"copyMethod":"Snapshot","volumeSnapshotName":"app-data-snapshot-...","pvcName":"app-data-snapshot-src","ready":true}
+{"copyMethod":"Snapshot","volumeSnapshotName":"app-data-snapshot-...","pvcName":"app-data-snapshot-src","ready":true,"storageClassName":"...","stagingTimeoutSeconds":600}
 ```
 
-*(Illustrative: `volumeSnapshotName` is generated; the rest is exact.)*
+*(Illustrative: `volumeSnapshotName` is generated and `storageClassName` is your class; the rest is exact.)*
 
 **4. Confirm the stage was reaped and the live PVC was never mounted.** Kopiur cleans up the staged objects on completion:
 
@@ -129,7 +129,10 @@ spec:
 
 ### How long staging may wait (`spec.staging.timeout`)
 
-The wait for `readyToUse` is bounded by a **staging deadline**, measured from the `VolumeSnapshot`'s creation:
+Staging has a **deadline budget** that bounds each of its phases:
+
+1. The `VolumeSnapshot` becoming `readyToUse` — measured from the VolumeSnapshot's creation.
+2. The **staged PVC binding** — a *fresh* budget measured from the staged PVC's creation. On an `Immediate`-binding StorageClass the CSI restore/clone runs at provision time and Kopiur waits for `Bound` **before** creating the mover Job (so a slow restore can never strand an unschedulable mover, and the VolumeSnapshot is never torn down under an in-flight restore). On a `WaitForFirstConsumer` class the bind happens when the mover pod schedules — Kopiur then keeps watching the staged PVC *while the Job runs* and fails the backup with the same reason if the bind blows the budget.
 
 ```yaml
 spec:
@@ -140,10 +143,10 @@ spec:
 ```
 
 - **Default `10m`** — plenty for drivers that cut snapshots in seconds (most local/on-cluster CSI), and bounded so a broken driver can't hold a `Snapshot` `Pending` forever and silently starve a `concurrencyPolicy: Forbid` schedule.
-- **Raise it** for backends whose snapshots take long to become ready — e.g. cloud snapshots of large volumes (the first EBS snapshot of a big volume can take well over 10 minutes).
+- **Raise it** for backends whose snapshots or restores take long — e.g. cloud snapshots of large volumes (the first EBS snapshot of a big volume can take well over 10 minutes), or a **CephFS full-clone restore of a small-file-heavy volume** (see [staging overrides](#staging-overrides) for the shallow-clone alternative that makes it near-instant instead).
 - **`timeout: "0"`** waits indefinitely (never fails on the deadline).
 
-Only this deadline fails staging. If it expires the backup goes `Failed` with reason `VolumeSnapshotFailed` (the snapshot was still reporting an error) or `StagingTimedOut` (no error — the driver/snapshot-controller is stuck), and the message names this field. A `Failed` backup is terminal; the next scheduled run (or a new `Snapshot`) retries.
+Only this deadline fails staging. If it expires the backup goes `Failed` with reason `VolumeSnapshotFailed` (the snapshot was still reporting an error), `StagingTimedOut` (no error — the driver/snapshot-controller is stuck), or `StagedPvcBindTimeout` (the snapshot was fine but the staged PVC never bound — the restore/clone is still provisioning or can't provision), and the message names this field. A `Failed` backup is terminal; the next scheduled run (or a new `Snapshot`) retries — and Kopiur reaps whatever staging objects the failed run already created.
 
 !!! note "A `VolumeSnapshot` error during the wait is NOT a failure"
     The snapshot-controller routinely reports **transient** errors on a perfectly healthy `VolumeSnapshot` — most commonly a benign `409 Conflict` (`"the object has been modified; please apply your changes to the latest version and try again"`) while it adds finalizers, which its own retry clears a moment later. Kopiur surfaces such errors on the `SourceStaged` condition for visibility but keeps waiting; it declares `VolumeSnapshotFailed` only if the snapshot is still not `readyToUse` when the staging deadline passes.
@@ -165,7 +168,36 @@ Use it when your CSI driver supports cloning (`CLONE_VOLUME`) but not snapshots.
 ```
 
 !!! warning "Clone requires driver support"
-    If your driver can't clone the volume, the staged PVC stays `Pending` and the backup never starts. If you see that, check the staged PVC's events (`kubectl describe pvc <snapshot-name>-src`) and use `Snapshot` or `Direct` instead.
+    If your driver can't clone the volume, the staged PVC stays `Pending` and the backup fails with `StagedPvcBindTimeout` once the [staging deadline](#how-long-staging-may-wait-specstagingtimeout) passes. If you see that, check the staged PVC's events (`kubectl describe pvc <snapshot-name>-src`) and use `Snapshot` or `Direct` instead.
+
+---
+
+## Staging overrides
+
+By default the staged PVC copies its `storageClassName` and `accessModes` **from the source PVC**. Two optional `spec.staging` fields override that — for the staged PVC only; your application's PVC is never touched:
+
+```yaml
+spec:
+    copyMethod: Snapshot   # overrides apply to Snapshot AND Clone
+    staging:
+        storageClassName: cephfs-backingsnapshot  # class for the STAGED PVC
+        accessModes: [ReadOnlyMany]                # modes for the STAGED PVC
+```
+
+- **`storageClassName`** — stage on a different class of the **same CSI driver**, typically one with different *restore parameters*. Kopiur verifies the driver matches up front and fails fast with `StagedClassMismatch` if it doesn't (a foreign driver can never provision from your source's snapshot — without the check you'd get an opaque bind timeout instead).
+- **`accessModes`** — request different modes for the stage (e.g. `[ReadOnlyMany]` for a snapshot-backed read-only class). The mover always mounts the staged source read-only regardless.
+- Both are meaningless without a staged PVC, so they're **rejected at admission** for `copyMethod: Direct`, NFS sources, and `pvcSelector` sources.
+
+### The flagship use: CephFS shallow snapshots
+
+On CephFS, restoring a VolumeSnapshot into a staged PVC is a **full subvolume clone** — an MDS-metadata-bound copy of every file. For a volume with many small files (a git server's loose objects, maildirs), that clone can take *many minutes* even at ~100 MB, blowing the staging budget on setup. ceph-csi's answer is a StorageClass with `backingSnapshot: "true"`: restore-from-snapshot then mounts the snapshot **shallowly** — metadata-only, read-only, ready in seconds. Point `spec.staging.storageClassName` at such a class and the whole problem disappears:
+
+```yaml
+--8<-- "deploy/examples/30-cephfs-shallow-snapshot.yaml"
+```
+
+!!! note "Same driver, shallow-capable versions, delete order"
+    The shallow class must use the **same provisioner** as your source's class (kopiur enforces this). CephFS shallow volumes need ceph-csi ≥ 3.7 and are read-only by design — request them `ReadOnlyMany`. ceph-csi reference-tracks the backing snapshot, and Kopiur always deletes the staged PVC **before** the VolumeSnapshot, so the cleanup order is safe for shallow mounts.
 
 ---
 
@@ -207,6 +239,11 @@ If a `SnapshotPolicy` never sets `copyMethod` and the cluster has no CSI snapsho
 | `SourceStaged=False`, reason **`VolumeSnapshotFailed`** | The VolumeSnapshot was **still reporting an error when the staging deadline passed** (`spec.staging.timeout`, default `10m`) — transient errors during the wait are retried, never fatal on their own. | Read the message (it includes the driver's last error); fix the class/driver, or raise `spec.staging.timeout` if the backend is just slow. The next scheduled run (or a new `Snapshot`) retries. |
 | `SourceStaged=False`, reason **`StagingTimedOut`** | The VolumeSnapshot never became `readyToUse` within the staging deadline and reported **no error** — the CSI driver / snapshot-controller is stuck or very slow. | Check the driver and the snapshot-controller; raise `spec.staging.timeout` (or set it to `"0"` to wait indefinitely) if the backend is just slow. |
 | `SourceStaged=False`, reason **`SourceNotCSIProvisioned`** | The source PVC has no `StorageClass` (a static/hostPath volume) — nothing to snapshot. | Use a CSI-provisioned PVC, or `copyMethod: Direct`. |
-| Backup stuck `Pending`, staged PVC `Pending` | `WaitForFirstConsumer` (normal — binds when the mover starts) **or** the driver can't clone (for `Clone`). | If it never binds, `kubectl describe pvc <name>-src` for the driver event; switch method if cloning is unsupported. |
+| `SourceStaged=False`, reason **`StagedClassNotFound`** | `spec.staging.storageClassName` names a StorageClass that doesn't exist. | Create the class, point the override at an existing one, or remove the override to stage on the source's class. |
+| `SourceStaged=False`, reason **`StagedClassMismatch`** | `spec.staging.storageClassName` is on a **different CSI driver** than the source — its provisioner can never restore/clone from your source, so the staged PVC would never bind. | Point the override at a class of the source's driver (the message names both), or remove it. |
+| `SourceStaged=False`, reason **`WaitingForStagedPvcBind`** (`Pending`, transient) | The staged PVC is still binding — the CSI restore/clone from the source is provisioning. Normal for slow restores; bounded by the [staging deadline](#how-long-staging-may-wait-specstagingtimeout). | Nothing, usually — it either binds or fails at the deadline with the row below. |
+| `SourceStaged=False` / phase `Failed`, reason **`StagedPvcBindTimeout`** | The staged PVC never reached `Bound` within `spec.staging.timeout` — the restore/clone is still provisioning (e.g. a CephFS **full clone** of a small-file-heavy volume) or the class can't provision it. | `kubectl describe pvc <name>-src` + the CSI provisioner logs; raise `spec.staging.timeout` if the copy is just slow, or (CephFS) stage on a [`backingSnapshot: "true"` shallow class](#the-flagship-use-cephfs-shallow-snapshots). |
+| Phase `Failed`, reason **`StagedPvcLost`** | The staged PVC reports `Lost` — its bound PV disappeared mid-stage. | Check the CSI driver / PV lifecycle; the next scheduled run retries. |
+| Backup stuck `Pending`, staged PVC `Pending` | `WaitForFirstConsumer` (normal — binds when the mover starts) **or** the driver can't clone (for `Clone`). | If it never binds, the backup fails at the staging deadline with `StagedPvcBindTimeout`; `kubectl describe pvc <name>-src` for the driver event; switch method if cloning is unsupported. |
 
 See also [Troubleshooting → Multi-Attach](troubleshooting.md) for the `Direct`-mode co-location path.

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -1532,7 +1532,9 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
-| `timeout` | string | — | How long the staged `VolumeSnapshot` may take to become `readyToUse` (measured from its creation) before the backup is failed (Go-style duration like `10m` or `1h`; default `10m`). A transient CSI/ snapshot-controller error during the wait is retried, never fatal on its own — only this deadline fails staging. A zero duration (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots take long to become ready (e.g. cloud snapshots of large volumes). |
+| `accessModes` | []enum: ReadWriteOnce \| ReadOnlyMany \| ReadWriteMany \| ReadWriteOncePod | — | Access modes for the staged PVC. Empty ⇒ copy the source PVC's modes. `ReadOnlyMany` pairs with snapshot-backed read-only classes (e.g. CephFS `backingSnapshot`); the mover always mounts the staged PVC read-only regardless of the mode. |
+| `storageClassName` | string | — | StorageClass for the **staged PVC** — the temporary PVC restored from the CSI `VolumeSnapshot` (`copyMethod: Snapshot`) or cloned from the source (`copyMethod: Clone`). Absent ⇒ the staged PVC copies the source PVC's class. Must belong to the **same CSI driver** as the source (staging fails fast on a mismatch). Flagship use: a rook-ceph CephFS class with `backingSnapshot: "true"`, which mounts the snapshot shallowly (metadata-only, near-instant, read-only) instead of running a full subvolume clone that can take many minutes on small-file-heavy volumes. |
+| `timeout` | string | — | How long each staging phase may take before the backup is failed (Go-style duration like `10m` or `1h`; default `10m`): first the staged `VolumeSnapshot` becoming `readyToUse` (measured from its creation), then — on an `Immediate`-binding StorageClass — the staged PVC binding (a fresh budget measured from the PVC's creation, covering the CSI restore/clone). A transient CSI/snapshot-controller error during either wait is retried, never fatal on its own — only this deadline fails staging. A zero duration (`0`/`0s`) waits indefinitely. Raise this for backends whose snapshots or clones take long (e.g. cloud snapshots of large volumes, CephFS full clones of small-file-heavy volumes). |
 
 #### `spec.upload` { #snapshotpolicy-spec-upload }
 
@@ -1769,6 +1771,8 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | `copyMethod` | string | — | The resolved capture method (`Snapshot` or `Clone`) that produced this stage. |
 | `pvcName` | string | — | Name of the staged `PersistentVolumeClaim` the mover mounts in place of the live source PVC. |
 | `ready` | boolean | — | `true` once the stage is ready for the mover. |
+| `stagingTimeoutSeconds` | integer | — | The resolved `spec.staging.timeout` (seconds) pinned when the stage was stamped, so the running-Job staged-PVC bind watchdog never re-resolves a policy that may have been edited or deleted mid-run. `0` = wait indefinitely. |
+| `storageClassName` | string | — | StorageClass of the staged PVC — `spec.staging.storageClassName` when set, else the source PVC's class. Pinned for observability (e.g. confirming a CephFS shallow-clone class actually took effect). |
 | `volumeSnapshotName` | string | — | Name of the `VolumeSnapshot` created from the source PVC (`copyMethod: Snapshot` only). |
 
 #### `status.stats` { #snapshot-status-stats }
@@ -1967,7 +1971,7 @@ Externally tagged — set **exactly one** of: `populator` · `pvc` · `pvcRef`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the PVC to create. |
-| `accessModes` | []string | — | Access modes for the new PVC (e.g. `["ReadWriteOnce"]`). |
+| `accessModes` | []enum: ReadWriteOnce \| ReadOnlyMany \| ReadWriteMany \| ReadWriteOncePod | — | Access modes for the new PVC; empty defaults to `ReadWriteOnce`. Closed enum in the schema; a non-canonical value persisted before enforcement decodes as `PvcAccessMode::Unknown` and is rejected per-CR with the value quoted (webhook + reconciler, via `validate_access_modes`) instead of poisoning the typed watcher. |
 | `capacity` | string | — | Requested size of the new PVC (e.g. `100Gi`). |
 | `storageClassName` | string | — | StorageClass for the new PVC; absent uses the cluster default. |
 

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -58,6 +58,30 @@ snapshot stack. See [Copy methods](../../copy-methods.md).
 
 The `VolumeSnapshotClass` used when `copyMethod` is `Snapshot` or `Clone`.
 
+### `staging`
+
+Knobs for the CSI capture (`copyMethod: Snapshot`/`Clone`) that runs before the
+mover:
+
+- `timeout` — the staging deadline budget (Go-style duration, default `10m`,
+  `"0"` = wait indefinitely). Bounds the `VolumeSnapshot` becoming `readyToUse`
+  **and** — as a fresh budget — the staged PVC binding (the CSI restore/clone
+  window), both pre-Job on `Immediate` classes and while the mover Job runs on
+  `WaitForFirstConsumer` classes.
+- `storageClassName` — StorageClass for the **staged PVC** only (absent ⇒ copy
+  the source PVC's class). Must belong to the **same CSI driver** as the source;
+  a mismatch fails fast with `StagedClassMismatch`. Flagship use: a rook-ceph
+  CephFS class with `backingSnapshot: "true"` for a near-instant shallow
+  read-only mount instead of a minutes-long full subvolume clone.
+- `accessModes` — access modes for the staged PVC (absent ⇒ copy the source's);
+  a closed enum of the four Kubernetes modes. `[ReadOnlyMany]` pairs with
+  snapshot-backed read-only classes; the mover always mounts the stage
+  read-only regardless.
+
+The two overrides need a staged PVC to act on, so they are **rejected at
+admission** for `copyMethod: Direct`, NFS sources, and `pvcSelector` sources. See
+[Copy methods → staging overrides](../../copy-methods.md#staging-overrides).
+
 ### `groupBy`
 
 Multi-PVC consistency grouping. `VolumeGroupSnapshot` (the default for multi-PVC


### PR DESCRIPTION
Closes #223.

## The report

> forgejo's data PVC is 11,676 tiny files in 150 MB (git loose objects/refs). kopiur's `copyMethod: Snapshot` restores the snapshot into a temp PVC by doing a full CephFS subvolume clone, which is MDS-metadata-bound — ~8.5 min for this file count. That blows past kopiur's fixed 300 s mover-pod-startup deadline; kopiur then deletes the source VolumeSnapshot mid-clone (`SnapshotDeletePending: Snapshot is being used to restore a PVC`), so the `-src` PVC never binds → the mover is Unschedulable → hard fail, every hour. — with VolSync the user pointed the temp PVC at a `cephfs-backingsnapshot` (`backingSnapshot: "true"`) StorageClass with `accessModes: [ReadOnlyMany]`, which kopiur couldn't express.

Two distinct defects underneath, plus the missing feature. All addressed here.

## Feature: `spec.staging.storageClassName` / `spec.staging.accessModes`

- Override the **staged PVC's** class and access modes (applies to `copyMethod: Snapshot` **and** `Clone`; absent ⇒ inherit from the source PVC, exactly as before — regression-pinned). The app's own PVC is never touched.
- Flagship use: a rook-ceph CephFS class with `backingSnapshot: "true"` — restore-from-snapshot becomes a **shallow, metadata-only, read-only mount, ready in seconds** instead of a minutes-long full subvolume clone. New `deploy/examples/30-cephfs-shallow-snapshot.yaml` is the reporter's exact setup; docs in `copy-methods.md` (new *Staging overrides* section).
- **Same-driver preflight**: an override class that doesn't exist (`StagedClassNotFound`) or is on a foreign CSI driver (`StagedClassMismatch`, message names both provisioners) fails fast at staging — without it the misconfig presents as an opaque 10-minute bind timeout.
- Admission rejects the overrides where no staged PVC exists to act on (`Direct`, NFS sources, `pvcSelector` sources), plus duplicate modes and the apiserver's `ReadWriteOncePod`-must-be-sole invariant (which otherwise wedges the run in an SSA retry loop instead of failing at apply).

### New `PvcAccessMode` type (and the Restore migration)

Access modes are now a **closed enum** — the CRD schema lists exactly the four canonical values, so a typo is rejected by the apiserver on every write. `restore.target.pvc.accessModes` migrated from `Vec<String>` to the same type (one encoding per concept). Because that tightens an existing stored field, decode is deliberately **graceful**: a hidden `Unknown(String)` variant (not in the schema) absorbs any legacy stored string instead of erroring the typed watch stream for the whole Kind — one bad CR can never wedge every other CR's reconciliation. The bad value is then rejected **loudly, per-CR**, with the offending string, field path, valid values, and fix quoted (shared validator ⇒ webhook and controller say the same thing; the controller path surfaces it as a Warning Event + structural backoff). The CLI's `--access-mode` validates at clap-parse time; `kopiur-migrate` refuses non-canonical VolSync modes as `Unmappable` (drives `--strict`) rather than emitting YAML doomed at apply.

## Race fix

- **Pre-Job bind gate** (`resolve_staging`): on an `Immediate`-binding class, the staged PVC must reach `Bound` before the mover Job is minted. Pure decision `pvc_bind_outcome` mirrors `vs_wait_outcome` exactly — Bound wins over the deadline (operator restart during a slow-but-successful bind never terminally fails a good stage), `Lost` is terminal on sight, a **fresh budget** anchored at the staged PVC's `creationTimestamp` bounded by `spec.staging.timeout` (default 10m, `"0"` = indefinite), deterministic Waiting messages (no status churn). `WaitForFirstConsumer` classes skip the gate (bind happens at pod schedule) — the existing WFFC e2e suites pass byte-identically. Both the Snapshot and Clone tails go through the same gate.
- **Running-Job watchdog**: while `status.staged` names a still-`Pending` staged PVC, the wedged-pod check is skipped (the pod *cannot* be wedged while its volume is provisioning — pre-fix this was exactly the 300 s `MoverPodWedged` misfire) and a bind that outlives the budget terminates with the same actionable `StagedPvcBindTimeout`. The budget is **pinned** in `status.staged.stagingTimeoutSeconds` at stamp time, so a policy edited or deleted mid-run can't change it. The PVC's own `status.phase` is the ground truth — WFFC bind hangs present as `PodScheduled=False/SchedulerError`, not `Unschedulable`, so scheduler-message parsing would have been dead code.
- **Pre-existing leak (found during review)**: the `StagingOutcome::Failed` arm never stamped `status.staged`, so every cleanup gate (`status.staged.is_some()`) skipped and a VS-deadline failure held a backend snapshot until the CR was deleted. The Failed arm now stamps `staged` (`ready: false`, deterministic names) and reaps immediately; `RunDecision::TerminalFailed` re-issues the reap on later reconciles (gated on the Job being terminal, mirroring the Succeeded path / #103), so even a transient API error during the failure-time cleanup self-heals.

Cleanup order was already PVC-before-VolumeSnapshot everywhere; the snapshot-controller's `snapshot-as-source-protection` finalizer drains an in-flight restore safely, and ceph-csi (≥ 3.7) reference-tracks the backing snapshot of shallow volumes, so the delete order is safe for the shallow-mount recipe too.

## Tests

- **Unit**: `pvc_bind_outcome` decision table (mirrors the `vs_wait_outcome` matrix), `effective_binding_mode`, `staged_class_preflight`, `build_staged_pvc` override/inherit matrix (verbatim-copy regression pin included), `staged_watchdog_budget`, `PvcAccessMode` schema/round-trip/legacy-decode, validator accept+reject for every new rule, CRD-schema walks pinning the enum-items encoding (first `Vec<unit-enum>` in the API), migrate refusal.
- **e2e** (new `crates/e2e/tests/staging_overrides.rs`): override happy path on a runtime-created Immediate-binding class (staged PVC carries both overrides, bind gate Bound→Ready, `Succeeded` with a real `kopiaSnapshotID`, `status.staged.storageClassName` recorded, stage reaped) + preflight fast-fail (terminal `Failed`/`StagedClassMismatch`, **no** Job/VolumeSnapshot/staged PVC ever created). `staging_deadline.rs` gains the leak regression trip-wire: the VolumeSnapshot of a staging-failed backup must be reaped and `status.staged` stamped. Existing `copy_methods.rs`/`staging_deadline.rs` WFFC suites unchanged (byte-stable `WaitingForVolumeSnapshot` reasons).
- **Not locally testable**: real CephFS `backingSnapshot` shallow semantics need rook-ceph — covered by the unit tables, the kind Immediate-class analogue, and the documented example.

## Compat notes

- All CRD changes are additive except the Restore `accessModes` type tightening — legacy stored values decode via `Unknown` and are rejected per-CR (see above), never a watcher-poisoning serde error. `deletionPolicy`/behavioral defaults unchanged.
- `spec.staging.timeout` now also bounds the staged PVC's bind (a fresh budget per phase). Setups whose Immediate-class restores routinely exceed 10 minutes previously failed via `MoverPodWedged` at 300 s — they now get the full budget and an actionable reason naming the knob (and the shallow-clone fix).

For the reporter: `spec.staging: { storageClassName: cephfs-backingsnapshot, accessModes: [ReadOnlyMany] }` — the exact VolSync setup, now expressible.