### PR TITLE
test(e2e): align staging-recover guard with the #223 staged-PVC bind gate

### DIFF
--- a/crates/e2e/tests/staging_deadline.rs
+++ b/crates/e2e/tests/staging_deadline.rs
@@ -347,16 +347,47 @@ async fn recover_body(client: &kube::Client, prefix: &str) -> anyhow::Result<()>
         .await
         .context("mark VolumeSnapshot ready")?;
 
-    // Staging recovers: SourceStaged=True and the staged PVC exists. (The staged PVC
-    // can never bind — the VS has no real content — so the run pends at the mover;
-    // recovery of STAGING is the asserted success condition.)
-    wait_condition(&backups, prefix, "SourceStaged", "True")
-        .await
-        .context("staging must recover once the VolumeSnapshot is ready")?;
+    // Staging RECOVERS: the operator accepts the now-ready VS, drops the transient
+    // error, and advances PAST the VolumeSnapshot wait to provision the staged PVC.
+    // It cannot reach `SourceStaged=True` here: this synthetic VS has no backing
+    // VolumeSnapshotContent (the snapshot-controller is quiesced), so the CSI restore
+    // has nothing to copy and the staged PVC never binds — the #223 staged-PVC bind
+    // gate therefore holds `SourceStaged=False` with reason `WaitingForStagedPvcBind`.
+    // Reaching that reason IS the recovery signal for #198: pre-fix code terminally
+    // `Failed` the Snapshot on the transient error and never got past the VS wait.
+    // (A real snapshot binds and reaches `SourceStaged=True`; copy_methods.rs covers
+    // that path.)
+    wait_until(
+        "staging recovers past the transient VS error to the staged-PVC bind gate",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let advanced = status_json(&backups, prefix)
+                .await
+                .get("conditions")
+                .and_then(|c| c.as_array())
+                .and_then(|a| {
+                    a.iter()
+                        .find(|c| c.get("type").and_then(|t| t.as_str()) == Some("SourceStaged"))
+                })
+                .is_some_and(|c| {
+                    c.get("status").and_then(|v| v.as_str()) == Some("False")
+                        && c.get("reason").and_then(|v| v.as_str())
+                            == Some("WaitingForStagedPvcBind")
+                });
+            Ok(advanced.then_some(()))
+        },
+    )
+    .await
+    .context("staging must recover past the transient VS error once the VS is ready")?;
+
+    // The recovery is real: the operator got past the VS wait and provisioned the
+    // staged PVC, and the transient error did NOT push the Snapshot terminal — it is
+    // still `Pending` (the whole point of #198).
     let staged = pvcs.get_opt(&format!("{prefix}-src")).await?;
     ensure!(
         staged.is_some(),
-        "the staged PVC must exist after staging recovered"
+        "the staged PVC must exist once staging recovered past the VS error"
     );
     let phase = status_json(&backups, prefix)
         .await
@@ -365,8 +396,9 @@ async fn recover_body(client: &kube::Client, prefix: &str) -> anyhow::Result<()>
         .unwrap_or_default()
         .to_string();
     ensure!(
-        phase != "Failed",
-        "the backup must not be Failed after staging recovered, got {phase:?}"
+        phase == "Pending",
+        "a recovered transient VS error must hold the Snapshot Pending (not Failed), \
+         got {phase:?}"
     );
     Ok(())
 }


### PR DESCRIPTION
## What

Fixes the deterministic `E2E (staging)` failure now red on `main` (introduced by #228, first exposed when the `staging` shard was wired into CI in the same push).

The `#198` transient-VolumeSnapshot-error recovery test (`transient_volumesnapshot_error_recovers_and_does_not_fail_the_backup`) asserted `SourceStaged=True` once the injected VolumeSnapshot is marked `readyToUse`. #228's `staged_pvc_bind_gate` redefined `SourceStaged=True` to require the staged PVC to actually **Bind** — but this scenario quiesces the snapshot-controller, so the VS has no backing `VolumeSnapshotContent` and the CSI restore can never bind the staged PVC. The assertion was therefore permanently unreachable → 420s timeout.

## Why it slipped through

The test was `#[ignore]`d and not in any CI shard until #228's follow-up added the `staging` shard. So its **first ever CI run** — the post-merge `main` push and the release PR — failed. `main` push [went red at #228](https://github.com/home-operations/kopiur/actions) while the prior `main` run was green.

## Fix

Assert the **reachable** recovery signal instead: the operator drops the transient error and advances *past* the VS wait to provision the staged PVC, surfacing `SourceStaged=False` / reason `WaitingForStagedPvcBind` with the Snapshot held `Pending`. That is exactly what separates the #198-fixed operator (recovers, progresses) from the pre-fix one (terminally `Failed` on first error). A real, bindable snapshot reaching `SourceStaged=True` is already covered by `copy_methods.rs`.

Test-only; **no operator behavior change**. `default_timeout()` (420s) sits under the 10m staging deadline, so the wait cannot race a legitimate bind-timeout.

## Verification

- `cargo test -p kopiur-e2e --features e2e --test staging_deadline --no-run` ✅
- `cargo clippy -p kopiur-e2e --features e2e --tests` ✅
- Behavioral: the `E2E (staging)` shard on this PR.