### PR TITLE
fix: populator no-op over bound PVCs, ClusterRepository secret namespace, stuck MaintenanceConfigured

### DIFF
--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -50,7 +50,9 @@ pub struct SecretKeyRef {
     /// reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
     /// absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
     /// mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+    /// needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+    /// other than the operator itself reads the `Secret`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     /// Which key inside the `Secret` to read.
@@ -69,7 +71,9 @@ pub struct SecretRef {
     /// reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
     /// absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
     /// mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+    /// needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+    /// other than the operator itself reads the `Secret`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 }

--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -45,7 +45,12 @@ pub trait PhaseLabel: Copy + PartialEq + 'static {
 pub struct SecretKeyRef {
     /// Name of the `Secret`.
     pub name: String,
-    /// Namespace of the `Secret`; absent = same namespace as the referrer.
+    /// Namespace of the `Secret`; absent = same namespace as the referrer. A
+    /// `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+    /// reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+    /// absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+    /// mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
     /// Which key inside the `Secret` to read.
@@ -59,7 +64,12 @@ pub struct SecretKeyRef {
 pub struct SecretRef {
     /// Name of the `Secret`.
     pub name: String,
-    /// Namespace of the `Secret`; absent = same namespace as the referrer.
+    /// Namespace of the `Secret`; absent = same namespace as the referrer. A
+    /// `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+    /// reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+    /// absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+    /// mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+    /// `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
 }

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -253,7 +253,30 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
     // below — whose branches return early — so it is applied/migrated/torn down on
     // every reconcile. Children live in `spec.server.namespace` (cluster-scoped
     // owners can't own them); cleanup is via the finalizer + back-reference labels.
-    reconcile_cluster_server(ctx, repo, &name, &api).await?;
+    //
+    // Degrade, don't crash: the web UI is auxiliary — backups and restores do not depend on
+    // it — so a problem here must NOT abort the reconcile before the backend match below,
+    // which is what actually bootstraps the repository. It used to `?`, so a server whose
+    // credentials Secret is not where we expect (e.g. an absent `passwordSecretRef.namespace`
+    // now resolving to the operator namespace rather than the server's) would take the whole
+    // repository down with it. Surface it as a Warning and carry on.
+    if let Err(e) = reconcile_cluster_server(ctx, repo, &name, &api).await {
+        tracing::warn!(error = %e, repo = %name, "failed to reconcile the kopia repository server; the repository itself is unaffected");
+        io::publish_warning_event(
+            ctx,
+            repo,
+            "RepositoryServerDegraded",
+            "CheckRepositoryServer",
+            &format!(
+                "the kopia repository server (spec.server) could not be reconciled: {e}. The \
+                 repository itself is unaffected — backups and restores continue. If its \
+                 credentials Secret lives in the server's namespace, pin it explicitly with \
+                 encryption.passwordSecretRef.namespace (a ClusterRepository otherwise reads it \
+                 from the operator's namespace)."
+            ),
+        )
+        .await;
+    }
     // Once a server is no longer configured (and any teardown above has run), the
     // cleanup finalizer is no longer needed.
     if !server_enabled {
@@ -798,7 +821,15 @@ async fn bootstrap_cluster_via_mover(
         // and a status patch that is skipped when nothing changed. It also gives the
         // Maintenance watch (`controllers.rs`) a reconcile that actually re-classifies, so
         // deleting the managed CR now re-applies it instead of being silently ignored.
-        ensure_cluster_maintenance(ctx, repo, name, api, &cluster_conditions(repo)).await;
+        //
+        // Build on a FRESH read of the conditions, not the watch-cached object: a Maintenance
+        // event can requeue us moments after the bootstrap finalize patched `Bootstrapped` /
+        // `BackendReachable`, while the informer store still holds the pre-patch copy — and
+        // the condition write below replaces the whole array, so a stale copy would silently
+        // resurrect it and drop those conditions.
+        let fresh = api.get_opt(name).await?;
+        let conditions = fresh.as_ref().map(cluster_conditions).unwrap_or_default();
+        ensure_cluster_maintenance(ctx, repo, name, api, &conditions).await;
         return Ok(Action::requeue(cluster_probe_aware_reconcile_interval(
             repo,
         )));
@@ -832,7 +863,16 @@ async fn bootstrap_cluster_via_mover(
             secret_names: &creds_names,
             repo_kind: "ClusterRepository",
             repo_name: name,
-            repo_secret_namespace: Some(&job_ns),
+            // The namespace the REFERENCE names, not the Job's. Passing the Job's namespace
+            // would make it tautologically equal and silence the cross-namespace branch of
+            // `missing_creds_message` — the branch that exists precisely to say "your
+            // ClusterRepository keeps that Secret in X, but the Job runs in Y".
+            repo_secret_namespace: repo
+                .spec
+                .encryption
+                .password_secret_ref
+                .namespace
+                .as_deref(),
         },
     )
     .await?;

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -75,6 +75,90 @@ fn cluster_maintenance_placement(ctx: &Context, repo: &ClusterRepository) -> Opt
         .or_else(|| ctx.operator_namespace.clone())
 }
 
+/// Project this `ClusterRepository`'s `spec.maintenance` into its managed `Maintenance` CR
+/// and refresh the `MaintenanceConfigured` condition (ADR §3.7; §11: ReadOnly cluster repos
+/// run no maintenance).
+///
+/// `conditions` is the condition set to build on — the FRESHLY patched set on the bootstrap
+/// finalize path (so this patch doesn't drop the `Bootstrapped` condition written moments
+/// earlier), or the cached status elsewhere.
+///
+/// Called on every reconcile that gets far enough to know the repo's state, including the
+/// steady-state pass of an already-`Ready` object-store repo. That last one is #231: the
+/// condition used to be written only at the tail of a bootstrap, so a value written during
+/// a bootstrap race (the informer store had not yet seen the just-applied Maintenance, or
+/// the apply transiently failed) froze — reading `MaintenanceDisabled` for days while the
+/// managed `Maintenance` sat right there, owned and running.
+async fn ensure_cluster_maintenance(
+    ctx: &Context,
+    repo: &ClusterRepository,
+    name: &str,
+    api: &Api<ClusterRepository>,
+    conditions: &[Condition],
+) {
+    if !repo.spec.mode.allows_writes() {
+        return;
+    }
+    let placement = cluster_maintenance_placement(ctx, repo);
+    io::ensure_maintenance(
+        ctx,
+        api,
+        repo,
+        &io::event_ref(repo),
+        RepositoryKind::ClusterRepository,
+        "ClusterRepository",
+        "",
+        None,
+        placement.as_deref(),
+        name,
+        repo.spec.maintenance.as_ref(),
+        conditions,
+        repo.metadata.generation,
+    )
+    .await;
+}
+
+/// The `ClusterRepository`'s currently-observed status conditions (empty when no status).
+fn cluster_conditions(repo: &ClusterRepository) -> Vec<Condition> {
+    repo.status
+        .as_ref()
+        .map(|s| s.conditions.clone())
+        .unwrap_or_default()
+}
+
+/// Which namespace a cluster-scoped repository reads its credential `Secret` from (and
+/// therefore runs its bootstrap `Job` in): the reference's explicit `namespace` if set,
+/// else the operator's own namespace (`KOPIUR_NAMESPACE`).
+///
+/// A `ClusterRepository` has no namespace of its own, so "absent = the referrer's
+/// namespace" cannot mean anything for it. Rather than refuse the object (#232: the
+/// reconcile hard-errored `passwordSecretRef.namespace is required`, contradicting the
+/// field's own documentation), default to the operator namespace — the same rule
+/// [`cluster_maintenance_placement`] already applies to `spec.maintenance.namespace`, and
+/// the namespace where a chart install's repository Secret conventionally lives.
+///
+/// Only an off-chart install with no `KOPIUR_NAMESPACE` has neither, and that is a real
+/// misconfiguration: refuse it with both fixes rather than guess a namespace. Pure.
+fn cluster_secret_namespace(
+    explicit: Option<&str>,
+    operator_namespace: Option<&str>,
+) -> Result<String> {
+    explicit
+        .or(operator_namespace)
+        .map(str::to_string)
+        .ok_or_else(|| {
+            Error::Validation(
+                "ClusterRepository encryption.passwordSecretRef.namespace is not set and the \
+                 operator's own namespace is unknown (KOPIUR_NAMESPACE is unset), so there is no \
+                 namespace to read the repository's credential Secret from — a cluster-scoped \
+                 ClusterRepository has none of its own to fall back on. Set \
+                 encryption.passwordSecretRef.namespace to the Secret's namespace, or set \
+                 KOPIUR_NAMESPACE on the controller (the Helm chart does this automatically)."
+                    .into(),
+            )
+        })
+}
+
 /// Reconcile a `ClusterRepository`.
 #[tracing::instrument(skip(repo, ctx), fields(kind = "ClusterRepository", name = %repo.name_any()))]
 pub async fn reconcile(repo: Arc<ClusterRepository>, ctx: Arc<Context>) -> Result<Action> {
@@ -176,8 +260,9 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
         io::remove_finalizer(&api, repo, SERVER_CLEANUP_FINALIZER).await?;
     }
 
-    // Same connect/create/status lifecycle as Repository. Cluster-scoped secret
-    // refs MUST carry an explicit namespace (webhook-enforced).
+    // Same connect/create/status lifecycle as Repository. A cluster-scoped secret ref has
+    // no referrer namespace to inherit, so an absent one resolves to the operator's
+    // namespace (`cluster_secret_namespace`).
     match &repo.spec.backend {
         // A PVC/NFS-backed filesystem repo is NOT reachable from the controller
         // in-process (the controller pod can't mount the repo volume), so — exactly
@@ -199,11 +284,10 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
             // rationale: a credential fix does not bump `generation`, so the gate must
             // also key on the Secret revision).
             let creds = io::repo_credentials(&repo.spec.encryption);
-            let secret_ns = creds.namespace.clone().ok_or_else(|| {
-                Error::Validation(
-                    "ClusterRepository encryption.passwordSecretRef.namespace is required".into(),
-                )
-            })?;
+            let secret_ns = cluster_secret_namespace(
+                creds.namespace.as_deref(),
+                ctx.operator_namespace.as_deref(),
+            )?;
             let (password, cred_version) =
                 io::read_repo_credential(&ctx.client, &secret_ns, &creds).await?;
 
@@ -364,31 +448,7 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
             // Cluster-scoped, so the metric namespace label is empty and
             // ref-matching ignores namespace. The (namespaced) Maintenance lands in
             // spec.maintenance.namespace, else the operator's own namespace.
-            let conditions = repo
-                .status
-                .as_ref()
-                .map(|s| s.conditions.clone())
-                .unwrap_or_default();
-            // §11: ReadOnly cluster repos run no maintenance.
-            if repo.spec.mode.allows_writes() {
-                let placement = cluster_maintenance_placement(ctx, repo);
-                io::ensure_maintenance(
-                    ctx,
-                    &api,
-                    repo,
-                    &io::event_ref(repo),
-                    RepositoryKind::ClusterRepository,
-                    "ClusterRepository",
-                    "",
-                    None,
-                    placement.as_deref(),
-                    &name,
-                    repo.spec.maintenance.as_ref(),
-                    &conditions,
-                    repo.metadata.generation,
-                )
-                .await;
-            }
+            ensure_cluster_maintenance(ctx, repo, &name, &api, &cluster_conditions(repo)).await;
         }
         other => {
             // Object-store backends bootstrap via a short-lived mover Job (ADR
@@ -509,12 +569,18 @@ async fn reconcile_cluster_server(
         (CLUSTER_REPOSITORY_UID_LABEL.to_string(), uid),
     ]);
 
-    // Cluster-scoped credentials Secret carries an explicit namespace; fall back to
-    // the server namespace if somehow unset.
+    // Which namespace the server MIRRORS the credentials Secret from. Same rule the
+    // repository itself uses (`cluster_secret_namespace`): the reference's explicit
+    // namespace, else the operator's — so "absent" means ONE thing on a ClusterRepository.
+    // Were this to keep defaulting to the server namespace while the repository defaulted
+    // to the operator's, a user who followed the documented default (Secret in the operator
+    // namespace) would bootstrap fine and then get a server pod wedged on a Secret that
+    // isn't in its namespace. The server namespace remains the last resort.
     let creds = io::repo_credentials(&repo.spec.encryption);
     let creds_src_namespace = creds
         .namespace
         .clone()
+        .or_else(|| ctx.operator_namespace.clone())
         .or_else(|| desired_ns.clone())
         .unwrap_or_default();
 
@@ -597,14 +663,13 @@ async fn bootstrap_cluster_via_mover(
     api: &Api<ClusterRepository>,
     backend: &Backend,
 ) -> Result<Action> {
-    // The Job + its result ConfigMap live in the credentials Secret's namespace
-    // (cluster-scoped refs must carry an explicit namespace — webhook-enforced).
+    // The Job + its result ConfigMap live in the credentials Secret's namespace: the
+    // reference's explicit namespace, else the operator's own (`cluster_secret_namespace`).
     let creds = io::repo_credentials(&repo.spec.encryption);
-    let job_ns = creds.namespace.clone().ok_or_else(|| {
-        Error::Validation(
-            "ClusterRepository encryption.passwordSecretRef.namespace is required".into(),
-        )
-    })?;
+    let job_ns = cluster_secret_namespace(
+        creds.namespace.as_deref(),
+        ctx.operator_namespace.as_deref(),
+    )?;
     let job_name = format!("{name}-bootstrap");
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), &job_ns);
 
@@ -723,6 +788,17 @@ async fn bootstrap_cluster_via_mover(
             chrono::Utc::now(),
         ))
     {
+        // This is the STEADY STATE of a Ready object-store repo (`bootstrap_create_due` is
+        // true for any non-Ready phase, so nothing that has yet to bootstrap gets here).
+        // Re-evaluate maintenance coverage before parking: it is the only pass a repo whose
+        // bootstrap Job has been TTL-reaped ever makes, and #231 is exactly what happens
+        // when the condition is never re-evaluated — a `MaintenanceDisabled` written during
+        // a bootstrap race froze for days while the managed `Maintenance` ran happily. Cheap
+        // and idempotent: a synchronous informer read, a deterministic server-side apply,
+        // and a status patch that is skipped when nothing changed. It also gives the
+        // Maintenance watch (`controllers.rs`) a reconcile that actually re-classifies, so
+        // deleting the managed CR now re-applies it instead of being silently ignored.
+        ensure_cluster_maintenance(ctx, repo, name, api, &cluster_conditions(repo)).await;
         return Ok(Action::requeue(cluster_probe_aware_reconcile_interval(
             repo,
         )));
@@ -742,7 +818,25 @@ async fn bootstrap_cluster_via_mover(
         repo.spec.create.as_ref(),
         repo.spec.mover_defaults.as_ref(),
     );
-    let creds_secrets = io::plain_creds(io::mover_creds_secrets(backend, &repo.spec.encryption));
+    // Preflight the credential Secret(s) the bootstrap mover loads via `envFrom`, in the
+    // namespace it will actually run in. Without this the Job launches against a Secret
+    // that isn't there, its pod wedges in `CreateContainerConfigError` until the bootstrap
+    // deadline, and the failure surfaces as a generic "mover pod crashed or never
+    // scheduled" — naming neither the Secret nor the namespace. That matters more now that
+    // `job_ns` can be DEFAULTED (#232): if the Secret lives somewhere else, say so.
+    let creds_names = io::mover_creds_secrets(backend, &repo.spec.encryption);
+    io::ensure_creds_present(
+        &ctx.client,
+        &job_ns,
+        &io::CredsContext {
+            secret_names: &creds_names,
+            repo_kind: "ClusterRepository",
+            repo_name: name,
+            repo_secret_namespace: Some(&job_ns),
+        },
+    )
+    .await?;
+    let creds_secrets = io::plain_creds(creds_names);
     let owner = io::owner_ref_for(repo, "ClusterRepository")?;
     // The bootstrap Job runs in the credentials Secret's namespace (`job_ns`).
     // Resolve its run identity there: the user's workload-identity SA
@@ -1084,26 +1178,7 @@ async fn finalize_cluster_bootstrap(
     // Ensure the managed Maintenance for this ClusterRepository (§3.7). Build on
     // the conditions we just patched (including `Bootstrapped`), not the stale
     // cached object, so this patch doesn't drop the `Bootstrapped` set above.
-    // §11: ReadOnly cluster repos run no maintenance.
-    if repo.spec.mode.allows_writes() {
-        let placement = cluster_maintenance_placement(ctx, repo);
-        io::ensure_maintenance(
-            ctx,
-            api,
-            repo,
-            &io::event_ref(repo),
-            RepositoryKind::ClusterRepository,
-            "ClusterRepository",
-            "",
-            None,
-            placement.as_deref(),
-            name,
-            repo.spec.maintenance.as_ref(),
-            &conditions,
-            repo.metadata.generation,
-        )
-        .await;
-    }
+    ensure_cluster_maintenance(ctx, repo, name, api, &conditions).await;
 
     // A probe consumes its Job exactly once (no lingering finished Job → no churn;
     // the next probe is a fresh connect). Requeue on the probe cadence.
@@ -1282,5 +1357,39 @@ mod tests {
     #[test]
     fn disallowed_and_no_fallback_yields_none() {
         assert_eq!(placement_namespace("evil", false, None), None);
+    }
+
+    // #232: a ClusterRepository is cluster-scoped, so "absent = the referrer's namespace"
+    // has nothing to resolve to. It used to hard-error `passwordSecretRef.namespace is
+    // required` on every reconcile, contradicting the field's own documentation; it now
+    // defaults to the operator's namespace, exactly like spec.maintenance.namespace.
+
+    #[test]
+    fn explicit_secret_namespace_wins_over_the_operator_namespace() {
+        assert_eq!(
+            cluster_secret_namespace(Some("vault"), Some("kopiur-system")).unwrap(),
+            "vault"
+        );
+    }
+
+    #[test]
+    fn absent_secret_namespace_defaults_to_the_operator_namespace() {
+        assert_eq!(
+            cluster_secret_namespace(None, Some("kopiur-system")).unwrap(),
+            "kopiur-system"
+        );
+    }
+
+    #[test]
+    fn absent_secret_namespace_without_an_operator_namespace_is_an_actionable_error() {
+        let err = cluster_secret_namespace(None, None).expect_err("must not guess a namespace");
+        let msg = err.to_string();
+        // Both fixes, so an off-chart install knows either lever will do.
+        assert!(
+            msg.contains("encryption.passwordSecretRef.namespace"),
+            "{msg}"
+        );
+        assert!(msg.contains("KOPIUR_NAMESPACE"), "{msg}");
+        assert!(matches!(err, Error::Validation(_)), "{err:?}");
     }
 }

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -101,6 +101,12 @@ pub const MAINTENANCE_DISABLED_REASON: &str = "MaintenanceDisabled";
 /// cannot be placed: neither `spec.maintenance.namespace` nor the operator
 /// namespace (`KOPIUR_NAMESPACE`) is set. A real misconfiguration, so it warns.
 pub const MAINTENANCE_NAMESPACE_UNRESOLVED_REASON: &str = "MaintenanceNamespaceUnresolved";
+/// Event + condition reason when maintenance is ENABLED but the operator could not apply
+/// its managed `Maintenance` (a failed server-side apply, or an un-buildable owner ref).
+/// Distinct from [`MAINTENANCE_DISABLED_REASON`], which is a deliberate opt-out: reporting
+/// a transient apply failure as "you disabled maintenance" pointed operators at entirely
+/// the wrong knob (#231). Warns, and is retried on every reconcile.
+pub const MAINTENANCE_APPLY_FAILED_REASON: &str = "MaintenanceApplyFailed";
 
 /// Status condition `type` recording the outcome of an object-store repository
 /// bootstrap Job (connect/create). `True` once the repository is reachable;
@@ -138,6 +144,17 @@ pub const BOOTSTRAP_JOB_FAILED_REASON: &str = "BootstrapJobFailed";
 pub const OP_RESTORE_POPULATE: &str = "restore-populate";
 /// `Restore` Ready reason once a populator restored its snapshot and rebound the volume.
 pub const RESTORE_POPULATED_REASON: &str = "RestoreSucceeded";
+/// `Restore` Ready reason when a populator's claiming PVC is ALREADY bound, so there is
+/// nothing to populate: a CSI volume-populator can only hand a volume to an unbound claim.
+/// A truthful terminal no-op — no prime PVC, no mover run (#233).
+pub const RESTORE_TARGET_ALREADY_BOUND_REASON: &str = "TargetAlreadyBound";
+/// Warning Event reason when the populator reaps leftover populate artifacts (a prime PVC
+/// and/or its mover Job) that can never be handed over because the claiming PVC is already
+/// bound. Pre-0.8 these leaked, each holding a full copy of the restored data (#233).
+pub const ORPHANED_PRIME_REAPED_REASON: &str = "OrphanedPrimePvcReaped";
+/// `action` for the already-bound no-op / orphan-reap Events: to actually restore into the
+/// claim, delete it and let it be recreated (keeping its `dataSourceRef`).
+pub const RECREATE_CLAIM_TO_RESTORE_ACTION: &str = "RecreateClaimToRestore";
 
 /// `Snapshot`/`Restore` condition surfaced when the mover Job's credential Secret is
 /// absent from the workload namespace — `False` carries the actionable message

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -144,6 +144,16 @@ pub const BOOTSTRAP_JOB_FAILED_REASON: &str = "BootstrapJobFailed";
 pub const OP_RESTORE_POPULATE: &str = "restore-populate";
 /// `Restore` Ready reason once a populator restored its snapshot and rebound the volume.
 pub const RESTORE_POPULATED_REASON: &str = "RestoreSucceeded";
+/// `Restore` Failed reason (and Warning Event) when the claiming PVC was bound out from
+/// under a populate that was still RUNNING — a provisioner handed it a volume without
+/// honoring its `dataSourceRef`, so the restore can never be delivered. Distinct from
+/// [`RESTORE_TARGET_ALREADY_BOUND_REASON`]: that one is a benign no-op over a claim that was
+/// already carrying its data; this one means the app is about to start on the WRONG volume.
+pub const POPULATE_HIJACKED_REASON: &str = "PopulateHijacked";
+/// `Restore` Ready reason while a populator that had completed as an already-bound no-op
+/// re-resolves its source, because its claiming PVC was re-created (and is unbound again,
+/// so it genuinely wants populating). Also re-anchors the `waitTimeout` window.
+pub const RESTORE_CLAIM_RECREATED_REASON: &str = "ClaimRecreated";
 /// `Restore` Ready reason when a populator's claiming PVC is ALREADY bound, so there is
 /// nothing to populate: a CSI volume-populator can only hand a volume to an unbound claim.
 /// A truthful terminal no-op — no prime PVC, no mover run (#233).

--- a/crates/controller/src/io/maintenance.rs
+++ b/crates/controller/src/io/maintenance.rs
@@ -89,12 +89,18 @@ pub enum MaintenanceCoverage {
     CoveredByManaged,
     /// A deliberate opt-out: `spec.maintenance.enabled: false` and nothing else covers it.
     DisabledBySpec,
-    /// Maintenance is ENABLED, but the operator could not apply its managed `Maintenance`.
+    /// Maintenance is ENABLED, nothing covers the repository, and the operator could not
+    /// apply its managed `Maintenance`.
+    ///
+    /// The apply error is deliberately NOT carried into the condition message: this runs on
+    /// every reconcile, and the hot-loop guard that suppresses an unchanged condition is a
+    /// byte comparison — an error string that varies between attempts (a `Conflict` naming a
+    /// resourceVersion, an API detail that moves) would defeat it and spin status writes and
+    /// Events at full speed. The verbatim error goes to the operator log instead, where it
+    /// costs nothing to vary.
     ApplyFailed {
         /// Namespace the managed `Maintenance` was to be applied in.
         namespace: String,
-        /// The apply (or owner-ref) error, verbatim, so the condition is actionable.
-        error: String,
     },
 }
 
@@ -139,15 +145,16 @@ pub fn maintenance_condition(
             ),
             false,
         ),
-        MaintenanceCoverage::ApplyFailed { namespace, error } => (
+        MaintenanceCoverage::ApplyFailed { namespace } => (
             false,
             MAINTENANCE_APPLY_FAILED_REASON,
             format!(
                 "maintenance is ENABLED for {metric_kind} {name}, but the operator could not \
-                 apply its managed Maintenance in namespace {namespace}: {error}; kopia storage \
-                 will not be reclaimed until this succeeds. It is retried on every reconcile — \
-                 if it persists, check that the namespace exists and that the operator has RBAC \
-                 to write Maintenance there"
+                 apply its managed Maintenance in namespace {namespace}, and nothing else \
+                 covers this repository; kopia storage will not be reclaimed until this \
+                 succeeds. It is retried on every reconcile — if it persists, check that the \
+                 namespace exists and that the operator has RBAC to write Maintenance there; \
+                 the apply error itself is in the operator log"
             ),
             true,
         ),
@@ -344,11 +351,21 @@ pub async fn ensure_maintenance<K>(
                     let mapi: Api<Maintenance> = Api::namespaced(ctx.client.clone(), ns);
                     match apply(&mapi, name, &desired).await {
                         Ok(_) => MaintenanceCoverage::CoveredByManaged,
+                        // An apply that fails while the managed `Maintenance` ALREADY exists
+                        // has not un-covered the repo: the CR is right there, owned, holding
+                        // its lease, running on schedule. Since this now runs on every
+                        // reconcile, treating a transient apiserver blip as "maintenance is
+                        // not configured" would flap the condition (and its gauge, and a
+                        // Warning) on every hiccup. Only report the failure when nothing
+                        // covers the repo — the state a user actually has to fix.
+                        Err(e) if managed.is_some() => {
+                            tracing::warn!(error = %e, repo = %name, namespace = %ns, "failed to re-apply the managed Maintenance; the existing one still covers this repository");
+                            MaintenanceCoverage::CoveredByManaged
+                        }
                         Err(e) => {
                             tracing::warn!(error = %e, repo = %name, namespace = %ns, "failed to apply managed Maintenance");
                             MaintenanceCoverage::ApplyFailed {
                                 namespace: ns.to_string(),
-                                error: e.to_string(),
                             }
                         }
                     }
@@ -357,7 +374,6 @@ pub async fn ensure_maintenance<K>(
                     tracing::warn!(error = %e, repo = %name, "cannot build owner reference for managed Maintenance");
                     MaintenanceCoverage::ApplyFailed {
                         namespace: ns.to_string(),
-                        error: e.to_string(),
                     }
                 }
             }
@@ -393,24 +409,12 @@ pub async fn ensure_maintenance<K>(
 
     let (status, reason, message, warn) = maintenance_condition(&coverage, metric_kind, name);
 
-    let conditions = upsert_condition(
-        existing_conditions,
-        MAINTENANCE_CONFIGURED_CONDITION,
-        status,
-        reason,
-        &message,
-        observed_generation,
-    );
-    // Skip the write when the upsert changed nothing: this runs on EVERY repo
-    // reconcile, and an identical re-write would bump `resourceVersion` and
-    // re-trigger the repo controller through its own watch (hot-loop).
-    if conditions.as_slice() == existing_conditions {
-        return;
-    }
-    // Warn only alongside a real condition transition. This runs on every reconcile now
-    // (including the steady-state object-store pass that #231 added), so an unconditional
-    // publish would mint the same Warning every reconcile interval for as long as the
-    // problem lasts — the condition is the durable signal; the Event marks the change.
+    // Publish the Warning while the problem PERSISTS, not just when the condition flips.
+    // Kubernetes aggregates repeats of an identical Event (bumping its count and
+    // lastTimestamp rather than minting new objects), so re-publishing keeps the signal
+    // alive for `kubectl describe` and Event-driven alerting; gating it on a condition
+    // change instead would emit exactly one Event ever and then go silent forever once it
+    // aged out of the Event TTL — while kopia storage quietly never got reclaimed.
     if warn
         && let Err(e) = ctx
             .recorder
@@ -427,6 +431,23 @@ pub async fn ensure_maintenance<K>(
             .await
     {
         tracing::warn!(error = %e, repo = %name, "failed to publish {reason} event");
+    }
+
+    let conditions = upsert_condition(
+        existing_conditions,
+        MAINTENANCE_CONFIGURED_CONDITION,
+        status,
+        reason,
+        &message,
+        observed_generation,
+    );
+    // Skip the write when the upsert changed nothing: this runs on EVERY repo
+    // reconcile, and an identical re-write would bump `resourceVersion` and
+    // re-trigger the repo controller through its own watch (hot-loop). Every `message`
+    // above is a pure function of (coverage, kind, name), so a steady state produces a
+    // byte-identical condition and this guard always fires.
+    if conditions.as_slice() == existing_conditions {
+        return;
     }
     if let Err(e) = patch_status(api, name, serde_json::json!({ "conditions": conditions })).await {
         tracing::warn!(error = %e, repo = %name, "failed to patch MaintenanceConfigured condition");

--- a/crates/controller/src/io/maintenance.rs
+++ b/crates/controller/src/io/maintenance.rs
@@ -18,8 +18,9 @@ use kopiur_api::maintenance::{
 };
 
 use crate::consts::{
-    CHECK_MAINTENANCE_ACTION, MAINTENANCE_CONFIGURED_CONDITION, MAINTENANCE_CONFIGURED_REASON,
-    MAINTENANCE_DISABLED_REASON, MAINTENANCE_NAMESPACE_UNRESOLVED_REASON,
+    CHECK_MAINTENANCE_ACTION, MAINTENANCE_APPLY_FAILED_REASON, MAINTENANCE_CONFIGURED_CONDITION,
+    MAINTENANCE_CONFIGURED_REASON, MAINTENANCE_DISABLED_REASON,
+    MAINTENANCE_NAMESPACE_UNRESOLVED_REASON,
 };
 use crate::context::Context;
 
@@ -69,6 +70,88 @@ pub enum MaintenanceAction {
     Leave,
     /// Wanted, but the (cluster-repo) placement namespace is unresolved.
     Unresolved,
+}
+
+/// What [`ensure_maintenance`] actually OBSERVED this pass, as a closed set — the input to
+/// the `MaintenanceConfigured` condition. Separate from [`MaintenanceAction`] (what the
+/// operator decided to DO) because the two disagree exactly where #231 bit: the operator
+/// intends to `Manage`, its apply fails, and the repo ends up not covered — which the old
+/// boolean `covered` flag lumped in with a deliberate opt-out and reported as
+/// "maintenance is disabled (spec.maintenance.enabled: false)", a claim that was simply
+/// false. Every not-covered state now says why it is not covered.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum MaintenanceCoverage {
+    /// Wanted, but the (cluster-repo) placement namespace is unresolved.
+    Unresolved,
+    /// An externally-authored `Maintenance` references the repo.
+    CoveredByForeign,
+    /// The operator's own managed `Maintenance` is applied and covers the repo.
+    CoveredByManaged,
+    /// A deliberate opt-out: `spec.maintenance.enabled: false` and nothing else covers it.
+    DisabledBySpec,
+    /// Maintenance is ENABLED, but the operator could not apply its managed `Maintenance`.
+    ApplyFailed {
+        /// Namespace the managed `Maintenance` was to be applied in.
+        namespace: String,
+        /// The apply (or owner-ref) error, verbatim, so the condition is actionable.
+        error: String,
+    },
+}
+
+/// The `MaintenanceConfigured` condition for an observed [`MaintenanceCoverage`]:
+/// `(status, reason, message, warn)`. Pure + exhaustive, so every coverage state — and in
+/// particular every NOT-covered state — carries a reason and a message that are true of it
+/// (#231). `warn` marks the states that also deserve a Warning Event.
+pub fn maintenance_condition(
+    coverage: &MaintenanceCoverage,
+    metric_kind: &str,
+    name: &str,
+) -> (bool, &'static str, String, bool) {
+    match coverage {
+        MaintenanceCoverage::Unresolved => (
+            false,
+            MAINTENANCE_NAMESPACE_UNRESOLVED_REASON,
+            format!(
+                "managed Maintenance for {metric_kind} {name} cannot be placed: set \
+                 spec.maintenance.namespace, or the operator's KOPIUR_NAMESPACE, so the \
+                 namespaced Maintenance CR has a home"
+            ),
+            true,
+        ),
+        MaintenanceCoverage::CoveredByForeign => (
+            true,
+            MAINTENANCE_CONFIGURED_REASON,
+            format!("an externally-authored Maintenance references {metric_kind} {name}"),
+            false,
+        ),
+        MaintenanceCoverage::CoveredByManaged => (
+            true,
+            MAINTENANCE_CONFIGURED_REASON,
+            format!("the operator manages a Maintenance for {metric_kind} {name}"),
+            false,
+        ),
+        MaintenanceCoverage::DisabledBySpec => (
+            false,
+            MAINTENANCE_DISABLED_REASON,
+            format!(
+                "maintenance is disabled for {metric_kind} {name} (spec.maintenance.enabled: \
+                 false) and no Maintenance references it; kopia storage will not be reclaimed"
+            ),
+            false,
+        ),
+        MaintenanceCoverage::ApplyFailed { namespace, error } => (
+            false,
+            MAINTENANCE_APPLY_FAILED_REASON,
+            format!(
+                "maintenance is ENABLED for {metric_kind} {name}, but the operator could not \
+                 apply its managed Maintenance in namespace {namespace}: {error}; kopia storage \
+                 will not be reclaimed until this succeeds. It is retried on every reconcile — \
+                 if it persists, check that the namespace exists and that the operator has RBAC \
+                 to write Maintenance there"
+            ),
+            true,
+        ),
+    }
 }
 
 /// Pure decision for the managed `Maintenance` (the design matrix in the plan):
@@ -192,6 +275,17 @@ pub fn build_managed_maintenance(
 ///   deliberate opt-out).
 /// - `ClusterRepository` whose managed Maintenance has no resolvable placement
 ///   namespace → condition `False` + Warning (`MaintenanceNamespaceUnresolved`).
+/// - enabled, but the managed `Maintenance` **could not be applied** (a failed SSA, or an
+///   un-buildable owner ref) → condition `False` + Warning (`MaintenanceApplyFailed`),
+///   naming the namespace and the error. This state used to be reported as
+///   `MaintenanceDisabled` — "you set spec.maintenance.enabled: false", which was simply
+///   untrue and pointed the operator at the wrong knob (#231).
+///
+/// Every not-covered state says WHY it is not covered, and the condition is re-evaluated on
+/// every reconcile (including the steady-state object-store pass), so a wrong value written
+/// during a bootstrap race self-corrects instead of freezing (#231). The Warning Event is
+/// published only when the condition actually changes — the condition is the durable
+/// signal, the Event marks the transition.
 ///
 /// Degrade-not-crash: if the shared informer store has not synced yet, the whole
 /// step is skipped (the `.watches` trigger + periodic requeue re-run it warm), so
@@ -233,11 +327,10 @@ pub async fn ensure_maintenance<K>(
         match_namespace,
     );
 
-    let mut covered = foreign;
-    let mut unresolved = false;
-
-    // Exhaustive match on the pure decision so every state is handled (ADR §5.5).
-    match maintenance_action(
+    // Exhaustive match on the pure decision so every state is handled (ADR §5.5), and the
+    // OBSERVED outcome — including "we tried to manage it and could not" — is carried out
+    // as a closed [`MaintenanceCoverage`] rather than collapsed into a boolean.
+    let coverage = match maintenance_action(
         enabled,
         foreign,
         managed.is_some(),
@@ -250,14 +343,22 @@ pub async fn ensure_maintenance<K>(
                     let desired = build_managed_maintenance(kind, name, ns, &spec, owner);
                     let mapi: Api<Maintenance> = Api::namespaced(ctx.client.clone(), ns);
                     match apply(&mapi, name, &desired).await {
-                        Ok(_) => covered = true,
+                        Ok(_) => MaintenanceCoverage::CoveredByManaged,
                         Err(e) => {
-                            tracing::warn!(error = %e, repo = %name, namespace = %ns, "failed to apply managed Maintenance")
+                            tracing::warn!(error = %e, repo = %name, namespace = %ns, "failed to apply managed Maintenance");
+                            MaintenanceCoverage::ApplyFailed {
+                                namespace: ns.to_string(),
+                                error: e.to_string(),
+                            }
                         }
                     }
                 }
                 Err(e) => {
-                    tracing::warn!(error = %e, repo = %name, "cannot build owner reference for managed Maintenance")
+                    tracing::warn!(error = %e, repo = %name, "cannot build owner reference for managed Maintenance");
+                    MaintenanceCoverage::ApplyFailed {
+                        namespace: ns.to_string(),
+                        error: e.to_string(),
+                    }
                 }
             }
         }
@@ -277,44 +378,39 @@ pub async fn ensure_maintenance<K>(
                     tracing::warn!(error = %e, repo = %name, "failed to delete managed Maintenance");
                 }
             }
+            coverage_without_managed(foreign)
         }
-        MaintenanceAction::Unresolved => unresolved = true,
-        MaintenanceAction::Leave => {}
-    }
+        MaintenanceAction::Unresolved => MaintenanceCoverage::Unresolved,
+        MaintenanceAction::Leave => coverage_without_managed(foreign),
+    };
 
+    let covered = matches!(
+        coverage,
+        MaintenanceCoverage::CoveredByForeign | MaintenanceCoverage::CoveredByManaged
+    );
     ctx.metrics
         .set_repository_maintenance_configured(metric_kind, metric_namespace, name, covered);
 
-    let (status, reason, message, warn) = if unresolved {
-        (
-            false,
-            MAINTENANCE_NAMESPACE_UNRESOLVED_REASON,
-            format!(
-                "managed Maintenance for {metric_kind} {name} cannot be placed: set \
-                 spec.maintenance.namespace, or the operator's KOPIUR_NAMESPACE, so the namespaced \
-                 Maintenance CR has a home"
-            ),
-            true,
-        )
-    } else if covered {
-        let msg = if foreign {
-            format!("an externally-authored Maintenance references {metric_kind} {name}")
-        } else {
-            format!("the operator manages a Maintenance for {metric_kind} {name}")
-        };
-        (true, MAINTENANCE_CONFIGURED_REASON, msg, false)
-    } else {
-        (
-            false,
-            MAINTENANCE_DISABLED_REASON,
-            format!(
-                "maintenance is disabled for {metric_kind} {name} (spec.maintenance.enabled: \
-                 false) and no Maintenance references it; kopia storage will not be reclaimed"
-            ),
-            false,
-        )
-    };
+    let (status, reason, message, warn) = maintenance_condition(&coverage, metric_kind, name);
 
+    let conditions = upsert_condition(
+        existing_conditions,
+        MAINTENANCE_CONFIGURED_CONDITION,
+        status,
+        reason,
+        &message,
+        observed_generation,
+    );
+    // Skip the write when the upsert changed nothing: this runs on EVERY repo
+    // reconcile, and an identical re-write would bump `resourceVersion` and
+    // re-trigger the repo controller through its own watch (hot-loop).
+    if conditions.as_slice() == existing_conditions {
+        return;
+    }
+    // Warn only alongside a real condition transition. This runs on every reconcile now
+    // (including the steady-state object-store pass that #231 added), so an unconditional
+    // publish would mint the same Warning every reconcile interval for as long as the
+    // problem lasts — the condition is the durable signal; the Event marks the change.
     if warn
         && let Err(e) = ctx
             .recorder
@@ -332,22 +428,20 @@ pub async fn ensure_maintenance<K>(
     {
         tracing::warn!(error = %e, repo = %name, "failed to publish {reason} event");
     }
-
-    let conditions = upsert_condition(
-        existing_conditions,
-        MAINTENANCE_CONFIGURED_CONDITION,
-        status,
-        reason,
-        &message,
-        observed_generation,
-    );
-    // Skip the write when the upsert changed nothing: this runs on EVERY repo
-    // reconcile, and an identical re-write would bump `resourceVersion` and
-    // re-trigger the repo controller through its own watch (hot-loop).
-    if conditions.as_slice() == existing_conditions {
-        return;
-    }
     if let Err(e) = patch_status(api, name, serde_json::json!({ "conditions": conditions })).await {
         tracing::warn!(error = %e, repo = %name, "failed to patch MaintenanceConfigured condition");
+    }
+}
+
+/// Coverage when the operator is NOT managing a `Maintenance` of its own (the `Unmanage` /
+/// `Leave` arms). A foreign `Maintenance` still covers the repo; otherwise the only way to
+/// reach these arms is `enabled == false` (`maintenance_action` routes an enabled,
+/// un-covered repo to `Manage`/`Unresolved`), so "disabled by spec" is provably true here
+/// rather than a catch-all guess (#231).
+fn coverage_without_managed(foreign: bool) -> MaintenanceCoverage {
+    if foreign {
+        MaintenanceCoverage::CoveredByForeign
+    } else {
+        MaintenanceCoverage::DisabledBySpec
     }
 }

--- a/crates/controller/src/io/tests.rs
+++ b/crates/controller/src/io/tests.rs
@@ -871,6 +871,80 @@ fn maintenance_action_covers_the_matrix() {
     assert_eq!(maintenance_action(false, true, false, true), Leave);
 }
 
+/// #231: every NOT-covered state must say why it is not covered. The old code branded all
+/// of them `MaintenanceDisabled` with a message asserting `spec.maintenance.enabled: false`
+/// and "no Maintenance references it" — both false when an apply had merely failed, which
+/// pointed operators at entirely the wrong knob.
+#[test]
+fn maintenance_condition_covers_every_coverage_state() {
+    use crate::consts::{
+        MAINTENANCE_APPLY_FAILED_REASON, MAINTENANCE_CONFIGURED_REASON,
+        MAINTENANCE_DISABLED_REASON, MAINTENANCE_NAMESPACE_UNRESOLVED_REASON,
+    };
+
+    // Covered, by either party → True, no warning.
+    let (status, reason, msg, warn) = maintenance_condition(
+        &MaintenanceCoverage::CoveredByManaged,
+        "ClusterRepository",
+        "expanse",
+    );
+    assert!(status);
+    assert_eq!(reason, MAINTENANCE_CONFIGURED_REASON);
+    assert!(!warn);
+    assert!(msg.contains("the operator manages a Maintenance"), "{msg}");
+
+    let (status, reason, msg, warn) = maintenance_condition(
+        &MaintenanceCoverage::CoveredByForeign,
+        "Repository",
+        "vault",
+    );
+    assert!(status);
+    assert_eq!(reason, MAINTENANCE_CONFIGURED_REASON);
+    assert!(!warn);
+    assert!(msg.contains("externally-authored"), "{msg}");
+
+    // A deliberate opt-out keeps its message — which is now provably true, since
+    // `maintenance_action` only reaches this state with `enabled == false`.
+    let (status, reason, msg, warn) =
+        maintenance_condition(&MaintenanceCoverage::DisabledBySpec, "Repository", "vault");
+    assert!(!status);
+    assert_eq!(reason, MAINTENANCE_DISABLED_REASON);
+    assert!(!warn, "a deliberate opt-out must not warn");
+    assert!(msg.contains("spec.maintenance.enabled: false"), "{msg}");
+
+    // THE #231 STATE: enabled, but the apply failed. It must NOT read as "disabled", and it
+    // must name the namespace and the underlying error so the operator can act.
+    let (status, reason, msg, warn) = maintenance_condition(
+        &MaintenanceCoverage::ApplyFailed {
+            namespace: "kopiur-system".into(),
+            error: "maintenances.kopiur.home-operations.com is forbidden".into(),
+        },
+        "ClusterRepository",
+        "expanse",
+    );
+    assert!(!status);
+    assert_eq!(reason, MAINTENANCE_APPLY_FAILED_REASON);
+    assert!(warn, "a failed apply is a real problem: warn");
+    assert!(msg.contains("ENABLED"), "{msg}");
+    assert!(msg.contains("kopiur-system"), "{msg}");
+    assert!(msg.contains("is forbidden"), "{msg}");
+    assert!(msg.contains("RBAC"), "{msg}");
+    assert!(
+        !msg.contains("spec.maintenance.enabled: false"),
+        "must never claim the user disabled maintenance: {msg}"
+    );
+
+    // Unplaceable cluster-repo Maintenance keeps its own distinct reason.
+    let (status, reason, _, warn) = maintenance_condition(
+        &MaintenanceCoverage::Unresolved,
+        "ClusterRepository",
+        "expanse",
+    );
+    assert!(!status);
+    assert_eq!(reason, MAINTENANCE_NAMESPACE_UNRESOLVED_REASON);
+    assert!(warn);
+}
+
 fn maint_referencing(
     name: &str,
     ns: &str,

--- a/crates/controller/src/io/tests.rs
+++ b/crates/controller/src/io/tests.rs
@@ -912,12 +912,11 @@ fn maintenance_condition_covers_every_coverage_state() {
     assert!(!warn, "a deliberate opt-out must not warn");
     assert!(msg.contains("spec.maintenance.enabled: false"), "{msg}");
 
-    // THE #231 STATE: enabled, but the apply failed. It must NOT read as "disabled", and it
-    // must name the namespace and the underlying error so the operator can act.
+    // THE #231 STATE: enabled, nothing covers the repo, and the apply failed. It must NOT
+    // read as "disabled", and it must name the namespace so the operator can act.
     let (status, reason, msg, warn) = maintenance_condition(
         &MaintenanceCoverage::ApplyFailed {
             namespace: "kopiur-system".into(),
-            error: "maintenances.kopiur.home-operations.com is forbidden".into(),
         },
         "ClusterRepository",
         "expanse",
@@ -927,12 +926,24 @@ fn maintenance_condition_covers_every_coverage_state() {
     assert!(warn, "a failed apply is a real problem: warn");
     assert!(msg.contains("ENABLED"), "{msg}");
     assert!(msg.contains("kopiur-system"), "{msg}");
-    assert!(msg.contains("is forbidden"), "{msg}");
     assert!(msg.contains("RBAC"), "{msg}");
     assert!(
         !msg.contains("spec.maintenance.enabled: false"),
         "must never claim the user disabled maintenance: {msg}"
     );
+    // The message is a pure function of (coverage, kind, name) — no interpolated apply
+    // error. `ensure_maintenance` now runs on EVERY reconcile and suppresses an unchanged
+    // condition by BYTE COMPARISON, so an error string that varies between attempts (a
+    // Conflict naming a resourceVersion) would defeat that guard and spin status writes +
+    // Events at full speed. The verbatim error belongs in the log, not the condition.
+    let (_, _, again, _) = maintenance_condition(
+        &MaintenanceCoverage::ApplyFailed {
+            namespace: "kopiur-system".into(),
+        },
+        "ClusterRepository",
+        "expanse",
+    );
+    assert_eq!(msg, again, "the condition message must be byte-stable");
 
     // Unplaceable cluster-repo Maintenance keeps its own distinct reason.
     let (status, reason, _, warn) = maintenance_condition(

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -507,13 +507,6 @@ fn last_refresh_at(repo: &Repository) -> Option<&str> {
         .and_then(|c| c.last_refresh_at.as_deref())
 }
 
-/// Drive the mover-Job bootstrap state machine: launch the Job, then on each
-/// reconcile reflect its progress (`Initializing` → `Ready`/`Failed`), reading the
-/// result the mover wrote into the work-spec ConfigMap. Used for object stores AND
-/// for volume-backed filesystem repos (PVC / inline NFS) — neither is reachable
-/// from the controller in-process. A filesystem backend's repo volume is mounted
-/// read-write so the mover can create/connect the repository.
-#[allow(clippy::too_many_arguments)]
 /// The `Repository`'s currently-observed status conditions (empty when it has no status).
 fn repo_conditions(
     repo: &Repository,
@@ -563,6 +556,13 @@ async fn ensure_repo_maintenance(
     .await;
 }
 
+/// Drive the mover-Job bootstrap state machine: launch the Job, then on each
+/// reconcile reflect its progress (`Initializing` → `Ready`/`Failed`), reading the
+/// result the mover wrote into the work-spec ConfigMap. Used for object stores AND
+/// for volume-backed filesystem repos (PVC / inline NFS) — neither is reachable
+/// from the controller in-process. A filesystem backend's repo volume is mounted
+/// read-write so the mover can create/connect the repository.
+#[allow(clippy::too_many_arguments)]
 async fn bootstrap_via_mover(
     ctx: &Context,
     repo: &Repository,
@@ -705,7 +705,15 @@ async fn bootstrap_via_mover(
         // condition is only ever written at the tail of a bootstrap, and a value written
         // during a bootstrap race freezes forever (#231). Cheap + idempotent; the status
         // patch is skipped when nothing changed.
-        ensure_repo_maintenance(ctx, repo, namespace, name, api, &repo_conditions(repo)).await;
+        //
+        // Build on a FRESH read of the conditions, not the watch-cached object: a Maintenance
+        // event can requeue us moments after the bootstrap finalize patched `Bootstrapped` /
+        // `BackendReachable`, while the informer store still holds the pre-patch copy — and
+        // the condition write below replaces the whole array, so a stale copy would silently
+        // resurrect it and drop those conditions.
+        let fresh = api.get_opt(name).await?;
+        let conditions = fresh.as_ref().map(repo_conditions).unwrap_or_default();
+        ensure_repo_maintenance(ctx, repo, namespace, name, api, &conditions).await;
         return Ok(Action::requeue(probe_aware_reconcile_interval(repo)));
     }
 

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -437,24 +437,7 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
             // Repository's Maintenance lives in the repo's namespace. ADR §3.7.
             // §11: a ReadOnly repository runs no maintenance (it serves restores
             // only). Skip the projection so no managed Maintenance is created.
-            if repo.spec.mode.allows_writes() {
-                io::ensure_maintenance(
-                    ctx,
-                    &api,
-                    repo,
-                    &io::event_ref(repo),
-                    RepositoryKind::Repository,
-                    "Repository",
-                    &namespace,
-                    Some(&namespace),
-                    Some(&namespace),
-                    &name,
-                    repo.spec.maintenance.as_ref(),
-                    &conditions,
-                    repo.metadata.generation,
-                )
-                .await;
-            }
+            ensure_repo_maintenance(ctx, repo, &namespace, &name, &api, &conditions).await;
         }
         other => {
             // Object-store backends run connect/create/status/catalog in a
@@ -531,6 +514,55 @@ fn last_refresh_at(repo: &Repository) -> Option<&str> {
 /// from the controller in-process. A filesystem backend's repo volume is mounted
 /// read-write so the mover can create/connect the repository.
 #[allow(clippy::too_many_arguments)]
+/// The `Repository`'s currently-observed status conditions (empty when it has no status).
+fn repo_conditions(
+    repo: &Repository,
+) -> Vec<k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition> {
+    repo.status
+        .as_ref()
+        .map(|s| s.conditions.clone())
+        .unwrap_or_default()
+}
+
+/// Project this `Repository`'s `spec.maintenance` into its managed `Maintenance` CR and
+/// refresh the `MaintenanceConfigured` condition (ADR §3.7; §11: a ReadOnly repository
+/// serves restores only and runs no maintenance).
+///
+/// `conditions` is the set to build on — the freshly patched one on the bootstrap finalize
+/// path (a status patch replaces the whole array, so re-reading the cached object there
+/// would drop conditions written moments earlier), or the cached status elsewhere.
+///
+/// The cluster-repo twin (`cluster_repository::ensure_cluster_maintenance`) carries the
+/// full rationale for calling this on the steady-state pass as well (#231).
+async fn ensure_repo_maintenance(
+    ctx: &Context,
+    repo: &Repository,
+    namespace: &str,
+    name: &str,
+    api: &Api<Repository>,
+    conditions: &[k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition],
+) {
+    if !repo.spec.mode.allows_writes() {
+        return;
+    }
+    io::ensure_maintenance(
+        ctx,
+        api,
+        repo,
+        &io::event_ref(repo),
+        RepositoryKind::Repository,
+        "Repository",
+        namespace,
+        Some(namespace),
+        Some(namespace),
+        name,
+        repo.spec.maintenance.as_ref(),
+        conditions,
+        repo.metadata.generation,
+    )
+    .await;
+}
+
 async fn bootstrap_via_mover(
     ctx: &Context,
     repo: &Repository,
@@ -667,6 +699,13 @@ async fn bootstrap_via_mover(
             chrono::Utc::now(),
         ))
     {
+        // The STEADY STATE of a Ready mover-bootstrapped repo (`bootstrap_create_due` is
+        // true for any non-Ready phase, so nothing pre-bootstrap reaches here). Re-evaluate
+        // maintenance coverage before parking — otherwise this repo's `MaintenanceConfigured`
+        // condition is only ever written at the tail of a bootstrap, and a value written
+        // during a bootstrap race freezes forever (#231). Cheap + idempotent; the status
+        // patch is skipped when nothing changed.
+        ensure_repo_maintenance(ctx, repo, namespace, name, api, &repo_conditions(repo)).await;
         return Ok(Action::requeue(probe_aware_reconcile_interval(repo)));
     }
 
@@ -1094,24 +1133,7 @@ async fn finalize_bootstrap(
     // cached object — otherwise this patch would drop the `Bootstrapped`
     // condition we set above (both writes replace the whole conditions array).
     // §11: a ReadOnly repository runs no maintenance — skip the projection.
-    if repo.spec.mode.allows_writes() {
-        io::ensure_maintenance(
-            ctx,
-            api,
-            repo,
-            &io::event_ref(repo),
-            RepositoryKind::Repository,
-            "Repository",
-            namespace,
-            Some(namespace),
-            Some(namespace),
-            name,
-            repo.spec.maintenance.as_ref(),
-            &conditions,
-            repo.metadata.generation,
-        )
-        .await;
-    }
+    ensure_repo_maintenance(ctx, repo, namespace, name, api, &conditions).await;
 
     // A probe consumes its Job exactly once: delete it so the steady state has no
     // lingering finished Job to re-read (no churn) and the next probe is a fresh

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -31,7 +31,7 @@ use crate::config;
 use crate::consts::{
     ALLOW_PRIVILEGED_MOVER_ACTION, API_VERSION, CREDENTIALS_AVAILABLE_CONDITION,
     CREDENTIALS_PROJECTED_REASON, MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION,
-    ORPHANED_PRIME_REAPED_REASON, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
+    ORPHANED_PRIME_REAPED_REASON, POPULATE_HIJACKED_REASON, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
     RECREATE_CLAIM_TO_RESTORE_ACTION, RESTORE_SECURITY_CONTEXT_COMPATIBLE_CONDITION,
     RESTORE_TARGET_ALREADY_BOUND_REASON, SECURITY_CONTEXT_COMPATIBLE_REASON,
 };
@@ -265,12 +265,17 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                 // up — `onMissingSnapshot` applies only once the window closes
                 // (ADR §4.6 G7).
                 let now = chrono::Utc::now().timestamp();
-                let created = restore
-                    .metadata
-                    .creation_timestamp
-                    .as_ref()
-                    .map(|t| t.0.as_second())
-                    .unwrap_or(now);
+                // Anchored at creation — or, for a populator whose claim was re-created
+                // after an already-bound no-op, at that re-open (`wait_window_anchor`).
+                let created = wait_window_anchor(
+                    restore,
+                    restore
+                        .metadata
+                        .creation_timestamp
+                        .as_ref()
+                        .map(|t| t.0.as_second())
+                        .unwrap_or(now),
+                );
                 let wait_timeout = restore
                     .spec
                     .policy
@@ -351,21 +356,6 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
         }),
     };
 
-    // Pin the deploy-or-restore "no snapshot" decision exactly once. This durably records
-    // the choice (so a snapshot that appears later can never silently restore over the
-    // provisioned volume) AND back-fills the pre-fix stuck-populator state that
-    // `pinned_decision` inferred from a `Completed`+unpinned Restore. Idempotent: re-pinning
-    // an already-`NoSnapshot` resolution is a server-side no-op. A bare `{resolved}` merge
-    // patch leaves phase/conditions to the target driver below (the `Resolved` domain
-    // condition is stamped at the driver's empty completion).
-    if decision == Some(Resolution::Empty)
-        && resolved.and_then(|r| r.resolution) != Some(ResolutionOutcome::NoSnapshot)
-    {
-        let mut pin = serde_json::json!({ "pinnedAt": chrono::Utc::now().to_rfc3339() });
-        pin["resolution"] = serde_json::to_value(ResolutionOutcome::NoSnapshot)?;
-        io::patch_status(&api, &name, serde_json::json!({ "resolved": pin })).await?;
-    }
-
     // Dispatch the decision to the target driver. Exhaustive over `Resolution` so a new
     // variant must be handled in both drivers before it compiles.
     match state {
@@ -383,6 +373,10 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                     ));
                 }
             };
+            // A direct restore always acts on its decision, so pin an empty outcome here.
+            if selection.is_none() {
+                pin_no_snapshot(&api, restore, &name).await?;
+            }
             drive_direct_restore(ctx, restore, &api, &namespace, &name, selection.as_ref()).await
         }
         PopulatorState::AwaitingClaim => {
@@ -399,6 +393,31 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
             drive_populator_restore(ctx, restore, &api, &namespace, &name, &work).await
         }
     }
+}
+
+/// Durably pin the deploy-or-restore "no snapshot" decision, so a snapshot that appears
+/// LATER can never silently restore over the volume we are about to provision empty
+/// (ADR §4.6). Idempotent: an already-`NoSnapshot` resolution is left alone.
+///
+/// Pinned at the point of USE, not at resolution. A populator that turns out to have
+/// nothing to populate (its claiming PVC is already bound — #233) must never record "this
+/// restore decided to come up empty", because that pin outlives the no-op: the user then
+/// follows the documented fix, re-creates the claim to get a real restore, and
+/// `pinned_decision` hands back `Empty` from the pin — provisioning an EMPTY volume and
+/// silently never restoring their data. Only a pass that actually provisions may pin.
+async fn pin_no_snapshot(api: &Api<Restore>, restore: &Restore, name: &str) -> Result<()> {
+    if restore
+        .status
+        .as_ref()
+        .and_then(|s| s.resolved.as_ref())
+        .and_then(|r| r.resolution)
+        == Some(ResolutionOutcome::NoSnapshot)
+    {
+        return Ok(());
+    }
+    let mut pin = serde_json::json!({ "pinnedAt": chrono::Utc::now().to_rfc3339() });
+    pin["resolution"] = serde_json::to_value(ResolutionOutcome::NoSnapshot)?;
+    io::patch_status(api, name, serde_json::json!({ "resolved": pin })).await
 }
 
 /// Park a populator `Restore` in `AwaitingClaim=True` / `Pending` with `reason`+`msg`
@@ -485,6 +504,22 @@ async fn drive_populator_restore(
     let prime_name = format!("prime-{consumer_uid}");
     let populate_job = format!("{name}-populate");
 
+    // Steady-state exit for a Restore that has already settled over a BOUND claim (a
+    // finished restore, or an already-bound no-op) and has no prime left to reap: nothing
+    // observable can change until the claim itself is re-created, which re-enqueues us with
+    // an UNBOUND claim and so cannot be missed. This keeps the per-heartbeat cost at one
+    // namespaced GET instead of the unfiltered, cluster-wide PersistentVolume LIST below —
+    // which, at the fleet scale this bug was reported from (one populator Restore per app),
+    // is pure read amplification against a handshake that is over. Gated on the prime being
+    // gone, so a reap whose best-effort delete did not land is still retried.
+    let settled_over_bound_claim = restore.status.as_ref().and_then(|s| s.phase)
+        == Some(RestorePhase::Completed)
+        && kstatus_settled_for(restore, RestorePhase::Completed)
+        && pvc_is_bound(&consumer);
+    if settled_over_bound_claim && pvc_api.get_opt(&prime_name).await?.is_none() {
+        return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+    }
+
     // The PV our populator earmarked for this consumer: claimRef → THIS consumer (name +
     // uid) AND our rebind annotation. `Some` proves the prime→consumer rebind was already
     // issued, so we never recreate the prime past that point.
@@ -547,7 +582,14 @@ async fn drive_populator_restore(
         // Unbound claim, no rebind outstanding: populate it.
         PopulatorHandshake::Populate => match work {
             PopulatorWork::Restore(sel) => Some(sel),
-            PopulatorWork::EmptyVolume => None,
+            PopulatorWork::EmptyVolume => {
+                // We are about to provision the empty volume, so NOW the deploy-or-restore
+                // decision is real and must be pinned (a later snapshot must never restore
+                // over it). Pinning any earlier would also pin a no-op that provisioned
+                // nothing — see `pin_no_snapshot`.
+                pin_no_snapshot(api, restore, name).await?;
+                None
+            }
             // The claim is unbound but we deliberately skipped resolution this pass (this
             // Restore had completed as an already-bound no-op and the claim has since been
             // re-created). Re-open resolution rather than treating "no selection" as
@@ -601,6 +643,7 @@ async fn drive_populator_restore(
             &populate_job,
             &prime_name,
             selection,
+            true, // the populate Job name is re-used across every claim this Restore populates
         )
         .await?
         {
@@ -711,14 +754,6 @@ async fn finalize_populator_success(
     prime_name: &str,
     pv_name: &str,
 ) -> Result<Action> {
-    finalize_populator(
-        ctx,
-        namespace,
-        populate_job,
-        prime_name,
-        PrimePvAction::RestoreOriginalPolicy(pv_name),
-    )
-    .await?;
     // Re-read `status.resolved` fresh: for a deferred restore the mover pins it in its own
     // terminal PATCH, which the cached `restore` (watch cache) may not yet reflect when a
     // PVC/PV bind event triggers this finalize reconcile — the direct path guards the same
@@ -758,7 +793,23 @@ async fn finalize_populator_success(
             msg,
         )
     };
+    // Write the outcome BEFORE tearing the artifacts down. `finalize_populator` strips the
+    // rebind annotation — the only evidence that the bound PV came from US — so a crash (or
+    // a transient API error) between the strip and this patch would leave a restore that
+    // genuinely ran looking, forever, like a claim we never touched: the next pass would see
+    // no annotation plus a bound claim, read it as `NothingToPopulate`, and relabel it
+    // `TargetAlreadyBound` ("no restore ran"), telling the user to delete the very PVC
+    // holding their freshly restored data. Patching first makes the reverse order harmless:
+    // the annotation still identifies our PV, so a crash simply replays this finalize.
     io::patch_status(api, name, status).await?;
+    finalize_populator(
+        ctx,
+        namespace,
+        populate_job,
+        prime_name,
+        PrimePvAction::RestoreOriginalPolicy(pv_name),
+    )
+    .await?;
     Ok(Action::requeue(std::time::Duration::from_secs(600)))
 }
 
@@ -802,28 +853,51 @@ async fn complete_populator_already_bound(
     // (and re-publishing the Event) on every heartbeat while it sits Terminating on a
     // finalizer would be pure churn.
     let live = |meta: &kube::core::ObjectMeta| meta.deletion_timestamp.is_none();
-    let mut artifacts = Vec::new();
-    if pvc_api
+    let prime_live = pvc_api
         .get_opt(prime_name)
         .await?
-        .is_some_and(|p| live(&p.metadata))
-    {
-        artifacts.push(format!("prime PVC `{prime_name}`"));
-    }
-    if job_api
+        .is_some_and(|p| live(&p.metadata));
+    let job = job_api
         .get_opt(populate_job)
         .await?
-        .is_some_and(|j| live(&j.metadata))
+        .filter(|j| live(&j.metadata));
+    let consumer_name = consumer.name_any();
+    let bound_volume = consumer
+        .spec
+        .as_ref()
+        .and_then(|s| s.volume_name.as_deref())
+        .filter(|v| !v.is_empty());
+
+    // A populate still RUNNING when the claim binds elsewhere is not a benign "nothing to
+    // populate" — it is a handover hijacked mid-flight (see [`fail_populate_hijacked`]).
+    if let Some(job) = job.as_ref()
+        && crate::snapshot::job_terminal_state(job).is_none()
     {
-        artifacts.push(format!("populate Job `{populate_job}`"));
+        return fail_populate_hijacked(
+            ctx,
+            restore,
+            api,
+            namespace,
+            name,
+            populate_job,
+            &consumer_name,
+            bound_volume,
+        )
+        .await;
     }
 
     let kept_pv = match pv {
         PrimePvAction::ForceRetain(p) => Some(p),
         PrimePvAction::RestoreOriginalPolicy(_) | PrimePvAction::Leave => None,
     };
+    let mut artifacts = Vec::new();
+    if prime_live {
+        artifacts.push(format!("prime PVC `{prime_name}`"));
+    }
+    if job.is_some() {
+        artifacts.push(format!("populate Job `{populate_job}`"));
+    }
     if !artifacts.is_empty() || kept_pv.is_some() {
-        let consumer_name = consumer.name_any();
         finalize_populator(ctx, namespace, populate_job, prime_name, pv).await?;
         let note = reaped_populate_artifacts_note(&artifacts, &consumer_name, kept_pv);
         tracing::warn!(%namespace, restore = %name, consumer = %consumer_name, "{note}");
@@ -840,12 +914,13 @@ async fn complete_populator_already_bound(
     let settled = restore.status.as_ref().and_then(|s| s.phase) == Some(RestorePhase::Completed)
         && kstatus_settled_for(restore, RestorePhase::Completed);
     if !settled {
-        let bound_volume = consumer
-            .spec
-            .as_ref()
-            .and_then(|s| s.volume_name.as_deref())
-            .filter(|v| !v.is_empty());
-        let msg = target_already_bound_message(&consumer.name_any(), bound_volume);
+        // A lost rebind gets its OWN message: a prime was provisioned, a restore DID run,
+        // and a full-size volume is now retained — saying "nothing was provisioned, no
+        // restore ran" there would hide storage the admin has just become responsible for.
+        let msg = match kept_pv {
+            Some(pv) => lost_rebind_message(&consumer_name, pv),
+            None => target_already_bound_message(&consumer_name, bound_volume),
+        };
         io::patch_status(
             api,
             name,
@@ -853,6 +928,55 @@ async fn complete_populator_already_bound(
                 restore,
                 RestorePhase::Completed,
                 RESTORE_TARGET_ALREADY_BOUND_REASON,
+                &msg,
+            ),
+        )
+        .await?;
+    }
+    Ok(Action::requeue(std::time::Duration::from_secs(600)))
+}
+
+/// The claiming PVC was bound out from under a populate that was STILL RUNNING: some
+/// provisioner handed it a volume without honoring its `dataSourceRef`, so the restore we
+/// are writing can never be delivered to it.
+///
+/// This is NOT the already-bound no-op (#233) even though it looks like one from the API:
+/// there the claim was bound long before, by an earlier successful restore, and the app is
+/// running on its own data. Here the app is about to come up on somebody else's — probably
+/// empty — volume, so completing `Ready=True` would tell `kubectl wait`, Flux and Argo that
+/// a restore landed when it did not. Fail honestly, cancel the doomed run, and LEAVE the
+/// prime PVC in place: it holds the data we were mid-way through writing, and a `Failed`
+/// populator is terminal at the reconcile guard, so nothing reaps it behind the user's back.
+#[allow(clippy::too_many_arguments)]
+async fn fail_populate_hijacked(
+    ctx: &Context,
+    restore: &Restore,
+    api: &Api<Restore>,
+    namespace: &str,
+    name: &str,
+    populate_job: &str,
+    consumer_name: &str,
+    bound_volume: Option<&str>,
+) -> Result<Action> {
+    let msg = populate_hijacked_message(consumer_name, bound_volume);
+    tracing::warn!(%namespace, restore = %name, consumer = %consumer_name, "{msg}");
+    io::delete_mover_run(&ctx.client, namespace, populate_job).await?;
+    io::publish_warning_event(
+        ctx,
+        restore,
+        POPULATE_HIJACKED_REASON,
+        RECREATE_CLAIM_TO_RESTORE_ACTION,
+        &msg,
+    )
+    .await;
+    if restore.status.as_ref().and_then(|s| s.phase) != Some(RestorePhase::Failed) {
+        io::patch_status(
+            api,
+            name,
+            restore_ready_status(
+                restore,
+                RestorePhase::Failed,
+                POPULATE_HIJACKED_REASON,
                 &msg,
             ),
         )
@@ -884,7 +1008,12 @@ async fn reopen_populator_resolution(
     io::patch_status(
         api,
         name,
-        restore_ready_status(restore, RestorePhase::Resolving, "ClaimRecreated", &msg),
+        restore_ready_status(
+            restore,
+            RestorePhase::Resolving,
+            crate::consts::RESTORE_CLAIM_RECREATED_REASON,
+            &msg,
+        ),
     )
     .await?;
     Ok(Action::requeue(std::time::Duration::from_secs(5)))
@@ -1324,7 +1453,18 @@ async fn drive_direct_restore(
 
     // The Job is named after the Restore and writes into the explicit target PVC;
     // the helper creates/tracks it, the phase writes stay here.
-    match run_restore_mover(ctx, restore, api, namespace, name, &target_pvc, selection).await? {
+    match run_restore_mover(
+        ctx,
+        restore,
+        api,
+        namespace,
+        name,
+        &target_pvc,
+        selection,
+        false, // a direct restore is one-shot: its Job name is never re-used
+    )
+    .await?
+    {
         MoverOutcome::Succeeded { duration_secs } => {
             if let Some(secs) = duration_secs {
                 ctx.metrics.set_restore_duration(namespace, name, secs);
@@ -1515,6 +1655,7 @@ async fn observe_restore_mover(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_restore_mover(
     ctx: &Context,
     restore: &Restore,
@@ -1523,15 +1664,22 @@ async fn run_restore_mover(
     job_name: &str,
     target_pvc: &str,
     selection: &RestoreSelection,
+    reusable_job_name: bool,
 ) -> Result<MoverOutcome> {
     use k8s_openapi::api::batch::v1::Job;
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
     if let Some(job) = job_api.get_opt(job_name).await? {
-        // A Job that is being DELETED is not this run's outcome. The populate Job name is
-        // stable (`<restore>-populate`), so a reaped-then-immediately-re-populated claim
-        // could otherwise read the outgoing Job's terminal `Succeeded` as its own and rebind
-        // a still-empty prime. Wait for the delete to land, then create a fresh Job.
-        if job.metadata.deletion_timestamp.is_some() {
+        // A Job being DELETED is not THIS run's outcome — but only where the Job name is
+        // re-used across runs, i.e. the populator (`<restore>-populate`, one name for every
+        // claim the reusable Restore ever populates). There, a reaped-then-immediately-
+        // re-populated claim could read the outgoing Job's terminal `Succeeded` as its own
+        // and rebind a still-empty prime. Wait for the delete to land, then create a fresh Job.
+        //
+        // A DIRECT restore is one-shot, so its Job name is never re-used: a terminating Job
+        // there IS this run's Job (typically TTL-reaped after succeeding), and ignoring its
+        // terminal state would drop the outcome and re-run a full restore over a target PVC
+        // the workload may already be writing to.
+        if reusable_job_name && job.metadata.deletion_timestamp.is_some() {
             return Ok(MoverOutcome::Running { created: false });
         }
         return observe_restore_mover(ctx, restore, namespace, job_name, &job).await;

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -31,8 +31,9 @@ use crate::config;
 use crate::consts::{
     ALLOW_PRIVILEGED_MOVER_ACTION, API_VERSION, CREDENTIALS_AVAILABLE_CONDITION,
     CREDENTIALS_PROJECTED_REASON, MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION,
-    PRIVILEGED_MOVER_NOT_PERMITTED_REASON, RESTORE_SECURITY_CONTEXT_COMPATIBLE_CONDITION,
-    SECURITY_CONTEXT_COMPATIBLE_REASON,
+    ORPHANED_PRIME_REAPED_REASON, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
+    RECREATE_CLAIM_TO_RESTORE_ACTION, RESTORE_SECURITY_CONTEXT_COMPATIBLE_CONDITION,
+    RESTORE_TARGET_ALREADY_BOUND_REASON, SECURITY_CONTEXT_COMPATIBLE_REASON,
 };
 use crate::context::Context;
 use crate::error::{Error, Result, error_policy_for};
@@ -73,22 +74,52 @@ pub enum Resolution {
 ///   decision was "empty". Treat it as [`Resolution::Empty`] and re-pin it on the next write
 ///   — DO NOT re-resolve, or a snapshot that appeared after the original decision would
 ///   silently restore over the (possibly already-bound, in-use) volume.
+///
+///   `noop_already_bound` carves the ONE other way a populator reaches `Completed` while
+///   unpinned out of that back-fill: an already-bound no-op (#233) on a DEFERRED source
+///   never ran the mover, and the mover is what pins a deferred source. Back-filling
+///   `NoSnapshot` there would durably record "this restore decided to come up empty", so a
+///   later, legitimate recreation of the claiming PVC would provision an EMPTY volume
+///   instead of restoring the snapshot. The three `Completed` populator states are told
+///   apart by their `Ready` reason: legacy stuck (`PopulatingPrimePvc`, back-fill),
+///   already-bound no-op (`TargetAlreadyBound`, re-resolve later), and a genuine
+///   deploy-or-restore (`NoSnapshotContinue`, which pinned and so never reaches this arm).
 /// - Otherwise → `None` (resolve now).
 fn pinned_decision(
     resolved: Option<&ResolvedRestore>,
     phase: Option<RestorePhase>,
     state: PopulatorState,
+    noop_already_bound: bool,
 ) -> Option<Resolution> {
     match resolved {
         Some(r) if r.resolution == Some(ResolutionOutcome::NoSnapshot) => Some(Resolution::Empty),
         Some(r) => r.kopia_snapshot_id.clone().map(Resolution::Snapshot),
         None if phase == Some(RestorePhase::Completed)
-            && state == PopulatorState::AwaitingClaim =>
+            && state == PopulatorState::AwaitingClaim
+            && !noop_already_bound =>
         {
             Some(Resolution::Empty)
         }
         None => None,
     }
+}
+
+/// The work a populator pass has to do, once the source decision is known. Distinguishing
+/// [`Self::EmptyVolume`] from [`Self::Unresolved`] is a data-safety requirement: both carry
+/// "no snapshot selection", but the first means *deliberately provision an empty volume*
+/// (deploy-or-restore) while the second means *we did not even look* — and provisioning an
+/// empty volume for the second would lose data (#233).
+enum PopulatorWork {
+    /// Restore this selection (a controller-pinned id, or a selector the mover resolves).
+    Restore(RestoreSelection),
+    /// Deploy-or-restore: no snapshot matched, so the empty prime PVC IS the result.
+    EmptyVolume,
+    /// The source was deliberately NOT resolved this pass — the `Restore` already completed
+    /// as an already-bound no-op, and re-resolving on every heartbeat would poll (and
+    /// eventually error-loop on) a `SnapshotPolicy`/`Repository` the user has since deleted.
+    /// If the claim turns out to need populating after all, the driver re-opens resolution
+    /// rather than provisioning an empty volume.
+    Unresolved,
 }
 
 /// Reconcile a `Restore`.
@@ -176,9 +207,24 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     // back-fill), returning `None` only when the source still has to be resolved.
     let resolved = restore.status.as_ref().and_then(|s| s.resolved.as_ref());
     let phase = restore.status.as_ref().and_then(|s| s.phase);
-    let decision = match pinned_decision(resolved, phase, state) {
-        Some(d) => d,
-        None => match resolve_snapshot(ctx, restore, &namespace).await? {
+
+    // A populator that completed as an already-bound NO-OP (#233) keeps reconciling
+    // forever — its `Completed` is deliberately non-terminal precisely so a recreated
+    // claim can still be populated later. Do NOT re-resolve its source on every one of
+    // those heartbeats: for `fromPolicy` that is a SnapshotPolicy + Repository GET per
+    // pass, and it turns into a `MissingDependency` error loop the moment the user deletes
+    // either (likely — as far as they are concerned the restore is done) on a CR whose
+    // status truthfully reads Completed/Ready. `drive_populator_restore` re-opens
+    // resolution if the claim ever comes back unbound.
+    let noop_already_bound = state == PopulatorState::AwaitingClaim
+        && phase == Some(RestorePhase::Completed)
+        && completed_as_target_already_bound(restore);
+
+    let decision = match pinned_decision(resolved, phase, state, noop_already_bound) {
+        Some(d) => Some(d),
+        // Deliberately unresolved this pass (see above).
+        None if noop_already_bound => None,
+        None => Some(match resolve_snapshot(ctx, restore, &namespace).await? {
             Some(ResolveOutcome::Pinned(res)) => {
                 // Pin the FULL resolution (outcome + id + provenance + timestamp) exactly
                 // once; the no-pin check above makes this a single write, so it cannot
@@ -302,7 +348,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
                     OnMissingSnapshot::Continue => Resolution::Empty,
                 }
             }
-        },
+        }),
     };
 
     // Pin the deploy-or-restore "no snapshot" decision exactly once. This durably records
@@ -312,7 +358,7 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
     // an already-`NoSnapshot` resolution is a server-side no-op. A bare `{resolved}` merge
     // patch leaves phase/conditions to the target driver below (the `Resolved` domain
     // condition is stamped at the driver's empty completion).
-    if decision == Resolution::Empty
+    if decision == Some(Resolution::Empty)
         && resolved.and_then(|r| r.resolution) != Some(ResolutionOutcome::NoSnapshot)
     {
         let mut pin = serde_json::json!({ "pinnedAt": chrono::Utc::now().to_rfc3339() });
@@ -320,21 +366,37 @@ async fn reconcile_inner(restore: &Restore, ctx: &Context) -> Result<Action> {
         io::patch_status(&api, &name, serde_json::json!({ "resolved": pin })).await?;
     }
 
-    // The mover work the decision dispatches: a concrete id, an in-Job selector, or
-    // nothing (deploy-or-restore empty volume). `None` is the only case that skips
-    // the mover entirely. Exhaustive so a new `Resolution` variant must be handled.
-    let selection = match &decision {
-        Resolution::Snapshot(id) => Some(RestoreSelection::Snapshot(id.clone())),
-        Resolution::Deferred(sel) => Some(RestoreSelection::Resolve(sel.clone())),
-        Resolution::Empty => None,
-    };
-
+    // Dispatch the decision to the target driver. Exhaustive over `Resolution` so a new
+    // variant must be handled in both drivers before it compiles.
     match state {
         PopulatorState::DirectTarget => {
+            // The mover work: a concrete id, an in-Job selector, or nothing (the
+            // deploy-or-restore empty volume — the only case that skips the mover).
+            let selection = match decision {
+                Some(Resolution::Snapshot(id)) => Some(RestoreSelection::Snapshot(id)),
+                Some(Resolution::Deferred(sel)) => Some(RestoreSelection::Resolve(sel)),
+                Some(Resolution::Empty) => None,
+                // Only a populator ever skips resolution (`noop_already_bound`).
+                None => {
+                    return Err(Error::Invariant(
+                        "direct restore reached dispatch with an unresolved source".into(),
+                    ));
+                }
+            };
             drive_direct_restore(ctx, restore, &api, &namespace, &name, selection.as_ref()).await
         }
         PopulatorState::AwaitingClaim => {
-            drive_populator_restore(ctx, restore, &api, &namespace, &name, selection.as_ref()).await
+            let work = match decision {
+                Some(Resolution::Snapshot(id)) => {
+                    PopulatorWork::Restore(RestoreSelection::Snapshot(id))
+                }
+                Some(Resolution::Deferred(sel)) => {
+                    PopulatorWork::Restore(RestoreSelection::Resolve(sel))
+                }
+                Some(Resolution::Empty) => PopulatorWork::EmptyVolume,
+                None => PopulatorWork::Unresolved,
+            };
+            drive_populator_restore(ctx, restore, &api, &namespace, &name, &work).await
         }
     }
 }
@@ -369,18 +431,26 @@ async fn park_awaiting_claim(
 /// are idempotent; the prime PV is set `Retain` before its PVC is deleted so the
 /// volume survives the swap.
 ///
-/// `selection` is `None` for deploy-or-restore (`onMissingSnapshot: Continue` with no
-/// matching snapshot): the empty, freshly-provisioned prime PVC IS the result, so the
-/// mover is skipped and the empty prime is rebound straight to the claiming PVC. A
-/// `Some` selection runs the mover into the prime (a deferred selector resolves in-Job,
-/// and may itself find no snapshot under `Continue` — then the prime stays empty).
+/// Where the handshake stands is a single exhaustive [`populator_handshake`] verdict over
+/// the claiming PVC and the PV we rebound to it. That closed decision is what keeps #233
+/// fixed: a populator can only hand a volume to an UNBOUND claim, so a `Restore` recreated
+/// over an already-bound claim ([`PopulatorHandshake::NothingToPopulate`]) completes as a
+/// truthful no-op and reaps any leftover prime instead of restoring into a prime that can
+/// never be adopted.
+///
+/// `work` is [`PopulatorWork::EmptyVolume`] for deploy-or-restore (`onMissingSnapshot:
+/// Continue` with no matching snapshot): the empty, freshly-provisioned prime PVC IS the
+/// result, so the mover is skipped and the empty prime is rebound straight to the claiming
+/// PVC. [`PopulatorWork::Restore`] runs the mover into the prime (a deferred selector
+/// resolves in-Job, and may itself find no snapshot under `Continue` — then the prime stays
+/// empty).
 async fn drive_populator_restore(
     ctx: &Context,
     restore: &Restore,
     api: &Api<Restore>,
     namespace: &str,
     name: &str,
-    selection: Option<&RestoreSelection>,
+    work: &PopulatorWork,
 ) -> Result<Action> {
     use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 
@@ -415,81 +485,79 @@ async fn drive_populator_restore(
     let prime_name = format!("prime-{consumer_uid}");
     let populate_job = format!("{name}-populate");
 
-    let phase = restore.status.as_ref().and_then(|s| s.phase);
-    // Terminal only once the consumer is bound: the mover stamps `Completed` on finishing
-    // the prime PVC, but the rebind may still be pending. Once bound, `finalize_populator`
-    // has stripped the rebind annotation so the `our_rebound_pv` probe below would no
-    // longer recognize our PV — short-circuit to avoid recreating the prime. While
-    // `Completed` but not yet bound, fall through to issue/await the rebind.
-    if phase == Some(RestorePhase::Completed) && pvc_is_bound(&consumer) {
-        return Ok(Action::requeue(std::time::Duration::from_secs(600)));
-    }
+    // The PV our populator earmarked for this consumer: claimRef → THIS consumer (name +
+    // uid) AND our rebind annotation. `Some` proves the prime→consumer rebind was already
+    // issued, so we never recreate the prime past that point.
+    let rebound = our_rebound_pv(ctx, namespace, &consumer_name, &consumer_uid).await?;
 
-    // The PV our populator earmarked for this consumer: claimRef → the consumer AND our
-    // rebind annotation. `Some` proves the prime→consumer rebind was already issued — so
-    // we never recreate the prime past that point, and we complete ONLY once the consumer
-    // is bound to THAT PV (not to an empty one a non-populator-aware provisioner handed it).
-    if let Some(pv_name) = our_rebound_pv(ctx, namespace, &consumer_name).await? {
-        if pvc_is_bound(&consumer)
-            && consumer
-                .spec
-                .as_ref()
-                .and_then(|s| s.volume_name.as_deref())
-                == Some(pv_name.as_str())
-        {
-            finalize_populator(ctx, namespace, &populate_job, &prime_name, Some(&pv_name)).await?;
-            // Branch the completion on whether a snapshot was actually restored. Read the
-            // pinned outcome (the controller pins it for a concrete id; the mover pins it
-            // for a deferred selector, which may itself have found nothing under
-            // `Continue`) rather than `selection.is_some()`, so a deferred no-match also
-            // stamps the empty message. A restore stamps `RestoreSucceeded`;
-            // deploy-or-restore (no snapshot) stamps `NoSnapshotContinue` + a
-            // `Resolved=True` domain condition so the empty outcome is self-describing.
-            // Re-read status.resolved fresh: for a deferred restore the mover pins it in
-            // its own terminal PATCH, which the cached `restore` (watch cache) may not yet
-            // reflect when a PVC/PV bind event triggers this finalize reconcile — the
-            // direct path guards the same race. Fall back to the cached value for the
-            // controller-pinned paths (which pin before dispatch).
-            let resolved = api
-                .get_opt(name)
-                .await?
-                .and_then(|r| r.status)
-                .and_then(|s| s.resolved)
-                .or_else(|| restore.status.as_ref().and_then(|s| s.resolved.clone()));
-            let restored = resolved.and_then(|r| r.resolution)
-                == Some(kopiur_api::ResolutionOutcome::Snapshot);
-            let status = if restored {
-                restore_ready_status(
-                    restore,
-                    RestorePhase::Completed,
-                    crate::consts::RESTORE_POPULATED_REASON,
-                    "populator: restored the snapshot into the claiming PVC and rebound the volume",
-                )
-            } else {
-                let msg = "populator: no snapshot found; provisioned an empty volume for the \
-                           claiming PVC (deploy-or-restore)";
-                let conditions = io::upsert_condition(
-                    &existing_conditions(restore),
-                    "Resolved",
-                    true,
-                    "NoSnapshotContinue",
-                    msg,
-                    restore.metadata.generation,
-                );
-                restore_ready_status_on(
-                    restore,
-                    &conditions,
-                    RestorePhase::Completed,
-                    "NoSnapshotContinue",
-                    msg,
-                )
-            };
-            io::patch_status(api, name, status).await?;
-            return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+    // The one closed decision: is there anything to populate, and if not, why? Exhaustive
+    // (no `_ =>`), so a new binding state cannot compile until it is handled here.
+    let selection = match populator_handshake(&consumer, rebound.as_deref()) {
+        // The handover landed: restore the PV's reclaim policy, GC the artifacts, complete.
+        PopulatorHandshake::FinalizeRebound { pv } => {
+            return finalize_populator_success(
+                ctx,
+                restore,
+                api,
+                namespace,
+                name,
+                &populate_job,
+                &prime_name,
+                &pv,
+            )
+            .await;
         }
         // Rebind issued; wait for the PV controller to bind our PV to the consumer.
-        return Ok(Action::requeue(std::time::Duration::from_secs(5)));
-    }
+        PopulatorHandshake::AwaitingBind => {
+            return Ok(Action::requeue(std::time::Duration::from_secs(5)));
+        }
+        // #233: the claim is already bound, so there is nothing to populate. Complete as a
+        // truthful no-op and reap any prime/Job that can never be handed over — including
+        // the orphans ≤0.7.x left `Bound` forever holding a full copy of the restored data.
+        PopulatorHandshake::NothingToPopulate => {
+            return complete_populator_already_bound(
+                ctx,
+                restore,
+                api,
+                namespace,
+                name,
+                &populate_job,
+                &prime_name,
+                &consumer,
+                PrimePvAction::Leave,
+            )
+            .await;
+        }
+        // Our rebind was issued but a different PV won the claim: the handover is lost.
+        // Same no-op completion, but our PV holds the restored data — keep it (`Retain`).
+        PopulatorHandshake::LostRebind { pv } => {
+            return complete_populator_already_bound(
+                ctx,
+                restore,
+                api,
+                namespace,
+                name,
+                &populate_job,
+                &prime_name,
+                &consumer,
+                PrimePvAction::ForceRetain(&pv),
+            )
+            .await;
+        }
+        // Unbound claim, no rebind outstanding: populate it.
+        PopulatorHandshake::Populate => match work {
+            PopulatorWork::Restore(sel) => Some(sel),
+            PopulatorWork::EmptyVolume => None,
+            // The claim is unbound but we deliberately skipped resolution this pass (this
+            // Restore had completed as an already-bound no-op and the claim has since been
+            // re-created). Re-open resolution rather than treating "no selection" as
+            // deploy-or-restore, which would provision an EMPTY volume over a claim the
+            // user expects restored.
+            PopulatorWork::Unresolved => {
+                return reopen_populator_resolution(api, restore, name, &consumer_name).await;
+            }
+        },
+    };
 
     // WaitForFirstConsumer gate: a late-binding StorageClass only provisions once a
     // pod schedules the claim (the `selected-node` annotation appears). Provision the
@@ -622,6 +690,206 @@ async fn drive_populator_restore(
     Ok(Action::requeue(std::time::Duration::from_secs(5)))
 }
 
+/// Complete a populator whose prime PV the claiming PVC actually bound
+/// ([`PopulatorHandshake::FinalizeRebound`]): restore the PV's original reclaim policy,
+/// GC the populate artifacts, and stamp the outcome.
+///
+/// The completion message branches on the PINNED resolution, not on whether a selection
+/// was dispatched: the controller pins a concrete id, while the mover pins a deferred
+/// selector — which may itself have found nothing under `Continue`. A real restore stamps
+/// `RestoreSucceeded`; deploy-or-restore stamps `NoSnapshotContinue` + a `Resolved=True`
+/// domain condition, so an empty outcome is self-describing rather than claiming data was
+/// written.
+#[allow(clippy::too_many_arguments)]
+async fn finalize_populator_success(
+    ctx: &Context,
+    restore: &Restore,
+    api: &Api<Restore>,
+    namespace: &str,
+    name: &str,
+    populate_job: &str,
+    prime_name: &str,
+    pv_name: &str,
+) -> Result<Action> {
+    finalize_populator(
+        ctx,
+        namespace,
+        populate_job,
+        prime_name,
+        PrimePvAction::RestoreOriginalPolicy(pv_name),
+    )
+    .await?;
+    // Re-read `status.resolved` fresh: for a deferred restore the mover pins it in its own
+    // terminal PATCH, which the cached `restore` (watch cache) may not yet reflect when a
+    // PVC/PV bind event triggers this finalize reconcile — the direct path guards the same
+    // race. Fall back to the cached value for the controller-pinned paths (which pin before
+    // dispatch).
+    let resolved = api
+        .get_opt(name)
+        .await?
+        .and_then(|r| r.status)
+        .and_then(|s| s.resolved)
+        .or_else(|| restore.status.as_ref().and_then(|s| s.resolved.clone()));
+    let restored =
+        resolved.and_then(|r| r.resolution) == Some(kopiur_api::ResolutionOutcome::Snapshot);
+    let status = if restored {
+        restore_ready_status(
+            restore,
+            RestorePhase::Completed,
+            crate::consts::RESTORE_POPULATED_REASON,
+            "populator: restored the snapshot into the claiming PVC and rebound the volume",
+        )
+    } else {
+        let msg = "populator: no snapshot found; provisioned an empty volume for the \
+                   claiming PVC (deploy-or-restore)";
+        let conditions = io::upsert_condition(
+            &existing_conditions(restore),
+            "Resolved",
+            true,
+            "NoSnapshotContinue",
+            msg,
+            restore.metadata.generation,
+        );
+        restore_ready_status_on(
+            restore,
+            &conditions,
+            RestorePhase::Completed,
+            "NoSnapshotContinue",
+            msg,
+        )
+    };
+    io::patch_status(api, name, status).await?;
+    Ok(Action::requeue(std::time::Duration::from_secs(600)))
+}
+
+/// Complete a populator whose claiming PVC is already bound, so there is nothing to
+/// populate (#233) — the CSI handover only applies to an UNBOUND claim.
+///
+/// Reaps any populate artifacts that can never be handed over (this is what collects the
+/// orphaned `prime-*` PVCs ≤0.7.x left `Bound` forever, each holding a full copy of the
+/// restored data; a still-running mover is cancelled with them, because its output can
+/// never reach the claim), then stamps a truthful terminal status.
+///
+/// The status write is self-gated on the kstatus trio rather than the phase alone, which
+/// does three jobs at once:
+/// - a legacy stuck orphan (`Completed` + `Ready=False/PopulatingPrimePvc`, the frozen
+///   state #233 reports) is NOT settled, so it heals exactly once; and
+/// - a SUCCESSFULLY finalized populator (`Completed` + `Ready=True/RestoreSucceeded`)
+///   reaches this same path on every steady heartbeat once `finalize_populator` has
+///   stripped its rebind annotation — it IS settled, so its truthful success message is
+///   never clobbered by the no-op message, and its artifacts are already gone so nothing
+///   is reaped and no Event fires; and
+/// - a freshly recreated `Restore` over a bound claim is not settled, so it completes.
+#[allow(clippy::too_many_arguments)]
+async fn complete_populator_already_bound(
+    ctx: &Context,
+    restore: &Restore,
+    api: &Api<Restore>,
+    namespace: &str,
+    name: &str,
+    populate_job: &str,
+    prime_name: &str,
+    consumer: &k8s_openapi::api::core::v1::PersistentVolumeClaim,
+    pv: PrimePvAction<'_>,
+) -> Result<Action> {
+    use k8s_openapi::api::batch::v1::Job;
+    use k8s_openapi::api::core::v1::PersistentVolumeClaim;
+
+    let pvc_api: Api<PersistentVolumeClaim> = Api::namespaced(ctx.client.clone(), namespace);
+    let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
+
+    // An object already being deleted is NOT an artifact to reap: re-issuing the delete
+    // (and re-publishing the Event) on every heartbeat while it sits Terminating on a
+    // finalizer would be pure churn.
+    let live = |meta: &kube::core::ObjectMeta| meta.deletion_timestamp.is_none();
+    let mut artifacts = Vec::new();
+    if pvc_api
+        .get_opt(prime_name)
+        .await?
+        .is_some_and(|p| live(&p.metadata))
+    {
+        artifacts.push(format!("prime PVC `{prime_name}`"));
+    }
+    if job_api
+        .get_opt(populate_job)
+        .await?
+        .is_some_and(|j| live(&j.metadata))
+    {
+        artifacts.push(format!("populate Job `{populate_job}`"));
+    }
+
+    let kept_pv = match pv {
+        PrimePvAction::ForceRetain(p) => Some(p),
+        PrimePvAction::RestoreOriginalPolicy(_) | PrimePvAction::Leave => None,
+    };
+    if !artifacts.is_empty() || kept_pv.is_some() {
+        let consumer_name = consumer.name_any();
+        finalize_populator(ctx, namespace, populate_job, prime_name, pv).await?;
+        let note = reaped_populate_artifacts_note(&artifacts, &consumer_name, kept_pv);
+        tracing::warn!(%namespace, restore = %name, consumer = %consumer_name, "{note}");
+        io::publish_warning_event(
+            ctx,
+            restore,
+            ORPHANED_PRIME_REAPED_REASON,
+            RECREATE_CLAIM_TO_RESTORE_ACTION,
+            &note,
+        )
+        .await;
+    }
+
+    let settled = restore.status.as_ref().and_then(|s| s.phase) == Some(RestorePhase::Completed)
+        && kstatus_settled_for(restore, RestorePhase::Completed);
+    if !settled {
+        let bound_volume = consumer
+            .spec
+            .as_ref()
+            .and_then(|s| s.volume_name.as_deref())
+            .filter(|v| !v.is_empty());
+        let msg = target_already_bound_message(&consumer.name_any(), bound_volume);
+        io::patch_status(
+            api,
+            name,
+            restore_ready_status(
+                restore,
+                RestorePhase::Completed,
+                RESTORE_TARGET_ALREADY_BOUND_REASON,
+                &msg,
+            ),
+        )
+        .await?;
+    }
+    Ok(Action::requeue(std::time::Duration::from_secs(600)))
+}
+
+/// Re-open source resolution on a populator that had completed as an already-bound no-op
+/// and whose claiming PVC has since been re-created (and is unbound again, so it genuinely
+/// wants populating).
+///
+/// Resolution is skipped on the no-op heartbeat (see `reconcile_inner`), so this pass has
+/// no snapshot selection to act on — and MUST NOT read that absence as deploy-or-restore,
+/// which would provision an empty volume over a claim the user expects restored. Moving
+/// the phase off `Completed` (and the `Ready` reason off `TargetAlreadyBound`) makes the
+/// next pass resolve normally; an already-pinned snapshot id is honored unchanged, so the
+/// re-created claim gets the SAME snapshot (ADR §4.6: pinned once, never re-resolved).
+async fn reopen_populator_resolution(
+    api: &Api<Restore>,
+    restore: &Restore,
+    name: &str,
+    consumer_name: &str,
+) -> Result<Action> {
+    let msg = format!(
+        "populator: the claiming PVC `{consumer_name}` is unbound again (re-created), so this \
+         Restore has work to do after all — re-resolving the restore source"
+    );
+    io::patch_status(
+        api,
+        name,
+        restore_ready_status(restore, RestorePhase::Resolving, "ClaimRecreated", &msg),
+    )
+    .await?;
+    Ok(Action::requeue(std::time::Duration::from_secs(5)))
+}
+
 /// The selected-node annotation a late-binding (`WaitForFirstConsumer`) PVC carries
 /// once the scheduler picks a node for its first consuming pod.
 const SELECTED_NODE_ANNOTATION: &str = "volume.kubernetes.io/selected-node";
@@ -631,13 +899,38 @@ const SELECTED_NODE_ANNOTATION: &str = "volume.kubernetes.io/selected-node";
 const PRIME_ORIGINAL_RECLAIM_ANNOTATION: &str =
     "kopiur.home-operations.com/populator-original-reclaim-policy";
 
-/// The `PersistentVolume` our populator earmarked for `consumer_name`: its `claimRef`
-/// targets the consumer and it carries [`PRIME_ORIGINAL_RECLAIM_ANNOTATION`] (stamped
-/// during the rebind). `Some` ⇒ the prime→consumer rebind has been issued.
+/// What to do with the `PersistentVolume` our populator earmarked, when tearing the
+/// populate artifacts down. Closed so the two very different "the consumer is bound"
+/// endings can never be confused — one of them reclaims the volume, the other must not.
+enum PrimePvAction<'a> {
+    /// The consumer bound to OUR PV (the handover landed): restore the reclaim policy we
+    /// stashed at rebind time and drop the annotation. The volume is now the consumer's.
+    RestoreOriginalPolicy(&'a str),
+    /// The handover was LOST (the consumer bound to a different PV). Our PV's `claimRef`
+    /// points at a claim that is bound elsewhere, so the PV controller will mark it
+    /// `Released` — and restoring the stashed policy (usually `Delete`) would then reap it,
+    /// destroying the data we just restored. Force `Retain` and drop the annotation
+    /// instead: the volume survives for the admin, and the stripped annotation makes the
+    /// next pass see a plain already-bound claim (idempotent, no repeat Event).
+    ForceRetain(&'a str),
+    /// No PV of ours is involved (no rebind was ever issued).
+    Leave,
+}
+
+/// The `PersistentVolume` our populator earmarked for this consumer: its `claimRef` targets
+/// the consumer by name AND uid, and it carries [`PRIME_ORIGINAL_RECLAIM_ANNOTATION`]
+/// (stamped during the rebind). `Some` ⇒ the prime→consumer rebind has been issued.
+///
+/// The uid match is load-bearing: `claimRef` is pinned to a specific PVC instance, so a PV
+/// left annotated from a PREVIOUS claim of the same name (deleted and re-created) must not
+/// be mistaken for a rebind of the current one — the PV controller will never bind a
+/// stale-uid `claimRef`, so treating it as an outstanding rebind would wedge the handshake
+/// on a 5s requeue forever.
 async fn our_rebound_pv(
     ctx: &Context,
     namespace: &str,
     consumer_name: &str,
+    consumer_uid: &str,
 ) -> Result<Option<String>> {
     use k8s_openapi::api::core::v1::PersistentVolume;
     let pv_api: Api<PersistentVolume> = Api::all(ctx.client.clone());
@@ -658,6 +951,7 @@ async fn our_rebound_pv(
                     .is_some_and(|cr| {
                         cr.name.as_deref() == Some(consumer_name)
                             && cr.namespace.as_deref() == Some(namespace)
+                            && cr.uid.as_deref() == Some(consumer_uid)
                     })
         })
         .map(|pv| pv.name_any()))
@@ -677,15 +971,6 @@ fn pvc_claims_restore(
                 && dsr.name == restore_name
                 && dsr.api_group.as_deref() == Some("kopiur.home-operations.com")
         })
-}
-
-/// True once `pvc` is bound to a `PersistentVolume`. Pure.
-fn pvc_is_bound(pvc: &k8s_openapi::api::core::v1::PersistentVolumeClaim) -> bool {
-    pvc.spec
-        .as_ref()
-        .and_then(|s| s.volume_name.as_deref())
-        .is_some_and(|v| !v.is_empty())
-        || pvc.status.as_ref().and_then(|s| s.phase.as_deref()) == Some("Bound")
 }
 
 /// Whether the claim's `StorageClass` binds late (`WaitForFirstConsumer`), so the
@@ -851,38 +1136,52 @@ async fn rebind_prime_to_consumer(
     Ok(true)
 }
 
-/// Finalize: restore the bound PV's original reclaim policy (stashed during rebind),
-/// then GC the populate Job/ConfigMap and any leftover prime PVC.
+/// Tear the populate artifacts down: settle the earmarked PV per [`PrimePvAction`], then
+/// GC the populate Job/ConfigMap and any leftover prime PVC. Every delete tolerates an
+/// absent object, so this is safe to call on a partially-completed handshake.
 async fn finalize_populator(
     ctx: &Context,
     namespace: &str,
     populate_job: &str,
     prime_name: &str,
-    bound_pv: Option<&str>,
+    pv: PrimePvAction<'_>,
 ) -> Result<()> {
     use k8s_openapi::api::batch::v1::Job;
     use k8s_openapi::api::core::v1::{ConfigMap, PersistentVolume, PersistentVolumeClaim};
-    if let Some(pv_name) = bound_pv {
+
+    // Exhaustive: the two bound endings settle the PV very differently, and conflating them
+    // would either leak a volume or destroy the restored data.
+    let policy = match pv {
+        PrimePvAction::RestoreOriginalPolicy(pv_name) => Some((pv_name, None)),
+        PrimePvAction::ForceRetain(pv_name) => Some((pv_name, Some("Retain".to_string()))),
+        PrimePvAction::Leave => None,
+    };
+    if let Some((pv_name, forced)) = policy {
         let pv_api: Api<PersistentVolume> = Api::all(ctx.client.clone());
-        if let Some(pv) = pv_api.get_opt(pv_name).await?
-            && let Some(orig) = pv
-                .metadata
-                .annotations
-                .as_ref()
-                .and_then(|a| a.get(PRIME_ORIGINAL_RECLAIM_ANNOTATION))
-                .cloned()
-        {
-            let patch = serde_json::json!({
-                "metadata": { "annotations": { PRIME_ORIGINAL_RECLAIM_ANNOTATION: serde_json::Value::Null } },
-                "spec": { "persistentVolumeReclaimPolicy": orig },
+        if let Some(pv) = pv_api.get_opt(pv_name).await? {
+            // `forced` wins (a lost rebind keeps the volume); otherwise put back the policy
+            // stashed at rebind time. With neither, the PV never went through our rebind —
+            // leave it exactly as it is.
+            let target = forced.or_else(|| {
+                pv.metadata
+                    .annotations
+                    .as_ref()
+                    .and_then(|a| a.get(PRIME_ORIGINAL_RECLAIM_ANNOTATION))
+                    .cloned()
             });
-            pv_api
-                .patch(
-                    pv_name,
-                    &kube::api::PatchParams::default(),
-                    &kube::api::Patch::Merge(patch),
-                )
-                .await?;
+            if let Some(target) = target {
+                let patch = serde_json::json!({
+                    "metadata": { "annotations": { PRIME_ORIGINAL_RECLAIM_ANNOTATION: serde_json::Value::Null } },
+                    "spec": { "persistentVolumeReclaimPolicy": target },
+                });
+                pv_api
+                    .patch(
+                        pv_name,
+                        &kube::api::PatchParams::default(),
+                        &kube::api::Patch::Merge(patch),
+                    )
+                    .await?;
+            }
         }
     }
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
@@ -1228,6 +1527,13 @@ async fn run_restore_mover(
     use k8s_openapi::api::batch::v1::Job;
     let job_api: Api<Job> = Api::namespaced(ctx.client.clone(), namespace);
     if let Some(job) = job_api.get_opt(job_name).await? {
+        // A Job that is being DELETED is not this run's outcome. The populate Job name is
+        // stable (`<restore>-populate`), so a reaped-then-immediately-re-populated claim
+        // could otherwise read the outgoing Job's terminal `Succeeded` as its own and rebind
+        // a still-empty prime. Wait for the delete to land, then create a fresh Job.
+        if job.metadata.deletion_timestamp.is_some() {
+            return Ok(MoverOutcome::Running { created: false });
+        }
         return observe_restore_mover(ctx, restore, namespace, job_name, &job).await;
     }
 

--- a/crates/controller/src/restore/plan.rs
+++ b/crates/controller/src/restore/plan.rs
@@ -209,6 +209,45 @@ pub(super) fn target_already_bound_message(
     )
 }
 
+/// What / why / fix when our rebind was issued but a DIFFERENT volume won the claim
+/// ([`PopulatorHandshake::LostRebind`]). Distinct from [`target_already_bound_message`]
+/// because here a prime PVC WAS provisioned and a restore DID run — saying otherwise would
+/// hide a full-size `Retain`ed volume the admin now owns. Pure.
+pub(super) fn lost_rebind_message(consumer_name: &str, kept_pv: &str) -> String {
+    format!(
+        "populator: the claiming PVC `{consumer_name}` bound to a DIFFERENT volume than the one \
+         this restore prepared for it, so the handover was lost and can never complete — a \
+         volume-populator only fills an UNBOUND claim, and something else (a provisioner that \
+         ignores dataSourceRef, or an earlier bind) got there first. The restored data is NOT \
+         in the claim: it is on PersistentVolume `{kept_pv}`, which was kept (forced \
+         reclaimPolicy: Retain) rather than reclaimed. Recover it from there, or delete the \
+         claiming PVC and let it be re-created so the restore can run again — and delete \
+         `{kept_pv}` once you no longer need it."
+    )
+}
+
+/// What / why / fix when the claiming PVC was bound out from under a restore that was still
+/// RUNNING: some provisioner handed the claim a volume without honoring its `dataSourceRef`,
+/// so the populate can never be delivered. Reported as a FAILURE — the app is about to start
+/// on that other volume, and calling this a success would tell `kubectl wait` / Flux that a
+/// restore landed when it did not. Pure.
+pub(super) fn populate_hijacked_message(consumer_name: &str, bound_volume: Option<&str>) -> String {
+    let volume = match bound_volume {
+        Some(v) => format!("PersistentVolume `{v}`"),
+        None => "another PersistentVolume".to_string(),
+    };
+    format!(
+        "populator: the claiming PVC `{consumer_name}` was bound to {volume} while this restore \
+         was still writing its prime volume, so the restored data can never reach the claim — \
+         the app will come up on whatever that volume holds (an empty one, if a provisioner \
+         bound it without honoring the dataSourceRef). This cluster cannot complete a \
+         volume-populator handshake for that claim: check that the StorageClass's provisioner \
+         supports populators (AnyVolumeDataSource + a populator-aware external-provisioner). \
+         The in-flight restore was cancelled and its prime PVC left in place for inspection; a \
+         Failed Restore is terminal, so fix the provisioner and create a NEW Restore."
+    )
+}
+
 /// What / why / fix for reaping populate artifacts that can never be handed over (#233).
 /// `artifacts` are pre-described (e.g. ``["prime PVC `prime-abc`"]``) so the note names only
 /// what actually existed; `kept_pv` is the PV holding restored data that a lost rebind left
@@ -335,6 +374,31 @@ pub(super) fn existing_conditions(restore: &Restore) -> Vec<Condition> {
         .map(|s| s.conditions.clone())
         .unwrap_or_default()
 }
+/// Where the `waitTimeout` window is anchored: the Restore's creation, or — when a
+/// populator RE-OPENED resolution because its claiming PVC was re-created — that moment
+/// instead (the `Ready` condition's transition into
+/// [`crate::consts::RESTORE_CLAIM_RECREATED_REASON`]).
+///
+/// Without the re-anchor, a populator that no-op'd months ago and is now asked to populate a
+/// freshly re-created claim would measure its wait window from a creation timestamp long
+/// past: `wait_remaining_secs` returns `None` on the very first pass, and a `fromPolicy`
+/// source (which defaults to `onMissingSnapshot: Continue`) would skip the wait entirely and
+/// provision an EMPTY volume the instant the snapshot happens not to be there yet — exactly
+/// what the user configured `waitTimeout` to prevent. Pure.
+pub(super) fn wait_window_anchor(restore: &Restore, created_epoch: i64) -> i64 {
+    use crate::consts::{READY_CONDITION, RESTORE_CLAIM_RECREATED_REASON};
+    restore
+        .status
+        .as_ref()
+        .and_then(|s| {
+            s.conditions
+                .iter()
+                .find(|c| c.type_ == READY_CONDITION && c.reason == RESTORE_CLAIM_RECREATED_REASON)
+                .map(|c| c.last_transition_time.0.as_second())
+        })
+        .map_or(created_epoch, |reopened| created_epoch.max(reopened))
+}
+
 /// Seconds left in the `waitTimeout` window that started at the Restore's
 /// creation, or `None` when no (parseable) window is configured or it has
 /// elapsed. Pure, clock-free — unit-tested without a cluster.

--- a/crates/controller/src/restore/plan.rs
+++ b/crates/controller/src/restore/plan.rs
@@ -5,6 +5,7 @@
 //! lists). These are the exhaustively-unit-tested decisions the reconcile core
 //! in [`super`] wires to the cluster.
 
+use k8s_openapi::api::core::v1::PersistentVolumeClaim;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 
 use kopiur_api::{OnMissingSnapshot, Restore, RestorePhase, RestoreSource, RestoreTarget};
@@ -99,6 +100,140 @@ pub(super) fn phase_is_terminal_at_guard(phase: RestorePhase, state: PopulatorSt
         RestorePhase::Completed => state == PopulatorState::DirectTarget,
         RestorePhase::Pending | RestorePhase::Resolving | RestorePhase::Restoring => false,
     }
+}
+
+/// True once `pvc` is bound to a `PersistentVolume`. Pure.
+pub(super) fn pvc_is_bound(pvc: &PersistentVolumeClaim) -> bool {
+    pvc.spec
+        .as_ref()
+        .and_then(|s| s.volume_name.as_deref())
+        .is_some_and(|v| !v.is_empty())
+        || pvc.status.as_ref().and_then(|s| s.phase.as_deref()) == Some("Bound")
+}
+
+/// Where the populator handshake stands for the observed `(claiming PVC, the PV we
+/// rebound to it)` pair — the decision that says whether there is anything to populate
+/// at all. Pure + exhaustive, so every binding ordering is settled in one unit-tested
+/// place and the reconcile loop just `match`es it.
+///
+/// [`Self::NothingToPopulate`] is the #233 fix. A CSI volume-populator can only hand a
+/// volume to an **unbound** claim, so a `Restore` recreated over a claim that is already
+/// bound (GitOps prunes and re-applies the CR while the app keeps running on its volume)
+/// must NOT provision a prime PVC and restore into it: that prime can never be adopted,
+/// and used to sit `Bound` forever holding a full copy of the data.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum PopulatorHandshake {
+    /// The consumer is bound to the PV we rebound to it — the handover landed. Finalize:
+    /// restore the PV's original reclaim policy and GC the populate artifacts.
+    FinalizeRebound { pv: String },
+    /// Our rebind is issued but the consumer has not bound yet — wait for the PV controller.
+    AwaitingBind,
+    /// Our rebind is issued, but the consumer bound to a **different** PV (a
+    /// non-populator-aware provisioner beat us to it): the handover is lost and can never
+    /// complete. Reap the populate artifacts and complete. Our PV holds the restored data,
+    /// so it is KEPT (forced `Retain`) rather than reclaimed.
+    LostRebind { pv: String },
+    /// No rebind of ours and the consumer is already bound: nothing to populate. Reap any
+    /// leftover populate artifacts and complete as a truthful no-op.
+    NothingToPopulate,
+    /// The consumer is unbound and no rebind is outstanding: run the populate path.
+    Populate,
+}
+
+/// Decide the [`PopulatorHandshake`] from the claiming PVC and the PV our populator
+/// earmarked for it (`None` ⇒ no rebind of ours is outstanding). Pure.
+///
+/// [`PopulatorHandshake::LostRebind`] keys on an explicit, **different**
+/// `spec.volumeName`. A claim that reads bound only through `status.phase` while our
+/// rebind is in flight stays [`PopulatorHandshake::AwaitingBind`]: reading it as a lost
+/// rebind would reap a perfectly healthy handover mid-bind.
+pub(super) fn populator_handshake(
+    consumer: &PersistentVolumeClaim,
+    our_rebound_pv: Option<&str>,
+) -> PopulatorHandshake {
+    let bound_volume = consumer
+        .spec
+        .as_ref()
+        .and_then(|s| s.volume_name.as_deref())
+        .filter(|v| !v.is_empty());
+    match (our_rebound_pv, bound_volume) {
+        (Some(ours), Some(bound)) if bound == ours => PopulatorHandshake::FinalizeRebound {
+            pv: ours.to_string(),
+        },
+        (Some(ours), Some(_)) => PopulatorHandshake::LostRebind {
+            pv: ours.to_string(),
+        },
+        (Some(_), None) => PopulatorHandshake::AwaitingBind,
+        (None, _) if pvc_is_bound(consumer) => PopulatorHandshake::NothingToPopulate,
+        (None, _) => PopulatorHandshake::Populate,
+    }
+}
+
+/// True when this `Restore` already completed as an already-bound **no-op**
+/// ([`crate::consts::RESTORE_TARGET_ALREADY_BOUND_REASON`] on its `Ready` condition).
+///
+/// Load-bearing twice over, both times to keep a no-op'd populator quiet and safe:
+/// - it suppresses source re-resolution on the 600s heartbeat (a populator's `Completed`
+///   is deliberately non-terminal, so the CR keeps reconciling — re-resolving would GET
+///   the `SnapshotPolicy`/`Repository` forever, and error-loop the moment a user deletes
+///   either); and
+/// - it suppresses the `Completed`+unpinned ⟹ "empty" back-fill in
+///   [`super::pinned_decision`], which would otherwise durably pin `NoSnapshot` on a
+///   deferred-source no-op and make a later, legitimate claim recreation come up EMPTY
+///   instead of restoring.
+pub(super) fn completed_as_target_already_bound(restore: &Restore) -> bool {
+    use crate::consts::{READY_CONDITION, RESTORE_TARGET_ALREADY_BOUND_REASON};
+    restore.status.as_ref().is_some_and(|s| {
+        s.conditions
+            .iter()
+            .any(|c| c.type_ == READY_CONDITION && c.reason == RESTORE_TARGET_ALREADY_BOUND_REASON)
+    })
+}
+
+/// What / why / fix for the already-bound no-op completion (#233). Pure, so the text a
+/// human acts on is unit-asserted.
+pub(super) fn target_already_bound_message(
+    consumer_name: &str,
+    bound_volume: Option<&str>,
+) -> String {
+    let volume = match bound_volume {
+        Some(v) => format!("PersistentVolume `{v}`"),
+        None => "a PersistentVolume".to_string(),
+    };
+    format!(
+        "populator: the claiming PVC `{consumer_name}` is already bound to {volume}, so there \
+         is nothing to populate — the CSI volume-populator handover only applies to an UNBOUND \
+         claim. No prime PVC was provisioned and no restore ran; the live volume was not \
+         touched. To restore into this claim, delete the PVC and let it be re-created (keeping \
+         its dataSourceRef)."
+    )
+}
+
+/// What / why / fix for reaping populate artifacts that can never be handed over (#233).
+/// `artifacts` are pre-described (e.g. ``["prime PVC `prime-abc`"]``) so the note names only
+/// what actually existed; `kept_pv` is the PV holding restored data that a lost rebind left
+/// behind. Deliberately neutral: this also fires on crash-recovery of a SUCCESSFUL restore
+/// (finalize stripped the PV annotation, then the controller died before deleting the prime),
+/// where nothing went wrong for the user. Pure.
+pub(super) fn reaped_populate_artifacts_note(
+    artifacts: &[String],
+    consumer_name: &str,
+    kept_pv: Option<&str>,
+) -> String {
+    let mut note = format!(
+        "populator: reaped leftover populate artifacts ({}) for the claiming PVC \
+         `{consumer_name}`: the claim is already bound, so they could never be handed over to \
+         it and the prime volume would otherwise hold a full copy of the restored data forever.",
+        artifacts.join(", ")
+    );
+    if let Some(pv) = kept_pv {
+        note.push_str(&format!(
+            " PersistentVolume `{pv}` holds the restored data and was KEPT (forced \
+             reclaimPolicy: Retain) rather than reclaimed — delete it manually if you do not \
+             want it."
+        ));
+    }
+    note
 }
 
 /// Map a `Restore` phase to its kstatus [`io::ReadyOutcome`] (ADR-0005 §2), so

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -182,6 +182,7 @@ fn pinned_decision_reads_the_pinned_outcome_and_never_re_resolves() {
             Some(&resolved_with(Some(ResolutionOutcome::NoSnapshot), None)),
             Some(Completed),
             AwaitingClaim,
+            false,
         ),
         Some(Resolution::Empty)
     );
@@ -195,6 +196,7 @@ fn pinned_decision_reads_the_pinned_outcome_and_never_re_resolves() {
             )),
             Some(Pending),
             DirectTarget,
+            false,
         ),
         Some(Resolution::Snapshot("k7".into()))
     );
@@ -205,6 +207,7 @@ fn pinned_decision_reads_the_pinned_outcome_and_never_re_resolves() {
             Some(&resolved_with(None, Some("k7"))),
             Some(Pending),
             DirectTarget,
+            false,
         ),
         Some(Resolution::Snapshot("k7".into()))
     );
@@ -213,16 +216,74 @@ fn pinned_decision_reads_the_pinned_outcome_and_never_re_resolves() {
     // resolved populator ALWAYS pins before Completed, so this unambiguously means
     // the decision was "empty" — back-fill Empty, do NOT re-resolve.
     assert_eq!(
-        pinned_decision(None, Some(Completed), AwaitingClaim),
+        pinned_decision(None, Some(Completed), AwaitingClaim, false),
         Some(Resolution::Empty)
     );
     // The same shape on a DIRECT target is not a stuck populator (its `Completed`
     // is terminal at the guard, so it never reaches here): require fresh resolution.
-    assert_eq!(pinned_decision(None, Some(Completed), DirectTarget), None);
+    assert_eq!(
+        pinned_decision(None, Some(Completed), DirectTarget, false),
+        None
+    );
 
     // A fresh, un-pinned restore must resolve.
-    assert_eq!(pinned_decision(None, Some(Pending), AwaitingClaim), None);
-    assert_eq!(pinned_decision(None, None, DirectTarget), None);
+    assert_eq!(
+        pinned_decision(None, Some(Pending), AwaitingClaim, false),
+        None
+    );
+    assert_eq!(pinned_decision(None, None, DirectTarget, false), None);
+}
+
+/// #233: the OTHER way a populator reaches `Completed` unpinned is an already-bound
+/// no-op on a DEFERRED source — the mover (which pins a deferred source) never ran.
+/// Back-filling `Empty` there would durably pin `NoSnapshot`, so a later, legitimate
+/// re-creation of the claiming PVC would provision an EMPTY volume instead of restoring
+/// the snapshot. The `noop_already_bound` flag must suppress exactly that back-fill —
+/// and nothing else.
+#[test]
+fn pinned_decision_skips_empty_backfill_after_already_bound_noop() {
+    use PopulatorState::AwaitingClaim;
+    use RestorePhase::Completed;
+
+    // The no-op'd populator: do NOT infer "empty", leave it unresolved so a recreated
+    // claim re-resolves and restores for real.
+    assert_eq!(
+        pinned_decision(None, Some(Completed), AwaitingClaim, true),
+        None
+    );
+    // The legacy stuck populator (same shape, but NOT an already-bound no-op) still
+    // back-fills — that heal must survive this fix.
+    assert_eq!(
+        pinned_decision(None, Some(Completed), AwaitingClaim, false),
+        Some(Resolution::Empty)
+    );
+    // A genuine deploy-or-restore PINNED `NoSnapshot`, so it reads its pin either way:
+    // the flag never overrides a real pin.
+    for noop in [true, false] {
+        assert_eq!(
+            pinned_decision(
+                Some(&resolved_with(Some(ResolutionOutcome::NoSnapshot), None)),
+                Some(Completed),
+                AwaitingClaim,
+                noop,
+            ),
+            Some(Resolution::Empty)
+        );
+        // …and a pinned snapshot id is likewise honored, so a recreated claim restores
+        // the SAME snapshot (ADR §4.6: pinned once, never re-resolved).
+        assert_eq!(
+            pinned_decision(
+                Some(&resolved_with(
+                    Some(ResolutionOutcome::Snapshot),
+                    Some("k9")
+                )),
+                Some(Completed),
+                AwaitingClaim,
+                noop,
+            ),
+            Some(Resolution::Snapshot("k9".into()))
+        );
+    }
 }
 
 // --- kstatus Ready conditions (ADR-0005 §2) -----------------------------
@@ -407,6 +468,152 @@ fn pvc_is_bound_reads_volume_name_or_phase() {
     assert!(!pvc_is_bound(&pvc(serde_json::json!({
         "metadata": { "name": "p" }, "spec": {}, "status": { "phase": "Pending" },
     }))));
+}
+
+// --- #233: the populator handshake verdict --------------------------------
+// The bug: a `Restore` re-created (GitOps prune + re-apply) over a claim that is
+// ALREADY bound used to provision a prime PVC and run a full restore into it, then
+// park forever — the prime could never be adopted (a CSI populator only hands volumes
+// to UNBOUND claims), so it sat `Bound` holding a complete copy of the data. Every
+// binding ordering is decided here, exhaustively, in one pure place.
+
+#[test]
+fn populator_handshake_covers_every_binding_ordering() {
+    let unbound = pvc(serde_json::json!({ "metadata": { "name": "c" }, "spec": {} }));
+    let bound_ours = pvc(serde_json::json!({
+        "metadata": { "name": "c" }, "spec": { "volumeName": "pv-ours" },
+    }));
+    let bound_foreign = pvc(serde_json::json!({
+        "metadata": { "name": "c" }, "spec": { "volumeName": "pv-theirs" },
+    }));
+    // Bound only through `status.phase` — `spec.volumeName` not observed yet.
+    let bound_by_phase = pvc(serde_json::json!({
+        "metadata": { "name": "c" }, "spec": {}, "status": { "phase": "Bound" },
+    }));
+
+    // No rebind of ours + unbound claim → the normal populate path (also the WFFC
+    // shape before a pod schedules the claim).
+    assert_eq!(
+        populator_handshake(&unbound, None),
+        PopulatorHandshake::Populate
+    );
+
+    // THE #233 CASE: no rebind of ours + an already-bound claim → nothing to populate.
+    assert_eq!(
+        populator_handshake(&bound_foreign, None),
+        PopulatorHandshake::NothingToPopulate
+    );
+    // …including a claim that only reads bound through its phase.
+    assert_eq!(
+        populator_handshake(&bound_by_phase, None),
+        PopulatorHandshake::NothingToPopulate
+    );
+
+    // Mid-handover: our rebind is issued but the claim has not bound yet. This is the
+    // guard that must NOT misfire — reaping here would kill a healthy restore.
+    assert_eq!(
+        populator_handshake(&unbound, Some("pv-ours")),
+        PopulatorHandshake::AwaitingBind
+    );
+    // Bound-by-phase-only WITH our rebind outstanding is still mid-handover, NOT a lost
+    // rebind: `spec.volumeName` is the only field that says WHICH volume won the claim.
+    assert_eq!(
+        populator_handshake(&bound_by_phase, Some("pv-ours")),
+        PopulatorHandshake::AwaitingBind
+    );
+
+    // The handover landed → finalize (restore the PV's reclaim policy, GC the prime).
+    assert_eq!(
+        populator_handshake(&bound_ours, Some("pv-ours")),
+        PopulatorHandshake::FinalizeRebound {
+            pv: "pv-ours".into()
+        }
+    );
+
+    // Our rebind was issued but a DIFFERENT PV won the claim: the handover is lost and
+    // can never complete. Reap — and keep our PV, which holds the restored data.
+    assert_eq!(
+        populator_handshake(&bound_foreign, Some("pv-ours")),
+        PopulatorHandshake::LostRebind {
+            pv: "pv-ours".into()
+        }
+    );
+}
+
+/// A populator Restore that is `Completed` with `Ready=True/<reason>`, parsed the
+/// cluster's way (JSON → typed).
+fn completed_populator_with_ready_reason(reason: &str) -> Restore {
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": "r", "namespace": "ns", "generation": 1 },
+        "spec": {
+            "source": { "snapshotRef": { "name": "b" } },
+            "target": { "populator": {} }
+        },
+        "status": {
+            "phase": "Completed",
+            "conditions": [{
+                "type": "Ready", "status": "True", "reason": reason, "message": "m",
+                "lastTransitionTime": "2026-01-01T00:00:00Z"
+            }]
+        }
+    }))
+    .expect("valid Restore")
+}
+
+/// The `Ready` reason is what tells the three `Completed` populator states apart, so it
+/// gates both the re-resolution skip and the `pinned_decision` back-fill.
+#[test]
+fn completed_as_target_already_bound_reads_ready_reason() {
+    assert!(completed_as_target_already_bound(
+        &completed_populator_with_ready_reason(crate::consts::RESTORE_TARGET_ALREADY_BOUND_REASON)
+    ));
+    // A real restore, and the legacy stuck-populator state, must NOT be mistaken for it —
+    // the first would have its success message clobbered, the second would never heal.
+    assert!(!completed_as_target_already_bound(
+        &completed_populator_with_ready_reason(crate::consts::RESTORE_POPULATED_REASON)
+    ));
+    assert!(!completed_as_target_already_bound(
+        &completed_populator_with_ready_reason("PopulatingPrimePvc")
+    ));
+    // No status at all (a fresh CR) is not a no-op completion either.
+    assert!(!completed_as_target_already_bound(&restore_with_condition(
+        "Resolved", "True"
+    )));
+}
+
+/// The no-op and reap messages are what a human reads when 49 prime PVCs vanish, so the
+/// what/why/fix text is asserted like any other behavior.
+#[test]
+fn target_already_bound_messages_say_what_why_fix() {
+    let msg = target_already_bound_message("plex-config", Some("pvc-abc"));
+    assert!(msg.contains("`plex-config`"), "{msg}");
+    assert!(msg.contains("already bound"), "{msg}");
+    assert!(msg.contains("PersistentVolume `pvc-abc`"), "{msg}");
+    // The fix: re-create the CLAIM (deleting the Restore just re-triggers this no-op).
+    assert!(msg.contains("delete the PVC"), "{msg}");
+    // Never claim a restore ran.
+    assert!(msg.contains("no restore ran"), "{msg}");
+    // A claim bound without an observed volumeName still reads sensibly.
+    assert!(
+        target_already_bound_message("plex-config", None).contains("a PersistentVolume"),
+        "unnamed volume must not render as an empty backtick pair"
+    );
+
+    let note =
+        reaped_populate_artifacts_note(&["prime PVC `prime-9f2`".to_string()], "plex-config", None);
+    assert!(note.contains("prime PVC `prime-9f2`"), "{note}");
+    assert!(note.contains("plex-config"), "{note}");
+    // A lost rebind must say the volume was KEPT — the data is in there.
+    let kept = reaped_populate_artifacts_note(
+        &["populate Job `plex-populate`".to_string()],
+        "plex-config",
+        Some("pv-xyz"),
+    );
+    assert!(kept.contains("pv-xyz"), "{kept}");
+    assert!(kept.contains("Retain"), "{kept}");
+    assert!(kept.contains("KEPT"), "{kept}");
 }
 
 // --- restore_flags (M2 flag sweep controller-glue guard) ---

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -616,6 +616,90 @@ fn target_already_bound_messages_say_what_why_fix() {
     assert!(kept.contains("KEPT"), "{kept}");
 }
 
+/// A LOST rebind is not an already-bound no-op: a prime WAS provisioned, a restore DID run,
+/// and a full-size volume is now `Retain`ed. Telling the operator "nothing was provisioned,
+/// no restore ran" there would hide storage they have just become responsible for.
+#[test]
+fn lost_rebind_message_never_claims_nothing_ran() {
+    let msg = lost_rebind_message("plex-config", "pv-ours");
+    assert!(msg.contains("`plex-config`"), "{msg}");
+    assert!(msg.contains("pv-ours"), "{msg}");
+    assert!(msg.contains("Retain"), "{msg}");
+    assert!(
+        !msg.contains("no restore ran"),
+        "a lost rebind DID run a restore: {msg}"
+    );
+    assert!(
+        msg.contains("restored data is NOT in the claim"),
+        "must say where the data actually is: {msg}"
+    );
+}
+
+/// A claim bound out from under a RUNNING populate is a hijacked handover, not a success:
+/// the app is about to start on someone else's (probably empty) volume, so reporting
+/// `Ready=True` would tell `kubectl wait`/Flux a restore landed when it did not.
+#[test]
+fn populate_hijacked_message_points_at_the_provisioner() {
+    let msg = populate_hijacked_message("plex-config", Some("pv-empty"));
+    assert!(msg.contains("`plex-config`"), "{msg}");
+    assert!(msg.contains("pv-empty"), "{msg}");
+    assert!(msg.contains("AnyVolumeDataSource"), "{msg}");
+    assert!(msg.contains("terminal"), "{msg}");
+    assert!(
+        populate_hijacked_message("plex-config", None).contains("another PersistentVolume"),
+        "an unnamed volume must not render as an empty backtick pair"
+    );
+}
+
+/// A populator that no-op'd long ago and is then asked to populate a FRESHLY re-created
+/// claim must measure its `waitTimeout` from the re-open, not from its own creation —
+/// otherwise the window is already spent, and a `fromPolicy` source (which defaults to
+/// `Continue`) skips the wait and provisions an EMPTY volume the instant the snapshot
+/// happens not to be there yet.
+#[test]
+fn wait_window_re_anchors_when_a_recreated_claim_reopens_resolution() {
+    let with_ready = |reason: &str, at: &str| -> Restore {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "kopiur.home-operations.com/v1alpha1",
+            "kind": "Restore",
+            "metadata": { "name": "r", "namespace": "ns", "generation": 1 },
+            "spec": {
+                "source": { "fromPolicy": { "name": "cfg" } },
+                "target": { "populator": {} }
+            },
+            "status": { "conditions": [{
+                "type": "Ready", "status": "False", "reason": reason, "message": "m",
+                "lastTransitionTime": at
+            }] }
+        }))
+        .expect("valid Restore")
+    };
+
+    // 2026-01-01T00:00:00Z == 1767225600. The Restore itself was created long before.
+    let created = 1_000_000_000;
+    let reopened = with_ready("ClaimRecreated", "2026-01-01T00:00:00Z");
+    assert_eq!(wait_window_anchor(&reopened, created), 1_767_225_600);
+
+    // Any other Ready reason leaves the window anchored at creation.
+    let normal = with_ready("PopulatingPrimePvc", "2026-01-01T00:00:00Z");
+    assert_eq!(wait_window_anchor(&normal, created), created);
+
+    // A re-open that somehow predates creation never SHORTENS the window.
+    let stale = with_ready("ClaimRecreated", "2001-09-09T01:46:40Z");
+    assert_eq!(wait_window_anchor(&stale, created), created);
+
+    // Net effect: the user's 5m window is fully available again from the re-open.
+    assert_eq!(
+        wait_remaining_secs(
+            wait_window_anchor(&reopened, created),
+            Some("5m"),
+            1_767_225_660,
+        ),
+        Some(240),
+        "the configured waitTimeout must actually apply to the re-created claim"
+    );
+}
+
 // --- restore_flags (M2 flag sweep controller-glue guard) ---
 
 #[test]

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -194,6 +194,12 @@ pub const BUCKETS: &[&str] = &[
     // Cluster-scoped safe-create guard: initialized once, then a wrong-password
     // ClusterRepository must NOT recreate over it.
     "kopiur-crepo-guard",
+    // #232: a ClusterRepository whose secret refs carry NO namespace — they must
+    // default to the operator's namespace instead of hard-erroring the reconcile.
+    "kopiur-crepo-defaultns",
+    // #231: MaintenanceConfigured must be re-evaluated at steady state (and the
+    // managed Maintenance re-applied), not frozen at whatever the bootstrap wrote.
+    "kopiur-crepo-maintcond",
     "kopiur-maint",
     "kopiur-xns-crepo",
     "kopiur-xns-repo",

--- a/crates/e2e/tests/object_store.rs
+++ b/crates/e2e/tests/object_store.rs
@@ -622,3 +622,196 @@ async fn clusterrepository_not_initialized_and_safe_create_guard() {
     let _ = crepos.delete(good, &DeleteParams::default()).await;
     let _ = crepos.delete(bad, &DeleteParams::default()).await;
 }
+
+/// #232: a `ClusterRepository` whose secret refs carry NO `namespace` must reconcile.
+///
+/// The CRD documents `namespace` as "absent = same namespace as the referrer", but a
+/// `ClusterRepository` is cluster-scoped and HAS no namespace — so the reconciler used to
+/// refuse the object outright ("encryption.passwordSecretRef.namespace is required"),
+/// contradicting its own schema and leaving users stuck. It now defaults to the operator's
+/// namespace (`KOPIUR_NAMESPACE`), the same rule `spec.maintenance.namespace` already used,
+/// and the namespace where a chart install's repository Secret conventionally lives.
+///
+/// This is the reporter's manifest, minus the namespaces: the e2e credential Secret already
+/// lives in the operator namespace, so the repo must reach `Ready` untouched. Pre-fix, the
+/// reconcile loops on a structural validation error and never bootstraps.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + MinIO"]
+async fn cluster_repository_defaults_secret_namespace_to_operator_namespace() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Minio]).await.expect("fixtures");
+    let client = world.client().clone();
+    let crepos: Api<ClusterRepository> = Api::all(client.clone());
+
+    let name = "e2e-crepo-defaultns";
+    let _ = crepos.delete(name, &DeleteParams::default()).await;
+
+    // Note what is NOT here: no `namespace` on either secret ref. The operator's own
+    // namespace is where the harness put `kopia-s3-creds`.
+    crepos
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "ClusterRepository",
+                "metadata": { "name": name },
+                "spec": {
+                    "backend": { "s3": {
+                        "bucket": "kopiur-crepo-defaultns",
+                        "endpoint": "minio.kopiur-e2e.svc.cluster.local:9000",
+                        "region": "us-east-1",
+                        "tls": { "disableTls": true },
+                        "auth": { "secretRef": { "name": "kopia-s3-creds" } }
+                    }},
+                    "encryption": {
+                        "passwordSecretRef": { "name": "kopia-s3-creds", "key": "KOPIA_PASSWORD" }
+                    },
+                    "create": { "enabled": true },
+                    "allowedNamespaces": { "all": true }
+                }
+            })),
+        )
+        .await
+        .expect("create namespace-less ClusterRepository");
+
+    wait_phase(&crepos, name, "Ready")
+        .await
+        .expect("a ClusterRepository with no secret-ref namespaces bootstraps against the operator namespace");
+
+    let status = status_json(&crepos, name).await;
+    assert!(
+        status
+            .get("uniqueId")
+            .and_then(|v| v.as_str())
+            .is_some_and(|u| !u.is_empty()),
+        "the repository is really initialized (a pinned uniqueId), got {status}"
+    );
+
+    let _ = crepos.delete(name, &DeleteParams::default()).await;
+}
+
+/// #231: `MaintenanceConfigured` must be re-evaluated at STEADY STATE on the object-store
+/// path — and the managed `Maintenance` re-applied when it goes missing.
+///
+/// The reported failure: the condition stuck at `False/MaintenanceDisabled` for two days
+/// while the operator-managed `Maintenance` existed, was owned by the repo, held its lease,
+/// and ran on schedule. `ensure_maintenance` was only ever reached at the tail of a
+/// bootstrap, so a value written during a bootstrap race froze forever — the repo's own
+/// `.watches(Maintenance)` requeue landed on a reconcile that early-exits before the check.
+///
+/// The test reproduces the frozen state structurally: delete the finished bootstrap Job
+/// (what the TTL controller does anyway), so the only reconcile left is the steady-state
+/// one. Then delete the managed `Maintenance` and prove the operator notices and repairs
+/// it. Pre-fix, nothing would ever re-apply it and the condition would never be re-read.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + MinIO"]
+async fn s3_cluster_repository_maintenance_self_corrects_at_steady_state() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Minio]).await.expect("fixtures");
+    let client = world.client().clone();
+    let crepos: Api<ClusterRepository> = Api::all(client.clone());
+    let maints: Api<Maintenance> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    let name = "e2e-crepo-maintcond";
+    let _ = crepos.delete(name, &DeleteParams::default()).await;
+
+    // No `maintenance` block at all → default-on, exactly like the report.
+    crepos
+        .create(
+            &PostParams::default(),
+            &cr(s3_cluster_repository_json(
+                name,
+                "kopiur-crepo-maintcond",
+                "kopia-s3-creds",
+                true,
+            )),
+        )
+        .await
+        .expect("create ClusterRepository with default-on maintenance");
+
+    wait_phase(&crepos, name, "Ready")
+        .await
+        .expect("the ClusterRepository bootstraps");
+    wait_until(
+        "MaintenanceConfigured=True",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = status_json(&crepos, name).await;
+            Ok(
+                (condition_status(&s, "MaintenanceConfigured").as_deref() == Some("True"))
+                    .then_some(()),
+            )
+        },
+    )
+    .await
+    .expect("a default-on repository reports its managed Maintenance as configured");
+
+    // Reach the frozen state: with the bootstrap Job gone (the TTL controller reaps it in
+    // the real world), every later reconcile takes the steady-state early-exit — the one
+    // that used to skip the maintenance check entirely.
+    let bootstrap_job = format!("{name}-bootstrap");
+    let _ = jobs
+        .delete(
+            &bootstrap_job,
+            &DeleteParams {
+                propagation_policy: Some(kube::api::PropagationPolicy::Background),
+                ..Default::default()
+            },
+        )
+        .await;
+    wait_until(
+        "the finished bootstrap Job is reaped",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(jobs.get_opt(&bootstrap_job).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("the bootstrap Job is gone, so only steady-state reconciles remain");
+
+    // Now break maintenance out from under the repo.
+    maints
+        .delete(name, &DeleteParams::default())
+        .await
+        .expect("delete the operator-managed Maintenance");
+
+    // The steady-state reconcile must re-apply it and keep the condition truthful. This is
+    // impossible pre-fix: the Maintenance-watch requeue lands on the early-exit.
+    let restored = wait_until(
+        "the managed Maintenance is re-applied",
+        default_timeout(),
+        poll_interval(),
+        || async { maints.get_opt(name).await },
+    )
+    .await
+    .expect("the operator re-creates the managed Maintenance it owns");
+    assert!(
+        restored
+            .metadata
+            .owner_references
+            .as_ref()
+            .is_some_and(|o| o
+                .iter()
+                .any(|r| r.kind == "ClusterRepository" && r.name == name)),
+        "the re-applied Maintenance is owned by the repository, not orphaned"
+    );
+
+    let s = status_json(&crepos, name).await;
+    assert_eq!(
+        condition_status(&s, "MaintenanceConfigured").as_deref(),
+        Some("True"),
+        "the condition must track reality, not freeze at whatever the bootstrap wrote: {s}"
+    );
+    assert_ne!(
+        condition_reason(&s, "MaintenanceConfigured").as_deref(),
+        Some("MaintenanceDisabled"),
+        "maintenance was never disabled here — that reason is the #231 lie: {s}"
+    );
+
+    let _ = crepos.delete(name, &DeleteParams::default()).await;
+}

--- a/crates/e2e/tests/repository_lifecycle.rs
+++ b/crates/e2e/tests/repository_lifecycle.rs
@@ -129,21 +129,48 @@ async fn assert_populator_binds_and_restores(
     seed: &str,
     prefix: &str,
 ) {
+    let populated = populate_claim(client, storage_class, repo, seed, prefix).await;
+    populated.cleanup(client).await;
+}
+
+/// The objects a [`populate_claim`] run left behind, so a caller can keep inspecting them
+/// (and clean up when done) instead of tearing them down immediately.
+struct PopulatedClaim {
+    restore: String,
+    claim: String,
+    reader: String,
+}
+
+impl PopulatedClaim {
+    async fn cleanup(&self, client: &kube::Client) {
+        let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+        let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+        let _ = pods.delete(&self.reader, &DeleteParams::default()).await;
+        let _ = pvcs.delete(&self.claim, &DeleteParams::default()).await;
+        let _ = restores
+            .delete(&self.restore, &DeleteParams::default())
+            .await;
+    }
+}
+
+/// Drive one populator handshake to completion and LEAVE the objects in place (the caller
+/// owns cleanup). Body of [`assert_populator_binds_and_restores`], split out so the #233
+/// regression test can keep the now-BOUND claim and then delete + re-create the `Restore`
+/// over it — the exact GitOps sequence that used to orphan a full-size prime PVC.
+async fn populate_claim(
+    client: &kube::Client,
+    storage_class: &str,
+    repo: &str,
+    seed: &str,
+    prefix: &str,
+) -> PopulatedClaim {
     let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
     let restore_name = format!("{prefix}-restore");
     restores
         .create(
             &PostParams::default(),
-            &cr(serde_json::json!({
-                "apiVersion": "kopiur.home-operations.com/v1alpha1",
-                "kind": "Restore",
-                "metadata": { "name": restore_name, "namespace": E2E_NAMESPACE },
-                "spec": {
-                    "repository": { "kind": "Repository", "name": repo },
-                    "source": { "snapshotRef": { "name": seed } },
-                    "target": { "populator": {} }
-                }
-            })),
+            &cr(populator_restore_json(&restore_name, repo, seed)),
         )
         .await
         .expect("create populator Restore");
@@ -202,11 +229,25 @@ async fn assert_populator_binds_and_restores(
         .await
         .expect("the populator Restore reaches Completed once the claim is bound");
 
-    let _ = pods.delete(&reader, &DeleteParams::default()).await;
-    let _ = pvcs.delete(&claim, &DeleteParams::default()).await;
-    let _ = restores
-        .delete(&restore_name, &DeleteParams::default())
-        .await;
+    PopulatedClaim {
+        restore: restore_name,
+        claim,
+        reader,
+    }
+}
+
+/// A populator `Restore` reading `seed` out of `repo` (`target.populator: {}`).
+fn populator_restore_json(name: &str, repo: &str, seed: &str) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": repo },
+            "source": { "snapshotRef": { "name": seed } },
+            "target": { "populator": {} }
+        }
+    })
 }
 
 /// ADR-0005 §9 end-to-end (Immediate binding): a PVC whose `dataSourceRef` claims a
@@ -283,6 +324,175 @@ async fn restore_populator_wffc_binds_pvc_and_restores_data() {
         "e2e-pop3",
     )
     .await;
+}
+
+/// #233: re-creating a populator `Restore` whose claiming PVC is ALREADY bound must be a
+/// no-op — no prime PVC, no mover run — and must reap any orphaned prime left behind.
+///
+/// This is the GitOps sequence that bit the reporter at fleet scale: a `ClusterRepository`
+/// rebuild pruned and re-applied all 49 `Restore` CRs at once, while their target PVCs
+/// stayed Bound and their apps kept running. Each recreated `Restore` provisioned a
+/// `prime-<uid>` PVC and ran a FULL restore into it — a prime that can never be adopted (a
+/// CSI populator only hands volumes to UNBOUND claims), so it sat `Bound` forever: 120 GiB
+/// of orphaned copies, plus 49 pointless repository reads.
+///
+/// The test manufactures the orphan explicitly (a `prime-<consumer-uid>` PVC carrying the
+/// operator's populate label) so the reap path is exercised deterministically, then asserts
+/// the recreated `Restore` completes as `TargetAlreadyBound` having touched nothing.
+///
+/// Red on the pre-fix controller: a freshly re-created CR has no phase, so the old
+/// `Completed && bound` short-circuit doesn't fire, and it adopts the prime and runs a
+/// mover into it — failing both the "no populate Job" and "prime is gone" assertions.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install + CSI snapshot stack"]
+async fn recreated_populator_restore_over_bound_claim_is_noop_and_reaps_orphaned_prime() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    if !csi_class_present_or_skip(&client, CSI_STORAGE_CLASS).await {
+        return;
+    }
+
+    ensure_seed(
+        &client,
+        "e2e-pop2-repo",
+        "e2e-pop2-policy",
+        "e2e-pop2-seed",
+        "populator2",
+    )
+    .await;
+
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // 1. A normal, successful populate: the claim ends up Bound with the restored data.
+    let populated = populate_claim(
+        &client,
+        CSI_STORAGE_CLASS,
+        "e2e-pop2-repo",
+        "e2e-pop2-seed",
+        "e2e-pop4",
+    )
+    .await;
+
+    let claim = pvcs
+        .get(&populated.claim)
+        .await
+        .expect("the claiming PVC exists");
+    let consumer_uid = claim.metadata.uid.clone().expect("claim uid");
+    let live_volume = claim
+        .spec
+        .as_ref()
+        .and_then(|s| s.volume_name.clone())
+        .expect("the claim is bound to a PV");
+
+    // 2. GitOps prunes the Restore. The claim stays Bound; the app keeps running.
+    restores
+        .delete(&populated.restore, &DeleteParams::default())
+        .await
+        .expect("delete the Restore");
+    wait_until(
+        "the pruned Restore is gone",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(restores
+                .get_opt(&populated.restore)
+                .await?
+                .is_none()
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("the Restore is pruned");
+
+    // 3. Manufacture the ≤0.7.x orphan: a prime PVC keyed to the consumer's uid, carrying
+    //    the operator's populate label — exactly what the buggy path left Bound forever.
+    let orphan_prime = format!("prime-{consumer_uid}");
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "PersistentVolumeClaim",
+            "metadata": {
+                "name": orphan_prime,
+                "namespace": E2E_NAMESPACE,
+                "labels": { "kopiur.home-operations.com/op": "restore-populate" },
+            },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": CSI_STORAGE_CLASS,
+                "resources": { "requests": { "storage": "1Gi" } },
+            }
+        })),
+    )
+    .await
+    .expect("create the orphaned prime PVC");
+
+    // 4. Flux re-applies the identical Restore over the still-bound claim.
+    restores
+        .create(
+            &PostParams::default(),
+            &cr(populator_restore_json(
+                &populated.restore,
+                "e2e-pop2-repo",
+                "e2e-pop2-seed",
+            )),
+        )
+        .await
+        .expect("re-create the populator Restore");
+
+    // 5. It completes as a truthful no-op: phase AND conditions agree (the reported bug had
+    //    `phase: Completed` frozen against `Ready=False/PopulatingPrimePvc` for days).
+    wait_phase(&restores, &populated.restore, "Completed")
+        .await
+        .expect("the re-created Restore completes without populating anything");
+    let ready = wait_condition(&restores, &populated.restore, "Ready", "True")
+        .await
+        .expect("Ready=True: the no-op is a settled, healthy outcome");
+    assert_eq!(
+        ready.get("reason").and_then(|r| r.as_str()),
+        Some("TargetAlreadyBound"),
+        "the completion must say WHY nothing happened: {ready:#}"
+    );
+
+    // 6. The orphaned prime is reaped — the whole point of #233.
+    wait_until(
+        "the orphaned prime PVC is reaped",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(pvcs.get_opt(&orphan_prime).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("the prime PVC that can never be adopted is deleted, not left Bound forever");
+
+    // 7. No mover ran: a full restore into an unadoptable prime is exactly the wasted work
+    //    (49 pointless repository reads, at fleet scale) the fix eliminates.
+    let populate_job = format!("{}-populate", populated.restore);
+    assert!(
+        jobs.get_opt(&populate_job)
+            .await
+            .expect("list jobs")
+            .is_none(),
+        "no populate Job may be created for an already-bound claim ({populate_job} exists)"
+    );
+
+    // 8. The live volume was never touched.
+    let after = pvcs
+        .get(&populated.claim)
+        .await
+        .expect("claim still exists");
+    assert_eq!(
+        after.spec.as_ref().and_then(|s| s.volume_name.clone()),
+        Some(live_volume),
+        "the app's bound volume must be left exactly as it was"
+    );
+
+    populated.cleanup(&client).await;
 }
 
 /// The `Resolved` condition's reason on a Restore status, if present.

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -80,7 +81,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -126,7 +133,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -199,7 +212,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -244,7 +263,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -271,7 +296,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -308,7 +339,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -386,7 +423,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -429,7 +472,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -571,7 +620,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2507,7 +2562,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -87,7 +87,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -139,7 +141,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -218,7 +222,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -269,7 +275,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -302,7 +310,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -345,7 +355,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -429,7 +441,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -478,7 +492,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -626,7 +642,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2568,7 +2586,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 38
 expression: "body(&artifacts, \"repositoryreplications\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -89,7 +90,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -135,7 +142,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -208,7 +221,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -253,7 +272,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -280,7 +305,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -317,7 +348,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -395,7 +432,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -438,7 +481,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -96,7 +96,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -148,7 +150,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -227,7 +231,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -278,7 +284,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -311,7 +319,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -354,7 +364,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -438,7 +450,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -487,7 +501,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -83,7 +83,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -135,7 +137,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -214,7 +218,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -265,7 +271,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -298,7 +306,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -341,7 +351,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -425,7 +437,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -474,7 +488,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -622,7 +638,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2564,7 +2582,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2762,7 +2782,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -2814,7 +2836,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -2893,7 +2917,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -2944,7 +2970,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -2977,7 +3005,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -3020,7 +3050,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -3104,7 +3136,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -3153,7 +3187,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -3310,7 +3346,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -5276,7 +5314,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -8981,7 +9021,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -9033,7 +9075,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -9112,7 +9156,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -9163,7 +9209,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -9196,7 +9244,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -9239,7 +9289,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -9323,7 +9375,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -9372,7 +9426,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -77,7 +77,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -123,7 +129,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -196,7 +208,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -241,7 +259,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -268,7 +292,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -305,7 +335,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -383,7 +419,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -426,7 +468,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -568,7 +616,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2504,7 +2558,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2696,7 +2756,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -2742,7 +2808,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -2815,7 +2887,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -2860,7 +2938,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -2887,7 +2971,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -2924,7 +3014,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -3002,7 +3098,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -3045,7 +3147,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -3196,7 +3304,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -5156,7 +5270,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -8855,7 +8975,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -8901,7 +9027,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -8974,7 +9106,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -9019,7 +9157,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -9046,7 +9190,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -9083,7 +9233,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -9161,7 +9317,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -9204,7 +9366,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -129,7 +129,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -175,7 +181,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -248,7 +260,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -293,7 +311,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -320,7 +344,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -357,7 +387,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -435,7 +471,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -478,7 +520,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -629,7 +677,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2589,7 +2643,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -135,7 +135,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -187,7 +189,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -266,7 +270,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -317,7 +323,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -350,7 +358,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -393,7 +403,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -477,7 +489,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -526,7 +540,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -683,7 +699,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2649,7 +2667,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -77,7 +77,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -123,7 +129,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -196,7 +208,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -241,7 +259,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -268,7 +292,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -305,7 +335,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -383,7 +419,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -426,7 +468,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -568,7 +616,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2504,7 +2558,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -83,7 +83,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -135,7 +137,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -214,7 +218,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -265,7 +271,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -298,7 +306,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -341,7 +351,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -425,7 +437,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -474,7 +488,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -622,7 +638,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2564,7 +2582,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -92,7 +92,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -144,7 +146,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -223,7 +227,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -274,7 +280,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -307,7 +315,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -350,7 +360,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -434,7 +446,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -483,7 +497,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -86,7 +86,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -132,7 +138,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -205,7 +217,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -250,7 +268,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -277,7 +301,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -314,7 +344,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -392,7 +428,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -435,7 +477,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -129,7 +129,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -175,7 +181,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -248,7 +260,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -293,7 +311,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -320,7 +344,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -357,7 +387,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -435,7 +471,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -478,7 +520,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -629,7 +677,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2589,7 +2643,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -135,7 +135,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -187,7 +189,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -266,7 +270,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -317,7 +323,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -350,7 +358,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -393,7 +403,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -477,7 +489,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -526,7 +540,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -683,7 +699,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2649,7 +2667,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -77,7 +77,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -123,7 +129,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -196,7 +208,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -241,7 +259,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -268,7 +292,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -305,7 +335,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -383,7 +419,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -426,7 +468,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -568,7 +616,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:
@@ -2504,7 +2558,13 @@ spec:
                         description: Name of the `Secret`.
                         type: string
                       namespace:
-                        description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                        description: |-
+                          Namespace of the `Secret`; absent = same namespace as the referrer. A
+                          `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                          reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                          absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                          mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -83,7 +83,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -135,7 +137,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -214,7 +218,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -265,7 +271,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -298,7 +306,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -341,7 +351,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -425,7 +437,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -474,7 +488,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -622,7 +638,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:
@@ -2564,7 +2582,9 @@ spec:
                           reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                           absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                           mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                          `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                          needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                          other than the operator itself reads the `Secret`.
                         nullable: true
                         type: string
                     required:

--- a/deploy/helm/kopiur/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/crds/repositoryreplications.yaml
@@ -92,7 +92,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -144,7 +146,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -223,7 +227,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -274,7 +280,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -307,7 +315,9 @@ spec:
                               reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                               absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                               mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                              needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                              other than the operator itself reads the `Secret`.
                             nullable: true
                             type: string
                         required:
@@ -350,7 +360,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -434,7 +446,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:
@@ -483,7 +497,9 @@ spec:
                                   reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
                                   absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
                                   mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
-                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which
+                                  needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything
+                                  other than the operator itself reads the `Secret`.
                                 nullable: true
                                 type: string
                             required:

--- a/deploy/helm/kopiur/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/crds/repositoryreplications.yaml
@@ -86,7 +86,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -132,7 +138,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -205,7 +217,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -250,7 +268,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -277,7 +301,13 @@ spec:
                             description: Name of the `Secret`.
                             type: string
                           namespace:
-                            description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                            description: |-
+                              Namespace of the `Secret`; absent = same namespace as the referrer. A
+                              `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                              reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                              absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                              mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                              `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                             nullable: true
                             type: string
                         required:
@@ -314,7 +344,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -392,7 +428,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:
@@ -435,7 +477,13 @@ spec:
                                 description: Name of the `Secret`.
                                 type: string
                               namespace:
-                                description: Namespace of the `Secret`; absent = same namespace as the referrer.
+                                description: |-
+                                  Namespace of the `Secret`; absent = same namespace as the referrer. A
+                                  `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT
+                                  reads the `Secret` (to connect, to bootstrap, or to run its repository server) an
+                                  absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload
+                                  mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace —
+                                  `envFrom` is namespace-local — so put it there, or use `credentialProjection`.
                                 nullable: true
                                 type: string
                             required:

--- a/docs/backends/index.md
+++ b/docs/backends/index.md
@@ -96,9 +96,14 @@ You don't manage the files — just put the value under the right key; the secre
 
 ///
 
-/// note | ClusterRepository: Secret refs need a namespace
+/// note | ClusterRepository: where Secret refs resolve
 
-The per-backend pages use a namespaced `Repository`. For a cluster-scoped `ClusterRepository` the same backend stanzas apply, but **every** Secret reference must carry an explicit `namespace:` (webhook-enforced), and the credential Secret must also reach each workload namespace — either replicate it yourself or turn on [credential projection](../movers.md#let-kopiur-project-the-credentials-secret-recommended-for-shared-repos) (recommended for shared repos). A worked S3 example is on the [S3 page](s3.md#as-a-clusterrepository).
+The per-backend pages use a namespaced `Repository`. The same backend stanzas apply to a cluster-scoped `ClusterRepository`, with one wrinkle: it has no namespace of its own, so "absent = the referrer's namespace" has nothing to resolve to.
+
+- **When the operator itself reads the Secret** — to connect, to bootstrap, or to run the repository server — a Secret reference with no `namespace:` resolves to the **operator's namespace** (`KOPIUR_NAMESPACE`, which the Helm chart sets for you). Setting `namespace:` explicitly always wins. Keeping the repository Secret next to the operator and omitting `namespace:` is the simplest thing that works.
+- **When a workload mover reads it** — a `Snapshot`, `Restore` or `Maintenance` Job — the Secret must exist in **that workload's namespace**, because `envFrom` is namespace-local. Replicate it yourself, or turn on [credential projection](../movers.md#let-kopiur-project-the-credentials-secret-recommended-for-shared-repos) (recommended for shared repos), which needs an explicit `namespace:` on the reference so it knows what to copy.
+
+A worked S3 example is on the [S3 page](s3.md#as-a-clusterrepository).
 
 ///
 

--- a/docs/backends/index.md
+++ b/docs/backends/index.md
@@ -100,8 +100,24 @@ You don't manage the files — just put the value under the right key; the secre
 
 The per-backend pages use a namespaced `Repository`. The same backend stanzas apply to a cluster-scoped `ClusterRepository`, with one wrinkle: it has no namespace of its own, so "absent = the referrer's namespace" has nothing to resolve to.
 
-- **When the operator itself reads the Secret** — to connect, to bootstrap, or to run the repository server — a Secret reference with no `namespace:` resolves to the **operator's namespace** (`KOPIUR_NAMESPACE`, which the Helm chart sets for you). Setting `namespace:` explicitly always wins. Keeping the repository Secret next to the operator and omitting `namespace:` is the simplest thing that works.
-- **When a workload mover reads it** — a `Snapshot`, `Restore` or `Maintenance` Job — the Secret must exist in **that workload's namespace**, because `envFrom` is namespace-local. Replicate it yourself, or turn on [credential projection](../movers.md#let-kopiur-project-the-credentials-secret-recommended-for-shared-repos) (recommended for shared repos), which needs an explicit `namespace:` on the reference so it knows what to copy.
+- **When the operator itself reads the Secret** — to connect, to bootstrap, or to run the repository server — a Secret reference with no `namespace:` resolves to the **operator's namespace** (`KOPIUR_NAMESPACE`, which the Helm chart sets for you). Setting `namespace:` explicitly always wins. This is what makes a `ClusterRepository` with no namespaces on its refs reach `Ready` at all.
+- **When a workload mover reads it** — a `Snapshot`, `Restore` or `Maintenance` Job — the Secret must exist in **that workload's namespace**, because `envFrom` is namespace-local. Either replicate it there yourself, or turn on [credential projection](../movers.md#let-kopiur-project-the-credentials-secret-recommended-for-shared-repos) (recommended for shared repos) and let Kopiur copy it in.
+
+/// warning | Set `namespace:` explicitly if anything other than the operator reads the Secret
+
+The operator-namespace default above applies **only** to the repository's own connect / bootstrap / server. The mover side does **not** default it: credential projection needs an explicit `namespace:` on the reference to know what to copy, and without projection a mover looks for a same-named Secret in its own namespace. So a `ClusterRepository` with no `namespace:` on its refs will reach `Ready` and then fail its `Snapshot`/`Restore` Jobs with a `MissingDependency` naming the Secret.
+
+**If you run backups (i.e. almost always), pin the namespace:**
+
+```yaml
+encryption:
+  passwordSecretRef:
+    name: kopiur-repository-secret
+    namespace: kopiur-system # where the Secret actually lives
+    key: KOPIA_PASSWORD
+```
+
+///
 
 A worked S3 example is on the [S3 page](s3.md#as-a-clusterrepository).
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -85,7 +85,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.azure.auth.workloadIdentity` { #repository-spec-backend-azure-auth-workloadidentity }
 
@@ -112,7 +112,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.filesystem` { #repository-spec-backend-filesystem }
 
@@ -163,7 +163,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.gcs.auth.workloadIdentity` { #repository-spec-backend-gcs-auth-workloadidentity }
 
@@ -183,7 +183,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.rclone` { #repository-spec-backend-rclone }
 
@@ -198,7 +198,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.s3` { #repository-spec-backend-s3 }
 
@@ -223,7 +223,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.s3.auth.workloadIdentity` { #repository-spec-backend-s3-auth-workloadidentity }
 
@@ -267,7 +267,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.webDav` { #repository-spec-backend-webdav }
 
@@ -287,7 +287,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `spec.encryption` { #repository-spec-encryption }
 
@@ -301,7 +301,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
 | `key` | string | — | Which key inside the `Secret` to read. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `spec.bootstrap` { #repository-spec-bootstrap }
 
@@ -613,7 +613,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `status.storageStats` { #repository-status-storagestats }
 
@@ -706,7 +706,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.azure.auth.workloadIdentity` { #clusterrepository-spec-backend-azure-auth-workloadidentity }
 
@@ -733,7 +733,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.filesystem` { #clusterrepository-spec-backend-filesystem }
 
@@ -784,7 +784,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.gcs.auth.workloadIdentity` { #clusterrepository-spec-backend-gcs-auth-workloadidentity }
 
@@ -804,7 +804,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.rclone` { #clusterrepository-spec-backend-rclone }
 
@@ -819,7 +819,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.s3` { #clusterrepository-spec-backend-s3 }
 
@@ -844,7 +844,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.backend.s3.auth.workloadIdentity` { #clusterrepository-spec-backend-s3-auth-workloadidentity }
 
@@ -888,7 +888,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.backend.webDav` { #clusterrepository-spec-backend-webdav }
 
@@ -908,7 +908,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `spec.encryption` { #clusterrepository-spec-encryption }
 
@@ -922,7 +922,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
 | `key` | string | — | Which key inside the `Secret` to read. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `spec.bootstrap` { #clusterrepository-spec-bootstrap }
 
@@ -1249,7 +1249,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `status.storageStats` { #clusterrepository-status-storagestats }
 
@@ -2397,7 +2397,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.destination.azure.auth.workloadIdentity` { #repositoryreplication-spec-destination-azure-auth-workloadidentity }
 
@@ -2424,7 +2424,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.destination.filesystem` { #repositoryreplication-spec-destination-filesystem }
 
@@ -2475,7 +2475,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.destination.gcs.auth.workloadIdentity` { #repositoryreplication-spec-destination-gcs-auth-workloadidentity }
 
@@ -2495,7 +2495,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.destination.rclone` { #repositoryreplication-spec-destination-rclone }
 
@@ -2510,7 +2510,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.destination.s3` { #repositoryreplication-spec-destination-s3 }
 
@@ -2535,7 +2535,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ###### `spec.destination.s3.auth.workloadIdentity` { #repositoryreplication-spec-destination-s3-auth-workloadidentity }
 
@@ -2579,7 +2579,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 ##### `spec.destination.webDav` { #repositoryreplication-spec-destination-webdav }
 
@@ -2599,7 +2599,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
 
 #### `spec.schedule` { #repositoryreplication-spec-schedule }
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -85,7 +85,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.azure.auth.workloadIdentity` { #repository-spec-backend-azure-auth-workloadidentity }
 
@@ -112,7 +112,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.filesystem` { #repository-spec-backend-filesystem }
 
@@ -163,7 +163,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.gcs.auth.workloadIdentity` { #repository-spec-backend-gcs-auth-workloadidentity }
 
@@ -183,7 +183,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.rclone` { #repository-spec-backend-rclone }
 
@@ -198,7 +198,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.s3` { #repository-spec-backend-s3 }
 
@@ -223,7 +223,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.s3.auth.workloadIdentity` { #repository-spec-backend-s3-auth-workloadidentity }
 
@@ -267,7 +267,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.webDav` { #repository-spec-backend-webdav }
 
@@ -287,7 +287,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `spec.encryption` { #repository-spec-encryption }
 
@@ -301,7 +301,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
 | `key` | string | — | Which key inside the `Secret` to read. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `spec.bootstrap` { #repository-spec-bootstrap }
 
@@ -613,7 +613,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `status.storageStats` { #repository-status-storagestats }
 
@@ -706,7 +706,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.azure.auth.workloadIdentity` { #clusterrepository-spec-backend-azure-auth-workloadidentity }
 
@@ -733,7 +733,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.filesystem` { #clusterrepository-spec-backend-filesystem }
 
@@ -784,7 +784,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.gcs.auth.workloadIdentity` { #clusterrepository-spec-backend-gcs-auth-workloadidentity }
 
@@ -804,7 +804,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.rclone` { #clusterrepository-spec-backend-rclone }
 
@@ -819,7 +819,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.s3` { #clusterrepository-spec-backend-s3 }
 
@@ -844,7 +844,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.backend.s3.auth.workloadIdentity` { #clusterrepository-spec-backend-s3-auth-workloadidentity }
 
@@ -888,7 +888,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.backend.webDav` { #clusterrepository-spec-backend-webdav }
 
@@ -908,7 +908,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `spec.encryption` { #clusterrepository-spec-encryption }
 
@@ -922,7 +922,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
 | `key` | string | — | Which key inside the `Secret` to read. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `spec.bootstrap` { #clusterrepository-spec-bootstrap }
 
@@ -1249,7 +1249,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `status.storageStats` { #clusterrepository-status-storagestats }
 
@@ -2397,7 +2397,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.destination.azure.auth.workloadIdentity` { #repositoryreplication-spec-destination-azure-auth-workloadidentity }
 
@@ -2424,7 +2424,7 @@ Externally tagged — set **exactly one** of: `azure` · `b2` · `filesystem` ·
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.destination.filesystem` { #repositoryreplication-spec-destination-filesystem }
 
@@ -2475,7 +2475,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.destination.gcs.auth.workloadIdentity` { #repositoryreplication-spec-destination-gcs-auth-workloadidentity }
 
@@ -2495,7 +2495,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.destination.rclone` { #repositoryreplication-spec-destination-rclone }
 
@@ -2510,7 +2510,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.destination.s3` { #repositoryreplication-spec-destination-s3 }
 
@@ -2535,7 +2535,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ###### `spec.destination.s3.auth.workloadIdentity` { #repositoryreplication-spec-destination-s3-auth-workloadidentity }
 
@@ -2579,7 +2579,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 ##### `spec.destination.webDav` { #repositoryreplication-spec-destination-webdav }
 
@@ -2599,7 +2599,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `name` | string | **required** | Name of the `Secret`. |
-| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`. |
+| `namespace` | string | — | Namespace of the `Secret`; absent = same namespace as the referrer. A `ClusterRepository` is cluster-scoped and has no namespace of its own, so when IT reads the `Secret` (to connect, to bootstrap, or to run its repository server) an absent namespace means the operator's namespace (`KOPIUR_NAMESPACE`). A workload mover (Snapshot/Restore/Maintenance) still needs the `Secret` in its OWN namespace — `envFrom` is namespace-local — so put it there, or use `credentialProjection`, which needs this namespace set EXPLICITLY to know what to copy. Set it whenever anything other than the operator itself reads the `Secret`. |
 
 #### `spec.schedule` { #repositoryreplication-spec-schedule }
 

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -134,6 +134,16 @@ Contrast a **direct** target (`pvc` / `pvcRef`): that restore _is_ one-shot. Onc
 
 ///
 
+/// note | Re-creating a populator `Restore` over a **bound** PVC does nothing (by design)
+
+The claim is what drives a populate, not the `Restore`. A volume populator can only hand a volume to an **unbound** claim, so if you delete and re-create the `Restore` (a GitOps prune and re-apply, a repository rebuild that cascades) while its claiming PVC is still **Bound** and the app is happily running on it, there is nothing to populate. Kopiur completes it as a no-op: `Completed` with `Ready=True reason=TargetAlreadyBound`, no prime PVC, no mover run, and your live volume untouched.
+
+To actually restore into that claim, delete the **PVC** (keeping its `dataSourceRef`) and let it be re-created — see the reusability note above.
+
+**Upgrading from ≤ 0.7.x?** That case used to run a full restore into a `prime-<uid>` PVC that could never be adopted, and then leak it: a Bound PVC holding a complete second copy of your data, one per re-created `Restore`. On upgrade, Kopiur reaps those automatically (watch for an `OrphanedPrimePvcReaped` event) for every orphan whose claiming PVC still exists. Any left over from a claim that has since been deleted are garbage-collected when their `Restore` is. To find them: `kubectl get pvc -A -l kopiur.home-operations.com/op=restore-populate`.
+
+///
+
 ## How to write — `options` and `policy`
 
 ```yaml

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -272,6 +272,8 @@ $ kubectl describe restore <name> -n <ns>
 | `Failed`, "no matching snapshot"        | The source resolved to nothing and `onMissingSnapshot: Fail`. | Verify the `snapshotRef`/identity; for deploy-or-restore use `fromPolicy` (which defaults to `Continue`).                                                         |
 | Stuck `Resolving`                       | Waiting for the source snapshot to appear (`waitTimeout`).    | Confirm the snapshot exists; raise `policy.waitTimeout` if a schedule is about to produce it.                                                                   |
 | PVC stuck `Pending` (populator)         | Volume-populator handshake not completing.                    | Need Kubernetes ≥ 1.24; install `volume-data-source-validator` to see the real event. See [Restores → deploy-or-restore](restores.md#deploy-or-restore-gitops). |
+| `prime-*` PVCs piling up, `Bound`, mounted by nothing | ≤ 0.7.x: a populator `Restore` re-created over an **already-bound** claim restored into a prime PVC that could never be adopted, and leaked it — one full copy of the data per re-created `Restore`. | Upgrade: Kopiur now completes that case as a no-op (`Ready=True reason=TargetAlreadyBound`) and reaps the orphans (`OrphanedPrimePvcReaped` event). List them with `kubectl get pvc -A -l kopiur.home-operations.com/op=restore-populate`; any whose claiming PVC is gone are collected with their `Restore`. |
+| Populator `Restore` says `TargetAlreadyBound` and restores nothing | Working as intended: its claiming PVC is already **Bound**, and a volume populator can only fill an **unbound** claim. | To really restore into it, delete the **PVC** (keep its `dataSourceRef`) and let it be re-created. Deleting the `Restore` just re-triggers the no-op. |
 | `identity` source rejected at admission | `source.identity` requires an explicit `spec.repository`.     | Add `spec.repository`.                                                                                                                                          |
 | Stuck `Pending`, `MoverPermitted=False` | The restore mover requests an elevated context (root / `privilegedMode`, container- or pod-level, possibly inherited). | Annotate the namespace (above), or drop the elevation from `spec.mover`. |
 | Restored files **owned by `65532`** / unreadable by the app | The mover wrote them as its own UID (no `mover.securityContext`). | Set `Restore.spec.mover.securityContext.runAsUser/Group` to the app's UID (or `inheritSecurityContextFrom`). |
@@ -318,6 +320,21 @@ $ kubectl describe maintenance <name> -n <ns>
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
 | `WaitingForRepository`    | The repository isn't `Ready` yet — fix that first.                                                                             |
 | lease held elsewhere      | Another owner holds the maintenance lease (shared repo). Adjust `takeoverPolicy` only if you're sure no one else maintains it. |
+
+The repository's own `MaintenanceConfigured` condition says whether anything is maintaining it at all:
+
+| `MaintenanceConfigured` reason | Meaning                                                                                                                                                  |
+| ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MaintenanceConfigured` (True) | A `Maintenance` covers the repo — either the operator-managed one, or one you authored yourself.                                                             |
+| `MaintenanceDisabled`          | You set `spec.maintenance.enabled: false` and nothing else references the repo. **Storage is never reclaimed.** A deliberate opt-out, so no warning is raised. |
+| `MaintenanceApplyFailed`       | Maintenance is **enabled**, but the operator could not apply its managed `Maintenance`. The message names the namespace and the error — usually missing RBAC, or a namespace that doesn't exist. It retries every reconcile. |
+| `MaintenanceNamespaceUnresolved` | A `ClusterRepository`'s managed `Maintenance` has nowhere to live: set `spec.maintenance.namespace`, or the operator's `KOPIUR_NAMESPACE`.                  |
+
+/// note | Upgrading from ≤ 0.7.x
+
+On object-store repositories this condition could get **stuck** at `MaintenanceDisabled` — even with maintenance enabled and the managed `Maintenance` present, owned, and running on schedule — because it was only ever evaluated at the tail of a bootstrap. It is now re-checked on every reconcile, so a stale value corrects itself shortly after upgrade, and a failed apply no longer masquerades as "you disabled maintenance".
+
+///
 
 If **every** run yields (`Ready=False`, reason `MaintenanceYielding`), kopia
 GC/compaction is not running at all — typically a repository whose kopia-side


### PR DESCRIPTION
Fixes #233, fixes #232, fixes #231.

Three unrelated bugs, all controller-side. No CRD shape changes — the schema diffs are doc-comment text only. Each fix has unit coverage plus an e2e that is red on the current code.

## #233 — a re-created populator `Restore` orphaned a full copy of the data

A CSI volume-populator can only hand a volume to an **unbound** claim. But when a `Restore` with `target.populator: {}` was deleted and re-created while its claiming PVC was still Bound — a GitOps prune and re-apply, a repository rebuild that cascades — the controller provisioned a `prime-<uid>` PVC anyway and ran a full restore into it. That prime could never be adopted, and nothing ever cleaned it up: a Bound PVC holding a complete second copy of the app's data, one per re-created `Restore`. The reporter's `ClusterRepository` rebuild re-created 49 of them at once and stranded 120 GiB (~360 GiB raw on replicated Ceph), plus 49 pointless full restores against the repository.

The root cause was that "where is the handshake?" lived in two ad-hoc `if` blocks, and the state *"bound, but to somebody else's PV"* fell between them. One of those blocks — `phase == Completed && bound → requeue 600s` — is what parked the orphan forever, and it's also why `status.phase: Completed` sat next to conditions frozen at `Ready=False/PopulatingPrimePvc` for four days.

Both are replaced by a single exhaustive `PopulatorHandshake` verdict, so a binding state can't be added without every caller being forced to handle it. An already-bound claim now completes as a truthful no-op (`Ready=True`, reason `TargetAlreadyBound`) having provisioned nothing and run no mover, and reaps any populate artifacts that can never be handed over. That reap is also what collects **existing** orphans on upgrade: a populator's `Completed` is deliberately non-terminal, so those CRs keep reconciling and land straight in the new path. No migration, no sweep. (Orphans whose claiming PVC has since been deleted are collected with their `Restore` instead — noted in the docs.)

Three things I want reviewers to look at, because they're where this got sharp:

- **A lost rebind must not reclaim its PV.** If the claim binds to a foreign PV mid-handshake, our PV holds freshly restored data and its `claimRef` points at a claim that's bound elsewhere — so the PV controller will mark it `Released`. Restoring the reclaim policy we stashed at rebind time (usually `Delete`) would then destroy exactly the data we just wrote. It forces `Retain` and names the volume in the event instead.
- **`our_rebound_pv` now matches `claimRef` by uid, not just name.** A PV left annotated from a previous claim of the same name would otherwise be read as an outstanding rebind for the *new* claim, which the PV controller will never bind — wedging the handshake on a 5s requeue forever.
- **A no-op'd `Restore` is excluded from the `Completed`+unpinned "empty" back-fill.** That back-fill exists to heal the old stuck-populator state, but a deferred-source no-op reaches `Completed` unpinned too (the mover, which pins deferred sources, never ran). Back-filling there would durably pin `NoSnapshot`, so a later, legitimate re-creation of the claim would provision an **empty** volume instead of restoring. It also skips source re-resolution on the heartbeat, so a no-op'd CR doesn't poll — and eventually error-loop on — a `SnapshotPolicy` the user has since deleted.

## #232 — `encryption.passwordSecretRef.namespace is required` on a ClusterRepository

The field documents itself as "absent = same namespace as the referrer", but a `ClusterRepository` is cluster-scoped and has no referrer namespace, so the reconcile just refused the object on every pass. It now defaults to the operator's namespace (`KOPIUR_NAMESPACE`) — the same rule `spec.maintenance.namespace` has always used, and where a chart install's repository Secret conventionally lives. An explicit `namespace:` still wins.

Two notes for review:

- The bootstrap path gains the credential preflight the namespaced `Repository` already had. Without it, a Secret that genuinely isn't in the defaulted namespace produced a mover pod stuck in `CreateContainerConfigError` until the 120s job deadline, surfacing as a generic "mover pod crashed or never scheduled" that named neither the Secret nor the namespace. Now it fails immediately and says which Secret it wanted, and where.
- **Small behavior change worth flagging:** the kopia web-UI server now resolves an absent creds namespace to the operator namespace as well, rather than the server's namespace, so "absent" means one thing on a ClusterRepository. If you have `spec.server` set *and* omitted `passwordSecretRef.namespace` *and* put the Secret in the server's namespace, add an explicit `namespace:` (your repository was hard-erroring every reconcile anyway).

The comments claiming this was "webhook-enforced" were stale — the webhook never checked it.

## #231 — `MaintenanceConfigured` stuck at `MaintenanceDisabled` while maintenance was running fine

On object-store repos the condition froze at `False/MaintenanceDisabled` for days while the managed `Maintenance` existed, was owned by the repo, held its lease, and ran on schedule — with `kopiur status` dutifully reporting the lie. `ensure_maintenance` was only ever reached at the tail of a bootstrap, so a value written during a bootstrap race (informer store hadn't seen the just-applied CR, or the initial apply blipped) was never re-evaluated. The repo's own `.watches(Maintenance)` requeue did fire — it just landed on a reconcile that early-exits before the check.

It's now also called on the steady-state pass, which is only reachable once the repo is `Ready` (so it can't apply a managed `Maintenance` for a repo that hasn't bootstrapped). That also makes the existing watch do something useful: delete the managed `Maintenance` and it gets re-applied instead of silently ignored.

Separately, the catch-all `else` branded **every** not-covered state `MaintenanceDisabled` with a message asserting `spec.maintenance.enabled: false` and "no Maintenance references it" — both false when an apply had merely failed, pointing operators at entirely the wrong knob. That's now a closed `MaintenanceCoverage` enum where each not-covered state says why: a failed apply reports `MaintenanceApplyFailed` with the namespace and the underlying error. Warning events are gated on an actual condition change, since this runs every reconcile now.

## Verification

`mise run build | test | clippy | fmt-check | complexity-check | gen-check` all pass; 1430 unit tests green, complexity ratchet unchanged at 31/31.

New e2e:
- `recreated_populator_restore_over_bound_claim_is_noop_and_reaps_orphaned_prime` — drives the reported sequence (populate → prune the Restore → manufacture the orphan prime → Flux re-applies) and asserts no prime, no mover Job, `TargetAlreadyBound`, and the live volume untouched. Red pre-fix: a fresh CR has no phase, so the old short-circuit doesn't fire and it restores into the orphan.
- `cluster_repository_defaults_secret_namespace_to_operator_namespace` — the reporter's manifest, namespaces omitted, reaching Ready.
- `s3_cluster_repository_maintenance_self_corrects_at_steady_state` — deletes the bootstrap Job to reach the frozen state, then deletes the managed Maintenance and proves the operator repairs it and keeps the condition honest.