### PR TITLE
feat: bound Snapshot CR reconcile cost at scale (#249)

### DIFF
--- a/crates/api/src/validate/mod.rs
+++ b/crates/api/src/validate/mod.rs
@@ -299,6 +299,65 @@ pub fn validate_cron(expr: &str) -> ValidationResult {
     }
 }
 
+/// A non-blocking admission WARNING (never a rejection) when a schedule's cron
+/// fires more often than hourly (issue #249). Every fire creates one per-run
+/// `Snapshot` CR per source, and they accumulate up to the `SnapshotPolicy`
+/// retention window — each terminal one is then re-reconciled for that whole
+/// window — so a sub-hourly cadence with a wide (or absent) retention can produce
+/// thousands of CRs. Sub-hourly is legitimate for some workloads, so this is a
+/// footgun heads-up, not a block.
+///
+/// Pure and cron-only: the schedule webhook is client-less and can't read the
+/// referenced policy's retention, so the message states the cadence and the
+/// CR-count relationship rather than an exact number. `None` for an hourly-or-slower
+/// cadence, or a cron that doesn't parse (that error is surfaced by [`validate_cron`]).
+pub fn schedule_cr_growth_warning(cron: &str) -> Option<String> {
+    let fires = schedule_fires_per_hour(cron)?;
+    if fires <= 1 {
+        return None;
+    }
+    Some(format!(
+        "schedule fires ~{fires}×/hour: each fire creates one Snapshot CR per source, and \
+         they accumulate up to the SnapshotPolicy retention window (CR count ≈ fires × \
+         retained snapshots). A sub-hourly schedule with a wide or absent retention can \
+         produce thousands of Snapshot CRs, each re-reconciled for its whole retention \
+         window. If unintended, use a coarser schedule, bound SnapshotPolicy.spec.retention, \
+         or set the Snapshot deletionPolicy to Retain/Orphan. See docs/backups.md \
+         ('How many Snapshot CRs will I have?')."
+    ))
+}
+
+/// Count how many times `cron` fires within one representative active hour. Pure and
+/// clock-free — anchored on the cron's FIRST fire from a fixed instant (not a fixed
+/// calendar hour), so a day-of-week / day-of-month constrained cron is measured
+/// during an hour it is actually active. `H` tokens are substituted to a fixed value
+/// first (they pick a minute within the window, not the cadence, so the count is
+/// H-independent). `None` if the cron doesn't parse.
+fn schedule_fires_per_hour(cron: &str) -> Option<u32> {
+    use chrono::{Duration, TimeZone, Utc};
+    let probe = cron
+        .split_whitespace()
+        .map(|f| if f == "H" { "0" } else { f })
+        .collect::<Vec<_>>()
+        .join(" ");
+    let parsed = crate::jitter::cron_parser().parse(&probe).ok()?;
+    let anchor = Utc.with_ymd_and_hms(2001, 1, 1, 0, 0, 0).single()?;
+    let first = parsed.find_next_occurrence(&anchor, true).ok()?;
+    let horizon = first + Duration::hours(1);
+    let mut cursor = first;
+    let mut count = 0u32;
+    // The cron grammar has no seconds field, so at most 60 fires/hour; cap defensively.
+    for _ in 0..61 {
+        let next = parsed.find_next_occurrence(&cursor, true).ok()?;
+        if next >= horizon {
+            break;
+        }
+        count += 1;
+        cursor = next + Duration::seconds(1);
+    }
+    Some(count)
+}
+
 /// Validate an optional Go-style `jitter` duration (`30m`, `1h`, …) against the SAME
 /// parser the controller uses at scheduling time, so a typo or an out-of-range value
 /// is rejected at apply time rather than silently degrading to *no jitter* at the

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -3936,3 +3936,37 @@ fn maintenance_owner_aliases_are_shape_validated_but_owner_is_not_tightened() {
     // regression) — the lease sanitizer collapses it safely at run time.
     assert!(validate_maintenance(&spec("admin@legacy-host", Vec::new())).is_empty());
 }
+
+// --- schedule_cr_growth_warning (issue #249) ---
+
+#[test]
+fn hourly_or_slower_schedules_get_no_growth_warning() {
+    // Hourly, jittered-hourly (H is minute-of-window, not cadence), and daily are
+    // all within the "one CR per hour or less" comfort zone → no warning.
+    for cron in ["0 * * * *", "H * * * *", "0 2 * * *", "0 0 * * 0"] {
+        assert_eq!(
+            schedule_cr_growth_warning(cron),
+            None,
+            "{cron} should not warn"
+        );
+    }
+}
+
+#[test]
+fn sub_hourly_schedules_warn_with_the_fires_per_hour_count() {
+    let ten = schedule_cr_growth_warning("*/10 * * * *").expect("*/10 warns");
+    assert!(ten.contains("6×/hour"), "{ten}");
+    assert!(ten.contains("docs/backups.md"), "{ten}");
+    let five = schedule_cr_growth_warning("*/5 * * * *").expect("*/5 warns");
+    assert!(five.contains("12×/hour"), "{five}");
+    let twice = schedule_cr_growth_warning("0,30 * * * *").expect("0,30 warns");
+    assert!(twice.contains("2×/hour"), "{twice}");
+}
+
+#[test]
+fn day_constrained_sub_hourly_schedule_still_warns() {
+    // The window anchors on the cron's FIRST fire, so a Sunday-only every-10-min
+    // schedule is measured during an active hour (a fixed Monday hour would miss it).
+    let w = schedule_cr_growth_warning("*/10 * * * 0").expect("sunday */10 warns");
+    assert!(w.contains("6×/hour"), "{w}");
+}

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -54,6 +54,16 @@ pub use plan::*;
 
 #[cfg(test)]
 mod tests;
+
+/// Steady-state requeue for a **terminal** `Snapshot` (Succeeded/Failed/Discovered
+/// and the settled pin/reap tails). These re-reconciles are pure no-ops — every
+/// cleanup transition is one-shot-stamped — so the interval is a straight
+/// reconcile-QPS lever with no behavior change (issue #249). At 600s a fleet of
+/// ~5k terminal CRs pinned ~8 no-op reconciles/second forever; 45 min cuts that by
+/// ~4.5×. Kept under an hour so a stuck-but-terminal CR still self-checks a couple
+/// of times per hour. Active work (pin spawn, staging, Job polling) keeps its own
+/// short requeues — only the terminal steady state is slowed here.
+const TERMINAL_SNAPSHOT_STEADY_REQUEUE: Duration = Duration::from_secs(45 * 60);
 /// Reconcile a `Snapshot`.
 ///
 /// IO is intentionally thin here: the decision logic ([`plan_deletion`],
@@ -112,7 +122,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             status["origin"] = serde_json::json!("discovered");
             io::patch_status(&api, &name, status).await?;
         }
-        return Ok(Action::requeue(Duration::from_secs(600)));
+        return Ok(Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE));
     }
 
     // Ensure the snapshot-cleanup finalizer before doing any work that creates a
@@ -311,7 +321,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             // periodic sweep — which an operator may legitimately have disabled. Once
             // stamped, we go back to `await_change()` and stop polling entirely.
             if !reap_backup_creds_once(backup, ctx, &api, &namespace, &name).await? {
-                return Ok(Action::requeue(Duration::from_secs(600)));
+                return Ok(Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE));
             }
             return Ok(Action::await_change());
         }
@@ -1915,7 +1925,7 @@ async fn reconcile_pin(
 ) -> Result<Action> {
     let desired = backup.spec.pin;
     let observed = backup.status.as_ref().and_then(|s| s.pinned);
-    let steady = Action::requeue(Duration::from_secs(600));
+    let steady = Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE);
     let action = pin_decision(desired, observed);
     let job_name = format!("{name}-pin");
 
@@ -2144,7 +2154,7 @@ fn pin_job_still_wanted(target: Option<bool>, action: PinAction) -> bool {
 /// action is still pending (the spawn path runs next pass), steady otherwise.
 fn post_pin_consume_action(action: PinAction) -> Action {
     match action {
-        PinAction::NoOp => Action::requeue(Duration::from_secs(600)),
+        PinAction::NoOp => Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE),
         PinAction::Pin | PinAction::Unpin => Action::requeue(Duration::from_secs(5)),
     }
 }

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -2,6 +2,18 @@ use super::*;
 use crate::consts::SKIP_SNAPSHOT_CLEANUP_ANNOTATION;
 use kopiur_api::common::NamespaceDeletePolicy;
 
+#[test]
+fn terminal_steady_requeue_is_bounded_reconcile_qps_relief() {
+    // Issue #249: terminal Snapshots re-reconcile on this interval for their whole
+    // retention window, so it must stay well above the old 600s (QPS relief) but
+    // under an hour (a terminal CR still self-checks a couple of times per hour).
+    let secs = TERMINAL_SNAPSHOT_STEADY_REQUEUE.as_secs();
+    assert!(
+        (30 * 60..=60 * 60).contains(&secs),
+        "terminal requeue {secs}s must be 30–60 min (was 600s before #249)"
+    );
+}
+
 fn ann(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
     pairs
         .iter()

--- a/crates/webhook/src/handlers.rs
+++ b/crates/webhook/src/handlers.rs
@@ -384,7 +384,15 @@ fn handle_snapshot_schedule(
     // CRD schema (ADR-0005 §1), so the apiserver materializes them. The webhook writes
     // no user spec (the status-only-write invariant, ADR-0005 §14(d)) — a write-back
     // into spec makes Argo/Flux perpetually `OutOfSync`.
-    Ok(resp)
+
+    // Non-blocking footgun warning for a sub-hourly cadence (issue #249): per-run
+    // Snapshot CRs accumulate up to the retention window and each re-reconciles for
+    // its whole life, so a sub-hourly schedule with a wide retention can pile up
+    // thousands of CRs. A warning, not a rejection — sub-hourly is legitimate.
+    let warnings = api::validate::schedule_cr_growth_warning(&spec.schedule.cron)
+        .into_iter()
+        .collect();
+    Ok(with_warnings(resp, warnings))
 }
 
 // --- Restore ----------------------------------------------------------------

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -167,6 +167,22 @@ If you set `retention:` but leave every bucket unset or `0`, GFS would prune **e
 kopia's `snapshot create` normally applies its own retention after every backup, and with nothing configured it falls back to kopia's defaults (`keepLatest: 10`, etc.) — values a wide `retention:` window above would blow right past, deleting backups behind Kopiur's back. Kopiur pins kopia's own retention to effectively-infinite on every identity it manages, so `retention:` above is the only thing that ever deletes a backup.
 ///
 
+### How many `Snapshot` CRs will I have?
+
+Kopiur keeps **one `Snapshot` CR per retained snapshot per source** — the CR _is_ the backup's lifecycle handle (finalizer + `deletionPolicy`), so the live CR count equals the retained snapshot count **by design**. It is set by _retention_, not by how often you schedule: a faster schedule fills the GFS window sooner but never exceeds it. Three independent populations add up:
+
+- **Successful backups** — bounded by GFS `retention`. The per-source upper bound is roughly the sum of the buckets you set (`keepLatest + keepHourly + keepDaily + …`, before GFS de-dups the overlap), times your number of sources. A policy with `keepHourly: 24, keepDaily: 14, keepWeekly: 8` retains ~40 CRs per source.
+- **Failed backups** — bounded by [`SnapshotSchedule.spec.failedJobsHistoryLimit`](#snapshotschedule--the-cron) (default `10` per schedule).
+- **Discovered snapshots** — materialized from the repository and bounded by [`spec.catalog.retain`](repositories.md) (`perIdentity` / `maxAgeDays`) on the `Repository` / `ClusterRepository`.
+
+A cluster with ~30 sources on a typical GFS window sits around 1–2k `Snapshot` CRs. Each is a few KiB in etcd (tens of MB total — comfortably fine), and each _terminal_ CR only re-reconciles as a no-op roughly every 45 minutes, so this scales. Because retention sets the count, a **sub-hourly** schedule paired with a wide retention is the way to accidentally accumulate thousands of CRs — the admission webhook emits a heads-up warning for sub-hourly crons (a warning, not a limit).
+
+/// warning | `retention` absent = unbounded CR growth
+
+Omitting `retention` entirely means Kopiur never prunes successful backups — the `Snapshot` CRs (and their kopia snapshots) grow **forever**. That is a legitimate "keep everything" choice, but it is genuinely unbounded, so budget for it or set a GFS window. (An empty-but-present `retention:` block is rejected — see above — so the only way to grow without bound is to omit `retention` deliberately.)
+
+///
+
 ### Identity — what kopia records (`username@hostname:path`)
 
 kopia stores every snapshot under an identity. Kopiur **re-resolves it from the live spec on every run** — the live `SnapshotPolicy.spec.identity` plus the live referenced repository's `identityDefaults` — not once at admission and frozen. `status.resolved.identity` mirrors the most recent resolution rather than being the source of truth a later run reads back. The defaults:


### PR DESCRIPTION
Implements the three changes proposed in #249 (which is the analysis + decision, authored by @perfectra1n). Raw `Snapshot` CR count isn't the ceiling — reconcile QPS is — so this is targeted QPS relief plus footgun guidance, with the archive/TTL idea explicitly rejected in the issue.

## Changes

1. **Raise the terminal-Snapshot steady-state requeue 600s → 45 min** via a named `TERMINAL_SNAPSHOT_STEADY_REQUEUE` constant across the four sites in `snapshot/mod.rs`. Every cleanup transition is one-shot-stamped, so these re-reconciles are pure no-ops — this is a straight reconcile-QPS lever (5k terminal CRs: ~8 → ~2 no-op reconciles/sec) with no behavior change. Guarded by a range test so it can't silently regress to 600s.
2. **Admission *warning* (not rejection) for sub-hourly schedules.** New pure `api::validate::schedule_cr_growth_warning` counts a cron's fires-per-hour (anchored on its first fire, so day-constrained crons are measured during an active hour) and, when sub-hourly, warns with the projected fires/hour and the CR-count relationship. Sub-hourly is legitimate, so it's a heads-up, not a block. Wired through the existing `with_warnings` path.
3. **Document the CR-count math** — a new "How many `Snapshot` CRs will I have?" section in `docs/backups.md`: CR count == retained snapshots by design, the per-population formula (GFS successful / `failedJobsHistoryLimit` / `catalog.retain` discovered), and a loud `warning` admonition that omitting `retention` is unbounded.

## Non-goals honored (from the issue)

- No `successfulJobsHistoryLimit` (retention is the GFS window, full stop).
- No archive/TTL mode (incoherent with the CR-owns-lifecycle invariant; would leak storage).
- No kopia-listing pagination (its own issue if a repo ever gets large enough).

Green on `cargo test`/`clippy -D warnings`/`fmt`/`mkdocs build --strict`/complexity ratchet.

Closes #249.
