### PR TITLE
ci: skip release-please churn and stop cancelling main runs

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
       # The release workflow's krew step pushes plugins/kopiur.yaml to main with
       # the bot app token, which (unlike GITHUB_TOKEN) retriggers workflows —
       # ignore it so a release doesn't re-run this workflow for a manifest bump.
@@ -17,11 +18,12 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,11 +17,13 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   push:
     branches:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
       # The release workflow's krew step pushes plugins/kopiur.yaml to main with
       # the bot app token, which (unlike GITHUB_TOKEN) retriggers workflows —
       # ignore it so a release doesn't re-run this workflow for a manifest bump.
@@ -33,7 +35,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/goreleaser-check.yaml
+++ b/.github/workflows/goreleaser-check.yaml
@@ -19,7 +19,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   binaries:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
       # The release workflow's krew step pushes plugins/kopiur.yaml to main with
       # the bot app token, which (unlike GITHUB_TOKEN) retriggers workflows —
       # ignore it so a release doesn't re-run this workflow for a manifest bump.
@@ -17,11 +18,12 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,6 +8,7 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
       # The release workflow's krew step pushes plugins/kopiur.yaml to main with
       # the bot app token, which (unlike GITHUB_TOKEN) retriggers workflows —
       # ignore it so a release doesn't re-run this workflow for a manifest bump.
@@ -17,11 +18,12 @@ on:
       - main
     paths-ignore:
       - "**.md"
+      - ".release-please-manifest.json"
   workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Consolidates the CI concurrency and `paths-ignore` changes from home-operations/miroir#265:

- `concurrency.cancel-in-progress` now only cancels **pull_request** runs, so pushes to `main` are no longer interrupted mid-run.
- `.release-please-manifest.json` added to `paths-ignore`, so release-please's manifest bumps no longer trigger these workflows.
