### PR TITLE
feat!: SnapshotPolicy deletion cascade + auto-adoption of discovered snapshots

### DIFF
--- a/crates/api/src/cluster_repository.rs
+++ b/crates/api/src/cluster_repository.rs
@@ -493,6 +493,43 @@ catalog:
     }
 
     #[test]
+    fn catalog_adoption_round_trips_on_cluster_repository() {
+        use crate::common::SnapshotAdoption;
+
+        let yaml = r#"
+backend: { filesystem: { path: /repo } }
+encryption: { passwordSecretRef: { name: s, namespace: kopia-system } }
+allowedNamespaces: { all: true }
+catalog:
+  adoption: Ignore
+"#;
+        let spec: ClusterRepositorySpec = from_yaml(yaml);
+        assert_eq!(
+            spec.catalog.as_ref().and_then(|c| c.adoption),
+            Some(SnapshotAdoption::Ignore)
+        );
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(json["catalog"]["adoption"], "Ignore");
+        let reparsed: ClusterRepositorySpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+
+        // Absent stays None and is elided.
+        let bare: ClusterRepositorySpec = from_yaml(
+            "backend: { filesystem: { path: /repo } }\n\
+             encryption: { passwordSecretRef: { name: s, namespace: kopia-system } }\n\
+             allowedNamespaces: { all: true }\n\
+             catalog: {}\n",
+        );
+        assert!(bare.catalog.as_ref().unwrap().adoption.is_none());
+        assert!(
+            serde_json::to_value(&bare).unwrap()["catalog"]
+                .get("adoption")
+                .is_none(),
+            "absent catalog.adoption must be elided"
+        );
+    }
+
+    #[test]
     fn catalog_foreign_snapshots_unknown_variant_is_rejected() {
         let value: serde_json::Value = serde_yaml::from_str("foreignSnapshots: Delete\n").unwrap();
         assert!(serde_json::from_value::<crate::common::CatalogBounds>(value).is_err());

--- a/crates/api/src/common/cache.rs
+++ b/crates/api/src/common/cache.rs
@@ -124,6 +124,20 @@ pub enum ForeignSnapshots {
     Fallback,
 }
 
+/// Whether a discovered snapshot whose resolved identity matches a live
+/// `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+/// policy's config label, `status.origin` flipped to `Adopted`) so GFS
+/// retention governs it and eventually prunes it, instead of it sitting in the
+/// catalog forever as an immortal `discovered` row.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
+pub enum SnapshotAdoption {
+    /// Automatically adopt an identity-matching discovered snapshot (the default).
+    #[default]
+    Adopt,
+    /// Leave identity-matching discovered snapshots alone; they stay `discovered`.
+    Ignore,
+}
+
 /// Bounds on materialization of `origin: discovered` `Snapshot` CRs.
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -154,6 +168,14 @@ pub struct CatalogBounds {
     /// configured fallback collector off.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreign_snapshots: Option<ForeignSnapshots>,
+    /// Whether a discovered snapshot matching a live `SnapshotPolicy`'s resolved
+    /// identity is automatically adopted. Per-policy `SnapshotPolicySpec.adoption`
+    /// overrides this when set; absent here resolves to
+    /// [`SnapshotAdoption::Adopt`] (see [`effective_adoption`]). NOT context-free
+    /// (it is the middle link of a policy → repo → constant inheritance chain),
+    /// so this field carries no schema default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adoption: Option<SnapshotAdoption>,
 }
 
 impl CatalogBounds {
@@ -185,6 +207,20 @@ impl CatalogBounds {
             .and_then(|c| c.foreign_snapshots)
             .unwrap_or_default()
     }
+}
+
+/// The effective adoption policy for a `SnapshotPolicy`: its own
+/// `spec.adoption` wins; else the target repository's `catalog.adoption`; else
+/// [`SnapshotAdoption::Adopt`]. Neither link is context-free (the repository
+/// link resolves per-repo, the policy link per-policy), so neither field
+/// carries a schema default — every read goes through this resolver.
+pub fn effective_adoption(
+    policy: Option<SnapshotAdoption>,
+    repo_catalog: Option<&CatalogBounds>,
+) -> SnapshotAdoption {
+    policy
+        .or_else(|| repo_catalog.and_then(|c| c.adoption))
+        .unwrap_or_default()
 }
 
 /// schemars default for [`CatalogBounds::refresh_interval`] — the string form of
@@ -254,6 +290,69 @@ mod tests {
         );
         // Unknown variant rejected.
         assert!(serde_json::from_value::<ForeignSnapshots>(serde_json::json!("Delete")).is_err());
+    }
+
+    #[test]
+    fn snapshot_adoption_serializes_to_bare_pascal_case_strings() {
+        // Same wire encoding as ForeignSnapshots/NamespaceDeletePolicy — bare
+        // PascalCase unit-variant strings.
+        assert_eq!(
+            serde_json::to_value(SnapshotAdoption::Adopt).unwrap(),
+            "Adopt"
+        );
+        assert_eq!(
+            serde_json::to_value(SnapshotAdoption::Ignore).unwrap(),
+            "Ignore"
+        );
+        assert_eq!(SnapshotAdoption::default(), SnapshotAdoption::Adopt);
+        assert_eq!(
+            serde_json::from_value::<SnapshotAdoption>(serde_json::json!("Adopt")).unwrap(),
+            SnapshotAdoption::Adopt
+        );
+        assert_eq!(
+            serde_json::from_value::<SnapshotAdoption>(serde_json::json!("Ignore")).unwrap(),
+            SnapshotAdoption::Ignore
+        );
+        // Unknown variant rejected.
+        assert!(serde_json::from_value::<SnapshotAdoption>(serde_json::json!("Fallback")).is_err());
+    }
+
+    #[test]
+    fn effective_adoption_precedence_matrix() {
+        let repo_adopt = CatalogBounds {
+            adoption: Some(SnapshotAdoption::Adopt),
+            ..Default::default()
+        };
+        let repo_ignore = CatalogBounds {
+            adoption: Some(SnapshotAdoption::Ignore),
+            ..Default::default()
+        };
+        let repo_unset = CatalogBounds::default();
+
+        // Policy wins over repo, either direction.
+        assert_eq!(
+            effective_adoption(Some(SnapshotAdoption::Ignore), Some(&repo_adopt)),
+            SnapshotAdoption::Ignore
+        );
+        assert_eq!(
+            effective_adoption(Some(SnapshotAdoption::Adopt), Some(&repo_ignore)),
+            SnapshotAdoption::Adopt
+        );
+        // Policy absent ⇒ repo value.
+        assert_eq!(
+            effective_adoption(None, Some(&repo_ignore)),
+            SnapshotAdoption::Ignore
+        );
+        assert_eq!(
+            effective_adoption(None, Some(&repo_adopt)),
+            SnapshotAdoption::Adopt
+        );
+        // Both absent (or repo catalog present but field unset) ⇒ Adopt.
+        assert_eq!(effective_adoption(None, None), SnapshotAdoption::Adopt);
+        assert_eq!(
+            effective_adoption(None, Some(&repo_unset)),
+            SnapshotAdoption::Adopt
+        );
     }
 
     #[test]

--- a/crates/api/src/common/mod.rs
+++ b/crates/api/src/common/mod.rs
@@ -555,6 +555,37 @@ pub enum ScheduleDeletePolicy {
     Delete,
 }
 
+/// What the deletion of a `SnapshotPolicy` does to the `Snapshot` CRs carrying
+/// its config label (the recipe's produced/adopted rows — NOT its kopia
+/// snapshot history in the abstract, which is exactly what `Retain` preserves).
+/// Default `Retain`: the CRs are removed but every kopia snapshot survives
+/// (rediscoverable/adoptable by a future `SnapshotPolicy`, including this one
+/// re-created). `Delete` opts into the cascade: each CR's own `deletionPolicy`
+/// applies, as EXTERNAL deletions subject to the per-repository mass-deletion
+/// breaker (`deletionProtection.threshold`).
+///
+/// Deliberately 2-variant (not reusing [`DeletionPolicy`]), mirroring
+/// [`ScheduleDeletePolicy`]: an `Orphan` in cascade position would differ from
+/// `Retain` only in per-CR event/metric bookkeeping — an invalid state made
+/// unrepresentable. The guard's `Retain` is exactly `DeletionPolicy::Retain`'s
+/// semantics (CR removed, kopia snapshot stays, catalog rediscovers it),
+/// deliberately NOT the `Orphan` event storm (no per-CR "orphaned" event/metric
+/// for every one of a deleted policy's Snapshots). Not [`ScheduleDeletePolicy`]
+/// itself: that type's doc contract is schedule-specific (its `Delete` arm talks
+/// about a *schedule* being gone/replaced), and a `SnapshotPolicy` deletion is a
+/// distinct trigger with its own semantics worth documenting on its own type.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
+pub enum PolicyDeletePolicy {
+    /// Keep the kopia snapshots: a Snapshot whose effective deletionPolicy is
+    /// `Delete` is downgraded to retain when its owning `SnapshotPolicy` is gone
+    /// (the fail-safe default).
+    #[default]
+    Retain,
+    /// Cascade: each Snapshot's own `deletionPolicy` applies even though the
+    /// owning `SnapshotPolicy` is gone (subject to the mass-deletion breaker).
+    Delete,
+}
+
 /// Mass-deletion circuit breaker for this repository's Snapshots.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
 #[serde(rename_all = "camelCase")]

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -82,16 +82,20 @@ pub enum ValidationError {
         got: String,
     },
 
-    /// A `Snapshot` with `origin: discovered` set `spec.onScheduleDelete`. Discovered
-    /// snapshots carry an empty spec and their owner is a repository, not a
-    /// `SnapshotSchedule` — a stamped cascade policy on one is meaningless, so it is
-    /// forbidden, exactly like a non-`Retain` `deletionPolicy` ([`Self::DiscoveredMustRetain`]).
+    /// A `Snapshot` with `origin: discovered` or `origin: adopted` set
+    /// `spec.onScheduleDelete`. Neither has an owning `SnapshotSchedule` for the
+    /// field to apply to: a `discovered` snapshot's owner is a repository, and an
+    /// `adopted` snapshot's owner is the `SnapshotPolicy` it was re-attached to —
+    /// a stamped cascade policy on either is meaningless, so it is forbidden,
+    /// exactly like a non-`Retain` `deletionPolicy` ([`Self::DiscoveredMustRetain`]).
     #[error(
-        "origin: discovered snapshots must not set onScheduleDelete (got {got:?}); a discovered \
+        "origin: {origin} snapshots must not set onScheduleDelete (got {got:?}); a {origin} \
          snapshot has no owning SnapshotSchedule for this field to apply to. Remove \
          spec.onScheduleDelete"
     )]
     DiscoveredCannotSetOnScheduleDelete {
+        /// The origin that forbids the field (`"discovered"` or `"adopted"`).
+        origin: &'static str,
         /// The rejected `onScheduleDelete` value that was set.
         got: String,
     },

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -528,6 +528,13 @@ pub struct CatalogStatus {
     /// started before the annotation was set).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub scan_request_honored: Option<String>,
+    /// RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+    /// a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+    /// reason the attempt fired). Used only to rate-limit token-driven attempts
+    /// on a Ready-but-unreachable repository — it is never compared against the
+    /// token for retirement (that's `scanRequestHonored`, by equality).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_request_attempt_at: Option<String>,
 }
 
 #[cfg(test)]
@@ -820,6 +827,32 @@ health:
                 .get("scanRequestHonored")
                 .is_none(),
             "absent scanRequestHonored must be elided"
+        );
+    }
+
+    #[test]
+    fn catalog_status_scan_request_attempt_at_roundtrips() {
+        let status: CatalogStatus = from_yaml(
+            "lastRefreshAt: 2026-06-01T00:00:00Z\nscanRequestAttemptAt: 2026-06-01T00:05:00Z\n",
+        );
+        assert_eq!(
+            status.scan_request_attempt_at.as_deref(),
+            Some("2026-06-01T00:05:00Z")
+        );
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["scanRequestAttemptAt"], "2026-06-01T00:05:00Z");
+        let back: CatalogStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(back, status);
+
+        // Absent stays None and is elided.
+        let bare: CatalogStatus = from_yaml("{}\n");
+        assert!(bare.scan_request_attempt_at.is_none());
+        assert!(
+            serde_json::to_value(&bare)
+                .unwrap()
+                .get("scanRequestAttemptAt")
+                .is_none(),
+            "absent scanRequestAttemptAt must be elided"
         );
     }
 

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -519,6 +519,15 @@ pub struct CatalogStatus {
     /// current.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub foreign_snapshot_count: Option<i64>,
+    /// The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+    /// annotation last honored by a completed catalog scan. Compared by
+    /// **equality** against the live annotation to decide whether a requested
+    /// on-demand scan is still pending — deliberately NOT a timestamp comparison
+    /// against `lastRefreshAt` (a periodic refresh completing after the request
+    /// was made would otherwise look like it honored the request even though it
+    /// started before the annotation was set).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_request_honored: Option<String>,
 }
 
 #[cfg(test)]
@@ -789,6 +798,32 @@ health:
     }
 
     #[test]
+    fn catalog_status_scan_request_honored_roundtrips() {
+        let status: CatalogStatus = from_yaml(
+            "lastRefreshAt: 2026-06-01T00:00:00Z\nscanRequestHonored: 2026-06-01T00:00:00Z\n",
+        );
+        assert_eq!(
+            status.scan_request_honored.as_deref(),
+            Some("2026-06-01T00:00:00Z")
+        );
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["scanRequestHonored"], "2026-06-01T00:00:00Z");
+        let back: CatalogStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(back, status);
+
+        // Absent stays None and is elided.
+        let bare: CatalogStatus = from_yaml("{}\n");
+        assert!(bare.scan_request_honored.is_none());
+        assert!(
+            serde_json::to_value(&bare)
+                .unwrap()
+                .get("scanRequestHonored")
+                .is_none(),
+            "absent scanRequestHonored must be elided"
+        );
+    }
+
+    #[test]
     fn repository_crd_exposes_index_blobs_print_column() {
         let crd = Repository::crd();
         let json = serde_json::to_value(&crd).unwrap();
@@ -1035,6 +1070,48 @@ health:
                 .get("foreignSnapshots")
                 .is_none(),
             "absent catalog.foreignSnapshots must be elided"
+        );
+    }
+
+    #[test]
+    fn catalog_adoption_round_trips_on_repository() {
+        use crate::common::SnapshotAdoption;
+
+        let spec: RepositorySpec = from_yaml(
+            "backend: { filesystem: { path: /repo } }\n\
+             encryption: { passwordSecretRef: { name: s } }\n\
+             catalog:\n  adoption: Ignore\n",
+        );
+        assert_eq!(
+            spec.catalog.as_ref().and_then(|c| c.adoption),
+            Some(SnapshotAdoption::Ignore)
+        );
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert_eq!(json["catalog"]["adoption"], "Ignore");
+        let reparsed: RepositorySpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+
+        // Absent stays None and is elided; no schema default (context-dependent).
+        let bare: RepositorySpec = from_yaml(
+            "backend: { filesystem: { path: /repo } }\n\
+             encryption: { passwordSecretRef: { name: s } }\n\
+             catalog: {}\n",
+        );
+        assert!(bare.catalog.as_ref().unwrap().adoption.is_none());
+        assert!(
+            serde_json::to_value(&bare).unwrap()["catalog"]
+                .get("adoption")
+                .is_none(),
+            "absent catalog.adoption must be elided"
+        );
+
+        let crd = Repository::crd();
+        let crd_json = serde_json::to_value(&crd).unwrap();
+        let prop = &crd_json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["catalog"]["properties"]["adoption"];
+        assert!(
+            prop.get("default").is_none(),
+            "catalog.adoption must NOT carry a schema default: {prop}"
         );
     }
 }

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -80,6 +80,12 @@ pub enum Origin {
     Manual,
     /// Materialized by the catalog scan for a snapshot kopiur didn't produce.
     Discovered,
+    /// A `discovered` snapshot whose resolved identity matched a live
+    /// `SnapshotPolicy` and was automatically (or explicitly) re-attached to
+    /// it: it now carries that policy's config label and is retention-governed
+    /// like any produced row, even though the operator did not create the
+    /// underlying kopia snapshot.
+    Adopted,
 }
 
 /// Lifecycle phase of a `Snapshot`.
@@ -109,6 +115,7 @@ impl Origin {
             Self::Scheduled => "scheduled",
             Self::Manual => "manual",
             Self::Discovered => "discovered",
+            Self::Adopted => "adopted",
         }
     }
 }
@@ -120,6 +127,9 @@ pub enum PrunedBy {
     Retention,
     /// `SnapshotSchedule.spec.failedJobsHistoryLimit` prune.
     FailedHistory,
+    /// Policy-deletion cascade under `onPolicyDelete: Retain` — release the
+    /// CR, never contact the repository.
+    PolicyCascade,
 }
 
 impl PrunedBy {
@@ -129,6 +139,7 @@ impl PrunedBy {
         match self {
             Self::Retention => "retention",
             Self::FailedHistory => "failed-history",
+            Self::PolicyCascade => "policy-cascade",
         }
     }
 
@@ -138,6 +149,7 @@ impl PrunedBy {
         match v {
             "retention" => Some(Self::Retention),
             "failed-history" => Some(Self::FailedHistory),
+            "policy-cascade" => Some(Self::PolicyCascade),
             _ => None,
         }
     }
@@ -430,7 +442,12 @@ mod tests {
 
     #[test]
     fn origin_label_value_matches_the_serde_encoding() {
-        for origin in [Origin::Scheduled, Origin::Manual, Origin::Discovered] {
+        for origin in [
+            Origin::Scheduled,
+            Origin::Manual,
+            Origin::Discovered,
+            Origin::Adopted,
+        ] {
             assert_eq!(
                 serde_json::to_value(origin).unwrap(),
                 origin.label_value(),
@@ -619,7 +636,11 @@ onScheduleDelete: Delete
 
     #[test]
     fn pruned_by_parse_is_the_exact_inverse_of_annotation_value() {
-        for variant in [PrunedBy::Retention, PrunedBy::FailedHistory] {
+        for variant in [
+            PrunedBy::Retention,
+            PrunedBy::FailedHistory,
+            PrunedBy::PolicyCascade,
+        ] {
             assert_eq!(
                 PrunedBy::parse(variant.annotation_value()),
                 Some(variant),
@@ -640,6 +661,7 @@ onScheduleDelete: Delete
             serde_json::to_value(Origin::Discovered).unwrap(),
             "discovered"
         );
+        assert_eq!(serde_json::to_value(Origin::Adopted).unwrap(), "adopted");
         assert_eq!(
             serde_json::to_value(SnapshotPhase::Succeeded).unwrap(),
             "Succeeded"

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -97,6 +97,42 @@ pub struct SnapshotPolicySpec {
     /// Opt-in credential-Secret projection into each backup mover's namespace (default off).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub credential_projection: Option<CredentialProjection>,
+    /// Deletion semantics for the `Snapshot` CRs carrying this recipe's config label.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub deletion: Option<PolicyDeletionSpec>,
+    /// Per-policy override of automatic adoption for discovered snapshots whose
+    /// resolved identity matches this recipe; absent inherits the repository's
+    /// `catalog.adoption` (see [`effective_adoption`](crate::common::effective_adoption)).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adoption: Option<crate::common::SnapshotAdoption>,
+}
+
+/// Deletion semantics for the `Snapshot`s carrying a `SnapshotPolicy`'s config
+/// label (sub-object per docs/dev/api-conventions.md §4 so future deletion
+/// knobs slot in without API breakage). Mirrors `SnapshotSchedule`'s
+/// [`ScheduleDeletionSpec`](crate::snapshot_schedule::ScheduleDeletionSpec).
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PolicyDeletionSpec {
+    /// Consulted by the Snapshot finalizer when the deletion is external and the
+    /// owning `SnapshotPolicy` is gone. Absent resolves to `Retain`.
+    #[serde(default = "default_on_policy_delete")]
+    #[schemars(default = "default_on_policy_delete")]
+    pub on_policy_delete: crate::common::PolicyDeletePolicy,
+}
+
+fn default_on_policy_delete() -> crate::common::PolicyDeletePolicy {
+    crate::common::PolicyDeletePolicy::Retain
+}
+
+/// The effective cascade policy for a `SnapshotPolicy`: `spec.deletion.onPolicyDelete`
+/// when the sub-object is present, else `Retain`. (A default nested under an
+/// ABSENT optional sub-object does not materialize server-side — every read
+/// goes through this resolver.)
+pub fn effective_on_policy_delete(
+    deletion: Option<&PolicyDeletionSpec>,
+) -> crate::common::PolicyDeletePolicy {
+    deletion.map(|d| d.on_policy_delete).unwrap_or_default()
 }
 
 /// A single backup source; exactly one of `pvc`, `pvcSelector`, `nfs` (webhook-enforced).
@@ -643,6 +679,9 @@ pub struct SnapshotPolicyStatus {
     /// Summary of GFS retention pruning against this config's `Snapshot` CRs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub retention: Option<RetentionSummary>,
+    /// Summary of automatic adoption of discovered snapshots into this recipe.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub adoption: Option<AdoptionSummary>,
     /// RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_successful_snapshot: Option<String>,
@@ -691,6 +730,34 @@ pub struct RetentionSummary {
     /// Number of `Snapshot` CRs deleted by the last prune pass.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_prune_deleted: Option<i64>,
+}
+
+/// Summary of the most recent automatic adoption pass for a `SnapshotPolicy` —
+/// discovered snapshots whose resolved identity matched this recipe and were
+/// re-attached (see `Origin::Adopted`), plus an on-demand re-scan request/ack
+/// pair mirroring the repository-level `catalog-scan-requested-at` annotation
+/// contract.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AdoptionSummary {
+    /// RFC3339 timestamp of the last adoption pass that adopted at least one snapshot.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_adoption_at: Option<String>,
+    /// Number of discovered `Snapshot` CRs adopted by the last adoption pass.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_adopted_count: Option<u32>,
+    /// Running total of `Snapshot` CRs ever adopted into this recipe.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub total_adopted: Option<u64>,
+    /// RFC3339 token echoing an in-flight on-demand adoption scan request for
+    /// this policy's identity; cleared once honored.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_requested_at: Option<String>,
+    /// The resolved kopia identity the requested scan was scoped to, pinned at
+    /// request time so a later identity-changing edit can't retarget an
+    /// in-flight scan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scan_requested_identity: Option<String>,
 }
 
 #[cfg(test)]
@@ -1466,5 +1533,171 @@ preflight:
         );
         let json = serde_json::to_value(&status).unwrap();
         assert_eq!(json["lastSuccessfulSnapshot"], "2026-06-09T02:00:00Z");
+    }
+
+    // --- policy-deletion cascade (spec.deletion.onPolicyDelete) --------------
+
+    #[test]
+    fn policy_deletion_on_policy_delete_schema_default_is_retain() {
+        // Mirrors snapshot_schedule's schedule_deletion_on_schedule_delete_schema_default_is_retain:
+        // context-free default, safe to server-side-materialize because
+        // effective_on_policy_delete maps an absent sub-object to the same value.
+        let crd = SnapshotPolicy::crd();
+        let json = serde_json::to_value(&crd).unwrap();
+        let spec = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"];
+        assert_eq!(
+            spec["properties"]["deletion"]["properties"]["onPolicyDelete"]["default"],
+            serde_json::json!("Retain")
+        );
+        assert_eq!(
+            effective_on_policy_delete(None),
+            crate::common::PolicyDeletePolicy::Retain
+        );
+    }
+
+    #[test]
+    fn policy_deletion_round_trips_and_absent_stays_none() {
+        use crate::common::PolicyDeletePolicy;
+
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             deletion: { onPolicyDelete: Delete }\n",
+        );
+        assert_eq!(
+            spec.deletion.as_ref().map(|d| d.on_policy_delete),
+            Some(PolicyDeletePolicy::Delete)
+        );
+        assert_eq!(
+            effective_on_policy_delete(spec.deletion.as_ref()),
+            PolicyDeletePolicy::Delete
+        );
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json["deletion"]["onPolicyDelete"], "Delete");
+        let reparsed: SnapshotPolicySpec = serde_json::from_value(json).unwrap();
+        assert_eq!(spec, reparsed);
+
+        // Absent sub-object stays None (not materialized to Retain client-side).
+        let bare: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\n",
+        );
+        assert!(bare.deletion.is_none());
+        assert!(
+            serde_json::to_value(&bare)
+                .unwrap()
+                .get("deletion")
+                .is_none(),
+            "absent deletion must be elided"
+        );
+        assert_eq!(
+            effective_on_policy_delete(bare.deletion.as_ref()),
+            PolicyDeletePolicy::Retain
+        );
+    }
+
+    #[test]
+    fn policy_deletion_unknown_on_policy_delete_value_is_rejected() {
+        let value: serde_json::Value =
+            serde_yaml::from_str("deletion:\n  onPolicyDelete: Orphan\n").unwrap();
+        assert!(serde_json::from_value::<SnapshotPolicySpec>(value).is_err());
+    }
+
+    #[test]
+    fn policy_delete_policy_serializes_to_expected_strings() {
+        use crate::common::PolicyDeletePolicy;
+
+        assert_eq!(
+            serde_json::to_value(PolicyDeletePolicy::Retain).unwrap(),
+            "Retain"
+        );
+        assert_eq!(
+            serde_json::to_value(PolicyDeletePolicy::Delete).unwrap(),
+            "Delete"
+        );
+        assert_eq!(PolicyDeletePolicy::default(), PolicyDeletePolicy::Retain);
+    }
+
+    // --- adoption (spec.adoption + status.adoption) --------------------------
+
+    #[test]
+    fn policy_adoption_round_trips_and_absent_stays_none() {
+        use crate::common::SnapshotAdoption;
+
+        let spec: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\n\
+             sources: [ { pvc: { name: d } } ]\n\
+             adoption: Ignore\n",
+        );
+        assert_eq!(spec.adoption, Some(SnapshotAdoption::Ignore));
+        let json = serde_json::to_value(&spec).unwrap();
+        assert_eq!(json["adoption"], "Ignore");
+        let reparsed: SnapshotPolicySpec = serde_json::from_value(json).unwrap();
+        assert_eq!(spec, reparsed);
+
+        let bare: SnapshotPolicySpec = from_yaml(
+            "repository: { kind: Repository, name: r }\nsources: [ { pvc: { name: d } } ]\n",
+        );
+        assert!(bare.adoption.is_none());
+        assert!(
+            serde_json::to_value(&bare)
+                .unwrap()
+                .get("adoption")
+                .is_none(),
+            "absent adoption must be elided"
+        );
+    }
+
+    #[test]
+    fn policy_adoption_schema_carries_no_default() {
+        // §4a: the effective default (`Adopt`) is context-dependent (a policy ->
+        // repo -> constant inheritance chain), so no schemars `default` is
+        // emitted for THIS field — the reference stays `—`.
+        let crd = SnapshotPolicy::crd();
+        let json = serde_json::to_value(&crd).unwrap();
+        let prop = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["adoption"];
+        assert!(
+            prop.get("default").is_none(),
+            "spec.adoption must NOT carry a schema default: {prop}"
+        );
+        assert_eq!(prop["enum"].as_array().map(|a| a.len()), Some(2), "{prop}");
+    }
+
+    #[test]
+    fn adoption_summary_status_roundtrips() {
+        let status: SnapshotPolicyStatus = from_yaml(
+            "adoption:\n  \
+             lastAdoptionAt: 2026-06-09T02:00:00Z\n  \
+             lastAdoptedCount: 3\n  \
+             totalAdopted: 42\n  \
+             scanRequestedAt: 2026-06-10T00:00:00Z\n  \
+             scanRequestedIdentity: postgres@billing\n",
+        );
+        let a = status.adoption.as_ref().expect("adoption");
+        assert_eq!(a.last_adoption_at.as_deref(), Some("2026-06-09T02:00:00Z"));
+        assert_eq!(a.last_adopted_count, Some(3));
+        assert_eq!(a.total_adopted, Some(42));
+        assert_eq!(a.scan_requested_at.as_deref(), Some("2026-06-10T00:00:00Z"));
+        assert_eq!(
+            a.scan_requested_identity.as_deref(),
+            Some("postgres@billing")
+        );
+
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["adoption"]["lastAdoptedCount"], 3);
+        assert_eq!(json["adoption"]["totalAdopted"], 42);
+        let reparsed: SnapshotPolicyStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(status, reparsed);
+
+        // Absent ⇒ None, elided.
+        let bare: SnapshotPolicyStatus = from_yaml("{}\n");
+        assert!(bare.adoption.is_none());
+        assert!(
+            serde_json::to_value(&bare)
+                .unwrap()
+                .get("adoption")
+                .is_none(),
+            "absent adoption summary must be elided"
+        );
     }
 }

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -107,22 +107,26 @@ pub fn validate_consumer_against_cluster_repo(
 /// A `Snapshot`'s `deletionPolicy` is legal for its origin (ADR §4.5).
 ///
 /// `origin: discovered` forces `Retain`: `None` (defaults to `Retain`) and an
-/// explicit `Retain` pass; `Delete`/`Orphan` are rejected. Other origins accept any
-/// policy.
+/// explicit `Retain` pass; `Delete`/`Orphan` are rejected. `discovered`'s
+/// underlying kopia snapshot was never created by the operator, so it must
+/// never be the thing that deletes it. `adopted` is the one exception: an
+/// adopted row was deliberately re-attached to a `SnapshotPolicy` precisely so
+/// GFS retention (and any `deletionPolicy`) governs it like a produced backup —
+/// any policy is allowed. `scheduled`/`manual` are unchanged (any policy).
 pub fn validate_backup_deletion_policy(
     origin: crate::snapshot::Origin,
     policy: Option<crate::common::DeletionPolicy>,
 ) -> ValidationResult {
     use crate::common::DeletionPolicy;
     use crate::snapshot::Origin;
-    if origin != Origin::Discovered {
-        return Ok(());
-    }
-    match policy {
-        None | Some(DeletionPolicy::Retain) => Ok(()),
-        Some(other) => Err(ValidationError::DiscoveredMustRetain {
-            got: format!("{other:?}"),
-        }),
+    match origin {
+        Origin::Discovered => match policy {
+            None | Some(DeletionPolicy::Retain) => Ok(()),
+            Some(other) => Err(ValidationError::DiscoveredMustRetain {
+                got: format!("{other:?}"),
+            }),
+        },
+        Origin::Adopted | Origin::Scheduled | Origin::Manual => Ok(()),
     }
 }
 

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -439,19 +439,22 @@ pub fn validate_backup(spec: &SnapshotSpec, origin: Origin) -> Vec<ValidationErr
 
 /// `origin: discovered` Snapshots carry an empty spec; a stamped cascade
 /// policy on one is meaningless (their owner is a repository, not a schedule)
-/// and forbidden, like a non-Retain deletionPolicy.
+/// and forbidden, like a non-Retain deletionPolicy. `origin: adopted` is
+/// forbidden for the same reason: an adopted row's owner is the
+/// `SnapshotPolicy` it was re-attached to, never a `SnapshotSchedule`.
 pub fn validate_backup_on_schedule_delete(
     origin: Origin,
     value: Option<ScheduleDeletePolicy>,
 ) -> ValidationResult {
-    if origin != Origin::Discovered {
-        return Ok(());
-    }
-    match value {
-        None => Ok(()),
-        Some(v) => Err(ValidationError::DiscoveredCannotSetOnScheduleDelete {
-            got: format!("{v:?}"),
-        }),
+    match origin {
+        Origin::Discovered | Origin::Adopted => match value {
+            None => Ok(()),
+            Some(v) => Err(ValidationError::DiscoveredCannotSetOnScheduleDelete {
+                origin: origin.label_value(),
+                got: format!("{v:?}"),
+            }),
+        },
+        Origin::Scheduled | Origin::Manual => Ok(()),
     }
 }
 

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -167,6 +167,21 @@ fn produced_origins_accept_any_policy() {
     }
 }
 
+#[test]
+fn adopted_accepts_any_policy() {
+    // Unlike `discovered`, an adopted row was deliberately re-attached to a
+    // SnapshotPolicy so it is managed like a produced backup — any deletionPolicy
+    // (including None/Delete/Orphan) is legal.
+    for p in [
+        None,
+        Some(DeletionPolicy::Delete),
+        Some(DeletionPolicy::Retain),
+        Some(DeletionPolicy::Orphan),
+    ] {
+        assert!(validate_backup_deletion_policy(Origin::Adopted, p).is_ok());
+    }
+}
+
 // --- validate_source ---
 
 #[test]
@@ -1184,6 +1199,8 @@ fn backup_config_aggregate_collects_multiple_errors() {
         hooks: None,
         mover: None,
         credential_projection: None,
+        deletion: None,
+        adoption: None,
     };
     let errs = validate_backup_config(&spec);
     // Both: ClusterRepo namespace forbidden + missing sources.
@@ -1231,6 +1248,8 @@ fn backup_config_valid_spec_has_no_errors() {
         hooks: None,
         mover: None,
         credential_projection: None,
+        deletion: None,
+        adoption: None,
     };
     assert!(validate_backup_config(&spec).is_empty());
 }
@@ -1257,22 +1276,26 @@ fn backup_aggregate_rejects_discovered_delete() {
 // --- validate_backup_on_schedule_delete ---
 
 #[test]
-fn discovered_on_schedule_delete_is_rejected_for_either_variant() {
-    for v in [ScheduleDeletePolicy::Retain, ScheduleDeletePolicy::Delete] {
-        let err = validate_backup_on_schedule_delete(Origin::Discovered, Some(v)).unwrap_err();
-        match &err {
-            ValidationError::DiscoveredCannotSetOnScheduleDelete { got } => {
-                assert_eq!(got, &format!("{v:?}"));
+fn discovered_and_adopted_on_schedule_delete_is_rejected_for_either_variant() {
+    for origin in [Origin::Discovered, Origin::Adopted] {
+        for v in [ScheduleDeletePolicy::Retain, ScheduleDeletePolicy::Delete] {
+            let err = validate_backup_on_schedule_delete(origin, Some(v)).unwrap_err();
+            match &err {
+                ValidationError::DiscoveredCannotSetOnScheduleDelete { origin: o, got } => {
+                    assert_eq!(*o, origin.label_value());
+                    assert_eq!(got, &format!("{v:?}"));
+                }
+                other => panic!("expected DiscoveredCannotSetOnScheduleDelete, got {other:?}"),
             }
-            other => panic!("expected DiscoveredCannotSetOnScheduleDelete, got {other:?}"),
+            // The message names the origin, the field, and the fix.
+            let msg = err.to_string();
+            assert!(msg.contains(origin.label_value()), "{msg}");
+            assert!(msg.contains("onScheduleDelete"), "{msg}");
+            assert!(msg.contains("Remove spec.onScheduleDelete"), "{msg}");
         }
-        // The message names the field and the fix.
-        let msg = err.to_string();
-        assert!(msg.contains("onScheduleDelete"), "{msg}");
-        assert!(msg.contains("Remove spec.onScheduleDelete"), "{msg}");
+        // Absent is fine.
+        assert!(validate_backup_on_schedule_delete(origin, None).is_ok());
     }
-    // Absent is fine on a discovered Snapshot.
-    assert!(validate_backup_on_schedule_delete(Origin::Discovered, None).is_ok());
 }
 
 #[test]

--- a/crates/cli/src/cmd/snapshots.rs
+++ b/crates/cli/src/cmd/snapshots.rs
@@ -134,6 +134,7 @@ fn origin_cell(origin: Option<Origin>) -> String {
         Some(Origin::Scheduled) => "scheduled".into(),
         Some(Origin::Manual) => "manual".into(),
         Some(Origin::Discovered) => "discovered".into(),
+        Some(Origin::Adopted) => "adopted".into(),
         None => EMPTY_CELL.into(),
     }
 }

--- a/crates/controller/src/adoption.rs
+++ b/crates/controller/src/adoption.rs
@@ -218,8 +218,14 @@ fn is_foreign_cluster(hostname: &str, cluster: Option<&str>) -> bool {
 /// candidate, in the `policy`'s namespace. **Pure.** The status is returned
 /// separately so the caller creates the CR then PATCHes the status subresource.
 ///
-/// - **Name**: `<policy>-adopted-<first16(snapshot_id)>`, length-capped by
-///   [`crate::naming::capped_name`].
+/// - **Name**: `<policy>-adopted-<first16(snapshot_id)>-<hash8(snapshot_id)>`,
+///   length-capped by [`crate::naming::capped_name`]. The first-16 prefix is
+///   kept for human correlation with the kopia id; the trailing
+///   [`crate::naming::short_hash`] of the FULL id makes the name
+///   collision-free even when two ids in the same policy share a ≥16-char
+///   prefix (two ids differing only after char 16 previously minted the SAME
+///   name — see the `adopted_row_matches_candidate` name-collision guard in
+///   `snapshot_policy.rs`, which this fix makes unreachable for that case).
 /// - **Labels**: mirror the discovered-row set — `origin: adopted`,
 ///   `SNAPSHOT_ID_LABEL`, `REPOSITORY_UID_LABEL` — plus `CONFIG_LABEL` (the
 ///   policy name) so retention governs it.
@@ -239,7 +245,8 @@ pub fn build_adopted_snapshot(
     let policy_name = policy.name_any();
     let namespace = policy.namespace().unwrap_or_default();
     let short: String = candidate.snapshot_id.chars().take(16).collect();
-    let cr_name = crate::naming::capped_name(&format!("{policy_name}-adopted-{short}"));
+    let hash = crate::naming::short_hash(&candidate.snapshot_id);
+    let cr_name = crate::naming::capped_name(&format!("{policy_name}-adopted-{short}-{hash}"));
 
     let mut labels = BTreeMap::new();
     labels.insert(
@@ -682,8 +689,10 @@ mod tests {
         };
         let (snap, status) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
 
-        // Name: <policy>-adopted-<first16(id)>, in the policy's namespace.
-        assert_eq!(snap.name_any(), "app-adopted-0123456789abcdef");
+        // Name: <policy>-adopted-<first16(id)>-<hash8(full id)>, in the policy's
+        // namespace. The trailing hash is over the FULL id (not just the
+        // first-16 prefix), so it stays distinct for ids sharing that prefix.
+        assert_eq!(snap.name_any(), "app-adopted-0123456789abcdef-f9c550c9");
         assert_eq!(snap.namespace().as_deref(), Some("billing"));
 
         // Labels mirror the discovered set + CONFIG_LABEL.
@@ -741,6 +750,68 @@ mod tests {
         let cand = candidate("aaa", identity("app", "billing", Some("/data")), false);
         let (snap, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
         assert_eq!(snap.spec.deletion_policy, Some(DeletionPolicy::Orphan));
+    }
+
+    /// The P1 regression test: two kopia snapshot ids that share a ≥16-char
+    /// prefix but differ afterward previously minted the SAME adopted-row
+    /// name (`<policy>-adopted-<first16>`), which drove the second adoption
+    /// into the create-409 branch in `snapshot_policy::adopt_one` — either
+    /// clobbering the first row's status (pre-91093e7) or, post-91093e7,
+    /// permanently wedging the second candidate behind the
+    /// `adopted_row_matches_candidate` stranger guard (skipped + re-warned
+    /// every pass, its discovered row never cleaned up). Appending a hash of
+    /// the FULL id makes the two names distinct.
+    #[test]
+    fn build_adopted_snapshot_names_differ_for_ids_sharing_a_16char_prefix() {
+        let policy = policy_fixture(None);
+        let ident = identity("app", "billing", Some("/data"));
+        let id_a = "0123456789abcdef-AAAA-tail-one";
+        let id_b = "0123456789abcdef-BBBB-tail-two";
+        assert_eq!(
+            &id_a[..16],
+            &id_b[..16],
+            "fixture precondition: shared 16-char prefix"
+        );
+        let cand_a = candidate(id_a, ident.clone(), false);
+        let cand_b = candidate(id_b, ident, false);
+        let (snap_a, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand_a);
+        let (snap_b, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand_b);
+        assert_ne!(
+            snap_a.name_any(),
+            snap_b.name_any(),
+            "distinct full ids must never collide on their first-16 prefix alone"
+        );
+    }
+
+    #[test]
+    fn build_adopted_snapshot_name_is_deterministic_for_the_same_full_id() {
+        let policy = policy_fixture(None);
+        let ident = identity("app", "billing", Some("/data"));
+        let cand = candidate("0123456789abcdef0123", ident, false);
+        let (snap_1, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
+        let (snap_2, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
+        assert_eq!(
+            snap_1.name_any(),
+            snap_2.name_any(),
+            "same (policy, full id) must always name the same, so idempotent \
+             re-adoption (already-carried-id skip; 409 -> ensure-status) converges"
+        );
+    }
+
+    #[test]
+    fn build_adopted_snapshot_name_stays_capped_for_long_policy_and_id() {
+        let mut policy = policy_fixture(None);
+        policy.metadata.name = Some("n".repeat(80));
+        let ident = identity("app", "billing", Some("/data"));
+        let long_id = "9".repeat(200);
+        let cand = candidate(&long_id, ident, false);
+        let (snap, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
+        let name = snap.name_any();
+        assert!(
+            name.len() <= 63,
+            "capped_name must still cap a long policy name + long id: {} chars ({name})",
+            name.len()
+        );
     }
 
     // -- event message -------------------------------------------------------

--- a/crates/controller/src/adoption.rs
+++ b/crates/controller/src/adoption.rs
@@ -1,0 +1,761 @@
+//! Auto-adoption of discovered snapshots into identity-matching
+//! `SnapshotPolicy`s (fixes #210).
+//!
+//! A `discovered` `Snapshot` row is an immortal catalog entry for a kopia
+//! snapshot the operator did not produce. When such a row's kopia identity
+//! EXACTLY matches a live `SnapshotPolicy`'s resolved identity, the policy
+//! *adopts* it: a fresh `origin: Adopted` `Snapshot` is created in the policy's
+//! namespace carrying the policy's config label, then the discovered row is
+//! deleted. The adopted row is now GFS-governed like any produced backup — it
+//! participates in `spec.retention` and is eventually pruned — instead of
+//! sitting in the catalog forever.
+//!
+//! This module is the **pure decision layer** ([`adoption_candidates`],
+//! [`plan_adoption`], [`build_adopted_snapshot`]); the kube LIST/create/delete
+//! is the thin IO in [`crate::snapshot_policy`]. Every rule below is unit-tested
+//! here.
+//!
+//! ## Safety invariants (each maps to a test)
+//!
+//! 1. **Cluster-wide LIST** (IO side): discovered candidates are LISTed via
+//!    `crate::controllers::scoped_api` so a `ClusterRepository`'s rows in other
+//!    namespaces are seen — a policy-namespaced LIST would silently miss them.
+//! 2. **Structured-identity equality** ([`identities_match`]): username AND
+//!    hostname AND `sourcePath` must all match exactly. NEVER via
+//!    `identity_string` (which omits the path when `None`, while kopia rows
+//!    always carry one — a false match).
+//! 3. **Foreign-cluster hard refusal** ([`is_foreign_cluster`]): even on an
+//!    exact identity match, a candidate whose hostname classifies
+//!    [`HostClass::ForeignCluster`] under the repository's
+//!    `identityDefaults.cluster` is refused (defense in depth).
+//! 4. **Recreate, never relabel** (IO side): the adopted row is created FIRST,
+//!    then the discovered row deleted — so a crash between the two is healed by
+//!    the next wave, never losing the catalog entry.
+//! 5. **No ownerReference** on adopted rows ([`build_adopted_snapshot`]) — a
+//!    repository owner-ref plus `deletionPolicy: Delete` would turn `kubectl
+//!    delete repository` into a GC-driven kopia-deletion wave.
+//! 6. **Adoption AFTER retention** (IO side), consuming SEPARATE LISTs.
+//! 7. **Batching**: at most [`POLICY_ADOPTION_BATCH`] adoptions per pass, in
+//!    deterministic (snapshot-id) order.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use kube::ResourceExt;
+
+use kopiur_api::common::{DeletionPolicy, PolicyRef, ResolvedIdentity, SnapshotAdoption};
+use kopiur_api::snapshot::{
+    ResolvedSnapshot, SnapshotInfo, SnapshotSpec, SnapshotStats, SnapshotStatus, SnapshotTiming,
+};
+use kopiur_api::{
+    HostClass, Origin, Snapshot, SnapshotPhase, SnapshotPolicy, classify_hostname, identity_string,
+};
+
+use crate::consts::{CONFIG_LABEL, ORIGIN_LABEL, REPOSITORY_UID_LABEL, SNAPSHOT_ID_LABEL};
+
+/// At most this many discovered snapshots are adopted per reconcile pass. This
+/// bound is what keeps the (unbatched) retention delete loop bounded per pass:
+/// each pass re-LISTs and re-plans, so any remainder is picked up next pass.
+pub const POLICY_ADOPTION_BATCH: usize = 50;
+
+/// A discovered `Snapshot` row eligible for adoption, distilled to the fields the
+/// planner and builder need. Extracted from a `discovered`-origin `Snapshot` CR
+/// by [`adoption_candidates`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionCandidate {
+    /// Namespace the discovered row lives in (where the delete lands — may differ
+    /// from the policy's namespace for a `ClusterRepository`).
+    pub namespace: String,
+    /// The discovered row's CR name.
+    pub name: String,
+    /// The kopia snapshot id this row represents (`status.snapshot.kopiaSnapshotID`).
+    pub snapshot_id: String,
+    /// The kopia identity recorded on the row (`status.snapshot.identity`).
+    pub identity: ResolvedIdentity,
+    /// The row's `status.timing`, carried onto the adopted row verbatim.
+    pub timing: Option<SnapshotTiming>,
+    /// The row's `status.stats`, carried onto the adopted row verbatim.
+    pub stats: Option<SnapshotStats>,
+    /// The row's `spec.pin`, carried onto the adopted row.
+    pub pinned: bool,
+}
+
+/// Extract adoption candidates from a `Snapshot` LIST: `discovered`-origin rows
+/// of THIS repository (`repo_uid`) that are not terminating and carry a
+/// resolvable kopia id + identity in status. Pure.
+///
+/// SKIPs (returns nothing for):
+/// - rows not labeled `origin: discovered` or not for `repo_uid`;
+/// - **terminating** rows (`metadata.deletionTimestamp` set) — a row already
+///   being expired must not be re-created under a new identity;
+/// - rows missing `status.snapshot` (no id/identity to match on).
+pub fn adoption_candidates(repo_uid: &str, rows: &[Snapshot]) -> Vec<AdoptionCandidate> {
+    rows.iter()
+        .filter_map(|s| {
+            let labels = s.labels();
+            if labels.get(ORIGIN_LABEL).map(String::as_str)
+                != Some(Origin::Discovered.label_value())
+            {
+                return None;
+            }
+            if labels.get(REPOSITORY_UID_LABEL).map(String::as_str) != Some(repo_uid) {
+                return None;
+            }
+            // SKIP terminating rows — never re-create one that is being expired.
+            if s.metadata.deletion_timestamp.is_some() {
+                return None;
+            }
+            let status = s.status.as_ref()?;
+            let info = status.snapshot.as_ref()?;
+            if info.kopia_snapshot_id.is_empty() {
+                return None;
+            }
+            Some(AdoptionCandidate {
+                namespace: s.namespace().unwrap_or_default(),
+                name: s.name_any(),
+                snapshot_id: info.kopia_snapshot_id.clone(),
+                identity: info.identity.clone(),
+                timing: status.timing.clone(),
+                stats: status.stats.clone(),
+                pinned: s.spec.pin,
+            })
+        })
+        .collect()
+}
+
+/// What one adoption pass decided: the rows to adopt (already filtered, sorted,
+/// and capped) and whether to request an on-demand catalog scan.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AdoptionPlan {
+    /// Candidates to adopt this pass (≤ [`POLICY_ADOPTION_BATCH`], snapshot-id order).
+    pub adopt: Vec<AdoptionCandidate>,
+    /// Whether to stamp the on-demand catalog-scan request on the repository.
+    pub request_scan: bool,
+}
+
+/// Decide the adoption plan for one pass. **Pure** — exhaustive over
+/// [`SnapshotAdoption`], no `_ =>`.
+///
+/// - [`SnapshotAdoption::Ignore`] → adopt nothing, request no scan.
+/// - [`SnapshotAdoption::Adopt`] → adopt every candidate that (inv. 2) matches
+///   the policy's live-resolved identity structurally AND (inv. 3) is not a
+///   foreign-cluster hostname AND is not already carried by a config-label
+///   `Snapshot` (`own_snapshot_ids`); sorted by snapshot id and capped at
+///   [`POLICY_ADOPTION_BATCH`] (inv. 7).
+///
+/// `request_scan` is true when this pass adopted anything (a wave implies more
+/// may exist behind the catalog's `retain` caps), OR — for a brand-new /
+/// delete-then-recreated policy — when NO candidate matched at all, the policy
+/// has no history yet, and no scan was already requested for THIS identity
+/// (`scan_requested_identity`). That last arm fires exactly once per (policy,
+/// identity): a scan that yields nothing stays quiet forever after.
+pub fn plan_adoption(
+    mode: SnapshotAdoption,
+    policy_identity: &ResolvedIdentity,
+    repo_cluster: Option<&str>,
+    candidates: Vec<AdoptionCandidate>,
+    own_snapshot_ids: &BTreeSet<String>,
+    has_history: bool,
+    scan_requested_identity: Option<&str>,
+) -> AdoptionPlan {
+    match mode {
+        SnapshotAdoption::Ignore => AdoptionPlan {
+            adopt: Vec::new(),
+            request_scan: false,
+        },
+        SnapshotAdoption::Adopt => {
+            // Identity-matching, non-foreign candidates (inv. 2 + 3). `matched_any`
+            // is computed BEFORE the own-id filter: a candidate that matched but is
+            // already ours means there IS relevant history, so it must not trigger a
+            // "nothing matched" scan request.
+            let mut matched: Vec<AdoptionCandidate> = candidates
+                .into_iter()
+                .filter(|c| {
+                    identities_match(policy_identity, &c.identity)
+                        && !is_foreign_cluster(&c.identity.hostname, repo_cluster)
+                })
+                .collect();
+            let matched_any = !matched.is_empty();
+            matched.retain(|c| !own_snapshot_ids.contains(&c.snapshot_id));
+            // Deterministic order (inv. 7) so a capped pass always adopts the same
+            // prefix, and the batch cap.
+            matched.sort_by(|a, b| a.snapshot_id.cmp(&b.snapshot_id));
+            matched.truncate(POLICY_ADOPTION_BATCH);
+            let adopt = matched;
+
+            let already_requested =
+                scan_requested_identity == Some(identity_string(policy_identity).as_str());
+            let request_scan =
+                !adopt.is_empty() || (!matched_any && !has_history && !already_requested);
+            AdoptionPlan {
+                adopt,
+                request_scan,
+            }
+        }
+    }
+}
+
+/// Structured identity equality (inv. 2): username AND hostname AND `sourcePath`
+/// all equal. Deliberately field-by-field, NOT [`identity_string`] — the string
+/// form drops the path when it is `None`, so `alice@host` would spuriously match
+/// `alice@host:/data` (kopia rows always carry a path).
+fn identities_match(policy: &ResolvedIdentity, candidate: &ResolvedIdentity) -> bool {
+    policy.username == candidate.username
+        && policy.hostname == candidate.hostname
+        && policy.source_path == candidate.source_path
+}
+
+/// Whether a hostname is another cluster's under this repository's
+/// `identityDefaults.cluster` (inv. 3). Only [`HostClass::ForeignCluster`]
+/// refuses; `Bare`/`OwnCluster` do not.
+fn is_foreign_cluster(hostname: &str, cluster: Option<&str>) -> bool {
+    matches!(
+        classify_hostname(hostname, cluster),
+        HostClass::ForeignCluster { .. }
+    )
+}
+
+/// Build the adopted `Snapshot` (spec + metadata) and its `status` for a
+/// candidate, in the `policy`'s namespace. **Pure.** The status is returned
+/// separately so the caller creates the CR then PATCHes the status subresource.
+///
+/// - **Name**: `<policy>-adopted-<first16(snapshot_id)>`, length-capped by
+///   [`crate::naming::capped_name`].
+/// - **Labels**: mirror the discovered-row set — `origin: adopted`,
+///   `SNAPSHOT_ID_LABEL`, `REPOSITORY_UID_LABEL` — plus `CONFIG_LABEL` (the
+///   policy name) so retention governs it.
+/// - **Spec**: `policyRef` = the policy; `deletionPolicy` =
+///   `spec.defaultDeletionPolicy` (else `Delete`); `pin` carried from the
+///   candidate; NO `onScheduleDelete`.
+/// - **Meta**: NO ownerReferences (inv. 5).
+/// - **Status**: `phase: Succeeded`, `origin: Adopted`, the kopia id + identity,
+///   timing + stats verbatim, and `resolved.repository` pinned via
+///   [`crate::snapshot::pinned_repository_ref`] — the pin that makes deletion,
+///   batching, and `produced_ids_for` attribute the row to its repository.
+pub fn build_adopted_snapshot(
+    policy: &SnapshotPolicy,
+    repo_uid: &str,
+    candidate: &AdoptionCandidate,
+) -> (Snapshot, SnapshotStatus) {
+    let policy_name = policy.name_any();
+    let namespace = policy.namespace().unwrap_or_default();
+    let short: String = candidate.snapshot_id.chars().take(16).collect();
+    let cr_name = crate::naming::capped_name(&format!("{policy_name}-adopted-{short}"));
+
+    let mut labels = BTreeMap::new();
+    labels.insert(
+        ORIGIN_LABEL.to_string(),
+        Origin::Adopted.label_value().to_string(),
+    );
+    labels.insert(CONFIG_LABEL.to_string(), policy_name.clone());
+    labels.insert(SNAPSHOT_ID_LABEL.to_string(), candidate.snapshot_id.clone());
+    labels.insert(REPOSITORY_UID_LABEL.to_string(), repo_uid.to_string());
+
+    let deletion_policy = policy
+        .spec
+        .default_deletion_policy
+        .unwrap_or(DeletionPolicy::Delete);
+
+    let mut snapshot = Snapshot::new(
+        &cr_name,
+        SnapshotSpec {
+            policy_ref: Some(PolicyRef {
+                name: policy_name.clone(),
+                namespace: None,
+            }),
+            tags: None,
+            failure_policy: None,
+            deletion_policy: Some(deletion_policy),
+            // Adopted rows have no owning schedule.
+            on_schedule_delete: None,
+            pin: candidate.pinned,
+            description: None,
+        },
+    );
+    // NO ownerReferences (inv. 5).
+    snapshot.metadata = crate::io::child_meta(&cr_name, &namespace, labels, None);
+
+    let pinned_repo = crate::snapshot::pinned_repository_ref(&policy.spec.repository, &namespace);
+    let status = SnapshotStatus {
+        phase: Some(SnapshotPhase::Succeeded),
+        origin: Some(Origin::Adopted),
+        snapshot: Some(SnapshotInfo {
+            kopia_snapshot_id: candidate.snapshot_id.clone(),
+            identity: candidate.identity.clone(),
+        }),
+        timing: candidate.timing.clone(),
+        stats: candidate.stats.clone(),
+        resolved: Some(ResolvedSnapshot {
+            repository: Some(pinned_repo),
+            sources: Vec::new(),
+            // Pin the recipe's projection opt-in like a produced row, so the
+            // deletion path re-projects credentials correctly (never reads the
+            // adopted row as "predates the pin").
+            credential_projection: Some(crate::snapshot::projection_to_pin(policy)),
+        }),
+        ..Default::default()
+    };
+
+    (snapshot, status)
+}
+
+/// The `SnapshotsAdopted` Normal-Event note. **Pure** so the required contents
+/// are unit-asserted: the count, the identity, that the rows are now GFS-governed
+/// and WILL be pruned per `spec.retention`, and BOTH opt-outs.
+pub fn adoption_event_message(count: u64, identity: &str) -> String {
+    format!(
+        "Adopted {count} discovered snapshot(s) matching identity {identity} into this \
+         SnapshotPolicy. They are now governed by GFS retention (spec.retention) and WILL be \
+         pruned like any snapshot this policy produces. To opt out of automatic adoption, set \
+         spec.adoption: Ignore on this SnapshotPolicy, or spec.catalog.adoption: Ignore on the \
+         referenced repository."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kopiur_api::common::RepositoryKind;
+    use kopiur_api::snapshot_policy::SnapshotPolicySpec;
+
+    /// An all-default (empty) `SnapshotSpec` (the type derives no `Default`).
+    fn empty_spec() -> SnapshotSpec {
+        serde_json::from_value(serde_json::json!({})).unwrap()
+    }
+
+    fn identity(user: &str, host: &str, path: Option<&str>) -> ResolvedIdentity {
+        ResolvedIdentity {
+            username: user.into(),
+            hostname: host.into(),
+            source_path: path.map(String::from),
+        }
+    }
+
+    /// A discovered `Snapshot` CR fixture: labels + status carrying id/identity.
+    fn discovered_row(repo_uid: &str, name: &str, id: &str, ident: ResolvedIdentity) -> Snapshot {
+        let mut labels = BTreeMap::new();
+        labels.insert(ORIGIN_LABEL.to_string(), "discovered".to_string());
+        labels.insert(REPOSITORY_UID_LABEL.to_string(), repo_uid.to_string());
+        labels.insert(SNAPSHOT_ID_LABEL.to_string(), id.to_string());
+        let mut s = Snapshot::new(name, empty_spec());
+        s.metadata.namespace = Some("disc-ns".to_string());
+        s.metadata.labels = Some(labels);
+        s.status = Some(SnapshotStatus {
+            phase: Some(SnapshotPhase::Discovered),
+            origin: Some(Origin::Discovered),
+            snapshot: Some(SnapshotInfo {
+                kopia_snapshot_id: id.to_string(),
+                identity: ident,
+            }),
+            timing: Some(SnapshotTiming {
+                start_time: Some("2026-01-01T00:00:00Z".into()),
+                end_time: Some("2026-01-01T00:01:00Z".into()),
+                duration_seconds: Some(60),
+            }),
+            stats: Some(SnapshotStats {
+                size_bytes: Some(1234),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        s
+    }
+
+    fn candidate(id: &str, ident: ResolvedIdentity, pinned: bool) -> AdoptionCandidate {
+        AdoptionCandidate {
+            namespace: "disc-ns".into(),
+            name: format!("row-{id}"),
+            snapshot_id: id.into(),
+            identity: ident,
+            timing: None,
+            stats: None,
+            pinned,
+        }
+    }
+
+    fn adopt_plan(
+        policy_identity: &ResolvedIdentity,
+        repo_cluster: Option<&str>,
+        candidates: Vec<AdoptionCandidate>,
+        own: &BTreeSet<String>,
+        has_history: bool,
+        requested: Option<&str>,
+    ) -> AdoptionPlan {
+        plan_adoption(
+            SnapshotAdoption::Adopt,
+            policy_identity,
+            repo_cluster,
+            candidates,
+            own,
+            has_history,
+            requested,
+        )
+    }
+
+    // -- adoption_candidates extraction --------------------------------------
+
+    #[test]
+    fn candidates_extract_matching_rows_and_skip_the_rest() {
+        let ident = identity("app", "billing", Some("/data"));
+        let mut rows = vec![
+            discovered_row("repo-1", "keep", "aaa", ident.clone()),
+            // wrong repo uid
+            discovered_row("repo-2", "wrong-repo", "bbb", ident.clone()),
+        ];
+        // Not a discovered row (origin label scheduled).
+        let mut scheduled = discovered_row("repo-1", "scheduled", "ccc", ident.clone());
+        scheduled
+            .metadata
+            .labels
+            .as_mut()
+            .unwrap()
+            .insert(ORIGIN_LABEL.to_string(), "scheduled".to_string());
+        rows.push(scheduled);
+        // Terminating row — skipped.
+        let mut terminating = discovered_row("repo-1", "terminating", "ddd", ident.clone());
+        terminating.metadata.deletion_timestamp =
+            Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                k8s_openapi::jiff::Timestamp::from_second(1_700_000_000).unwrap(),
+            ));
+        rows.push(terminating);
+        // Missing status.snapshot — skipped.
+        let mut no_status = discovered_row("repo-1", "no-status", "eee", ident.clone());
+        no_status.status.as_mut().unwrap().snapshot = None;
+        rows.push(no_status);
+
+        let got = adoption_candidates("repo-1", &rows);
+        assert_eq!(
+            got.len(),
+            1,
+            "only the one matching, live, status-carrying row"
+        );
+        assert_eq!(got[0].snapshot_id, "aaa");
+        assert_eq!(got[0].namespace, "disc-ns");
+        assert_eq!(got[0].identity, ident);
+    }
+
+    #[test]
+    fn candidates_carry_the_pin_flag() {
+        let ident = identity("app", "billing", Some("/data"));
+        let mut row = discovered_row("repo-1", "pinned", "aaa", ident);
+        row.spec.pin = true;
+        let got = adoption_candidates("repo-1", &[row]);
+        assert_eq!(got.len(), 1);
+        assert!(got[0].pinned, "spec.pin is carried onto the candidate");
+    }
+
+    // -- plan_adoption: matching + refusals ----------------------------------
+
+    #[test]
+    fn exact_identity_match_is_adopted() {
+        let id = identity("app", "billing", Some("/data"));
+        let plan = adopt_plan(
+            &id,
+            None,
+            vec![candidate("aaa", id.clone(), false)],
+            &BTreeSet::new(),
+            false,
+            None,
+        );
+        assert_eq!(plan.adopt.len(), 1);
+        assert_eq!(plan.adopt[0].snapshot_id, "aaa");
+        assert!(
+            plan.request_scan,
+            "a non-empty adopt always requests a rescan"
+        );
+    }
+
+    #[test]
+    fn near_miss_on_username_hostname_or_path_is_not_adopted() {
+        let policy = identity("app", "billing", Some("/data"));
+        let cands = vec![
+            candidate("u", identity("app-2", "billing", Some("/data")), false),
+            candidate("h", identity("app", "billing-2", Some("/data")), false),
+            candidate("p", identity("app", "billing", Some("/other")), false),
+            // path present vs absent must NOT match (the identity_string trap).
+            candidate("none", identity("app", "billing", None), false),
+        ];
+        let plan = adopt_plan(&policy, None, cands, &BTreeSet::new(), false, None);
+        assert!(plan.adopt.is_empty(), "no near-miss is adopted");
+    }
+
+    #[test]
+    fn foreign_cluster_hostname_is_refused_even_on_exact_match() {
+        // The candidate's identity is byte-identical to the policy's, but the
+        // hostname classifies ForeignCluster under the repo's cluster — refused.
+        let policy = identity("app", "prod.west", Some("/data"));
+        let cand = candidate("aaa", identity("app", "prod.west", Some("/data")), false);
+        let plan = adopt_plan(
+            &policy,
+            Some("east"),
+            vec![cand],
+            &BTreeSet::new(),
+            false,
+            None,
+        );
+        assert!(
+            plan.adopt.is_empty(),
+            "an exact match that is another cluster's is still refused"
+        );
+        // With no cluster identity the same host is Bare → adopted.
+        let plan = adopt_plan(
+            &policy,
+            None,
+            vec![candidate(
+                "aaa",
+                identity("app", "prod.west", Some("/data")),
+                false,
+            )],
+            &BTreeSet::new(),
+            false,
+            None,
+        );
+        assert_eq!(
+            plan.adopt.len(),
+            1,
+            "no cluster mode: host is bare, adopted"
+        );
+    }
+
+    #[test]
+    fn already_carried_id_is_skipped() {
+        let id = identity("app", "billing", Some("/data"));
+        let own: BTreeSet<String> = ["aaa".to_string()].into_iter().collect();
+        let plan = adopt_plan(
+            &id,
+            None,
+            vec![candidate("aaa", id.clone(), false)],
+            &own,
+            true,
+            None,
+        );
+        assert!(
+            plan.adopt.is_empty(),
+            "an already-owned kopia id is not re-adopted"
+        );
+        assert!(
+            !plan.request_scan,
+            "a matched-but-owned candidate is not 'nothing matched', and history exists"
+        );
+    }
+
+    #[test]
+    fn pinned_candidate_is_carried_into_the_adopt_set() {
+        let id = identity("app", "billing", Some("/data"));
+        let plan = adopt_plan(
+            &id,
+            None,
+            vec![candidate("aaa", id.clone(), true)],
+            &BTreeSet::new(),
+            false,
+            None,
+        );
+        assert!(plan.adopt[0].pinned);
+    }
+
+    #[test]
+    fn ignore_mode_is_inert() {
+        let id = identity("app", "billing", Some("/data"));
+        let plan = plan_adoption(
+            SnapshotAdoption::Ignore,
+            &id,
+            None,
+            vec![candidate("aaa", id.clone(), false)],
+            &BTreeSet::new(),
+            false,
+            None,
+        );
+        assert!(plan.adopt.is_empty());
+        assert!(!plan.request_scan);
+    }
+
+    #[test]
+    fn empty_candidates_with_history_adopts_nothing_and_stays_quiet() {
+        let id = identity("app", "billing", Some("/data"));
+        let plan = adopt_plan(&id, None, vec![], &BTreeSet::new(), true, None);
+        assert!(plan.adopt.is_empty());
+        assert!(!plan.request_scan);
+    }
+
+    // -- request_scan truth table --------------------------------------------
+
+    #[test]
+    fn request_scan_truth_table() {
+        let id = identity("app", "billing", Some("/data"));
+        let none: Vec<AdoptionCandidate> = vec![];
+
+        // no history + never requested → true (ask exactly once).
+        assert!(adopt_plan(&id, None, none.clone(), &BTreeSet::new(), false, None).request_scan);
+        // no history + already requested for THIS identity → false.
+        assert!(
+            !adopt_plan(
+                &id,
+                None,
+                none.clone(),
+                &BTreeSet::new(),
+                false,
+                Some(&identity_string(&id))
+            )
+            .request_scan
+        );
+        // has history + no matches → false.
+        assert!(!adopt_plan(&id, None, none.clone(), &BTreeSet::new(), true, None).request_scan);
+        // non-empty adopt → true (regardless of history/requested).
+        assert!(
+            adopt_plan(
+                &id,
+                None,
+                vec![candidate("aaa", id.clone(), false)],
+                &BTreeSet::new(),
+                true,
+                Some(&identity_string(&id))
+            )
+            .request_scan
+        );
+        // A DIFFERENT identity's prior request does not suppress this one.
+        assert!(
+            adopt_plan(
+                &id,
+                None,
+                none,
+                &BTreeSet::new(),
+                false,
+                Some("other@host:/x")
+            )
+            .request_scan
+        );
+    }
+
+    // -- batching + deterministic order --------------------------------------
+
+    #[test]
+    fn batch_cap_and_deterministic_order() {
+        let id = identity("app", "billing", Some("/data"));
+        // 60 matching candidates, ids "id00".."id59" inserted in reverse.
+        let mut cands: Vec<AdoptionCandidate> = (0..60)
+            .rev()
+            .map(|i| candidate(&format!("id{i:02}"), id.clone(), false))
+            .collect();
+        // Shuffle-ish: also push a duplicate-order perturbation.
+        cands.rotate_left(7);
+        let plan = adopt_plan(&id, None, cands, &BTreeSet::new(), false, None);
+        assert_eq!(plan.adopt.len(), POLICY_ADOPTION_BATCH, "capped at 50");
+        // Sorted ascending by snapshot id, so the first 50 are id00..id49.
+        let ids: Vec<&str> = plan.adopt.iter().map(|c| c.snapshot_id.as_str()).collect();
+        let want: Vec<String> = (0..POLICY_ADOPTION_BATCH)
+            .map(|i| format!("id{i:02}"))
+            .collect();
+        assert_eq!(ids, want.iter().map(String::as_str).collect::<Vec<_>>());
+    }
+
+    // -- build_adopted_snapshot ----------------------------------------------
+
+    fn policy_fixture(deletion: Option<DeletionPolicy>) -> SnapshotPolicy {
+        let spec: SnapshotPolicySpec = serde_json::from_value(serde_json::json!({
+            "repository": { "kind": "Repository", "name": "nas" },
+            "sources": [{ "pvc": { "name": "data" } }],
+        }))
+        .unwrap();
+        let mut p = SnapshotPolicy::new("app", spec);
+        p.spec.default_deletion_policy = deletion;
+        p.metadata.namespace = Some("billing".into());
+        p
+    }
+
+    #[test]
+    fn build_adopted_snapshot_field_by_field() {
+        let policy = policy_fixture(None);
+        let cand = AdoptionCandidate {
+            namespace: "disc-ns".into(),
+            name: "row-aaa".into(),
+            snapshot_id: "0123456789abcdef0123".into(),
+            identity: identity("app", "billing", Some("/data")),
+            timing: Some(SnapshotTiming {
+                start_time: Some("2026-01-01T00:00:00Z".into()),
+                end_time: Some("2026-01-01T00:01:00Z".into()),
+                duration_seconds: Some(60),
+            }),
+            stats: Some(SnapshotStats {
+                size_bytes: Some(4096),
+                ..Default::default()
+            }),
+            pinned: true,
+        };
+        let (snap, status) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
+
+        // Name: <policy>-adopted-<first16(id)>, in the policy's namespace.
+        assert_eq!(snap.name_any(), "app-adopted-0123456789abcdef");
+        assert_eq!(snap.namespace().as_deref(), Some("billing"));
+
+        // Labels mirror the discovered set + CONFIG_LABEL.
+        let labels = snap.labels();
+        assert_eq!(
+            labels.get(ORIGIN_LABEL).map(String::as_str),
+            Some("adopted")
+        );
+        assert_eq!(labels.get(CONFIG_LABEL).map(String::as_str), Some("app"));
+        assert_eq!(
+            labels.get(SNAPSHOT_ID_LABEL).map(String::as_str),
+            Some("0123456789abcdef0123")
+        );
+        assert_eq!(
+            labels.get(REPOSITORY_UID_LABEL).map(String::as_str),
+            Some("repo-uid-1")
+        );
+
+        // Spec: policyRef, deletionPolicy default = Delete, pin carried, no onScheduleDelete.
+        assert_eq!(snap.spec.policy_ref.as_ref().unwrap().name, "app");
+        assert_eq!(snap.spec.deletion_policy, Some(DeletionPolicy::Delete));
+        assert!(snap.spec.pin, "candidate.pinned is carried");
+        assert!(snap.spec.on_schedule_delete.is_none());
+
+        // Meta: NO ownerReferences (inv. 5).
+        assert!(
+            snap.metadata.owner_references.is_none(),
+            "adopted rows carry NO ownerReference"
+        );
+
+        // Status: phase/origin, id+identity, timing+stats verbatim, resolved-repo pin.
+        assert_eq!(status.phase, Some(SnapshotPhase::Succeeded));
+        assert_eq!(status.origin, Some(Origin::Adopted));
+        let info = status.snapshot.as_ref().unwrap();
+        assert_eq!(info.kopia_snapshot_id, "0123456789abcdef0123");
+        assert_eq!(info.identity, cand.identity);
+        assert_eq!(status.timing, cand.timing);
+        assert_eq!(status.stats, cand.stats);
+        let pinned = status
+            .resolved
+            .as_ref()
+            .unwrap()
+            .repository
+            .as_ref()
+            .unwrap();
+        assert_eq!(pinned.kind, RepositoryKind::Repository);
+        assert_eq!(pinned.name, "nas");
+        // A namespaced Repository ref pins the namespace it resolved against.
+        assert_eq!(pinned.namespace.as_deref(), Some("billing"));
+    }
+
+    #[test]
+    fn build_adopted_snapshot_honors_default_deletion_policy() {
+        let policy = policy_fixture(Some(DeletionPolicy::Orphan));
+        let cand = candidate("aaa", identity("app", "billing", Some("/data")), false);
+        let (snap, _) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
+        assert_eq!(snap.spec.deletion_policy, Some(DeletionPolicy::Orphan));
+    }
+
+    // -- event message -------------------------------------------------------
+
+    #[test]
+    fn adoption_event_message_states_count_identity_governance_and_both_opt_outs() {
+        let msg = adoption_event_message(3, "app@billing:/data");
+        assert!(msg.contains('3'), "count");
+        assert!(msg.contains("app@billing:/data"), "identity");
+        assert!(msg.contains("spec.retention"), "GFS governance / pruning");
+        assert!(msg.contains("pruned"), "states rows WILL be pruned");
+        assert!(msg.contains("spec.adoption: Ignore"), "policy opt-out");
+        assert!(
+            msg.contains("spec.catalog.adoption: Ignore"),
+            "repository opt-out"
+        );
+    }
+}

--- a/crates/controller/src/cache.rs
+++ b/crates/controller/src/cache.rs
@@ -163,6 +163,7 @@ mod tests {
             owner_ref: Default::default(),
             deletion_protection: None,
             mass_deletion_ack: None,
+            catalog: None,
         }
     }
 

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -152,15 +152,6 @@ pub fn reverify_due(token: Option<&str>, honored: Option<&str>, phase_ready: boo
     phase_ready && token.is_some() && token != honored
 }
 
-/// Whether a pending `catalog-scan-requested-at` token (stamped by the policy
-/// reconciler, M6, when adopting a delete-then-recreated repository) should force
-/// a catalog scan/bootstrap NOW, bypassing the refresh timer — the on-demand
-/// counterpart to [`refresh_due`]. Retirement is by TOKEN EQUALITY against
-/// `honored` (`status.catalog.scanRequestHonored`), deliberately NOT a comparison
-/// against `last_refresh_at`: a periodic- or generation-driven scan that happens
-/// to complete after the token was written must not look like it honored a
-/// request it started before the request even existed.
-///
 /// Whether a `catalog-scan-requested-at` token is still PENDING: present,
 /// non-empty, and not yet retired by TOKEN EQUALITY against `honored`
 /// (`status.catalog.scanRequestHonored`). Pure equality retirement — NO rate

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -66,6 +66,18 @@
 //! repository's status is byte-stable between refreshes (the status-churn rule).
 //! Object-store repositories re-list by recycling their finished bootstrap Job
 //! ([`bootstrap_recycle_due`]); bare-path filesystem repositories re-list in-process.
+//!
+//! A third, **on-demand** mechanism (M4) sits alongside the two above: the policy
+//! reconciler (M6) stamps `kopiur.home-operations.com/catalog-scan-requested-at`
+//! (an opaque RFC3339 token) on the `Repository`/`ClusterRepository` when adopting
+//! a delete-then-recreated repository, so its discovered snapshots materialize
+//! immediately rather than waiting for a spec change or the periodic-refresh
+//! timer. [`scan_requested_due`] decides whether a pending token should fire —
+//! retired by TOKEN EQUALITY against `status.catalog.scanRequestHonored` (never a
+//! `lastRefreshAt` comparison, which would let an unrelated periodic/generation
+//! scan silently "honor" a request it started before the request even existed),
+//! and rate-limited via `status.catalog.scanRequestAttemptAt` so a pending token
+//! against an unreachable backend cannot recreate bootstrap Jobs forever.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -124,6 +136,53 @@ pub fn reverify_due(token: Option<&str>, honored: Option<&str>, phase_ready: boo
     phase_ready && token.is_some() && token != honored
 }
 
+/// Whether a pending `catalog-scan-requested-at` token (stamped by the policy
+/// reconciler, M6, when adopting a delete-then-recreated repository) should force
+/// a catalog scan/bootstrap NOW, bypassing the refresh timer — the on-demand
+/// counterpart to [`refresh_due`]. Retirement is by TOKEN EQUALITY against
+/// `honored` (`status.catalog.scanRequestHonored`), deliberately NOT a comparison
+/// against `last_refresh_at`: a periodic- or generation-driven scan that happens
+/// to complete after the token was written must not look like it honored a
+/// request it started before the request even existed.
+///
+/// True iff ALL of:
+/// 1. `token` is present and non-empty.
+/// 2. `token != honored` (still pending).
+/// 3. Rate limit: `attempt_at` is `None`, OR `attempt_at` sorts lexicographically
+///    before `token` (a NEWER token than the last attempt re-arms immediately —
+///    RFC3339 timestamps sort chronologically), OR the previous attempt for THIS
+///    token is stale (`now - parse(attempt_at) >= retry_interval`: one retry per
+///    interval). An unparseable `attempt_at` is treated as absent (fail open —
+///    this code is the only writer of that field, so a parse failure means
+///    "never attempted", not "malformed forever").
+pub fn scan_requested_due(
+    token: Option<&str>,
+    honored: Option<&str>,
+    attempt_at: Option<&str>,
+    retry_interval: std::time::Duration,
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(token) = token.filter(|t| !t.is_empty()) else {
+        return false;
+    };
+    if Some(token) == honored {
+        return false;
+    }
+    let Some(attempt_at) = attempt_at else {
+        return true;
+    };
+    if attempt_at < token {
+        return true;
+    }
+    let Ok(attempt) = DateTime::parse_from_rfc3339(attempt_at) else {
+        return true;
+    };
+    let Ok(interval) = chrono::Duration::from_std(retry_interval) else {
+        return true;
+    };
+    attempt.with_timezone(&Utc) + interval <= now
+}
+
 /// Whether a `Snapshot` should (re)write the reverify-request annotation. Rate
 /// limited via the existing timestamp (shared across `Snapshot`s) so a wave of
 /// failures forces at most one re-probe per `min_interval`. Absent/unparseable ⇒ yes.
@@ -163,6 +222,7 @@ pub fn reconcile_interval(catalog: Option<&CatalogBounds>) -> std::time::Duratio
 /// and either the catalog refresh is due or the spec changed since the result
 /// was taken (`generation != observedGeneration` — a re-pointed backend must
 /// re-bootstrap, not keep reporting the old repository's identity).
+#[allow(clippy::too_many_arguments)]
 pub fn bootstrap_recycle_due(
     phase_is_ready: bool,
     generation: Option<i64>,
@@ -170,6 +230,10 @@ pub fn bootstrap_recycle_due(
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
     periodic_enabled: bool,
+    scan_requested_token: Option<&str>,
+    scan_requested_honored: Option<&str>,
+    scan_requested_attempt_at: Option<&str>,
+    scan_requested_retry_interval: std::time::Duration,
     now: DateTime<Utc>,
 ) -> bool {
     if !phase_is_ready {
@@ -180,25 +244,46 @@ pub fn bootstrap_recycle_due(
     }
     // The timed refresh arm only fires when periodic refresh is opted in; otherwise a
     // succeeded bootstrap is never recycled on a timer (one-time bootstrap semantics).
-    periodic_enabled && refresh_due(last_refresh_at, interval, now)
+    // The token arm (`scan_requested_due`) fires regardless of `periodic_enabled` — an
+    // on-demand request must not depend on an opt-in feature the user may not have set.
+    (periodic_enabled && refresh_due(last_refresh_at, interval, now))
+        || scan_requested_due(
+            scan_requested_token,
+            scan_requested_honored,
+            scan_requested_attempt_at,
+            scan_requested_retry_interval,
+            now,
+        )
 }
 
 /// `true` when a fresh repository listing should actually be SCANNED into the
 /// catalog (materialize/expire discovered rows): the timed refresh is due, OR
-/// the spec changed since the last reconciled generation. The generation arm is
-/// load-bearing for `catalog.retain` edits: a tightened `perIdentity` recycles
-/// the bootstrap Job for a fresh listing ([`bootstrap_recycle_due`]'s own
-/// generation arm), but gating the scan on `refresh_due` alone then threw that
-/// fresh result away — the over-cap rows only expired at the NEXT timed
-/// refresh (up to `refreshInterval` later), not on the spec change that asked
-/// for it. The caller passes the PRE-reconcile `status.observedGeneration`
-/// (the cached object), so the scan runs exactly once per spec change.
+/// the spec changed since the last reconciled generation, OR a
+/// `catalog-scan-requested-at` token is pending ([`scan_requested_due`]). The
+/// generation arm is load-bearing for `catalog.retain` edits: a tightened
+/// `perIdentity` recycles the bootstrap Job for a fresh listing
+/// ([`bootstrap_recycle_due`]'s own generation arm), but gating the scan on
+/// `refresh_due` alone then threw that fresh result away — the over-cap rows
+/// only expired at the NEXT timed refresh (up to `refreshInterval` later), not
+/// on the spec change that asked for it. The caller passes the PRE-reconcile
+/// `status.observedGeneration` (the cached object), so the scan runs exactly
+/// once per spec change. `scan_requested_token`/`_honored`/`_attempt_at` are the
+/// live annotation + status fields (`None` behaves byte-identically to before
+/// this arm existed); `scan_requested_retry_interval` is
+/// [`kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`], NOT the caller's
+/// `interval` (the token backoff cadence is fixed, independent of the user's
+/// configured `catalog.refreshInterval`).
+#[allow(clippy::too_many_arguments)]
 pub fn scan_due(
     generation: Option<i64>,
     observed_generation: Option<i64>,
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
     periodic_enabled: bool,
+    scan_requested_token: Option<&str>,
+    scan_requested_honored: Option<&str>,
+    scan_requested_attempt_at: Option<&str>,
+    scan_requested_retry_interval: std::time::Duration,
     now: DateTime<Utc>,
 ) -> bool {
     if generation != observed_generation {
@@ -206,7 +291,14 @@ pub fn scan_due(
     }
     // The initial scan runs on the generation arm above (first reconcile, spec change);
     // the timed re-scan only fires when periodic refresh is opted in.
-    periodic_enabled && refresh_due(last_refresh_at, interval, now)
+    (periodic_enabled && refresh_due(last_refresh_at, interval, now))
+        || scan_requested_due(
+            scan_requested_token,
+            scan_requested_honored,
+            scan_requested_attempt_at,
+            scan_requested_retry_interval,
+            now,
+        )
 }
 
 /// `true` when the *no-Job* path may (re-)create the bootstrap Job. The finished
@@ -224,6 +316,7 @@ pub fn scan_due(
 /// created). Unlike re-running *succeeded* work this converges, and the
 /// in-process filesystem path's stricter `terminal_gate_holds` hard-stop keys
 /// on a credential `resourceVersion` the mover path does not pin (yet).
+#[allow(clippy::too_many_arguments)]
 pub fn bootstrap_create_due(
     phase_is_ready: bool,
     generation: Option<i64>,
@@ -231,6 +324,10 @@ pub fn bootstrap_create_due(
     last_refresh_at: Option<&str>,
     interval: std::time::Duration,
     periodic_enabled: bool,
+    scan_requested_token: Option<&str>,
+    scan_requested_honored: Option<&str>,
+    scan_requested_attempt_at: Option<&str>,
+    scan_requested_retry_interval: std::time::Duration,
     now: DateTime<Utc>,
 ) -> bool {
     if !phase_is_ready {
@@ -243,6 +340,10 @@ pub fn bootstrap_create_due(
         last_refresh_at,
         interval,
         periodic_enabled,
+        scan_requested_token,
+        scan_requested_honored,
+        scan_requested_attempt_at,
+        scan_requested_retry_interval,
         now,
     )
 }
@@ -1258,6 +1359,10 @@ mod tests {
             None,
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + spec changed → recycle even when fresh — independent of the
@@ -1269,6 +1374,10 @@ mod tests {
             Some(&fresh),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + same generation + fresh → keep the finished Job.
@@ -1279,6 +1388,10 @@ mod tests {
             Some(&fresh),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + same generation + stale + periodic ON → recycle for a fresh listing.
@@ -1289,6 +1402,10 @@ mod tests {
             Some(&stale),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + same generation + stale + periodic OFF (default) → do NOT recycle
@@ -1300,6 +1417,45 @@ mod tests {
             Some(&stale),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
+    }
+
+    // Regression: with no scan-request token (M4), every arm above is byte-identical
+    // to pre-M4 behavior — this pins that `None` truly is a no-op, not just "usually".
+    #[test]
+    fn bootstrap_recycle_due_with_no_token_is_unchanged() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let fresh = (now - chrono::Duration::minutes(5)).to_rfc3339();
+        assert!(!bootstrap_recycle_due(
+            true,
+            Some(2),
+            Some(2),
+            Some(&fresh),
+            interval,
+            true,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
+        assert!(!bootstrap_recycle_due(
+            true,
+            Some(2),
+            Some(2),
+            Some(&fresh),
+            interval,
+            false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
     }
@@ -1322,6 +1478,10 @@ mod tests {
             Some(&fresh),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Settled generation + fresh stamp → byte-stable, no scan (the
@@ -1332,6 +1492,10 @@ mod tests {
             Some(&fresh),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Settled generation + stale stamp + periodic ON → the timed refresh fires.
@@ -1342,6 +1506,10 @@ mod tests {
             Some(&stale),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Settled generation + stale stamp + periodic OFF (default) → no timed re-scan.
@@ -1351,11 +1519,47 @@ mod tests {
             Some(&stale),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Never scanned + periodic OFF → still no timed scan (the initial scan runs on
         // the generation arm, not this timer).
-        assert!(!scan_due(Some(1), Some(1), None, interval, false, now));
+        assert!(!scan_due(
+            Some(1),
+            Some(1),
+            None,
+            interval,
+            false,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
+    }
+
+    // Regression: with no scan-request token (M4), `scan_due` is byte-identical to
+    // pre-M4 behavior.
+    #[test]
+    fn scan_due_with_no_token_is_unchanged() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let stale = (now - chrono::Duration::minutes(61)).to_rfc3339();
+        assert!(!scan_due(
+            Some(3),
+            Some(3),
+            Some(&stale),
+            interval,
+            false,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
     }
 
     // Regression guard for the TTL-reap loop: when the kube TTL controller
@@ -1377,6 +1581,10 @@ mod tests {
             None,
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + same generation + fresh scan → HOLD: the reaped Job must not
@@ -1388,6 +1596,10 @@ mod tests {
             Some(&fresh),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + refresh due + periodic ON → re-create for a fresh listing.
@@ -1398,6 +1610,10 @@ mod tests {
             Some(&stale),
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + refresh due + periodic OFF (default) → HOLD: no timed re-create.
@@ -1408,6 +1624,10 @@ mod tests {
             Some(&stale),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready + spec changed → re-create even when fresh (independent of the flag).
@@ -1418,6 +1638,10 @@ mod tests {
             Some(&fresh),
             interval,
             false,
+            None,
+            None,
+            None,
+            interval,
             now
         ));
         // Ready but never stamped + periodic ON → defensive re-run.
@@ -1428,6 +1652,102 @@ mod tests {
             None,
             interval,
             true,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
+    }
+
+    // Regression: with no scan-request token (M4), `bootstrap_create_due` is
+    // byte-identical to pre-M4 behavior.
+    #[test]
+    fn bootstrap_create_due_with_no_token_is_unchanged() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let fresh = (now - chrono::Duration::minutes(5)).to_rfc3339();
+        assert!(!bootstrap_create_due(
+            true,
+            Some(2),
+            Some(2),
+            Some(&fresh),
+            interval,
+            true,
+            None,
+            None,
+            None,
+            interval,
+            now
+        ));
+    }
+
+    #[test]
+    fn scan_requested_due_matrix() {
+        let now = Utc::now();
+        let retry = std::time::Duration::from_secs(3600);
+        let token = "2026-06-01T00:00:00Z";
+
+        // No token at all → never due.
+        assert!(!scan_requested_due(None, None, None, retry, now));
+        // Empty-string token (defensive; annotation value should never actually be
+        // empty, but the predicate must not treat it as pending) → never due.
+        assert!(!scan_requested_due(Some(""), None, None, retry, now));
+        // Token present, never honored, never attempted → due.
+        assert!(scan_requested_due(Some(token), None, None, retry, now));
+        // Token equals the last honored token → retired, not due.
+        assert!(!scan_requested_due(
+            Some(token),
+            Some(token),
+            None,
+            retry,
+            now
+        ));
+        // Token differs from an OLDER honored token → still due (a fresh request
+        // after a prior one was honored).
+        assert!(scan_requested_due(
+            Some(token),
+            Some("2026-05-01T00:00:00Z"),
+            None,
+            retry,
+            now
+        ));
+
+        // Attempt lexicographically OLDER than the token (a stale attempt predating
+        // this request, e.g. from a prior token) → re-arm immediately, due.
+        assert!(scan_requested_due(
+            Some(token),
+            None,
+            Some("2026-05-01T00:00:00Z"),
+            retry,
+            now
+        ));
+        // Attempt NEWER than the token and still fresh (within retry_interval) →
+        // rate-limited, not due.
+        let fresh_attempt = (now - chrono::Duration::minutes(5)).to_rfc3339();
+        assert!(!scan_requested_due(
+            Some(token),
+            None,
+            Some(&fresh_attempt),
+            retry,
+            now
+        ));
+        // Attempt NEWER than the token but stale (>= retry_interval old) → one retry
+        // per interval, due again.
+        let stale_attempt = (now - chrono::Duration::minutes(61)).to_rfc3339();
+        assert!(scan_requested_due(
+            Some(token),
+            None,
+            Some(&stale_attempt),
+            retry,
+            now
+        ));
+        // Unparseable attempt → fail open, due.
+        assert!(scan_requested_due(
+            Some(token),
+            None,
+            Some("not-a-time"),
+            retry,
             now
         ));
     }

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -410,19 +410,21 @@ impl ScanOwner<'_> {
     }
 }
 
-/// The kopia snapshot ids of scheduled/manual `Snapshot` CRs that resolve to
-/// this repository CR (via `status.resolved.repository` or the owner reference —
+/// The kopia snapshot ids of scheduled/manual/adopted `Snapshot` CRs that resolve
+/// to this repository CR (via `status.resolved.repository` or the owner reference —
 /// the same derivation `Restore` and the kubectl plugin use). These are this
-/// cluster's *produced* snapshots: a rescan must never duplicate them as
-/// discovered rows. Origin uses [`crate::snapshot::resolve_origin`]'s precedence
-/// (status, then label, default manual) — NOT the label alone, because a bare
-/// `kubectl create` manual Snapshot may never carry the origin label. Pure.
+/// cluster's *produced* (or adopted-into-managed) snapshots: a rescan must never
+/// duplicate them as discovered rows. Origin uses
+/// [`crate::snapshot::resolve_origin`]'s precedence (status, then label, default
+/// manual) — NOT the label alone, because a bare `kubectl create` manual Snapshot
+/// may never carry the origin label. Pure.
 pub fn produced_ids_for(owner: ScanOwner<'_>, snapshots: &[Snapshot]) -> BTreeSet<String> {
     use kopiur_api::Origin;
     snapshots
         .iter()
         .filter(|s| match crate::snapshot::resolve_origin(s) {
-            Origin::Scheduled | Origin::Manual => true,
+            // Adopted ids must never re-materialize as discovered rows either.
+            Origin::Scheduled | Origin::Manual | Origin::Adopted => true,
             Origin::Discovered => false,
         })
         .filter(|s| {

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -72,12 +72,28 @@
 //! (an opaque RFC3339 token) on the `Repository`/`ClusterRepository` when adopting
 //! a delete-then-recreated repository, so its discovered snapshots materialize
 //! immediately rather than waiting for a spec change or the periodic-refresh
-//! timer. [`scan_requested_due`] decides whether a pending token should fire —
-//! retired by TOKEN EQUALITY against `status.catalog.scanRequestHonored` (never a
-//! `lastRefreshAt` comparison, which would let an unrelated periodic/generation
-//! scan silently "honor" a request it started before the request even existed),
-//! and rate-limited via `status.catalog.scanRequestAttemptAt` so a pending token
-//! against an unreachable backend cannot recreate bootstrap Jobs forever.
+//! timer. Retirement is by TOKEN EQUALITY against `status.catalog.scanRequestHonored`
+//! (never a `lastRefreshAt` comparison, which would let an unrelated periodic/
+//! generation scan silently "honor" a request it started before the request even
+//! existed). The predicate is deliberately split in two, because a pending token
+//! feeds two DIFFERENT decisions that must not share a rate limit:
+//!
+//! - [`scan_requested_pending`] — pure equality retirement, no rate limit. Used
+//!   by [`scan_due`] to decide whether an ALREADY-COMPLETED bootstrap/listing
+//!   should be materialized into the catalog now.
+//! - [`scan_requested_due`] — [`scan_requested_pending`] plus a rate limit via
+//!   `status.catalog.scanRequestAttemptAt`. Used by [`bootstrap_recycle_due`]/
+//!   [`bootstrap_create_due`] to decide whether a NEW bootstrap Job may be
+//!   LAUNCHED, so a pending token against an unreachable backend cannot recreate
+//!   Jobs forever.
+//!
+//! Conflating the two (gating `scan_due` on the same rate-limited predicate that
+//! gates the launch) wedges the request forever: `bootstrap_create_due` stamps
+//! `scanRequestAttemptAt` the instant it launches a Job for a pending token, and
+//! the finalize pass that scans that Job's result runs moments later — so it
+//! would always see its own fresh stamp and refuse to scan, repeating
+//! recycle→create→succeed→no-scan on every retry interval without ever honoring
+//! the request.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -145,16 +161,45 @@ pub fn reverify_due(token: Option<&str>, honored: Option<&str>, phase_ready: boo
 /// to complete after the token was written must not look like it honored a
 /// request it started before the request even existed.
 ///
-/// True iff ALL of:
-/// 1. `token` is present and non-empty.
-/// 2. `token != honored` (still pending).
-/// 3. Rate limit: `attempt_at` is `None`, OR `attempt_at` sorts lexicographically
-///    before `token` (a NEWER token than the last attempt re-arms immediately —
-///    RFC3339 timestamps sort chronologically), OR the previous attempt for THIS
-///    token is stale (`now - parse(attempt_at) >= retry_interval`: one retry per
-///    interval). An unparseable `attempt_at` is treated as absent (fail open —
-///    this code is the only writer of that field, so a parse failure means
-///    "never attempted", not "malformed forever").
+/// Whether a `catalog-scan-requested-at` token is still PENDING: present,
+/// non-empty, and not yet retired by TOKEN EQUALITY against `honored`
+/// (`status.catalog.scanRequestHonored`). Pure equality retirement — NO rate
+/// limit.
+///
+/// This is the predicate [`scan_due`]'s token arm uses (deliberately NOT
+/// [`scan_requested_due`]): `scan_due` decides whether an ALREADY-COMPLETED
+/// bootstrap/listing gets materialized into the catalog, and that decision
+/// must never be gated on the launch-side attempt stamp. [`bootstrap_recycle_due`]/
+/// [`bootstrap_create_due`] write `scanRequestAttemptAt` the moment they launch a
+/// Job for a pending token; if `scan_due`'s finalize-time check reused that same
+/// rate-limited predicate, it would see its OWN just-written, still-fresh stamp
+/// and refuse to scan — wedging the request forever behind a
+/// recycle→create→succeed→no-scan loop that repeats every retry interval without
+/// ever honoring it. Retirement still happens exactly once: [`scan`] writes
+/// `scanRequestHonored` in the SAME pass that scans, so the next reconcile's
+/// `token != honored` check is immediately false.
+pub fn scan_requested_pending(token: Option<&str>, honored: Option<&str>) -> bool {
+    let Some(token) = token.filter(|t| !t.is_empty()) else {
+        return false;
+    };
+    Some(token) != honored
+}
+
+/// Whether a pending scan-request token should be allowed to LAUNCH a new
+/// bootstrap/scan attempt NOW — [`scan_requested_pending`] plus a rate limit on
+/// top. Used only by [`bootstrap_recycle_due`]/[`bootstrap_create_due`] (which
+/// decide whether to recreate a bootstrap Job against a possibly-unreachable
+/// backend); [`scan_due`] uses the un-rate-limited [`scan_requested_pending`]
+/// instead — see its doc for why conflating the two wedges the token forever.
+///
+/// True iff [`scan_requested_pending`] AND the rate limit allows a launch now:
+/// `attempt_at` is `None`, OR `attempt_at` sorts lexicographically before
+/// `token` (a NEWER token than the last attempt re-arms immediately — RFC3339
+/// timestamps sort chronologically), OR the previous attempt for THIS token is
+/// stale (`now - parse(attempt_at) >= retry_interval`: one retry per interval).
+/// An unparseable `attempt_at` is treated as absent (fail open — this code is
+/// the only writer of that field, so a parse failure means "never attempted",
+/// not "malformed forever").
 pub fn scan_requested_due(
     token: Option<&str>,
     honored: Option<&str>,
@@ -162,12 +207,12 @@ pub fn scan_requested_due(
     retry_interval: std::time::Duration,
     now: DateTime<Utc>,
 ) -> bool {
-    let Some(token) = token.filter(|t| !t.is_empty()) else {
-        return false;
-    };
-    if Some(token) == honored {
+    if !scan_requested_pending(token, honored) {
         return false;
     }
+    // `scan_requested_pending` returning `true` guarantees `token` is `Some`
+    // and non-empty.
+    let token = token.unwrap_or_default();
     let Some(attempt_at) = attempt_at else {
         return true;
     };
@@ -244,8 +289,13 @@ pub fn bootstrap_recycle_due(
     }
     // The timed refresh arm only fires when periodic refresh is opted in; otherwise a
     // succeeded bootstrap is never recycled on a timer (one-time bootstrap semantics).
-    // The token arm (`scan_requested_due`) fires regardless of `periodic_enabled` — an
-    // on-demand request must not depend on an opt-in feature the user may not have set.
+    // The token arm uses the RATE-LIMITED `scan_requested_due` (not
+    // `scan_requested_pending`): this predicate decides whether to recycle a
+    // finished Job so a NEW one gets launched, and a pending token against an
+    // unreachable backend must not do that on every reconcile — see
+    // `scan_requested_pending`'s doc for the full rationale of the split. Fires
+    // regardless of `periodic_enabled` — an on-demand request must not depend on
+    // an opt-in feature the user may not have set.
     (periodic_enabled && refresh_due(last_refresh_at, interval, now))
         || scan_requested_due(
             scan_requested_token,
@@ -259,20 +309,24 @@ pub fn bootstrap_recycle_due(
 /// `true` when a fresh repository listing should actually be SCANNED into the
 /// catalog (materialize/expire discovered rows): the timed refresh is due, OR
 /// the spec changed since the last reconciled generation, OR a
-/// `catalog-scan-requested-at` token is pending ([`scan_requested_due`]). The
-/// generation arm is load-bearing for `catalog.retain` edits: a tightened
+/// `catalog-scan-requested-at` token is pending ([`scan_requested_pending`]).
+/// The generation arm is load-bearing for `catalog.retain` edits: a tightened
 /// `perIdentity` recycles the bootstrap Job for a fresh listing
 /// ([`bootstrap_recycle_due`]'s own generation arm), but gating the scan on
 /// `refresh_due` alone then threw that fresh result away — the over-cap rows
 /// only expired at the NEXT timed refresh (up to `refreshInterval` later), not
 /// on the spec change that asked for it. The caller passes the PRE-reconcile
 /// `status.observedGeneration` (the cached object), so the scan runs exactly
-/// once per spec change. `scan_requested_token`/`_honored`/`_attempt_at` are the
-/// live annotation + status fields (`None` behaves byte-identically to before
-/// this arm existed); `scan_requested_retry_interval` is
-/// [`kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL`], NOT the caller's
-/// `interval` (the token backoff cadence is fixed, independent of the user's
-/// configured `catalog.refreshInterval`).
+/// once per spec change. `scan_requested_token`/`_honored` are the live
+/// annotation + status fields (`None` behaves byte-identically to before this
+/// arm existed).
+///
+/// Deliberately [`scan_requested_pending`] (equality-retirement only, NO rate
+/// limit), NOT [`scan_requested_due`]: this predicate gates scanning a listing
+/// that ALREADY EXISTS (in-process, or from an already-succeeded bootstrap
+/// Job), not launching new work against a possibly-unreachable backend — see
+/// [`scan_requested_pending`]'s doc for why reusing the rate-limited predicate
+/// here would wedge every pending token behind the launch-side attempt stamp.
 #[allow(clippy::too_many_arguments)]
 pub fn scan_due(
     generation: Option<i64>,
@@ -282,8 +336,6 @@ pub fn scan_due(
     periodic_enabled: bool,
     scan_requested_token: Option<&str>,
     scan_requested_honored: Option<&str>,
-    scan_requested_attempt_at: Option<&str>,
-    scan_requested_retry_interval: std::time::Duration,
     now: DateTime<Utc>,
 ) -> bool {
     if generation != observed_generation {
@@ -292,13 +344,7 @@ pub fn scan_due(
     // The initial scan runs on the generation arm above (first reconcile, spec change);
     // the timed re-scan only fires when periodic refresh is opted in.
     (periodic_enabled && refresh_due(last_refresh_at, interval, now))
-        || scan_requested_due(
-            scan_requested_token,
-            scan_requested_honored,
-            scan_requested_attempt_at,
-            scan_requested_retry_interval,
-            now,
-        )
+        || scan_requested_pending(scan_requested_token, scan_requested_honored)
 }
 
 /// `true` when the *no-Job* path may (re-)create the bootstrap Job. The finished
@@ -1480,8 +1526,6 @@ mod tests {
             false,
             None,
             None,
-            None,
-            interval,
             now
         ));
         // Settled generation + fresh stamp → byte-stable, no scan (the
@@ -1494,8 +1538,6 @@ mod tests {
             true,
             None,
             None,
-            None,
-            interval,
             now
         ));
         // Settled generation + stale stamp + periodic ON → the timed refresh fires.
@@ -1508,8 +1550,6 @@ mod tests {
             true,
             None,
             None,
-            None,
-            interval,
             now
         ));
         // Settled generation + stale stamp + periodic OFF (default) → no timed re-scan.
@@ -1521,8 +1561,6 @@ mod tests {
             false,
             None,
             None,
-            None,
-            interval,
             now
         ));
         // Never scanned + periodic OFF → still no timed scan (the initial scan runs on
@@ -1535,8 +1573,6 @@ mod tests {
             false,
             None,
             None,
-            None,
-            interval,
             now
         ));
     }
@@ -1556,7 +1592,107 @@ mod tests {
             false,
             None,
             None,
+            now
+        ));
+    }
+
+    // Unit matrix for `scan_requested_pending`: pure equality retirement, no
+    // rate limit (Part C of the M4-review fix brief).
+    #[test]
+    fn scan_requested_pending_matrix() {
+        // No token → never pending.
+        assert!(!scan_requested_pending(None, None));
+        // Empty-string token (defensive) → never pending.
+        assert!(!scan_requested_pending(Some(""), None));
+        // Token present, never honored → pending.
+        assert!(scan_requested_pending(Some("t1"), None));
+        // Token equals the last honored token → retired, not pending.
+        assert!(!scan_requested_pending(Some("t1"), Some("t1")));
+        // Token differs from the last honored token (a fresh request after a
+        // prior one was honored) → pending.
+        assert!(scan_requested_pending(Some("t2"), Some("t1")));
+    }
+
+    // Critical regression for the M4 review defect: `scan_due`'s token arm used
+    // to delegate to the RATE-LIMITED `scan_requested_due`, so the finalize pass
+    // scanning a just-succeeded, token-driven bootstrap Job would see the very
+    // `scanRequestAttemptAt` stamp that launched it — still fresh — and refuse to
+    // scan. That wedged every pending token behind an infinite
+    // recycle→create→succeed→no-scan loop (bounded churn, unbounded duration;
+    // `scanRequestHonored` never written). This must fail on the pre-fix `scan_due`
+    // (which took `attempt_at`/`retry_interval` and OR'd in `scan_requested_due`).
+    #[test]
+    fn scan_due_fires_on_pending_token_even_when_the_launch_side_rate_limit_would_hold() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let token = "2026-06-01T00:00:00Z";
+        let fresh_attempt = (now - chrono::Duration::minutes(1)).to_rfc3339();
+
+        // Sanity: the LAUNCH-side rate-limited predicate correctly holds here —
+        // this is exactly what must keep protecting an unreachable repo from Job
+        // churn (traced in `bootstrap_recycle_due`/`bootstrap_create_due` below).
+        assert!(!scan_requested_due(
+            Some(token),
             None,
+            Some(&fresh_attempt),
+            interval,
+            now
+        ));
+        // But `scan_due` — deciding whether to materialize an ALREADY-COMPLETED
+        // listing — must fire anyway: the token is still pending, and this
+        // predicate is not the launch gate.
+        assert!(scan_due(
+            Some(2),
+            Some(2),
+            None,
+            interval,
+            false,
+            Some(token),
+            None,
+            now
+        ));
+    }
+
+    // The launch-side predicates must keep the rate limit intact: a pending
+    // token with a fresh attempt stamp does NOT relaunch a bootstrap Job (the
+    // guard against churning Jobs against an unreachable repository).
+    #[test]
+    fn bootstrap_recycle_due_holds_on_pending_token_with_fresh_attempt() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let token = "2026-06-01T00:00:00Z";
+        let fresh_attempt = (now - chrono::Duration::minutes(1)).to_rfc3339();
+        assert!(!bootstrap_recycle_due(
+            true,
+            Some(2),
+            Some(2),
+            None,
+            interval,
+            false,
+            Some(token),
+            None,
+            Some(&fresh_attempt),
+            interval,
+            now
+        ));
+    }
+
+    #[test]
+    fn bootstrap_create_due_holds_on_pending_token_with_fresh_attempt() {
+        let now = Utc::now();
+        let interval = std::time::Duration::from_secs(3600);
+        let token = "2026-06-01T00:00:00Z";
+        let fresh_attempt = (now - chrono::Duration::minutes(1)).to_rfc3339();
+        assert!(!bootstrap_create_due(
+            true,
+            Some(2),
+            Some(2),
+            None,
+            interval,
+            false,
+            Some(token),
+            None,
+            Some(&fresh_attempt),
             interval,
             now
         ));

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -532,8 +532,6 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
                 CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                 cluster_scan_requested_token(repo),
                 cluster_scan_requested_honored(repo),
-                cluster_scan_requested_attempt_at(repo),
-                kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -1502,8 +1500,6 @@ async fn finalize_cluster_bootstrap(
         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
         cluster_scan_requested_token(repo),
         cluster_scan_requested_honored(repo),
-        cluster_scan_requested_attempt_at(repo),
-        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
         chrono::Utc::now(),
     ) {
         run_cluster_catalog_scan(

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -143,7 +143,7 @@ fn mass_deletion_ack_raw(repo: &ClusterRepository) -> Option<&str> {
 /// live Snapshot store (ADR-0005 §6; shared
 /// [`crate::snapshot::repo_mass_deletion_conditions`]). Unchanged when the store
 /// is unset/unsynced.
-fn fold_mass_deletion(
+async fn fold_mass_deletion(
     ctx: &Context,
     repo: &ClusterRepository,
     conditions: &[Condition],
@@ -153,9 +153,11 @@ fn fold_mass_deletion(
         &cluster_repository_ref(repo),
         mass_deletion_ack_raw(repo),
         repo.spec.deletion_protection.as_ref(),
+        repo.spec.on_namespace_delete,
         conditions,
         repo.metadata.generation,
     )
+    .await
 }
 
 /// Which namespace a cluster-scoped repository reads its credential `Secret` from (and
@@ -477,7 +479,7 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
                 .map(|s| s.conditions.clone())
                 .unwrap_or_default();
             // Non-blocking MassDeletionHeld condition from the live Snapshot store.
-            let existing = fold_mass_deletion(ctx, repo, &existing);
+            let existing = fold_mass_deletion(ctx, repo, &existing).await;
             let conditions = io::set_ready(
                 &existing,
                 repo.metadata.generation,
@@ -976,7 +978,7 @@ async fn bootstrap_cluster_via_mover(
         // ack-drain watch also lands here on an annotation edit). Own guarded
         // write from the FRESH conditions (no clobber, skipped when unchanged);
         // ensure_maintenance then builds on the folded array.
-        let conditions = fold_mass_deletion(ctx, repo, &conditions);
+        let conditions = fold_mass_deletion(ctx, repo, &conditions).await;
         let current = fresh
             .as_ref()
             .and_then(|f| serde_json::to_value(&f.status).ok());
@@ -1409,7 +1411,7 @@ async fn finalize_cluster_bootstrap(
     }
     // Non-blocking MassDeletionHeld condition from the live Snapshot store,
     // folded into the conditions array before the kstatus set_ready.
-    let conditions = fold_mass_deletion(ctx, repo, &conditions);
+    let conditions = fold_mass_deletion(ctx, repo, &conditions).await;
     // Publish the standard kstatus Ready/Reconciling/Stalled conditions for the
     // healthy repository (issue #245), layered onto the conditions built above so
     // the merge-patch replace of `conditions` still carries Bootstrapped and

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -530,6 +530,10 @@ async fn reconcile_inner(repo: &ClusterRepository, ctx: &Context) -> Result<Acti
                 cluster_last_refresh_at(repo),
                 interval,
                 CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+                cluster_scan_requested_token(repo),
+                cluster_scan_requested_honored(repo),
+                cluster_scan_requested_attempt_at(repo),
+                kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -563,6 +567,34 @@ fn cluster_last_refresh_at(repo: &ClusterRepository) -> Option<&str> {
         .as_ref()
         .and_then(|s| s.catalog.as_ref())
         .and_then(|c| c.last_refresh_at.as_deref())
+}
+
+/// The live `catalog-scan-requested-at` annotation value (opaque token; the
+/// writer is the policy reconciler, M6). `None` when never requested.
+fn cluster_scan_requested_token(repo: &ClusterRepository) -> Option<&str> {
+    repo.metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::CATALOG_SCAN_REQUESTED_ANNOTATION))
+        .map(String::as_str)
+}
+
+/// `status.catalog.scanRequestHonored` from the cached object — the token last
+/// retired by a completed scan (equality-compared against the live annotation).
+fn cluster_scan_requested_honored(repo: &ClusterRepository) -> Option<&str> {
+    repo.status
+        .as_ref()
+        .and_then(|s| s.catalog.as_ref())
+        .and_then(|c| c.scan_request_honored.as_deref())
+}
+
+/// `status.catalog.scanRequestAttemptAt` from the cached object — rate-limits
+/// how often a pending token may (re-)launch a bootstrap/scan attempt.
+fn cluster_scan_requested_attempt_at(repo: &ClusterRepository) -> Option<&str> {
+    repo.status
+        .as_ref()
+        .and_then(|s| s.catalog.as_ref())
+        .and_then(|c| c.scan_request_attempt_at.as_deref())
 }
 
 /// The `DiscoveredSnapshotUnplaced` Warning event body: names the offending
@@ -647,16 +679,24 @@ async fn run_cluster_catalog_scan(
     let size_bytes = crate::repository::logical_bytes_under_management(listing);
     ctx.metrics.set_repo_size_bytes("", name, size_bytes);
 
+    let mut catalog_patch = serde_json::json!({
+        "discoveredBackupCount": outcome.discovered,
+        "lastRefreshAt": chrono::Utc::now().to_rfc3339(),
+        "foreignSnapshotCount": foreign_total,
+    });
+    // Retire a pending `catalog-scan-requested-at` token: ANY completed scan (not
+    // just one the token itself triggered) honors it — see the `Repository` twin
+    // (`run_catalog_scan`). `scanRequestAttemptAt` is deliberately left as-is;
+    // equality retirement makes it inert from here on regardless of its value.
+    if let Some(token) = cluster_scan_requested_token(repo) {
+        catalog_patch["scanRequestHonored"] = serde_json::Value::String(token.to_string());
+    }
     let api: Api<ClusterRepository> = Api::all(ctx.client.clone());
     io::patch_status(
         &api,
         name,
         serde_json::json!({
-            "catalog": {
-                "discoveredBackupCount": outcome.discovered,
-                "lastRefreshAt": chrono::Utc::now().to_rfc3339(),
-                "foreignSnapshotCount": foreign_total,
-            },
+            "catalog": catalog_patch,
             "storageStats": { "snapshotCount": total_snapshot_count, "totalSizeBytes": size_bytes },
         }),
     )
@@ -876,6 +916,10 @@ async fn bootstrap_cluster_via_mover(
                         cluster_last_refresh_at(repo),
                         interval,
                         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+                        cluster_scan_requested_token(repo),
+                        cluster_scan_requested_honored(repo),
+                        cluster_scan_requested_attempt_at(repo),
+                        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                         chrono::Utc::now(),
                     )
                 {
@@ -905,6 +949,10 @@ async fn bootstrap_cluster_via_mover(
             cluster_last_refresh_at(repo),
             CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
             CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+            cluster_scan_requested_token(repo),
+            cluster_scan_requested_honored(repo),
+            cluster_scan_requested_attempt_at(repo),
+            kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
             chrono::Utc::now(),
         ))
     {
@@ -946,6 +994,19 @@ async fn bootstrap_cluster_via_mover(
             repo,
         )));
     }
+
+    // Whether we are about to launch a Job BECAUSE OF a pending scan-request
+    // token (regardless of whatever else also fired the gate above) — used only
+    // to stamp `scanRequestAttemptAt` below, the token arm's own rate limit. It
+    // never gates anything else, so recomputing it here (rather than plumbing a
+    // bool out of `bootstrap_create_due`) is simplest and stays pure.
+    let token_driven_scan_request = catalog::scan_requested_due(
+        cluster_scan_requested_token(repo),
+        cluster_scan_requested_honored(repo),
+        cluster_scan_requested_attempt_at(repo),
+        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
+        chrono::Utc::now(),
+    );
 
     // Part A: only a never-bootstrapped ClusterRepository (no pinned `uniqueId`)
     // may carry `auto_create`; a once-`Ready` one re-runs as a pure connect probe.
@@ -1115,6 +1176,16 @@ async fn bootstrap_cluster_via_mover(
     };
     if let Some(token) = reverify_token {
         create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    // Rate-limit backoff for the scan-request token: stamped BEFORE the outcome is
+    // known (a probe-style failure never lands in `run_cluster_catalog_scan`, so
+    // the honored-write there is not a reliable place to bound retries) — see
+    // `catalog::scan_requested_due`. Merge-patched under `catalog` so the other
+    // `status.catalog` fields (lastRefreshAt, scanRequestHonored, ...) are untouched.
+    if token_driven_scan_request {
+        create_status["catalog"] = serde_json::json!({
+            "scanRequestAttemptAt": chrono::Utc::now().to_rfc3339(),
+        });
     }
     io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), namespace = %job_ns, "launched ClusterRepository bootstrap Job");
@@ -1429,6 +1500,10 @@ async fn finalize_cluster_bootstrap(
         cluster_last_refresh_at(repo),
         interval,
         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+        cluster_scan_requested_token(repo),
+        cluster_scan_requested_honored(repo),
+        cluster_scan_requested_attempt_at(repo),
+        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
         chrono::Utc::now(),
     ) {
         run_cluster_catalog_scan(

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -102,6 +102,20 @@ pub const REVERIFY_REQUESTED_ANNOTATION: &str = "kopiur.home-operations.com/reve
 pub const CATALOG_SCAN_REQUESTED_ANNOTATION: &str =
     "kopiur.home-operations.com/catalog-scan-requested-at";
 
+/// Normal Event reason on a `SnapshotPolicy` when auto-adoption re-attached one
+/// or more discovered snapshots into it (M6). The note names the count, the
+/// resolved identity, that the rows are now GFS-governed, and both opt-outs.
+pub const SNAPSHOTS_ADOPTED_REASON: &str = "SnapshotsAdopted";
+/// Event `action` (guidance) for [`SNAPSHOTS_ADOPTED_REASON`]: how to opt out of
+/// automatic adoption.
+pub const REVIEW_ADOPTION_ACTION: &str = "ReviewAdoption";
+/// Normal Event reason on a `SnapshotPolicy` when it stamped an on-demand
+/// catalog-scan request ([`CATALOG_SCAN_REQUESTED_ANNOTATION`]) on its
+/// repository so newly-recreated snapshots materialize for adoption (M6).
+pub const ADOPTION_SCAN_REQUESTED_REASON: &str = "AdoptionScanRequested";
+/// Event `action` (guidance) for [`ADOPTION_SCAN_REQUESTED_REASON`].
+pub const AWAIT_CATALOG_SCAN_ACTION: &str = "AwaitCatalogScan";
+
 /// Condition reason when a `Maintenance` (managed or external) covers the repo.
 pub const MAINTENANCE_CONFIGURED_REASON: &str = "MaintenanceConfigured";
 /// `action` for the maintenance-configuration check Event.

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -90,6 +90,18 @@ pub const REPLICATION_SLOT_ANNOTATION: &str = "kopiur.home-operations.com/replic
 /// `status.lastReverifyAt`; rate-limited so a wave of failures forces one re-probe.
 pub const REVERIFY_REQUESTED_ANNOTATION: &str = "kopiur.home-operations.com/reverify-requested-at";
 
+/// Annotation stamped on a `Repository`/`ClusterRepository` (writer: the policy
+/// reconciler, M6) to REQUEST an on-demand catalog scan — e.g. after adopting a
+/// delete-then-recreated repository, so its discovered snapshots materialize
+/// immediately instead of waiting for the next spec change or (opt-in) periodic
+/// refresh. The RFC3339 timestamp VALUE is an opaque token: honored once via
+/// `status.catalog.scanRequestHonored` (equality, never a `lastRefreshAt`
+/// comparison — see [`crate::catalog::scan_requested_due`]), and rate-limited via
+/// `status.catalog.scanRequestAttemptAt` so a pending token against an
+/// unreachable backend cannot recreate bootstrap Jobs on every reconcile.
+pub const CATALOG_SCAN_REQUESTED_ANNOTATION: &str =
+    "kopiur.home-operations.com/catalog-scan-requested-at";
+
 /// Condition reason when a `Maintenance` (managed or external) covers the repo.
 pub const MAINTENANCE_CONFIGURED_REASON: &str = "MaintenanceConfigured";
 /// `action` for the maintenance-configuration check Event.

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -516,6 +516,10 @@ pub const SNAPSHOT_DELETION_HELD_REASON: &str = "SnapshotDeletionHeld";
 /// guard (`onScheduleDelete: Retain` with a gone/replaced owning
 /// `SnapshotSchedule`).
 pub const SNAPSHOT_RETAINED_ON_SCHEDULE_DELETE_REASON: &str = "SnapshotRetainedOnScheduleDelete";
+/// Event reason when a `Snapshot` is retained by the policy-deletion cascade
+/// (`pruned-by: policy-cascade`, stamped when the owning `SnapshotPolicy` is
+/// gone and `onPolicyDelete: Retain`).
+pub const SNAPSHOT_RETAINED_ON_POLICY_DELETE_REASON: &str = "SnapshotRetainedOnPolicyDelete";
 /// Event reason when [`ALLOW_MASS_DELETION_ANNOTATION`]'s value fails to parse
 /// as an RFC3339 timestamp — the ack is ignored (fail-safe) rather than
 /// silently disarming the breaker.
@@ -540,3 +544,6 @@ pub const ACKNOWLEDGE_MASS_DELETION_ACTION: &str = "AcknowledgeMassDeletion";
 /// Event `action` for `SnapshotRetainedOnScheduleDelete`: opt into cascading
 /// deletes by setting the schedule's `spec.deletion.onScheduleDelete: Delete`.
 pub const ENABLE_SCHEDULE_CASCADE_ACTION: &str = "EnableScheduleCascade";
+/// Event `action` for `SnapshotRetainedOnPolicyDelete`: opt into cascading
+/// deletes by setting the policy's `spec.deletion.onPolicyDelete: Delete`.
+pub const ENABLE_POLICY_CASCADE_ACTION: &str = "EnablePolicyCascade";

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -455,6 +455,12 @@ pub const CHECK_WEBHOOK_CONFIGURATION_ACTION: &str = "CheckWebhookConfiguration"
 pub const WEBHOOK_CERT_NOT_AFTER_ANNOTATION: &str =
     "kopiur.home-operations.com/webhook-cert-not-after";
 
+/// Finalizer on a `SnapshotPolicy`, driving the deletion cascade onto its
+/// `Snapshot` children (`spec.deletion.onPolicyDelete`,
+/// [`crate::snapshot_policy::plan_policy_cascade`]) before the CR is removed.
+/// Controller-only — the webhook never stamps it.
+pub const POLICY_CLEANUP_FINALIZER: &str = "kopiur.home-operations.com/policy-cleanup";
+
 // --- kopia web-UI server (spec.server) -------------------------------------
 
 /// Finalizer on a `ClusterRepository` whose server children (Deployment/Service/

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -68,6 +68,39 @@ pub async fn publish_warning_event<K>(
     }
 }
 
+/// Emit a `Normal` Event on `obj` so an informational message is visible via
+/// `kubectl describe`/`get events`, not only in the controller log. The `Normal`
+/// counterpart to [`publish_warning_event`]: used for expected, non-error
+/// milestones (e.g. auto-adoption re-attaching discovered snapshots, M6).
+/// Best-effort: a publish failure is logged, never fatal.
+pub async fn publish_normal_event<K>(
+    ctx: &Context,
+    obj: &K,
+    reason: &str,
+    action: &str,
+    message: &str,
+) where
+    K: Resource<DynamicType = ()>,
+{
+    let regarding = event_ref(obj);
+    if let Err(e) = ctx
+        .recorder
+        .publish(
+            &Event {
+                type_: EventType::Normal,
+                reason: reason.into(),
+                note: Some(message.to_string()),
+                action: action.into(),
+                secondary: None,
+            },
+            &regarding,
+        )
+        .await
+    {
+        tracing::warn!(error = %e, reason, "failed to publish Normal event");
+    }
+}
+
 /// Emit a `Warning` Event on an explicit [`ObjectReference`], for a referent the
 /// reconciler does not hold as a typed object — e.g. the deletion finalizer
 /// warning about a malformed `allow-mass-deletion` ack on the repository CR it

--- a/crates/controller/src/io/prune.rs
+++ b/crates/controller/src/io/prune.rs
@@ -57,3 +57,19 @@ pub async fn annotate_then_delete_snapshot(
         Err(e) => Err(Error::Kube(e)),
     }
 }
+
+/// Bare UNSTAMPED delete of `name` — no `pruned-by` annotation. Used for the
+/// `SnapshotPolicy` deletion cascade's `delete_only` set
+/// ([`crate::snapshot_policy::PolicyCascadePlan`]): those children must
+/// classify as an EXTERNAL deletion (indistinguishable from a `kubectl
+/// delete`) so the per-repository mass-deletion breaker gates them — stamping
+/// here would launder an externally-classified deletion past the breaker.
+/// 404-tolerant and idempotent, mirroring [`annotate_then_delete_snapshot`]'s
+/// delete half.
+pub async fn delete_snapshot(api: &Api<Snapshot>, name: &str) -> Result<()> {
+    match api.delete(name, &DeleteParams::default()).await {
+        Ok(_) => Ok(()),
+        Err(kube::Error::Api(ae)) if ae.code == 404 => Ok(()),
+        Err(e) => Err(Error::Kube(e)),
+    }
+}

--- a/crates/controller/src/io/repo.rs
+++ b/crates/controller/src/io/repo.rs
@@ -6,8 +6,9 @@ use kube::runtime::reflector::Store;
 
 use kopiur_api::backend::Backend;
 use kopiur_api::common::{
-    DeletionProtectionSpec, Encryption, IdentityDefaults, MoverDefaults, NamespaceDeletePolicy,
-    PhaseLabel, RepositoryKind, RepositoryMode, RepositoryRef, ScheduleDefaults,
+    CatalogBounds, DeletionProtectionSpec, Encryption, IdentityDefaults, MoverDefaults,
+    NamespaceDeletePolicy, PhaseLabel, RepositoryKind, RepositoryMode, RepositoryRef,
+    ScheduleDefaults,
 };
 use kopiur_api::preflight::{PreflightInputs, UNKNOWN_AGE};
 use kopiur_api::repository::{RepositoryHealthStatus, RepositoryPhase, StorageStats};
@@ -102,6 +103,15 @@ pub struct ResolvedRepository {
     /// malformed value loudly rather than silently disarming the breaker) is
     /// the consumer's job (M4's breaker evaluation), not this resolver's.
     pub mass_deletion_ack: Option<String>,
+    /// The repository's `spec.catalog` bounds (`CatalogBounds`), cloned verbatim
+    /// from either repo kind. Carries `catalog.adoption`, the middle link of the
+    /// policy → repo → constant adoption-policy chain the `SnapshotPolicy`
+    /// reconciler resolves via
+    /// [`kopiur_api::common::effective_adoption`](kopiur_api::common::effective_adoption)
+    /// before running auto-adoption (M6). `None` → no catalog config, so
+    /// adoption falls through to the policy's own `spec.adoption` (else the
+    /// default).
+    pub catalog: Option<CatalogBounds>,
 }
 
 /// Which API a [`RepositoryRef`] resolves against, derived purely from `kind`.
@@ -204,6 +214,7 @@ pub async fn resolve_repository_ref(
                 owner_ref,
                 deletion_protection: repo.spec.deletion_protection,
                 mass_deletion_ack,
+                catalog: repo.spec.catalog,
             })
         }
         RepoLookup::Cluster { name } => {
@@ -231,6 +242,7 @@ pub async fn resolve_repository_ref(
                 owner_ref,
                 deletion_protection: repo.spec.deletion_protection,
                 mass_deletion_ack,
+                catalog: repo.spec.catalog,
             })
         }
     }
@@ -498,6 +510,44 @@ pub async fn request_repository_reverify(
         }
     }
     Ok(())
+}
+
+/// Stamp the on-demand catalog-scan-request annotation
+/// ([`crate::consts::CATALOG_SCAN_REQUESTED_ANNOTATION`]) with `token` (an opaque
+/// RFC3339 timestamp) on the referenced `Repository`/`ClusterRepository`, so its
+/// discovered snapshots re-materialize now instead of waiting for the next spec
+/// change or periodic refresh (M6 auto-adoption). Mirrors the reverify-annotation
+/// idiom ([`request_repository_reverify`]) but carries no rate limit of its own —
+/// the policy reconciler already gates *when* it stamps (per-identity, once, or on
+/// an actual adoption wave). 404-tolerant: a repository deleted out from under the
+/// policy is a no-op, not an error.
+pub async fn request_catalog_scan(
+    client: &kube::Client,
+    repo_ref: &RepositoryRef,
+    default_ns: &str,
+    token: &str,
+) -> Result<()> {
+    let key = crate::consts::CATALOG_SCAN_REQUESTED_ANNOTATION;
+    let body = Patch::Merge(serde_json::json!({
+        "metadata": { "annotations": { key: token } }
+    }));
+    let pp = PatchParams::apply(super::apply::FIELD_MANAGER);
+    let outcome = match repo_lookup(repo_ref, default_ns) {
+        RepoLookup::Namespaced { namespace, name } => {
+            let api: Api<Repository> = Api::namespaced(client.clone(), &namespace);
+            api.patch(&name, &pp, &body).await.map(|_| ())
+        }
+        RepoLookup::Cluster { name } => {
+            let api: Api<ClusterRepository> = Api::all(client.clone());
+            api.patch(&name, &pp, &body).await.map(|_| ())
+        }
+    };
+    match outcome {
+        Ok(()) => Ok(()),
+        // The repository was deleted out from under the policy — a no-op.
+        Err(kube::Error::Api(ae)) if ae.code == 404 => Ok(()),
+        Err(e) => Err(Error::Kube(e)),
+    }
 }
 
 /// Whether the named `Namespace` is being torn down — its `deletionTimestamp` is

--- a/crates/controller/src/lib.rs
+++ b/crates/controller/src/lib.rs
@@ -1,6 +1,7 @@
 #![warn(missing_docs)]
 #![doc = include_str!("../README.md")]
 
+pub mod adoption;
 pub mod cache;
 pub mod catalog;
 pub mod cluster_repository;

--- a/crates/controller/src/metrics.rs
+++ b/crates/controller/src/metrics.rs
@@ -72,6 +72,7 @@ pub struct Metrics {
     orphaned_snapshots: Counter<u64>,
     snapshot_deletions: Counter<u64>,
     snapshots_cascade_retained: Counter<u64>,
+    snapshots_policy_cascade_retained: Counter<u64>,
     snapshot_delete_batch_jobs: Counter<u64>,
     snapshot_delete_batch_members: Counter<u64>,
     work_spec_cms_swept: Counter<u64>,
@@ -117,6 +118,13 @@ pub enum SnapshotDeletionOutcome {
     /// variant to `inc_snapshot_deletion` directly — it also bumps the
     /// narrower `kopiur_snapshots_cascade_retained` counter in one place.
     CascadeRetained,
+    /// Retained specifically because the policy-deletion cascade fired
+    /// (`pruned-by: policy-cascade` with the Snapshot's own effective
+    /// `deletionPolicy: Delete`). Prefer
+    /// [`Metrics::inc_snapshot_policy_cascade_retained`] over passing this
+    /// variant to `inc_snapshot_deletion` directly — it also bumps the
+    /// narrower `kopiur_snapshots_policy_cascade_retained` counter in one place.
+    PolicyCascadeRetained,
 }
 
 impl SnapshotDeletionOutcome {
@@ -127,6 +135,7 @@ impl SnapshotDeletionOutcome {
             SnapshotDeletionOutcome::Retained => "retained",
             SnapshotDeletionOutcome::Orphaned => "orphaned",
             SnapshotDeletionOutcome::CascadeRetained => "cascade_retained",
+            SnapshotDeletionOutcome::PolicyCascadeRetained => "policy_cascade_retained",
         }
     }
 }
@@ -249,8 +258,8 @@ impl Metrics {
         let snapshot_deletions = m
             .u64_counter("kopiur_snapshot_deletions")
             .with_description(
-                "Total Snapshot finalizer resolutions, by outcome \
-                 (deleted|retained|orphaned|cascade_retained) and namespace. Distinct from \
+                "Total Snapshot finalizer resolutions, by outcome (deleted|retained|orphaned| \
+                 cascade_retained|policy_cascade_retained) and namespace. Distinct from \
                  kopiur_snapshot_deletion_failures_total, which counts kopia delete-call \
                  FAILURES during finalizer handling, not resolutions — never sum the two.",
             )
@@ -263,6 +272,18 @@ impl Metrics {
                  A narrower, always-alongside view of \
                  kopiur_snapshot_deletions{outcome=\"cascade_retained\"} — both are bumped \
                  together by inc_snapshot_cascade_retained so the two series can't drift apart.",
+            )
+            .build();
+        let snapshots_policy_cascade_retained = m
+            .u64_counter("kopiur_snapshots_policy_cascade_retained")
+            .with_description(
+                "Total Snapshots retained specifically by the policy-deletion cascade \
+                 (pruned-by: policy-cascade with the Snapshot's own effective deletionPolicy: \
+                 Delete, when the owning SnapshotPolicy is gone and onPolicyDelete: Retain). A \
+                 narrower, always-alongside view of \
+                 kopiur_snapshot_deletions{outcome=\"policy_cascade_retained\"} — both are \
+                 bumped together by inc_snapshot_policy_cascade_retained so the two series can't \
+                 drift apart.",
             )
             .build();
         let snapshot_delete_batch_jobs = m
@@ -400,6 +421,7 @@ impl Metrics {
             orphaned_snapshots,
             snapshot_deletions,
             snapshots_cascade_retained,
+            snapshots_policy_cascade_retained,
             snapshot_delete_batch_jobs,
             snapshot_delete_batch_members,
             work_spec_cms_swept,
@@ -861,6 +883,17 @@ impl Metrics {
     pub fn inc_snapshot_cascade_retained(&self, ns: &str) {
         self.inc_snapshot_deletion(ns, SnapshotDeletionOutcome::CascadeRetained);
         self.snapshots_cascade_retained
+            .add(1, &[KeyValue::new("namespace", ns.to_string())]);
+    }
+
+    /// Record a `Snapshot` retained by the policy-deletion cascade: bumps BOTH
+    /// `kopiur_snapshot_deletions{outcome="policy_cascade_retained"}` and the
+    /// narrower `kopiur_snapshots_policy_cascade_retained`, in the one place,
+    /// so the two series can never drift apart. Call this INSTEAD OF
+    /// `inc_snapshot_deletion(ns, SnapshotDeletionOutcome::PolicyCascadeRetained)`.
+    pub fn inc_snapshot_policy_cascade_retained(&self, ns: &str) {
+        self.inc_snapshot_deletion(ns, SnapshotDeletionOutcome::PolicyCascadeRetained);
+        self.snapshots_policy_cascade_retained
             .add(1, &[KeyValue::new("namespace", ns.to_string())]);
     }
 
@@ -2048,6 +2081,7 @@ mod tests {
         let m = Metrics::new();
         m.inc_snapshot_deletion("ns", SnapshotDeletionOutcome::Deleted);
         m.inc_snapshot_cascade_retained("ns");
+        m.inc_snapshot_policy_cascade_retained("ns");
         m.inc_snapshot_delete_batch_job(BatchJobOutcome::Succeeded);
         m.inc_snapshot_delete_batch_members(BatchMemberOutcome::Deleted, 3);
 
@@ -2071,6 +2105,10 @@ mod tests {
         assert!(text.contains("outcome=\"deleted\""), "{text}");
         assert!(
             text.contains("kopiur_snapshots_cascade_retained_total"),
+            "{text}"
+        );
+        assert!(
+            text.contains("kopiur_snapshots_policy_cascade_retained_total"),
             "{text}"
         );
         assert!(

--- a/crates/controller/src/metrics.rs
+++ b/crates/controller/src/metrics.rs
@@ -81,6 +81,7 @@ pub struct Metrics {
     creds_secrets_reaped: Counter<u64>,
     projected_secrets_live: Gauge<i64>,
     snapshots_live: Gauge<i64>,
+    snapshots_adopted: Counter<u64>,
     schedule_backups_created: Counter<u64>,
     secrets_projected: Counter<u64>,
     backups_refused: Counter<u64>,
@@ -379,6 +380,16 @@ impl Metrics {
                  deliberate safe default) and this is the only thing that will tell you so.",
             )
             .build();
+        let snapshots_adopted = m
+            .u64_counter("kopiur_snapshots_adopted")
+            .with_description(
+                "Total discovered Snapshots auto-adopted into an identity-matching \
+                 SnapshotPolicy (status.origin flipped to Adopted), by namespace and policy. \
+                 Adopted rows are then GFS-governed and eventually pruned by the policy's \
+                 spec.retention — opt out with spec.adoption: Ignore on the policy or \
+                 spec.catalog.adoption: Ignore on the repository.",
+            )
+            .build();
         let schedule_backups_created = m
             .u64_counter("kopiur_schedule_snapshots_created")
             .with_description("Total Snapshot CRs created by a SnapshotSchedule.")
@@ -468,6 +479,7 @@ impl Metrics {
             creds_secrets_reaped,
             projected_secrets_live,
             snapshots_live,
+            snapshots_adopted,
             schedule_backups_created,
             secrets_projected,
             backups_refused,
@@ -996,6 +1008,19 @@ impl Metrics {
     /// Count a Snapshot CR created by a SnapshotSchedule.
     pub fn inc_schedule_backup_created(&self, ns: &str, name: &str) {
         self.schedule_backups_created.add(1, &ns_name(ns, name));
+    }
+
+    /// Count `n` discovered Snapshots auto-adopted into a `SnapshotPolicy`
+    /// (labels: `namespace`, `policy`). Called once per adoption wave with the
+    /// wave's count.
+    pub fn inc_snapshots_adopted(&self, ns: &str, policy: &str, n: u64) {
+        self.snapshots_adopted.add(
+            n,
+            &[
+                KeyValue::new("namespace", ns.to_string()),
+                KeyValue::new("policy", policy.to_string()),
+            ],
+        );
     }
 
     /// Count a backup refused by policy. `reason` is the same machine-readable

--- a/crates/controller/src/metrics.rs
+++ b/crates/controller/src/metrics.rs
@@ -73,6 +73,7 @@ pub struct Metrics {
     snapshot_deletions: Counter<u64>,
     snapshots_cascade_retained: Counter<u64>,
     snapshots_policy_cascade_retained: Counter<u64>,
+    policy_cascade_children_deleted: Counter<u64>,
     snapshot_delete_batch_jobs: Counter<u64>,
     snapshot_delete_batch_members: Counter<u64>,
     work_spec_cms_swept: Counter<u64>,
@@ -136,6 +137,31 @@ impl SnapshotDeletionOutcome {
             SnapshotDeletionOutcome::Orphaned => "orphaned",
             SnapshotDeletionOutcome::CascadeRetained => "cascade_retained",
             SnapshotDeletionOutcome::PolicyCascadeRetained => "policy_cascade_retained",
+        }
+    }
+}
+
+/// The `mode` label value for `kopiur_policy_cascade_children_deleted`: which
+/// `SnapshotPolicy` deletion-cascade mode ([`kopiur_api::common::PolicyDeletePolicy`])
+/// produced this action. Kept controller-local (mirroring
+/// [`SnapshotDeletionOutcome`]) so the metric label is a closed set independent
+/// of the API enum's wire representation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PolicyCascadeMode {
+    /// `PolicyDeletePolicy::Retain`: the child was stamped `pruned-by:
+    /// policy-cascade` then deleted (its kopia snapshot is never touched).
+    Retain,
+    /// `PolicyDeletePolicy::Delete`: the child was bare-deleted, unstamped,
+    /// classifying as an ordinary external deletion.
+    Delete,
+}
+
+impl PolicyCascadeMode {
+    /// The `mode` label value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PolicyCascadeMode::Retain => "retain",
+            PolicyCascadeMode::Delete => "delete",
         }
     }
 }
@@ -286,6 +312,18 @@ impl Metrics {
                  drift apart.",
             )
             .build();
+        let policy_cascade_children_deleted = m
+            .u64_counter("kopiur_policy_cascade_children_deleted")
+            .with_description(
+                "Total Snapshot children acted on by a SnapshotPolicy deletion-cascade \
+                 finalizer, by mode: retain = stamped pruned-by: policy-cascade then \
+                 deleted (the kopia snapshot itself is never touched); delete = a bare \
+                 unstamped delete, classifying as an ordinary external deletion subject \
+                 to the per-repository mass-deletion breaker. A terminating child merely \
+                 reclassified by a stamp-only pass is NOT counted here — its eventual \
+                 resolution is already covered by kopiur_snapshots_policy_cascade_retained.",
+            )
+            .build();
         let snapshot_delete_batch_jobs = m
             .u64_counter("kopiur_snapshot_delete_batch_jobs")
             .with_description(
@@ -422,6 +460,7 @@ impl Metrics {
             snapshot_deletions,
             snapshots_cascade_retained,
             snapshots_policy_cascade_retained,
+            policy_cascade_children_deleted,
             snapshot_delete_batch_jobs,
             snapshot_delete_batch_members,
             work_spec_cms_swept,
@@ -895,6 +934,20 @@ impl Metrics {
         self.inc_snapshot_deletion(ns, SnapshotDeletionOutcome::PolicyCascadeRetained);
         self.snapshots_policy_cascade_retained
             .add(1, &[KeyValue::new("namespace", ns.to_string())]);
+    }
+
+    /// Count one `Snapshot` child acted on by the `SnapshotPolicy`
+    /// deletion-cascade finalizer in `namespace`, under `mode`
+    /// (`stamp_and_delete` under Retain, bare `delete_only` under Delete —
+    /// NOT the non-blocking `stamp_only` reclassification).
+    pub fn inc_policy_cascade_children_deleted(&self, ns: &str, mode: PolicyCascadeMode) {
+        self.policy_cascade_children_deleted.add(
+            1,
+            &[
+                KeyValue::new("namespace", ns.to_string()),
+                KeyValue::new("mode", mode.as_str()),
+            ],
+        );
     }
 
     /// Count one mass-deletion batch-delete Job reaching a terminal outcome.

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -479,7 +479,7 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
             }
             // Non-blocking MassDeletionHeld condition from the live Snapshot store
             // (mirrors IndexBlobHealth), folded into the same conditions array.
-            let conditions = fold_mass_deletion(ctx, repo, &conditions);
+            let conditions = fold_mass_deletion(ctx, repo, &conditions).await;
             // Always publish the kstatus Ready conditions for the healthy bare-path
             // repo (issue #245), layered on any conditions built above — even when
             // no index-blob count was read, so a resume clears the suspend branch's
@@ -665,7 +665,7 @@ fn mass_deletion_ack_raw(repo: &Repository) -> Option<&str> {
 /// live Snapshot store (ADR-0005 §6; delegates to the shared
 /// [`crate::snapshot::repo_mass_deletion_conditions`]). Returns `conditions`
 /// unchanged when the store is unset/unsynced.
-fn fold_mass_deletion(
+async fn fold_mass_deletion(
     ctx: &Context,
     repo: &Repository,
     conditions: &[k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition],
@@ -675,9 +675,11 @@ fn fold_mass_deletion(
         &repository_ref(repo),
         mass_deletion_ack_raw(repo),
         repo.spec.deletion_protection.as_ref(),
+        repo.spec.on_namespace_delete,
         conditions,
         repo.metadata.generation,
     )
+    .await
 }
 
 /// Project this `Repository`'s `spec.maintenance` into its managed `Maintenance` CR and
@@ -895,7 +897,7 @@ async fn bootstrap_via_mover(
         // Own guarded write, sourced from the FRESH conditions so it carries all
         // of them (no clobber) and is skipped when unchanged; ensure_maintenance
         // then builds on the folded array.
-        let conditions = fold_mass_deletion(ctx, repo, &conditions);
+        let conditions = fold_mass_deletion(ctx, repo, &conditions).await;
         let current = fresh
             .as_ref()
             .and_then(|f| serde_json::to_value(&f.status).ok());
@@ -1425,7 +1427,7 @@ async fn finalize_bootstrap(
     // Non-blocking MassDeletionHeld condition from the live Snapshot store
     // (mirrors IndexBlobHealth), folded into the same conditions array before the
     // kstatus set_ready so the merge-patch replace carries it too.
-    let conditions = fold_mass_deletion(ctx, repo, &conditions);
+    let conditions = fold_mass_deletion(ctx, repo, &conditions).await;
     // Publish the standard kstatus Ready/Reconciling/Stalled conditions for the
     // healthy repository (issue #245), layered onto the conditions built above so
     // the merge-patch replace of `conditions` still carries Bootstrapped and

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -515,8 +515,6 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
                 CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
                 scan_requested_token(repo),
                 scan_requested_honored(repo),
-                scan_requested_attempt_at(repo),
-                kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -1482,8 +1480,6 @@ async fn finalize_bootstrap(
         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
         scan_requested_token(repo),
         scan_requested_honored(repo),
-        scan_requested_attempt_at(repo),
-        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
         chrono::Utc::now(),
     ) {
         run_catalog_scan(

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -513,6 +513,10 @@ async fn reconcile_inner(repo: &Repository, ctx: &Context) -> Result<Action> {
                 last_refresh_at(repo),
                 interval,
                 CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+                scan_requested_token(repo),
+                scan_requested_honored(repo),
+                scan_requested_attempt_at(repo),
+                kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                 chrono::Utc::now(),
             ) {
                 let listing = client.snapshot_list(None).await?;
@@ -599,6 +603,34 @@ fn last_refresh_at(repo: &Repository) -> Option<&str> {
         .as_ref()
         .and_then(|s| s.catalog.as_ref())
         .and_then(|c| c.last_refresh_at.as_deref())
+}
+
+/// The live `catalog-scan-requested-at` annotation value (opaque token; the
+/// writer is the policy reconciler, M6). `None` when never requested.
+fn scan_requested_token(repo: &Repository) -> Option<&str> {
+    repo.metadata
+        .annotations
+        .as_ref()
+        .and_then(|a| a.get(crate::consts::CATALOG_SCAN_REQUESTED_ANNOTATION))
+        .map(String::as_str)
+}
+
+/// `status.catalog.scanRequestHonored` from the cached object — the token last
+/// retired by a completed scan (equality-compared against the live annotation).
+fn scan_requested_honored(repo: &Repository) -> Option<&str> {
+    repo.status
+        .as_ref()
+        .and_then(|s| s.catalog.as_ref())
+        .and_then(|c| c.scan_request_honored.as_deref())
+}
+
+/// `status.catalog.scanRequestAttemptAt` from the cached object — rate-limits
+/// how often a pending token may (re-)launch a bootstrap/scan attempt.
+fn scan_requested_attempt_at(repo: &Repository) -> Option<&str> {
+    repo.status
+        .as_ref()
+        .and_then(|s| s.catalog.as_ref())
+        .and_then(|c| c.scan_request_attempt_at.as_deref())
 }
 
 /// The `Repository`'s currently-observed status conditions (empty when it has no status).
@@ -805,6 +837,10 @@ async fn bootstrap_via_mover(
                         last_refresh_at(repo),
                         interval,
                         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+                        scan_requested_token(repo),
+                        scan_requested_honored(repo),
+                        scan_requested_attempt_at(repo),
+                        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
                         chrono::Utc::now(),
                     )
                 {
@@ -835,6 +871,10 @@ async fn bootstrap_via_mover(
             last_refresh_at(repo),
             CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref()),
             CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+            scan_requested_token(repo),
+            scan_requested_honored(repo),
+            scan_requested_attempt_at(repo),
+            kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
             chrono::Utc::now(),
         ))
     {
@@ -871,6 +911,19 @@ async fn bootstrap_via_mover(
         ensure_repo_maintenance(ctx, repo, namespace, name, api, &conditions).await;
         return Ok(Action::requeue(probe_aware_reconcile_interval(repo)));
     }
+
+    // Whether we are about to launch a Job BECAUSE OF a pending scan-request
+    // token (regardless of whatever else also fired the gate above) — used only
+    // to stamp `scanRequestAttemptAt` below, the token arm's own rate limit. It
+    // never gates anything else, so recomputing it here (rather than plumbing a
+    // bool out of `bootstrap_create_due`) is simplest and stays pure.
+    let token_driven_scan_request = catalog::scan_requested_due(
+        scan_requested_token(repo),
+        scan_requested_honored(repo),
+        scan_requested_attempt_at(repo),
+        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
+        chrono::Utc::now(),
+    );
 
     // Build + apply the Job (ConfigMap carries the work spec; the result is
     // written back into the same ConfigMap under `result.json`).
@@ -1056,6 +1109,16 @@ async fn bootstrap_via_mover(
     };
     if let Some(token) = reverify_token {
         create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    // Rate-limit backoff for the scan-request token: stamped BEFORE the outcome is
+    // known (a probe-style failure never lands in `run_catalog_scan`, so the
+    // honored-write there is not a reliable place to bound retries) — see
+    // `catalog::scan_requested_due`. Merge-patched under `catalog` so the other
+    // `status.catalog` fields (lastRefreshAt, scanRequestHonored, ...) are untouched.
+    if token_driven_scan_request {
+        create_status["catalog"] = serde_json::json!({
+            "scanRequestAttemptAt": chrono::Utc::now().to_rfc3339(),
+        });
     }
     io::patch_status(api, name, create_status).await?;
     tracing::info!(repo = %name, backend = backend.kind_str(), "launched repository bootstrap Job");
@@ -1417,6 +1480,10 @@ async fn finalize_bootstrap(
         last_refresh_at(repo),
         interval,
         CatalogBounds::periodic_refresh_enabled(repo.spec.catalog.as_ref()),
+        scan_requested_token(repo),
+        scan_requested_honored(repo),
+        scan_requested_attempt_at(repo),
+        kopiur_api::consts::DEFAULT_CATALOG_REFRESH_INTERVAL,
         chrono::Utc::now(),
     ) {
         run_catalog_scan(
@@ -1632,15 +1699,24 @@ async fn run_catalog_scan(
         .set_repo_size_bytes(namespace, repo_name, size_bytes);
 
     let api: Api<Repository> = Api::namespaced(ctx.client.clone(), namespace);
+    let mut catalog_patch = serde_json::json!({
+        "discoveredBackupCount": outcome.discovered,
+        "lastRefreshAt": chrono::Utc::now().to_rfc3339(),
+        "foreignSnapshotCount": foreign_total,
+    });
+    // Retire a pending `catalog-scan-requested-at` token: ANY completed scan (not
+    // just one the token itself triggered) honors it, since the request was for
+    // "materialize the catalog", not "run a scan for this specific reason".
+    // `scanRequestAttemptAt` is deliberately left as-is — equality retirement
+    // (`token == honored`) makes it inert from here on regardless of its value.
+    if let Some(token) = scan_requested_token(repo) {
+        catalog_patch["scanRequestHonored"] = serde_json::Value::String(token.to_string());
+    }
     io::patch_status(
         &api,
         repo_name,
         serde_json::json!({
-            "catalog": {
-                "discoveredBackupCount": outcome.discovered,
-                "lastRefreshAt": chrono::Utc::now().to_rfc3339(),
-                "foreignSnapshotCount": foreign_total,
-            },
+            "catalog": catalog_patch,
             "storageStats": { "snapshotCount": total_snapshot_count, "totalSizeBytes": size_bytes },
         }),
     )

--- a/crates/controller/src/repository_replication.rs
+++ b/crates/controller/src/repository_replication.rs
@@ -613,6 +613,7 @@ mod tests {
             mode: RepositoryMode::ReadWrite,
             deletion_protection: None,
             mass_deletion_ack: None,
+            catalog: None,
         }
     }
 

--- a/crates/controller/src/snapshot/batch.rs
+++ b/crates/controller/src/snapshot/batch.rs
@@ -329,10 +329,23 @@ pub struct FireEligibility<'a> {
     /// The repository's namespace-deletion cascade policy — a terminating-
     /// namespace peer is fireable ONLY under `Delete`.
     pub on_namespace_delete: NamespaceDeletePolicy,
-    /// The member namespaces observed TERMINATING at fire time (resolved once
-    /// per distinct namespace by the caller). A namespace whose terminating-ness
-    /// could not be read is treated as terminating here — fail-safe UNDER-fire.
+    /// The member namespaces excluded from an `Orphan` peer's fire: `confirmed`
+    /// terminating ∪ `unreadable` (resolved once per distinct namespace by the
+    /// caller). An `onNamespaceDelete: Orphan` peer whose namespace is terminating
+    /// OR unreadable plans `OrphanSnapshot` on its OWN reconcile and must never be
+    /// deleted by a peer's fire, so both go here ([`fire_namespace_ok`]).
     pub terminating_namespaces: &'a HashSet<String>,
+    /// The member namespaces whose terminating-ness could NOT be read at fire time
+    /// (a `namespace_is_terminating` GET erred). A peer in such a namespace is
+    /// EXCLUDED from the FIRE set OUTRIGHT ([`fire_namespace_readable_ok`]),
+    /// regardless of `on_namespace_delete`: we cannot confirm the namespace is
+    /// terminating, so we must not delete a peer on the assumption that it is (its
+    /// own self-fire, whose LIVE namespace read resolves to NOT-terminating via
+    /// `unwrap_or(false)`, drains it correctly). Such a member is still COUNTED
+    /// toward the breaker (over-count is fail-safe). This set is a subset of
+    /// `terminating_namespaces`, so an `Orphan` peer is withheld by that exclusion
+    /// as well — belt-and-braces.
+    pub unreadable_namespaces: &'a HashSet<String>,
     /// Whether the `SnapshotSchedule` reflector store is synced. While `false`,
     /// a schedule-owned EXTERNAL peer is excluded (its owner state would default
     /// to `Alive`, disabling the cascade guard).
@@ -350,7 +363,10 @@ pub struct FireEligibility<'a> {
 ///   held wave's kopia data without an ack.
 /// - IMPORTANT-2: a peer whose namespace is terminating is excluded unless the
 ///   repository's `onNamespaceDelete` is `Delete` (an `Orphan`-destined member
-///   plans `OrphanSnapshot` on its own reconcile — never delete it here).
+///   plans `OrphanSnapshot` on its own reconcile — never delete it here). A peer
+///   whose namespace was UNREADABLE at fire time is excluded outright, whatever
+///   the policy — an unconfirmed terminating state must never authorize a peer's
+///   destructive delete ([`fire_namespace_readable_ok`]).
 /// - IMPORTANT-3a: while the schedule store is unsynced, a schedule-owned
 ///   EXTERNAL peer is excluded (cascade-retain-destined children would look
 ///   fireable when the owner lookup defaults to `Alive`).
@@ -371,6 +387,7 @@ pub fn fire_eligible(pending: Vec<PendingMember>, cx: &FireEligibility<'_>) -> V
             m.uid == cx.self_uid
                 || (fire_pin_ok(m)
                     && fire_schedule_ok(m, cx.schedule_synced)
+                    && fire_namespace_readable_ok(m, cx.unreadable_namespaces)
                     && fire_namespace_ok(m, cx.terminating_namespaces, cx.on_namespace_delete)
                     && fire_breaker_ok(m, breaker_tripping, cx.ack))
         })
@@ -389,6 +406,16 @@ fn fire_pin_ok(m: &PendingMember) -> bool {
 /// even during the store's startup window.
 fn fire_schedule_ok(m: &PendingMember, schedule_synced: bool) -> bool {
     schedule_synced || !m.external || !m.schedule_owned
+}
+
+/// IMPORTANT-2 (readable half): a peer whose namespace could NOT be read as
+/// terminating at fire time is NEVER fireable by a peer — we cannot confirm the
+/// namespace is being torn down, so a destructive delete must not ride an
+/// unconfirmed assumption (its own self-fire, whose LIVE read fails to
+/// NOT-terminating, drains it). Independent of `onNamespaceDelete`: an unreadable
+/// namespace is withheld under `Delete` too (unlike a CONFIRMED-terminating one).
+fn fire_namespace_readable_ok(m: &PendingMember, unreadable: &HashSet<String>) -> bool {
+    !unreadable.contains(&m.namespace)
 }
 
 /// IMPORTANT-2: a terminating-namespace peer is fireable only under
@@ -1265,6 +1292,37 @@ mod tests {
     }
 
     #[test]
+    fn pending_members_unreadable_namespace_keeps_retain_cascade_child_quiet() {
+        // C1 (plan half): a namespace whose terminating-ness could NOT be read is
+        // resolved into the `unreadable` set — NOT `confirmed` — and `pending_members`
+        // is fed ONLY the confirmed set. So a `policy-cascade` retain child in an
+        // unreadable namespace is evaluated in NON-terminating form and stays quiet-
+        // retained (never a counted/fireable destructive delete), exactly as the
+        // finalizer's self-CR path resolves the same unreadable read
+        // (`unwrap_or(false)`). On HEAD (Err→terminating merged into ONE set) it would
+        // have been counted AND become fireable under `onNamespaceDelete: Delete`.
+        let mut backup = member_fixture(
+            "pc",
+            true,
+            true,
+            Some(DeletionPolicy::Delete),
+            false,
+            false,
+            true,
+            Some(repo_ref()),
+        );
+        stamp_policy_cascade(&mut backup);
+        let s = Arc::new(backup);
+        // The child's namespace ("media") is UNREADABLE → absent from the confirmed
+        // set fed to pending_members.
+        let confirmed = HashSet::new();
+        assert!(
+            pending_members(&[s], KEY, alive, &confirmed, NamespaceDeletePolicy::Delete).is_empty(),
+            "a policy-cascade child in an unreadable namespace stays retain (not counted, not fireable)"
+        );
+    }
+
+    #[test]
     fn pending_members_retention_prune_stays_non_external_under_ns_teardown_delete() {
         // A genuine operator prune keeps `external: false` even in a terminating
         // namespace under Delete — it rides the batch Job but must never trip the
@@ -1377,9 +1435,17 @@ mod tests {
         }
     }
 
+    /// A shared empty `HashSet<String>` with `'static` lifetime, for the
+    /// `unreadable_namespaces` default in [`fire_cx`] (a fn can't return a borrow
+    /// of a set it creates locally).
+    fn empty_ns_set() -> &'static HashSet<String> {
+        static EMPTY: std::sync::OnceLock<HashSet<String>> = std::sync::OnceLock::new();
+        EMPTY.get_or_init(HashSet::new)
+    }
+
     /// A `FireEligibility` with benign defaults: no breaker (threshold 0), no
-    /// ack, `Delete` ns policy, nothing terminating, schedule synced. Each test
-    /// perturbs exactly the axis it exercises.
+    /// ack, `Delete` ns policy, nothing terminating, nothing unreadable, schedule
+    /// synced. Each test perturbs exactly the axis it exercises.
     fn fire_cx<'a>(self_uid: &'a str, terminating: &'a HashSet<String>) -> FireEligibility<'a> {
         FireEligibility {
             self_uid,
@@ -1387,6 +1453,7 @@ mod tests {
             ack: None,
             on_namespace_delete: NamespaceDeletePolicy::Delete,
             terminating_namespaces: terminating,
+            unreadable_namespaces: empty_ns_set(),
             schedule_synced: true,
         }
     }
@@ -1519,6 +1586,72 @@ mod tests {
             ..fire_cx("self", &terminating)
         };
         assert_eq!(fire_eligible(pending(), &delete).len(), 3);
+    }
+
+    #[test]
+    fn fire_eligible_excludes_unreadable_namespace_peer_even_under_delete() {
+        // C1: a peer whose namespace could NOT be read (an `Err` from
+        // `namespace_is_terminating`) is EXCLUDED from the fire set even under
+        // `onNamespaceDelete: Delete` — an unconfirmed terminating state must never
+        // authorize a peer's destructive delete. HEAD merged `Err` into the single
+        // `terminating` set, so under `Delete` such a peer WOULD have fired and
+        // deleted retain-promised kopia data in a namespace that is NOT terminating.
+        // The triggering self bypasses the exclusion (its finalizer path resolved
+        // authoritatively); a CONFIRMED-terminating peer under Delete still fires.
+        let unreadable: HashSet<String> = HashSet::from(["unreadable".to_string()]);
+        // The caller feeds `confirmed ∪ unreadable` as `terminating_namespaces`
+        // (here a separate CONFIRMED-terminating namespace "dying" joins the union).
+        let all: HashSet<String> = ["unreadable".to_string(), "dying".to_string()]
+            .into_iter()
+            .collect();
+        let cx = FireEligibility {
+            on_namespace_delete: NamespaceDeletePolicy::Delete,
+            unreadable_namespaces: &unreadable,
+            ..fire_cx("self", &all)
+        };
+        let pending = vec![
+            fmember("self", "unreadable", 100, true, true, false), // trigger in unreadable ns
+            fmember("unreadable-peer", "unreadable", 100, true, true, false),
+            fmember("confirmed-peer", "dying", 100, true, true, false), // confirmed-terminating
+            fmember("live-peer", "live", 100, true, true, false),
+        ];
+        assert_eq!(
+            sorted_uids(fire_eligible(pending, &cx)),
+            vec!["confirmed-peer", "live-peer", "self"],
+            "the unreadable-namespace PEER is withheld; self bypass + confirmed-terminating \
+             (Delete) + live peers fire"
+        );
+    }
+
+    #[test]
+    fn fire_eligible_excludes_unreadable_namespace_orphan_peer() {
+        // C1 (pre-existing protection preserved): an `Orphan` peer whose namespace
+        // is unreadable is still excluded from fire. Both the readable check AND the
+        // ns-Orphan exclusion (unreadable ∈ the `confirmed ∪ unreadable` union)
+        // withhold it — belt-and-braces.
+        let unreadable: HashSet<String> = HashSet::from(["unreadable".to_string()]);
+        let all: HashSet<String> = unreadable.clone();
+        let cx = FireEligibility {
+            on_namespace_delete: NamespaceDeletePolicy::Orphan,
+            unreadable_namespaces: &unreadable,
+            ..fire_cx("self", &all)
+        };
+        let pending = vec![
+            fmember("self", "live", 100, true, true, false),
+            fmember(
+                "unreadable-orphan-peer",
+                "unreadable",
+                100,
+                true,
+                true,
+                false,
+            ),
+        ];
+        assert_eq!(
+            sorted_uids(fire_eligible(pending, &cx)),
+            vec!["self"],
+            "an Orphan peer in an unreadable namespace stays withheld"
+        );
     }
 
     #[test]

--- a/crates/controller/src/snapshot/batch.rs
+++ b/crates/controller/src/snapshot/batch.rs
@@ -9,7 +9,7 @@
 //! to name/where to run it — all pure and clock-injected, so the whole
 //! decision surface is unit-tested without a cluster.
 
-use std::collections::HashSet;
+use std::collections::{BTreeSet, HashSet};
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -20,9 +20,9 @@ use kopiur_mover::workspec::SnapshotAnchor;
 use kube::{Resource, ResourceExt};
 
 use super::plan::{
-    BreakerState, DeletionFacts, DeletionPlan, OwnerState, effective_deletion_policy,
-    effective_on_schedule_delete, pinned_repository, plan_deletion, pruned_by, resolve_origin,
-    schedule_owner_ref,
+    BreakerState, DeletionFacts, DeletionPlan, OwnerState, breaker_relevant,
+    effective_deletion_policy, effective_on_schedule_delete, pinned_repository, plan_deletion,
+    pruned_by, resolve_origin, schedule_owner_ref,
 };
 
 /// Stable per-repo key from the `status.resolved.repository` pin:
@@ -66,12 +66,16 @@ pub struct PendingMember {
     pub snapshot_id: String,
     /// Stale-id self-heal anchor (mirrors `SnapshotDeleteOp::anchor`).
     pub anchor: SnapshotAnchor,
-    /// No valid pruned-by annotation. An operator prune's own plan (with the
-    /// breaker allowed) is ALSO `DeleteSnapshot`, so it IS eligible for the
-    /// same batch Job as an external deletion (dispatch is identical either
-    /// way) — this flag exists so the breaker-count logic downstream
-    /// ([`super::plan::counts_toward_breaker`], stricter than this filter)
-    /// can tell the two apart without re-deriving pruned-by itself.
+    /// Breaker-RELEVANT ([`super::plan::breaker_relevant`]): this member is a
+    /// destructive external delete that counts toward / can be held by the
+    /// mass-deletion breaker, NOT an exempt operator prune. Unstamped and
+    /// `policy-cascade` (which only reaches the counting set as a destructive
+    /// delete under an `onNamespaceDelete: Delete` teardown) are external;
+    /// `retention`/`failed-history` prunes are not. All ride the same batch Job
+    /// (dispatch is identical); this flag lets the count/held-set/ack-value logic
+    /// tell them apart without re-deriving pruned-by, and shares its exhaustive
+    /// classification with [`super::plan::counts_toward_breaker`] so they never
+    /// disagree on which stamps are exempt.
     pub external: bool,
     /// The CR's `metadata.deletionTimestamp`, converted to `chrono`.
     pub deletion_timestamp: chrono::DateTime<chrono::Utc>,
@@ -133,6 +137,43 @@ fn repo_matches(backup: &Snapshot, key: &str) -> bool {
     }
 }
 
+/// Distinct namespaces of the pending delete CANDIDATES for `key` — every CR
+/// with a `deletionTimestamp`, our finalizer, a matching repo pin, and a recorded
+/// snapshot id, BEFORE the plan filter. The caller resolves terminating-namespace
+/// state over these and feeds it to [`pending_members`], so each member's plan is
+/// evaluated in its real `(ns_terminating, ns_policy)` form. This is a SUPERSET of
+/// the final member namespaces (a retain-cascade member whose plan flips to a
+/// destructive external delete under `onNamespaceDelete: Delete` is dropped by the
+/// `ns_terminating: false` plan check but its namespace is retained here), so no
+/// would-flip member's namespace is missed. A candidate must have a
+/// `deletionTimestamp` — so this is bounded by the CRs actually being deleted, not
+/// the whole store.
+pub fn pending_candidate_namespaces(snapshots: &[Arc<Snapshot>], key: &str) -> BTreeSet<String> {
+    snapshots
+        .iter()
+        .filter(|s| is_pending_candidate(s, key))
+        .filter_map(|s| s.namespace())
+        .collect()
+}
+
+/// The candidate gate shared by [`pending_candidate_namespaces`] and
+/// [`pending_member_for`]: pending (`deletionTimestamp`), our finalizer present,
+/// repo pin matches `key`, and a recorded kopia snapshot id. Everything but the
+/// plan classification (which is what the namespace-terminating state feeds).
+fn is_pending_candidate(backup: &Snapshot, key: &str) -> bool {
+    deletion_timestamp_utc(backup).is_some()
+        && backup
+            .finalizers()
+            .iter()
+            .any(|f| f == crate::consts::SNAPSHOT_CLEANUP_FINALIZER)
+        && repo_matches(backup, key)
+        && backup
+            .status
+            .as_ref()
+            .and_then(|s| s.snapshot.as_ref())
+            .is_some()
+}
+
 /// Filter a Store snapshot list to the pending destructive set for `key`:
 /// `deletionTimestamp` set + our finalizer still present + plan-would-be
 /// `DeleteSnapshot` (re-run [`plan_deletion`] with `breaker = Allowed`; this
@@ -142,14 +183,26 @@ fn repo_matches(backup: &Snapshot, key: &str) -> bool {
 /// `status.snapshot.kopiaSnapshotID` present + repo match (see
 /// [`repo_matches`]). `owner_lookup` supplies the owner state for each
 /// candidate (the caller's schedule Store lookup).
+///
+/// Each member's plan is evaluated in its REAL `(ns_terminating, ns_policy)`
+/// form: `terminating` is the set of member namespaces observed terminating
+/// (resolved by the caller over [`pending_candidate_namespaces`]), and `ns_policy`
+/// is the repository's `onNamespaceDelete`. This is what makes a retain-cascade
+/// member (a `policy-cascade` stamp, or a schedule-cascade Retain) that flips to a
+/// destructive external delete under an `onNamespaceDelete: Delete` namespace
+/// teardown COUNT toward the breaker and become fireable — exactly like an
+/// unstamped external child. A non-terminating member's plan ignores `ns_policy`,
+/// so it is classified identically to the old `ns_terminating: false` form.
 pub fn pending_members(
     snapshots: &[Arc<Snapshot>],
     key: &str,
     owner_lookup: impl Fn(&Snapshot) -> OwnerState,
+    terminating: &HashSet<String>,
+    ns_policy: NamespaceDeletePolicy,
 ) -> Vec<PendingMember> {
     snapshots
         .iter()
-        .filter_map(|s| pending_member_for(s, key, &owner_lookup))
+        .filter_map(|s| pending_member_for(s, key, &owner_lookup, terminating, ns_policy))
         .collect()
 }
 
@@ -157,6 +210,8 @@ fn pending_member_for(
     backup: &Snapshot,
     key: &str,
     owner_lookup: &impl Fn(&Snapshot) -> OwnerState,
+    terminating: &HashSet<String>,
+    ns_policy: NamespaceDeletePolicy,
 ) -> Option<PendingMember> {
     let deletion_timestamp = deletion_timestamp_utc(backup)?;
     if !backup
@@ -176,14 +231,15 @@ fn pending_member_for(
         .as_ref()?
         .kopia_snapshot_id
         .clone();
+    let namespace = backup.namespace()?;
 
     let facts = DeletionFacts {
         policy: effective_deletion_policy(backup.spec.deletion_policy, resolve_origin(backup)),
         annotations: backup.annotations(),
         owner: owner_lookup(backup),
         cascade: effective_on_schedule_delete(backup.spec.on_schedule_delete),
-        ns_terminating: false,
-        ns_policy: None,
+        ns_terminating: terminating.contains(&namespace),
+        ns_policy: Some(ns_policy),
         breaker: BreakerState::Allowed,
     };
     if !matches!(plan_deletion(facts), DeletionPlan::DeleteSnapshot) {
@@ -191,12 +247,12 @@ fn pending_member_for(
     }
 
     Some(PendingMember {
-        namespace: backup.namespace()?,
+        namespace,
         name: backup.name_any(),
         uid: backup.uid()?,
         snapshot_id,
         anchor: anchor_for(backup),
-        external: pruned_by(backup.annotations()).is_none(),
+        external: breaker_relevant(pruned_by(backup.annotations())),
         deletion_timestamp,
         pinned: pinned_repository(backup).is_some(),
         schedule_owned: schedule_owner_ref(backup).is_some(),
@@ -861,7 +917,13 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        let members = pending_members(&[s], KEY, alive);
+        let members = pending_members(
+            &[s],
+            KEY,
+            alive,
+            &HashSet::new(),
+            NamespaceDeletePolicy::Delete,
+        );
         assert_eq!(members.len(), 1);
         assert_eq!(members[0].name, "a");
         assert_eq!(members[0].snapshot_id, "k-a");
@@ -894,7 +956,13 @@ mod tests {
             controller: Some(true),
             ..Default::default()
         }]);
-        let members = pending_members(&[Arc::new(backup)], KEY, alive);
+        let members = pending_members(
+            &[Arc::new(backup)],
+            KEY,
+            alive,
+            &HashSet::new(),
+            NamespaceDeletePolicy::Delete,
+        );
         assert_eq!(members.len(), 1);
         assert!(
             members[0].schedule_owned,
@@ -914,7 +982,16 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -929,7 +1006,16 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -944,7 +1030,16 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -959,7 +1054,16 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -981,7 +1085,13 @@ mod tests {
             true,
             Some(repo_ref()),
         ));
-        let members = pending_members(&[s], KEY, alive);
+        let members = pending_members(
+            &[s],
+            KEY,
+            alive,
+            &HashSet::new(),
+            NamespaceDeletePolicy::Delete,
+        );
         assert_eq!(members.len(), 1);
         assert!(!members[0].external);
     }
@@ -998,7 +1108,16 @@ mod tests {
             false,
             Some(repo_ref()),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -1014,7 +1133,16 @@ mod tests {
             true,
             Some(other),
         ));
-        assert!(pending_members(&[s], KEY, alive).is_empty());
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty()
+        );
     }
 
     #[test]
@@ -1030,16 +1158,169 @@ mod tests {
             true,
             None,
         ));
-        let matched = pending_members(&[Arc::clone(&s)], KEY, alive);
+        let matched = pending_members(
+            &[Arc::clone(&s)],
+            KEY,
+            alive,
+            &HashSet::new(),
+            NamespaceDeletePolicy::Delete,
+        );
         assert_eq!(matched.len(), 1);
         assert!(
             !matched[0].pinned,
             "an unpinned CR is `pinned: false` — the FIRE set excludes it as a peer"
         );
         assert_eq!(
-            pending_members(&[s], "clusterrepository:other", alive).len(),
+            pending_members(
+                &[s],
+                "clusterrepository:other",
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .len(),
             1
         );
+    }
+
+    /// Overwrite a fixture's `pruned-by` stamp with `policy-cascade` (the
+    /// `member_fixture` `pruned` flag only stamps `retention`).
+    fn stamp_policy_cascade(backup: &mut Snapshot) {
+        use kopiur_api::consts::PRUNED_BY_ANNOTATION;
+        use kopiur_api::snapshot::PrunedBy;
+        backup
+            .metadata
+            .annotations
+            .get_or_insert_with(BTreeMap::new)
+            .insert(
+                PRUNED_BY_ANNOTATION.to_string(),
+                PrunedBy::PolicyCascade.annotation_value().to_string(),
+            );
+    }
+
+    fn terminating_media() -> HashSet<String> {
+        HashSet::from(["media".to_string()])
+    }
+
+    #[test]
+    fn pending_members_includes_policy_cascade_child_under_ns_teardown_delete() {
+        // The PR #272 gap: a `policy-cascade`-stamped child in a TERMINATING
+        // namespace under `onNamespaceDelete: Delete` is an external destructive
+        // delete (plan_ns_delete → plan_external), so the counting set MUST include
+        // it — both so the breaker counts it AND so `fire_batch`'s self-uid bypass
+        // can fire it. On HEAD (`ns_terminating: false` hardcoded) its plan was
+        // RetainSnapshotOnPolicyDelete → EXCLUDED → never counted, never deleted.
+        let mut backup = member_fixture(
+            "pc",
+            true,
+            true,
+            Some(DeletionPolicy::Delete),
+            false,
+            false,
+            true,
+            Some(repo_ref()),
+        );
+        stamp_policy_cascade(&mut backup);
+        let s = Arc::new(backup);
+
+        let members = pending_members(
+            &[Arc::clone(&s)],
+            KEY,
+            alive,
+            &terminating_media(),
+            NamespaceDeletePolicy::Delete,
+        );
+        assert_eq!(members.len(), 1, "counted under ns-teardown Delete");
+        assert!(
+            members[0].external,
+            "a policy-cascade teardown delete is breaker-RELEVANT (external), so \
+             unacked_breaker_count/fire_breaker_ok can hold it like any external child"
+        );
+
+        // Live namespace → quiet retain → excluded (steady-state behavior kept).
+        assert!(
+            pending_members(
+                &[Arc::clone(&s)],
+                KEY,
+                alive,
+                &HashSet::new(),
+                NamespaceDeletePolicy::Delete
+            )
+            .is_empty(),
+            "a policy-cascade child in a live namespace stays quiet-retained, not counted"
+        );
+
+        // Terminating but ns policy Orphan → OrphanSnapshot → excluded.
+        assert!(
+            pending_members(
+                &[s],
+                KEY,
+                alive,
+                &terminating_media(),
+                NamespaceDeletePolicy::Orphan
+            )
+            .is_empty(),
+            "under Orphan the terminating child is orphaned, never a destructive delete"
+        );
+    }
+
+    #[test]
+    fn pending_members_retention_prune_stays_non_external_under_ns_teardown_delete() {
+        // A genuine operator prune keeps `external: false` even in a terminating
+        // namespace under Delete — it rides the batch Job but must never trip the
+        // breaker (retention keeps working during an incident).
+        let s = Arc::new(member_fixture(
+            "ret",
+            true,
+            true,
+            Some(DeletionPolicy::Delete),
+            false,
+            true, // pruned → retention stamp
+            true,
+            Some(repo_ref()),
+        ));
+        let members = pending_members(
+            &[s],
+            KEY,
+            alive,
+            &terminating_media(),
+            NamespaceDeletePolicy::Delete,
+        );
+        assert_eq!(members.len(), 1);
+        assert!(!members[0].external, "retention prune is breaker-exempt");
+    }
+
+    #[test]
+    fn pending_candidate_namespaces_covers_would_flip_retain_cascade_members() {
+        // The candidate set must include the namespace of a `policy-cascade` child
+        // whose live-form plan is a RETAIN (dropped by the plan filter) — otherwise
+        // its namespace's terminating-ness is never resolved and it can never flip
+        // to a counted/fireable delete. A candidate needs only a deletionTimestamp +
+        // finalizer + repo match + snapshot id, NOT a destructive plan.
+        let mut cascade = member_fixture(
+            "pc",
+            true,
+            true,
+            Some(DeletionPolicy::Delete),
+            false,
+            false,
+            true,
+            Some(repo_ref()),
+        );
+        stamp_policy_cascade(&mut cascade);
+        // A non-deleting CR is NOT a candidate (bounds the namespace reads).
+        let live = member_fixture(
+            "live",
+            false,
+            true,
+            Some(DeletionPolicy::Delete),
+            false,
+            false,
+            true,
+            Some(repo_ref()),
+        );
+        let nss = pending_candidate_namespaces(&[Arc::new(cascade), Arc::new(live)], KEY);
+        assert_eq!(nss, BTreeSet::from(["media".to_string()]));
     }
 
     // --- fireable_members --------------------------------------------------

--- a/crates/controller/src/snapshot/build.rs
+++ b/crates/controller/src/snapshot/build.rs
@@ -320,6 +320,7 @@ pub(super) fn origin_str(origin: Origin) -> &'static str {
         Origin::Scheduled => "scheduled",
         Origin::Manual => "manual",
         Origin::Discovered => "discovered",
+        Origin::Adopted => "adopted",
     }
 }
 

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -43,17 +43,18 @@ use crate::config;
 use crate::consts::{
     ACKNOWLEDGE_MASS_DELETION_ACTION, ALLOW_PRIVILEGED_MOVER_ACTION, API_VERSION,
     CREDENTIALS_AVAILABLE_CONDITION, CREDENTIALS_PROJECTED_REASON, DELETE_MEMBERS_ANNOTATION,
-    DELETE_REPO_LABEL, DELETION_HELD_CONDITION, ENABLE_SCHEDULE_CASCADE_ACTION, FIX_HOOK_ACTION,
-    FIX_SNAPSHOT_STACK_ACTION, HOOKS_SUCCEEDED_CONDITION, INHERIT_APPLIED_REASON,
-    INHERIT_FALLBACK_REASON, INHERIT_OVERRIDDEN_REASON, INHERIT_PINNED_NO_UID_REASON,
-    INVALID_MASS_DELETION_ACK_REASON, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
-    MASS_DELETION_ACKNOWLEDGED_REASON, MASS_DELETION_BREAKER_REASON,
-    MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION, MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION,
-    OP_LABEL, OP_SNAPSHOT_DELETE_BATCH, PIN_WORKLOAD_RUN_AS_USER_ACTION,
-    PRIVILEGED_MOVER_NOT_PERMITTED_REASON, SECURITY_CONTEXT_COMPATIBLE_CONDITION,
-    SECURITY_CONTEXT_COMPATIBLE_REASON, SECURITY_CONTEXT_INHERITED_CONDITION,
-    SKIP_SNAPSHOT_CLEANUP_ANNOTATION, SNAPSHOT_CLEANUP_FINALIZER, SNAPSHOT_DELETION_HELD_REASON,
-    SNAPSHOT_INCOMPLETE_REASON, SNAPSHOT_RETAINED_ON_SCHEDULE_DELETE_REASON,
+    DELETE_REPO_LABEL, DELETION_HELD_CONDITION, ENABLE_POLICY_CASCADE_ACTION,
+    ENABLE_SCHEDULE_CASCADE_ACTION, FIX_HOOK_ACTION, FIX_SNAPSHOT_STACK_ACTION,
+    HOOKS_SUCCEEDED_CONDITION, INHERIT_APPLIED_REASON, INHERIT_FALLBACK_REASON,
+    INHERIT_OVERRIDDEN_REASON, INHERIT_PINNED_NO_UID_REASON, INVALID_MASS_DELETION_ACK_REASON,
+    MANAGED_BY_LABEL, MANAGED_BY_VALUE, MASS_DELETION_ACKNOWLEDGED_REASON,
+    MASS_DELETION_BREAKER_REASON, MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION,
+    MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION, OP_LABEL, OP_SNAPSHOT_DELETE_BATCH,
+    PIN_WORKLOAD_RUN_AS_USER_ACTION, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
+    SECURITY_CONTEXT_COMPATIBLE_CONDITION, SECURITY_CONTEXT_COMPATIBLE_REASON,
+    SECURITY_CONTEXT_INHERITED_CONDITION, SKIP_SNAPSHOT_CLEANUP_ANNOTATION,
+    SNAPSHOT_CLEANUP_FINALIZER, SNAPSHOT_DELETION_HELD_REASON, SNAPSHOT_INCOMPLETE_REASON,
+    SNAPSHOT_RETAINED_ON_POLICY_DELETE_REASON, SNAPSHOT_RETAINED_ON_SCHEDULE_DELETE_REASON,
     SOURCE_STAGED_CONDITION, SOURCE_STAGED_REASON,
 };
 use crate::context::Context;
@@ -1903,30 +1904,38 @@ async fn handle_deletion(
         .await
         .unwrap_or(false);
 
-    let (plan, resolved, hold) = match gather_deletion_facts(
-        ctx,
-        backup,
-        namespace,
-        policy,
-        ns_terminating,
-    )
-    .await?
+    let decision = match gather_deletion_facts(ctx, backup, namespace, policy, ns_terminating)
+        .await?
     {
         DeletionOutcome::StoresNotSynced => {
             tracing::info!(backup = %name, "snapshot store not synced yet; deferring deletion (no destructive work)");
             return Ok(Action::requeue(Duration::from_secs(15)));
         }
-        DeletionOutcome::Decided(d) => {
-            let DeletionDecision {
-                plan,
-                resolved,
-                hold,
-            } = *d;
-            (plan, resolved, hold)
-        }
+        DeletionOutcome::Decided(d) => *d,
     };
-    tracing::info!(?plan, backup = %name, ns_terminating, "executing backup deletion plan");
+    tracing::info!(plan = ?decision.plan, backup = %name, ns_terminating, "executing backup deletion plan");
 
+    execute_deletion_plan(decision, backup, ctx, api, namespace, name, ns_terminating).await
+}
+
+/// Dispatch the tested [`plan_deletion`] decision to its executor. Extracted
+/// from [`handle_deletion`] to keep that function under the
+/// cognitive-complexity ratchet — every arm here is pure dispatch (no new
+/// decision logic; the decision itself is `plan_deletion`'s job).
+async fn execute_deletion_plan(
+    decision: DeletionDecision,
+    backup: &Snapshot,
+    ctx: &Context,
+    api: &Api<Snapshot>,
+    namespace: &str,
+    name: &str,
+    ns_terminating: bool,
+) -> Result<Action> {
+    let DeletionDecision {
+        plan,
+        resolved,
+        hold,
+    } = decision;
     match plan {
         DeletionPlan::DeleteSnapshot => {
             execute_delete_snapshot(backup, ctx, api, namespace, name, ns_terminating, resolved)
@@ -1954,6 +1963,9 @@ async fn handle_deletion(
         }
         DeletionPlan::RetainSnapshotOnScheduleDelete => {
             retain_on_schedule_delete(ctx, api, backup, namespace, name).await
+        }
+        DeletionPlan::RetainSnapshotOnPolicyDelete => {
+            retain_on_policy_delete(ctx, api, backup, namespace, name).await
         }
         DeletionPlan::HoldSnapshotDeletion => hold_deletion(ctx, api, backup, name, hold).await,
     }
@@ -2032,6 +2044,39 @@ async fn retain_on_schedule_delete(
              refresh interval. To cascade deletes when a schedule is removed, set the schedule's \
              `spec.deletion.onScheduleDelete: Delete`."
         ),
+    )
+    .await;
+    io::remove_finalizer(api, backup, SNAPSHOT_CLEANUP_FINALIZER).await?;
+    Ok(Action::await_change())
+}
+
+/// Executor for [`DeletionPlan::RetainSnapshotOnPolicyDelete`]: this Snapshot
+/// carries a `policy-cascade` prune stamp (its owning `SnapshotPolicy` was
+/// deleted under `onPolicyDelete: Retain`) and its own effective
+/// `deletionPolicy` is `Delete`. Release the finalizer WITHOUT contacting the
+/// repository (same as `RetainSnapshot`), bump the policy-cascade-retained
+/// counter (the SINGLE increment point for both counters), and emit ONE
+/// Warning event saying what happened, why, and how to opt into cascading
+/// deletes. Mirrors [`retain_on_schedule_delete`] exactly in shape.
+async fn retain_on_policy_delete(
+    ctx: &Context,
+    api: &Api<Snapshot>,
+    backup: &Snapshot,
+    namespace: &str,
+    name: &str,
+) -> Result<Action> {
+    ctx.metrics.inc_snapshot_policy_cascade_retained(namespace);
+    let snapshot_recorded = backup
+        .status
+        .as_ref()
+        .and_then(|s| s.snapshot.as_ref())
+        .is_some();
+    io::publish_warning_event(
+        ctx,
+        backup,
+        SNAPSHOT_RETAINED_ON_POLICY_DELETE_REASON,
+        ENABLE_POLICY_CASCADE_ACTION,
+        &policy_cascade_retained_message(namespace, name, snapshot_recorded),
     )
     .await;
     io::remove_finalizer(api, backup, SNAPSHOT_CLEANUP_FINALIZER).await?;

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -1693,11 +1693,21 @@ pub(crate) fn schedule_owner_lookup(ctx: &Context) -> impl Fn(&Snapshot) -> Owne
 ///
 /// A bad ack is NOT warned about here (the deletion path already publishes
 /// `InvalidMassDeletionAck`); it is simply treated as absent for the count.
-pub(crate) fn repo_mass_deletion_conditions(
+///
+/// `on_namespace_delete` is the repository's cascade policy: the count is
+/// evaluated in each member's real `(ns_terminating, ns_policy)` form (resolving
+/// terminating state over the pending-delete candidates), so this alert-only
+/// mirror agrees with the authoritative deletion-path breaker even during a
+/// namespace teardown — a `policy-cascade`-stamped child that flips to a
+/// destructive external delete under `onNamespaceDelete: Delete` is counted here
+/// too. The candidate set is bounded by the CRs actually being deleted, so the
+/// namespace reads are near-zero in steady state.
+pub(crate) async fn repo_mass_deletion_conditions(
     ctx: &Context,
     repo_ref: &RepositoryRef,
     raw_ack: Option<&str>,
     deletion_protection: Option<&kopiur_api::common::DeletionProtectionSpec>,
+    on_namespace_delete: NamespaceDeletePolicy,
     existing: &[Condition],
     generation: Option<i64>,
 ) -> Vec<Condition> {
@@ -1714,10 +1724,16 @@ pub(crate) fn repo_mass_deletion_conditions(
     let now = chrono::Utc::now();
     let (ack, _invalid) = parse_mass_deletion_ack(raw_ack, now);
     let threshold = kopiur_api::consts::effective_mass_deletion_threshold(deletion_protection);
+    let state = store.state();
+    let key = repo_key(repo_ref);
+    let terminating =
+        resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(&state, &key)).await;
     let members = pending_members(
-        &store.state(),
-        &repo_key(repo_ref),
+        &state,
+        &key,
         schedule_owner_lookup(ctx),
+        &terminating,
+        on_namespace_delete,
     );
     let unacked = unacked_breaker_count(&members, ack);
     let newest = newest_pending_deletion(&members).map(|d| d.to_rfc3339());
@@ -1791,10 +1807,20 @@ async fn resolve_breaker(
     }
     let threshold =
         kopiur_api::consts::effective_mass_deletion_threshold(repo.deletion_protection.as_ref());
+    let state = store.state();
+    let key = repo_key(repo_ref);
+    // Count in the REAL `(ns_terminating, ns_policy)` form so an external
+    // destructive delete that only arises under an `onNamespaceDelete: Delete`
+    // namespace teardown (a `policy-cascade`-stamped child) is counted — and thus
+    // can HOLD the wave — exactly like an unstamped external child.
+    let terminating =
+        resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(&state, &key)).await;
     let members = pending_members(
-        &store.state(),
-        &repo_key(repo_ref),
+        &state,
+        &key,
         schedule_owner_lookup(ctx),
+        &terminating,
+        repo.on_namespace_delete,
     );
     let pending = unacked_breaker_count(&members, ack);
     let ack_value = newest_pending_deletion(&members).map(|d| d.to_rfc3339());
@@ -1842,12 +1868,11 @@ async fn gather_deletion_facts(
             breaker,
         };
 
-    // Does the breaker apply to THIS deletion (external destructive Delete)?
-    // Evaluated in the stable `ns_terminating: false` form — a "is this CR
-    // breaker-relevant" predicate independent of namespace state.
-    let breaker_applies = counts_toward_breaker(mk(BreakerState::Allowed, false, None));
-    // Would a per-CR delete run? Gates resolving the repository (needed for the
-    // ns policy, to place/build the Job, and — new in M4 — the breaker repo_key).
+    // Would a per-CR delete run in the live-namespace form? Gates resolving the
+    // repository (needed for the ns policy, to place/build the Job, and the
+    // breaker repo_key). The repository is ALSO always resolved while the
+    // namespace terminates (below), so `ns_policy` is available whenever the real
+    // `(ns_terminating, ns_policy)` form needs it.
     let would_delete = matches!(
         plan_deletion(mk(BreakerState::Allowed, false, None)),
         DeletionPlan::DeleteSnapshot
@@ -1862,6 +1887,17 @@ async fn gather_deletion_facts(
         .as_ref()
         .and_then(|r| r.as_ref().ok())
         .map(|(_, repo)| repo.on_namespace_delete);
+
+    // Does the breaker apply to THIS deletion (external destructive Delete)?
+    // Computed in the REAL `(ns_terminating, ns_policy)` form — NOT the stable
+    // `false` form — so an external destructive delete that only arises under a
+    // namespace teardown with `onNamespaceDelete: Delete` (e.g. a
+    // `policy-cascade`-stamped child whose namespace a human deleted with the
+    // explicit opt-in) counts toward / is held by the breaker exactly like an
+    // unstamped external child. In the live-namespace case `ns_terminating` is
+    // false and `plan_deletion` ignores `ns_policy`, so this equals the old form.
+    let breaker_applies =
+        counts_toward_breaker(mk(BreakerState::Allowed, ns_terminating, ns_policy));
 
     // Breaker: only for an external-destructive CR, and only once the repository
     // resolved (its `repo_key` scopes the pending count). A repo that can no
@@ -2678,31 +2714,36 @@ async fn reap_batch_jobs(
     }
 }
 
-/// Resolve, once per DISTINCT member namespace, whether it is TERMINATING (the
-/// same `namespace_is_terminating` check the finalizer path uses for the self
-/// CR). Feeds the FIRE set's IMPORTANT-2 exclusion: an `onNamespaceDelete:
+/// Resolve, once per DISTINCT namespace, whether it is TERMINATING (the same
+/// `namespace_is_terminating` check the finalizer path uses for the self CR).
+/// `namespaces` are the pending-delete CANDIDATE namespaces
+/// ([`pending_candidate_namespaces`]), resolved BEFORE the counting set is built
+/// so each member's plan is evaluated in its real `(ns_terminating, ns_policy)`
+/// form. Feeds BOTH the counting set (a retain-cascade member flips to a
+/// destructive external delete under `onNamespaceDelete: Delete`, so it must
+/// count/fire) AND the FIRE set's IMPORTANT-2 exclusion (an `onNamespaceDelete:
 /// Orphan` peer whose namespace is being torn down plans `OrphanSnapshot` on its
-/// OWN reconcile and must never be deleted by a peer's fire. Bounded — a batch is
-/// ≤200 members, and distinct namespaces are typically far fewer.
+/// OWN reconcile and must never be deleted by a peer's fire). Bounded — a
+/// candidate must carry a `deletionTimestamp`, so this is the set of CRs actually
+/// being deleted for the repo, not the whole store.
 ///
-/// Fail-safe (fire-path = UNDER-fire): a namespace whose terminating-ness cannot
-/// be read is treated as terminating, so its `Orphan` peers are withheld and
-/// retried rather than deleted on a guess. (A 403 in a namespaced-scope install
-/// resolves to "not terminating" inside `namespace_is_terminating`, so this never
-/// wedges an install that legitimately cannot read Namespaces.)
-async fn terminating_member_namespaces(
+/// Fail-safe: a namespace whose terminating-ness cannot be read is treated as
+/// terminating. For the fire path this is UNDER-fire (its `Orphan` peers are
+/// withheld and retried); for the count it is a fail-safe OVER-count that trips
+/// the breaker earlier. (A 403 in a namespaced-scope install resolves to "not
+/// terminating" inside `namespace_is_terminating`, so this never wedges an install
+/// that legitimately cannot read Namespaces.)
+async fn resolve_terminating_namespaces(
     ctx: &Context,
-    pending: &[PendingMember],
+    namespaces: &std::collections::BTreeSet<String>,
 ) -> HashSet<String> {
-    let distinct: std::collections::BTreeSet<&str> =
-        pending.iter().map(|m| m.namespace.as_str()).collect();
     let mut terminating = HashSet::new();
-    for ns in distinct {
+    for ns in namespaces {
         if io::namespace_is_terminating(&ctx.client, ns)
             .await
             .unwrap_or(true)
         {
-            terminating.insert(ns.to_string());
+            terminating.insert(ns.clone());
         }
     }
     terminating
@@ -2730,8 +2771,23 @@ async fn fire_batch(
 ) -> Result<Action> {
     use std::sync::atomic::Ordering;
     let key = repo_key(repo_ref);
+    // Resolve which candidate namespaces are terminating BEFORE building the
+    // counting set, so each member's plan is evaluated in its real
+    // `(ns_terminating, ns_policy)` form: a retain-cascade member (a
+    // `policy-cascade` stamp, or a schedule-cascade Retain) flips to a destructive
+    // external delete under `onNamespaceDelete: Delete`, so it must be counted AND
+    // become fireable — exactly like an unstamped external child. The SAME
+    // terminating set gates the FIRE-path IMPORTANT-2 (ns-Orphan) exclusion below.
+    let terminating =
+        resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(state, &key)).await;
     // COUNTING set: maximally inclusive (over-count is fail-safe).
-    let pending = pending_members(state, &key, schedule_owner_lookup(ctx));
+    let pending = pending_members(
+        state,
+        &key,
+        schedule_owner_lookup(ctx),
+        &terminating,
+        repo.on_namespace_delete,
+    );
     // FIRE set: maximally EXCLUSIVE (under-fire is fail-safe). Drop members the
     // count deliberately over-includes — breaker-HELD externals (CRITICAL-1),
     // ns-Orphan-destined peers (IMPORTANT-2), schedule-owned peers while the
@@ -2743,7 +2799,6 @@ async fn fire_batch(
     let (ack, _invalid) = parse_mass_deletion_ack(repo.mass_deletion_ack.as_deref(), now);
     let threshold =
         kopiur_api::consts::effective_mass_deletion_threshold(repo.deletion_protection.as_ref());
-    let terminating = terminating_member_namespaces(ctx, &pending).await;
     let self_uid = backup.uid().unwrap_or_default();
     let eligible = fire_eligible(
         pending,

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -119,6 +119,61 @@ fn snapshot_stalled(backup: &Snapshot) -> bool {
     })
 }
 
+/// `Origin::Discovered` steady-state pin: catalog rows, not runs — never spawn a
+/// Job. Pins the `Discovered` phase (with kstatus Ready, ADR-0005 §2) and
+/// `status.origin` if unset, then stops. Extracted from `reconcile_inner`'s
+/// `match origin` (pure refactor of existing behavior — no semantic change) to
+/// keep the match legible under the complexity ratchet.
+async fn pin_discovered_row(backup: &Snapshot, api: &Api<Snapshot>, name: &str) -> Result<Action> {
+    if needs_terminal_pin(
+        backup.status.as_ref().and_then(|s| s.phase),
+        SnapshotPhase::Discovered,
+    ) {
+        let mut status = snapshot_ready_status(
+            backup,
+            SnapshotPhase::Discovered,
+            "Discovered",
+            "catalog-materialized snapshot",
+        );
+        status["origin"] = serde_json::json!("discovered");
+        io::patch_status(api, name, status).await?;
+    }
+    Ok(Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE))
+}
+
+/// `Origin::Adopted` steady-state pin: a row the catalog scan / auto-adoption
+/// re-attached to a live `SnapshotPolicy` without the operator itself producing
+/// the underlying kopia snapshot. It is retention-visible HISTORY — like
+/// `Discovered`, it must never enter the backup-run machinery — but unlike a
+/// plain `Discovered` row it IS retention-governed (ADR: adopted rows are
+/// managed like any produced backup), so it pins `phase: Succeeded`, not
+/// `Discovered`. Mirrors [`pin_discovered_row`]'s idempotent guard: the status
+/// patch (phase + terminal kstatus Ready + `status.origin`) only fires when the
+/// phase hasn't already converged, so a repeat reconcile is a no-op.
+///
+/// Belt-and-braces: an adopted row is normally stamped with the
+/// snapshot-cleanup finalizer by the mutating webhook at admission (same as
+/// every other `Snapshot`), but this arm returns before `reconcile_inner`'s main
+/// `ensure_finalizer` call below, so self-heal it here too — a no-op cluster
+/// call when the finalizer is already present.
+async fn pin_adopted_row(backup: &Snapshot, api: &Api<Snapshot>, name: &str) -> Result<Action> {
+    io::ensure_finalizer(api, backup, SNAPSHOT_CLEANUP_FINALIZER).await?;
+    if needs_terminal_pin(
+        backup.status.as_ref().and_then(|s| s.phase),
+        SnapshotPhase::Succeeded,
+    ) {
+        let mut status = snapshot_ready_status(
+            backup,
+            SnapshotPhase::Succeeded,
+            "Adopted",
+            "adopted snapshot: retention-visible history re-attached to a SnapshotPolicy",
+        );
+        status["origin"] = serde_json::json!("adopted");
+        io::patch_status(api, name, status).await?;
+    }
+    Ok(Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE))
+}
+
 async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
     let origin = resolve_origin(backup);
     let policy = effective_deletion_policy(backup.spec.deletion_policy, origin);
@@ -132,20 +187,15 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
         return handle_deletion(backup, ctx, &api, &namespace, &name, policy).await;
     }
 
-    // Discovered backups are catalog rows, not runs: never spawn a Job. Pin the
-    // Discovered phase (with kstatus Ready, ADR-0005 §2) if unset and stop.
-    if origin == Origin::Discovered {
-        if backup.status.as_ref().and_then(|s| s.phase) != Some(SnapshotPhase::Discovered) {
-            let mut status = snapshot_ready_status(
-                backup,
-                SnapshotPhase::Discovered,
-                "Discovered",
-                "catalog-materialized snapshot",
-            );
-            status["origin"] = serde_json::json!("discovered");
-            io::patch_status(&api, &name, status).await?;
-        }
-        return Ok(Action::requeue(TERMINAL_SNAPSHOT_STEADY_REQUEUE));
+    // Exhaustive over `Origin` (ADR §5.5): `Discovered` and `Adopted` rows are
+    // catalog history, not runs, and must return BEFORE any of the backup-run
+    // machinery below (`run_decision`, post-hooks, staged reap, pin jobs) —
+    // `Scheduled`/`Manual` are the only origins that ever mint a mover Job, so
+    // they fall through to it.
+    match origin {
+        Origin::Discovered => return pin_discovered_row(backup, &api, &name).await,
+        Origin::Adopted => return pin_adopted_row(backup, &api, &name).await,
+        Origin::Scheduled | Origin::Manual => {}
     }
 
     // Ensure the snapshot-cleanup finalizer before doing any work that creates a

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -158,10 +158,23 @@ async fn pin_discovered_row(backup: &Snapshot, api: &Api<Snapshot>, name: &str) 
 /// call when the finalizer is already present.
 async fn pin_adopted_row(backup: &Snapshot, api: &Api<Snapshot>, name: &str) -> Result<Action> {
     io::ensure_finalizer(api, backup, SNAPSHOT_CLEANUP_FINALIZER).await?;
-    if needs_terminal_pin(
-        backup.status.as_ref().and_then(|s| s.phase),
-        SnapshotPhase::Succeeded,
-    ) {
+    // PROVENANCE GATE: pin `Succeeded`/terminal-kstatus ONLY for a
+    // CONTROLLER-WRITTEN adopted row — one whose `status.snapshot` was set by
+    // `adopt_one`'s create→status-patch flow. A user-applied BARE `origin: adopted`
+    // label with no `status.snapshot` resolves `Adopted` (via the label fallback in
+    // `resolve_origin`) but must stay PHASE-LESS: a phantom `Succeeded` row would
+    // enter `retention_view` (creationTimestamp fallback), claim a GFS bucket, and
+    // displace a REAL snapshot into the breaker-exempt retention delete set — and it
+    // would set `has_history`, suppressing a recreated policy's on-demand scan. The
+    // genuine adopt flow converges within a pass (create → status patch → next
+    // reconcile pins), so an interim row is only transiently phase-less and invisible
+    // to retention.
+    if plan::adopted_row_has_provenance(backup)
+        && needs_terminal_pin(
+            backup.status.as_ref().and_then(|s| s.phase),
+            SnapshotPhase::Succeeded,
+        )
+    {
         let mut status = snapshot_ready_status(
             backup,
             SnapshotPhase::Succeeded,

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -2086,14 +2086,7 @@ async fn retain_on_schedule_delete(
         backup,
         SNAPSHOT_RETAINED_ON_SCHEDULE_DELETE_REASON,
         ENABLE_SCHEDULE_CASCADE_ACTION,
-        &format!(
-            "Snapshot `{namespace}/{name}` was RETAINED, not deleted: its owning SnapshotSchedule \
-             is gone/replaced and the schedule's `onScheduleDelete` is `Retain` (the safe default), \
-             so the kopia snapshot is kept even though this Snapshot's deletionPolicy is `Delete`. \
-             The catalog will rediscover it as `origin: discovered` within the repository's catalog \
-             refresh interval. To cascade deletes when a schedule is removed, set the schedule's \
-             `spec.deletion.onScheduleDelete: Delete`."
-        ),
+        &schedule_cascade_retained_message(namespace, name),
     )
     .await;
     io::remove_finalizer(api, backup, SNAPSHOT_CLEANUP_FINALIZER).await?;

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -1709,11 +1709,14 @@ pub(crate) fn schedule_owner_lookup(ctx: &Context) -> impl Fn(&Snapshot) -> Owne
 ///
 /// `on_namespace_delete` is the repository's cascade policy: the count is
 /// evaluated in each member's real `(ns_terminating, ns_policy)` form (resolving
-/// terminating state over the pending-delete candidates), so this alert-only
-/// mirror agrees with the authoritative deletion-path breaker even during a
-/// namespace teardown — a `policy-cascade`-stamped child that flips to a
-/// destructive external delete under `onNamespaceDelete: Delete` is counted here
-/// too. The candidate set is bounded by the CRs actually being deleted, so the
+/// terminating state over the pending-delete candidates — only CONFIRMED-terminating
+/// namespaces count as terminating here), so this alert-only mirror agrees with the
+/// authoritative deletion-path breaker even during a namespace teardown — a
+/// `policy-cascade`-stamped child that flips to a destructive external delete under
+/// `onNamespaceDelete: Delete` is counted here too. Conversely, a terminating-ns
+/// member whose real plan is `OrphanSnapshot` (`onNamespaceDelete: Orphan`) is NOT
+/// counted toward the breaker — the mirror softens correctly during Orphan
+/// teardowns. The candidate set is bounded by the CRs actually being deleted, so the
 /// namespace reads are near-zero in steady state.
 pub(crate) async fn repo_mass_deletion_conditions(
     ctx: &Context,
@@ -1739,13 +1742,16 @@ pub(crate) async fn repo_mass_deletion_conditions(
     let threshold = kopiur_api::consts::effective_mass_deletion_threshold(deletion_protection);
     let state = store.state();
     let key = repo_key(repo_ref);
+    // Only CONFIRMED-terminating namespaces feed the count-as-terminating plan
+    // evaluation; an unreadable namespace must not flip a retain child into a
+    // counted destructive delete (C1).
     let terminating =
         resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(&state, &key)).await;
     let members = pending_members(
         &state,
         &key,
         schedule_owner_lookup(ctx),
-        &terminating,
+        &terminating.confirmed,
         on_namespace_delete,
     );
     let unacked = unacked_breaker_count(&members, ack);
@@ -1825,14 +1831,17 @@ async fn resolve_breaker(
     // Count in the REAL `(ns_terminating, ns_policy)` form so an external
     // destructive delete that only arises under an `onNamespaceDelete: Delete`
     // namespace teardown (a `policy-cascade`-stamped child) is counted — and thus
-    // can HOLD the wave — exactly like an unstamped external child.
+    // can HOLD the wave — exactly like an unstamped external child. Only
+    // CONFIRMED-terminating namespaces count as terminating; an unreadable one
+    // stays retain-form for plan/count (C1), matching the self-CR path's
+    // `unwrap_or(false)`.
     let terminating =
         resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(&state, &key)).await;
     let members = pending_members(
         &state,
         &key,
         schedule_owner_lookup(ctx),
-        &terminating,
+        &terminating.confirmed,
         repo.on_namespace_delete,
     );
     let pending = unacked_breaker_count(&members, ack);
@@ -1997,8 +2006,13 @@ async fn handle_deletion(
     // down, the repository's `onNamespaceDelete` decides. Default `Orphan` keeps
     // off-site history (a `kubectl delete ns` must not be a data-loss event); only an
     // explicit `Delete` cascades to the per-Snapshot plan. On a transient read error
-    // fall back to the per-Snapshot plan: a single delete still works, and the
-    // namespace-cascade case re-evaluates on the next pass once the read succeeds.
+    // fall back to the per-Snapshot plan (`unwrap_or(false)` = NOT terminating): a
+    // single delete still works, and the namespace-cascade case re-evaluates on the
+    // next pass once the read succeeds. This is the SAME direction the peer-driven
+    // batch path takes for an unreadable namespace ([`resolve_terminating_namespaces`]
+    // routes `Err` into `unreadable`, which never counts as terminating for
+    // plan/count) — so an unreadable namespace never turns a Retain into a delete on
+    // either path.
     let ns_terminating = io::namespace_is_terminating(&ctx.client, namespace)
         .await
         .unwrap_or(false);
@@ -2727,39 +2741,80 @@ async fn reap_batch_jobs(
     }
 }
 
+/// Resolving pending-delete candidate namespaces' terminating state, split by
+/// READ CONFIDENCE so the plan/count path and the FIRE path treat an UNREADABLE
+/// namespace differently — they must (see the field docs).
+struct TerminatingNamespaces {
+    /// Namespaces a successful GET proved TERMINATING (`Ok(true)`). ONLY these
+    /// feed plan evaluation ([`batch::pending_members`]) and breaker
+    /// counting-as-terminating: an unreadable namespace must NOT flip a
+    /// retain-destined draining child into a destructive `DeleteSnapshot` member
+    /// in a namespace that is NOT being deleted. This keeps the peer-driven batch
+    /// path symmetric with the finalizer's self-CR path, which resolves the same
+    /// read to NOT-terminating (`unwrap_or(false)`).
+    confirmed: HashSet<String>,
+    /// Namespaces whose terminating-ness could NOT be read (`Err`). EXCLUDED from
+    /// plan evaluation / counting-as-terminating (a retain-cascade child keeps
+    /// retain semantics), but folded into the FIRE path's ns-Orphan exclusion (via
+    /// [`Self::orphan_exclusion`]) AND excluded from the FIRE set OUTRIGHT: a peer
+    /// whose namespace we cannot confirm terminating is never deleted on the
+    /// assumption that it is — its own self-fire (authoritative LIVE resolution)
+    /// drains it. Counting such a member toward the breaker is still fine
+    /// (over-count is fail-safe).
+    unreadable: HashSet<String>,
+}
+
+impl TerminatingNamespaces {
+    /// `confirmed ∪ unreadable` — the set fed to the FIRE path's ns-Orphan
+    /// exclusion ([`batch::FireEligibility::terminating_namespaces`]): an
+    /// `onNamespaceDelete: Orphan` peer whose namespace is terminating OR unreadable
+    /// plans `OrphanSnapshot` on its OWN reconcile and must never be deleted by a
+    /// peer's fire.
+    fn orphan_exclusion(&self) -> HashSet<String> {
+        self.confirmed.union(&self.unreadable).cloned().collect()
+    }
+}
+
 /// Resolve, once per DISTINCT namespace, whether it is TERMINATING (the same
-/// `namespace_is_terminating` check the finalizer path uses for the self CR).
-/// `namespaces` are the pending-delete CANDIDATE namespaces
-/// ([`pending_candidate_namespaces`]), resolved BEFORE the counting set is built
-/// so each member's plan is evaluated in its real `(ns_terminating, ns_policy)`
-/// form. Feeds BOTH the counting set (a retain-cascade member flips to a
-/// destructive external delete under `onNamespaceDelete: Delete`, so it must
-/// count/fire) AND the FIRE set's IMPORTANT-2 exclusion (an `onNamespaceDelete:
-/// Orphan` peer whose namespace is being torn down plans `OrphanSnapshot` on its
-/// OWN reconcile and must never be deleted by a peer's fire). Bounded — a
-/// candidate must carry a `deletionTimestamp`, so this is the set of CRs actually
-/// being deleted for the repo, not the whole store.
+/// `namespace_is_terminating` check the finalizer path uses for the self CR),
+/// splitting the result into CONFIRMED-terminating (`Ok(true)`) and UNREADABLE
+/// (`Err`) sets. `namespaces` are the pending-delete CANDIDATE namespaces
+/// ([`batch::pending_candidate_namespaces`]), resolved BEFORE the counting set is
+/// built so each member's plan is evaluated in its real `(ns_terminating,
+/// ns_policy)` form. Bounded — a candidate must carry a `deletionTimestamp`, so
+/// this is the set of CRs actually being deleted for the repo, not the whole store.
 ///
-/// Fail-safe: a namespace whose terminating-ness cannot be read is treated as
-/// terminating. For the fire path this is UNDER-fire (its `Orphan` peers are
-/// withheld and retried); for the count it is a fail-safe OVER-count that trips
-/// the breaker earlier. (A 403 in a namespaced-scope install resolves to "not
-/// terminating" inside `namespace_is_terminating`, so this never wedges an install
-/// that legitimately cannot read Namespaces.)
+/// The Err direction is NOT treated as terminating for plan/count (that would let
+/// a transient read error flip a retain-destined child into a destructive external
+/// delete under `onNamespaceDelete: Delete` — deleting data Retain promised to keep
+/// in a namespace that is NOT being deleted). Instead, an unreadable namespace is
+/// (a) excluded from plan/count-as-terminating — matching the self-CR path's
+/// `unwrap_or(false)` — while still (b) protecting its `Orphan` peers on the fire
+/// path (via [`TerminatingNamespaces::orphan_exclusion`]) and (c) withheld from the
+/// FIRE set outright. (A 403 in a namespaced-scope install resolves to `Ok(false)`
+/// — "not terminating" — inside `namespace_is_terminating`, so it lands in NEITHER
+/// set and never wedges an install that legitimately cannot read Namespaces.)
 async fn resolve_terminating_namespaces(
     ctx: &Context,
     namespaces: &std::collections::BTreeSet<String>,
-) -> HashSet<String> {
-    let mut terminating = HashSet::new();
+) -> TerminatingNamespaces {
+    let mut confirmed = HashSet::new();
+    let mut unreadable = HashSet::new();
     for ns in namespaces {
-        if io::namespace_is_terminating(&ctx.client, ns)
-            .await
-            .unwrap_or(true)
-        {
-            terminating.insert(ns.clone());
+        match io::namespace_is_terminating(&ctx.client, ns).await {
+            Ok(true) => {
+                confirmed.insert(ns.clone());
+            }
+            Ok(false) => {}
+            Err(_) => {
+                unreadable.insert(ns.clone());
+            }
         }
     }
-    terminating
+    TerminatingNamespaces {
+        confirmed,
+        unreadable,
+    }
 }
 
 /// §3: this CR is not enrolled — pick the fireable set for its repository
@@ -2786,33 +2841,44 @@ async fn fire_batch(
     let key = repo_key(repo_ref);
     // Resolve which candidate namespaces are terminating BEFORE building the
     // counting set, so each member's plan is evaluated in its real
-    // `(ns_terminating, ns_policy)` form: a retain-cascade member (a
-    // `policy-cascade` stamp, or a schedule-cascade Retain) flips to a destructive
-    // external delete under `onNamespaceDelete: Delete`, so it must be counted AND
-    // become fireable — exactly like an unstamped external child. The SAME
-    // terminating set gates the FIRE-path IMPORTANT-2 (ns-Orphan) exclusion below.
+    // `(ns_terminating, ns_policy)` form. The resolution splits into CONFIRMED
+    // (`Ok(true)`) and UNREADABLE (`Err`): ONLY confirmed feeds the plan/count (a
+    // retain-cascade member — a `policy-cascade` stamp, or a schedule-cascade
+    // Retain — flips to a destructive external delete under `onNamespaceDelete:
+    // Delete` only when its namespace is CONFIRMED terminating, so it must then be
+    // counted AND become fireable, exactly like an unstamped external child). An
+    // unreadable namespace stays retain-form here (C1) — it must not flip a retain
+    // child into a destructive delete in a namespace that is NOT being deleted.
     let terminating =
         resolve_terminating_namespaces(ctx, &pending_candidate_namespaces(state, &key)).await;
-    // COUNTING set: maximally inclusive (over-count is fail-safe).
+    // COUNTING set: maximally inclusive (over-count is fail-safe). Confirmed-only
+    // for the plan; an unstamped external member in an UNREADABLE namespace still
+    // lands here (its plan is `DeleteSnapshot` regardless of ns state) and counts
+    // toward the breaker — over-count stays safe.
     let pending = pending_members(
         state,
         &key,
         schedule_owner_lookup(ctx),
-        &terminating,
+        &terminating.confirmed,
         repo.on_namespace_delete,
     );
     // FIRE set: maximally EXCLUSIVE (under-fire is fail-safe). Drop members the
     // count deliberately over-includes — breaker-HELD externals (CRITICAL-1),
-    // ns-Orphan-destined peers (IMPORTANT-2), schedule-owned peers while the
-    // schedule store is unsynced (IMPORTANT-3a), and unpinned PEERS
-    // (IMPORTANT-4) — BEFORE the no-overlap exclusion. The ack is parsed exactly
-    // as the breaker does; its invalid-value warning is already published by
-    // `resolve_breaker` on the external-CR path, so it is not re-emitted here.
+    // ns-Orphan-destined peers (IMPORTANT-2) plus any UNREADABLE-namespace peer
+    // outright, schedule-owned peers while the schedule store is unsynced
+    // (IMPORTANT-3a), and unpinned PEERS (IMPORTANT-4) — BEFORE the no-overlap
+    // exclusion. The ns-Orphan exclusion sees `confirmed ∪ unreadable` (an Orphan
+    // peer in a terminating-or-unreadable namespace is withheld); the unreadable
+    // set additionally withholds ANY peer there, whatever the policy. The ack is
+    // parsed exactly as the breaker does; its invalid-value warning is already
+    // published by `resolve_breaker` on the external-CR path, so it is not
+    // re-emitted here.
     let now = chrono::Utc::now();
     let (ack, _invalid) = parse_mass_deletion_ack(repo.mass_deletion_ack.as_deref(), now);
     let threshold =
         kopiur_api::consts::effective_mass_deletion_threshold(repo.deletion_protection.as_ref());
     let self_uid = backup.uid().unwrap_or_default();
+    let orphan_exclusion = terminating.orphan_exclusion();
     let eligible = fire_eligible(
         pending,
         &FireEligibility {
@@ -2820,7 +2886,8 @@ async fn fire_batch(
             threshold,
             ack,
             on_namespace_delete: repo.on_namespace_delete,
-            terminating_namespaces: &terminating,
+            terminating_namespaces: &orphan_exclusion,
+            unreadable_namespaces: &terminating.unreadable,
             schedule_synced: ctx.schedule_synced.load(Ordering::Acquire),
         },
     );

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -126,10 +126,16 @@ pub fn pruned_by(annotations: &BTreeMap<String, String>) -> Option<PrunedBy> {
 /// 2. `ns_terminating`:
 ///    - `ns_policy == None` → `OrphanSnapshot` (existing fail-safe, unchanged).
 ///    - `Some(Orphan)` → `OrphanSnapshot` (existing default, unchanged).
-///    - `Some(Delete)` → fall through to steps 4/5 BYPASSING step 3 (during ns
-///      teardown the schedule is always gone; letting the cascade guard fire
-///      would silently nullify the documented repo-level opt-in) — but NOT
-///      bypassing the breaker.
+///    - `Some(Delete)` → [`plan_ns_delete`]: an EXPLICIT repo-level opt-in.
+///      Retention/failed-history prunes keep their operator-prune semantics
+///      (step 4), but BOTH the schedule cascade guard (step 3 — during ns
+///      teardown the schedule is always gone) AND the IMPLICIT `policy-cascade`
+///      Retain stamp are overridden: an unstamped OR `policy-cascade`-stamped
+///      child resolves as external destructive (step 5, breaker-gated). The
+///      policy cleanup finalizer stamps its live children `policy-cascade`
+///      during the SAME teardown (default `onPolicyDelete: Retain`), and letting
+///      that quiet-retain downgrade win would silently nullify the opt-in and
+///      lose off-site data the user asked to reclaim.
 /// 3. Cascade guard (only when not ns-terminating): `pruned_by == None && owner
 ///    == GoneOrReplaced`:
 ///    - cascade `Retain` && policy `Delete` → `RetainSnapshotOnScheduleDelete`
@@ -155,13 +161,39 @@ pub fn plan_deletion(f: DeletionFacts<'_>) -> DeletionPlan {
     plan_live_namespace(&f)
 }
 
-/// Step 2: namespace-deletion cascade (ADR-0005 §5). `Delete` bypasses the
-/// cascade guard (step 3) but not the breaker (steps 4-6 still apply).
+/// Step 2: namespace-deletion cascade (ADR-0005 §5). `Delete` is an explicit
+/// repo-level opt-in that bypasses the schedule cascade guard (step 3) AND
+/// overrides the implicit `policy-cascade` Retain stamp (see [`plan_ns_delete`]),
+/// but does not bypass the breaker for external destructive deletes.
 fn plan_ns_terminating(f: &DeletionFacts<'_>) -> DeletionPlan {
     match f.ns_policy {
         None => DeletionPlan::OrphanSnapshot,
         Some(NamespaceDeletePolicy::Orphan) => DeletionPlan::OrphanSnapshot,
-        Some(NamespaceDeletePolicy::Delete) => plan_prune_or_external(f),
+        Some(NamespaceDeletePolicy::Delete) => plan_ns_delete(f),
+    }
+}
+
+/// Step 2, the `Some(Delete)` arm: an EXPLICIT `onNamespaceDelete: Delete`
+/// repo-level opt-in. **Exhaustive over [`PrunedBy`]** (no catch-all): a new
+/// prune kind must decide its namespace-teardown fate here.
+///
+/// - `None` (unstamped) → external destructive ([`plan_external`], breaker-gated).
+/// - `Some(PolicyCascade)` → ALSO external destructive. The opt-in is explicit;
+///   the `policy-cascade` stamp is IMPLICIT — the `SnapshotPolicy` cleanup
+///   finalizer stamps its live children during this SAME namespace teardown,
+///   defaulting to `onPolicyDelete: Retain`. Routing that through [`plan_prune`]
+///   would hit the quiet-retain downgrade
+///   ([`RetainSnapshotOnPolicyDelete`](DeletionPlan::RetainSnapshotOnPolicyDelete))
+///   and silently nullify the opt-in, losing off-site data the user asked to
+///   reclaim. So an explicit ns-delete opt-in WINS over the implicit stamp.
+///   (The retain-wins-ties rule is only for schedule-vs-policy cascade races,
+///   NOT for an explicit namespace-delete opt-in.)
+/// - `Some(Retention | FailedHistory)` → a genuine operator prune keeps its
+///   prune semantics ([`plan_prune`]): never held; effective policy decides.
+fn plan_ns_delete(f: &DeletionFacts<'_>) -> DeletionPlan {
+    match pruned_by(f.annotations) {
+        None | Some(PrunedBy::PolicyCascade) => plan_external(f.policy, f.breaker),
+        Some(p @ (PrunedBy::Retention | PrunedBy::FailedHistory)) => plan_prune(p, f.policy),
     }
 }
 

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -41,6 +41,15 @@ pub enum DeletionPlan {
     /// `SnapshotRetainedOnScheduleDelete` + cascade-retained counter — loud
     /// but not an orphan-metric storm. (Executor lands in M4.)
     RetainSnapshotOnScheduleDelete,
+    /// A `SnapshotPolicy`-deletion cascade prune (`pruned-by: policy-cascade`,
+    /// stamped by the `SnapshotPolicy` finalizer under `onPolicyDelete: Retain`
+    /// — M3) whose Snapshot's own effective `deletionPolicy` is `Delete`. The
+    /// whole point of the `policy-cascade` stamp is to NEVER contact the
+    /// repository, so this is the loud downgrade: same executor shape as
+    /// `RetainSnapshot` (release finalizer, no repo contact) PLUS a Warning
+    /// event `SnapshotRetainedOnPolicyDelete` + a policy-cascade-retained
+    /// counter — loud but not an orphan-metric storm.
+    RetainSnapshotOnPolicyDelete,
     /// Mass-deletion breaker: do NO delete work, keep the finalizer, phase
     /// Deleting + `DeletionHeld=True` condition, requeue long. Drained by the
     /// repo ack annotation. (Executor lands in M4.)
@@ -128,8 +137,8 @@ pub fn pruned_by(annotations: &BTreeMap<String, String>) -> Option<PrunedBy> {
 ///    - cascade `Retain` && policy `Orphan` → `OrphanSnapshot`
 ///    - cascade `Delete` → fall through (opt-in cascade; still external ⇒
 ///      breaker applies).
-/// 4. Operator prune (`pruned_by == Some(_)`): match policy exhaustively —
-///    Delete→DeleteSnapshot, Retain→RetainSnapshot, Orphan→OrphanSnapshot.
+/// 4. Operator prune (`pruned_by == Some(_)`): match `(prune kind, policy)`
+///    exhaustively via [`plan_prune`] — see its doc for the full 3×3 table.
 ///    NEVER held (retention must keep working during an incident; its rate is
 ///    bounded elsewhere).
 /// 5. External destructive (policy Delete): breaker Held →
@@ -200,18 +209,42 @@ fn plan_cascade_guard(
 /// gates `Delete`).
 fn plan_prune_or_external(f: &DeletionFacts<'_>) -> DeletionPlan {
     match pruned_by(f.annotations) {
-        Some(_) => plan_prune(f.policy),
+        Some(p) => plan_prune(p, f.policy),
         None => plan_external(f.policy, f.breaker),
     }
 }
 
 /// Step 4: operator prune. NEVER held — retention/history-limit pruning must
 /// keep working during an incident; its own rate is bounded elsewhere.
-fn plan_prune(policy: DeletionPolicy) -> DeletionPlan {
-    match policy {
-        DeletionPolicy::Delete => DeletionPlan::DeleteSnapshot,
-        DeletionPolicy::Retain => DeletionPlan::RetainSnapshot,
-        DeletionPolicy::Orphan => DeletionPlan::OrphanSnapshot,
+///
+/// **Exhaustive over both [`PrunedBy`] and [`DeletionPolicy`]** (a flat 3×3
+/// match, no catch-all): a new variant of either enum fails to compile until
+/// every cell is decided (ADR §5.5).
+///
+/// | [`PrunedBy`] \\ [`DeletionPolicy`] | `Delete` | `Retain` | `Orphan` |
+/// |---|---|---|---|
+/// | `Retention` | `DeleteSnapshot` | `RetainSnapshot` | `OrphanSnapshot` |
+/// | `FailedHistory` | `DeleteSnapshot` | `RetainSnapshot` | `OrphanSnapshot` |
+/// | `PolicyCascade` | [`RetainSnapshotOnPolicyDelete`](DeletionPlan::RetainSnapshotOnPolicyDelete) | `RetainSnapshot` | `OrphanSnapshot` |
+///
+/// The `PolicyCascade`/`Delete` cell is the one loud downgrade: a policy
+/// cascade prune under `onPolicyDelete: Retain` never contacts the
+/// repository, even though the Snapshot's own effective policy asked for
+/// `Delete` — that is the entire reason the finalizer stamps `policy-cascade`
+/// instead of leaving the annotation absent.
+fn plan_prune(pruned: PrunedBy, policy: DeletionPolicy) -> DeletionPlan {
+    match (pruned, policy) {
+        (PrunedBy::Retention, DeletionPolicy::Delete) => DeletionPlan::DeleteSnapshot,
+        (PrunedBy::Retention, DeletionPolicy::Retain) => DeletionPlan::RetainSnapshot,
+        (PrunedBy::Retention, DeletionPolicy::Orphan) => DeletionPlan::OrphanSnapshot,
+        (PrunedBy::FailedHistory, DeletionPolicy::Delete) => DeletionPlan::DeleteSnapshot,
+        (PrunedBy::FailedHistory, DeletionPolicy::Retain) => DeletionPlan::RetainSnapshot,
+        (PrunedBy::FailedHistory, DeletionPolicy::Orphan) => DeletionPlan::OrphanSnapshot,
+        (PrunedBy::PolicyCascade, DeletionPolicy::Delete) => {
+            DeletionPlan::RetainSnapshotOnPolicyDelete
+        }
+        (PrunedBy::PolicyCascade, DeletionPolicy::Retain) => DeletionPlan::RetainSnapshot,
+        (PrunedBy::PolicyCascade, DeletionPolicy::Orphan) => DeletionPlan::OrphanSnapshot,
     }
 }
 
@@ -404,6 +437,34 @@ pub fn mass_deletion_hold_message(
         repo.name,
         mass_deletion_ack_command(repo, ack_value),
         SKIP_SNAPSHOT_CLEANUP_ANNOTATION,
+    )
+}
+
+/// The `SnapshotRetainedOnPolicyDelete` Warning event message for
+/// [`DeletionPlan::RetainSnapshotOnPolicyDelete`]'s executor. Names the CR,
+/// states what became of the kopia snapshot — retained in the repository, or
+/// (`snapshot_recorded == false`) never completed at all because the run was
+/// cancelled mid-flight before any kopia snapshot existed — that it (or any
+/// future one matching the same identity) will be rediscoverable/adoptable,
+/// and the opt-in for users who wanted the cascade to actually delete
+/// kopia-side data. Pure so both phrasings are unit-tested.
+pub fn policy_cascade_retained_message(
+    namespace: &str,
+    name: &str,
+    snapshot_recorded: bool,
+) -> String {
+    let outcome = if snapshot_recorded {
+        "its kopia snapshot was RETAINED in the repository, not deleted"
+    } else {
+        "the kopia snapshot for this run was never completed (the run was cancelled mid-flight), \
+         so there was nothing in the repository to delete"
+    };
+    format!(
+        "Snapshot `{namespace}/{name}` was released, not deleted: its owning SnapshotPolicy is gone \
+         and the policy's `onPolicyDelete` is `Retain` (the safe default), so {outcome}. Any kopia \
+         snapshot it did create remains rediscoverable/adoptable by a future SnapshotPolicy with a \
+         matching identity (catalog scan / auto-adoption). To cascade deletes when a SnapshotPolicy is \
+         removed, set the policy's `spec.deletion.onPolicyDelete: Delete`."
     )
 }
 

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -832,6 +832,17 @@ pub(super) fn should_run_preflight(phase: Option<SnapshotPhase>) -> bool {
     matches!(phase, None | Some(SnapshotPhase::Pending))
 }
 
+/// Whether a terminal steady-state pin arm (`pin_discovered_row`/
+/// `pin_adopted_row` in [`super`]) needs to patch status this reconcile: the
+/// observed phase hasn't already converged to the arm's `target` (`Discovered`
+/// for a discovered row, `Succeeded` for an adopted one). Pure + shared, so the
+/// "only pin when unset/divergent" idempotence both arms rely on — never
+/// re-patching (and so never re-generating kstatus conditions/timestamps) once
+/// pinned — is unit-tested without a cluster (M5).
+pub(super) fn needs_terminal_pin(observed: Option<SnapshotPhase>, target: SnapshotPhase) -> bool {
+    observed != Some(target)
+}
+
 /// Whether the preflight deadline has passed: `preflight_since + timeout <= now`.
 /// `timeout == None` ⇒ indefinite (never expires); `preflight_since == None` (the
 /// failure just started this reconcile) ⇒ not expired. Pure / clock-injected.

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -867,7 +867,10 @@ pub fn effective_deletion_policy(
     match origin {
         // Discovered snapshots are never ours to delete — forced Retain.
         Origin::Discovered => DeletionPolicy::Retain,
-        Origin::Scheduled | Origin::Manual => spec_policy.unwrap_or(DeletionPolicy::Delete),
+        // Adopted rows are managed like any produced backup: same fallback default.
+        Origin::Scheduled | Origin::Manual | Origin::Adopted => {
+            spec_policy.unwrap_or(DeletionPolicy::Delete)
+        }
     }
 }
 
@@ -913,6 +916,7 @@ pub fn resolve_origin(b: &Snapshot) -> Origin {
     {
         Some("scheduled") => Origin::Scheduled,
         Some("discovered") => Origin::Discovered,
+        Some("adopted") => Origin::Adopted,
         _ => Origin::Manual,
     }
 }

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -440,6 +440,28 @@ pub fn mass_deletion_hold_message(
     )
 }
 
+/// The `SnapshotRetainedOnScheduleDelete` Warning event message for
+/// [`DeletionPlan::RetainSnapshotOnScheduleDelete`]'s executor. Names the CR,
+/// states that the kopia snapshot was kept, and says how it comes back:
+/// rediscovered on the *next catalog scan* (not a promise of "within the
+/// refresh interval" — `periodicRefresh` is off by default, so nothing runs on
+/// a timer unless the user turned it on; the real triggers are a bootstrap, a
+/// spec change, or a recreated policy's automatic scan request), then
+/// auto-adopted by default once a matching `SnapshotPolicy` exists. Pure so
+/// the wording is unit-tested.
+pub fn schedule_cascade_retained_message(namespace: &str, name: &str) -> String {
+    format!(
+        "Snapshot `{namespace}/{name}` was RETAINED, not deleted: its owning SnapshotSchedule \
+         is gone/replaced and the schedule's `onScheduleDelete` is `Retain` (the safe default), \
+         so the kopia snapshot is kept even though this Snapshot's deletionPolicy is `Delete`. It \
+         will be rediscovered as `origin: discovered` on the next catalog scan (e.g. a bootstrap, \
+         a spec change, or a recreated policy's automatic scan request — not necessarily on a \
+         timer, since periodic refresh is off by default) and auto-adopted by default once a \
+         SnapshotPolicy with a matching identity exists. To cascade deletes when a schedule is \
+         removed, set the schedule's `spec.deletion.onScheduleDelete: Delete`."
+    )
+}
+
 /// The `SnapshotRetainedOnPolicyDelete` Warning event message for
 /// [`DeletionPlan::RetainSnapshotOnPolicyDelete`]'s executor. Names the CR,
 /// states what became of the kopia snapshot — retained in the repository, or

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -938,6 +938,24 @@ pub(super) fn needs_terminal_pin(observed: Option<SnapshotPhase>, target: Snapsh
     observed != Some(target)
 }
 
+/// Whether an `Adopted`-resolving row carries CONTROLLER-WRITTEN provenance —
+/// `status.snapshot`, the kopia id `adopt_one`'s create→status-patch flow records.
+/// [`super::pin_adopted_row`] pins `phase: Succeeded` ONLY when this holds: a
+/// user-applied BARE `origin: adopted` label (which `resolve_origin` still resolves
+/// to `Adopted` via its label fallback) has no `status.snapshot`, and pinning it
+/// would mint a phantom `Succeeded` row that enters GFS retention and sets
+/// `has_history`. Pure + shared with the retention-side provenance guards so the
+/// "only a real adopted row is Succeeded/history" rule is unit-tested without a
+/// cluster. The genuine adopt flow converges within a pass, so an interim row is
+/// only transiently phase-less.
+pub(super) fn adopted_row_has_provenance(backup: &Snapshot) -> bool {
+    backup
+        .status
+        .as_ref()
+        .and_then(|s| s.snapshot.as_ref())
+        .is_some()
+}
+
 /// Whether the preflight deadline has passed: `preflight_since + timeout <= now`.
 /// `timeout == None` ⇒ indefinite (never expires); `preflight_since == None` (the
 /// failure just started this reconcile) ⇒ not expired. Pure / clock-injected.

--- a/crates/controller/src/snapshot/plan.rs
+++ b/crates/controller/src/snapshot/plan.rs
@@ -320,12 +320,29 @@ pub fn owner_state_from(fetched: Option<&SnapshotSchedule>, owner: &OwnerReferen
     }
 }
 
-/// Whether this pending deletion counts toward its repository's breaker:
-/// external (no valid pruned-by) AND its plan WITHOUT the breaker is
+/// Whether this pending deletion counts toward its repository's breaker: a
+/// destructive EXTERNAL delete whose plan WITHOUT the breaker is
 /// `DeleteSnapshot`. Implemented by re-running [`plan_deletion`] with
 /// `breaker = Allowed` — one decision function, no forked logic.
+///
+/// The `pruned-by` stamp is **exhaustively** classified (no catch-all), because
+/// not every stamp is breaker-exempt:
+///
+/// - `Retention` / `FailedHistory` are OPERATOR prunes — bounded, deliberate,
+///   steady-state deletes whose rate is governed elsewhere; they are exempt
+///   EVERYWHERE (retention must keep working during an incident, never held).
+/// - `PolicyCascade` and unstamped (`None`) are NOT exempt: they fall through to
+///   the plan check. A `policy-cascade`-stamped child is quiet-retained in
+///   steady state (its plan is `RetainSnapshotOnPolicyDelete`, not
+///   `DeleteSnapshot`, so it still doesn't count), but under a namespace
+///   teardown with `onNamespaceDelete: Delete` its plan becomes an external
+///   destructive `DeleteSnapshot` ([`plan_ns_delete`] → [`plan_external`]) — a
+///   mass deletion that only happens because a human deleted a namespace, so it
+///   MUST count/hold exactly like an unstamped external child. A new
+///   [`PrunedBy`] variant fails to compile until its breaker fate is decided
+///   here (ADR §5.5).
 pub fn counts_toward_breaker(f: DeletionFacts<'_>) -> bool {
-    if pruned_by(f.annotations).is_some() {
+    if !breaker_relevant(pruned_by(f.annotations)) {
         return false;
     }
     matches!(
@@ -335,6 +352,30 @@ pub fn counts_toward_breaker(f: DeletionFacts<'_>) -> bool {
         }),
         DeletionPlan::DeleteSnapshot
     )
+}
+
+/// Whether a `pruned-by` classification is breaker-RELEVANT — a destructive
+/// EXTERNAL delete that counts toward / can be held by the mass-deletion breaker
+/// — as opposed to an exempt OPERATOR prune. **Exhaustive over [`PrunedBy`]** (no
+/// catch-all):
+///
+/// - `Retention` / `FailedHistory` → `false`: operator prunes, exempt everywhere.
+/// - `None` (unstamped) / `PolicyCascade` → `true`: breaker-relevant. A
+///   `PolicyCascade` member only ever reaches the destructive `DeleteSnapshot`
+///   plan (and so the counting set) under an `onNamespaceDelete: Delete` namespace
+///   teardown — a mass deletion a human triggered by deleting a namespace, which
+///   must count/hold like any external child.
+///
+/// The single source of truth shared by [`counts_toward_breaker`] and the
+/// [`crate::snapshot::batch::PendingMember::external`] flag, so the breaker's
+/// count, its held-set, and the surfaced ack value never disagree on which
+/// stamps are exempt. A new [`PrunedBy`] variant fails to compile until its
+/// breaker relevance is decided here (ADR §5.5).
+pub fn breaker_relevant(pruned: Option<PrunedBy>) -> bool {
+    match pruned {
+        Some(PrunedBy::Retention | PrunedBy::FailedHistory) => false,
+        None | Some(PrunedBy::PolicyCascade) => true,
+    }
 }
 
 /// Clamp a parsed ack timestamp to `<= now` (clock-skew guard): a future ack

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -1117,6 +1117,111 @@ fn operator_pruned_bypasses_guard_and_breaker() {
     }
 }
 
+// -- plan_prune: the variant-aware (PrunedBy × DeletionPolicy) 3×3 matrix (M2) --
+
+#[test]
+fn plan_prune_matrix_covers_every_prunedby_x_policy_cell() {
+    let cases = [
+        (
+            PrunedBy::Retention,
+            DeletionPolicy::Delete,
+            DeletionPlan::DeleteSnapshot,
+        ),
+        (
+            PrunedBy::Retention,
+            DeletionPolicy::Retain,
+            DeletionPlan::RetainSnapshot,
+        ),
+        (
+            PrunedBy::Retention,
+            DeletionPolicy::Orphan,
+            DeletionPlan::OrphanSnapshot,
+        ),
+        (
+            PrunedBy::FailedHistory,
+            DeletionPolicy::Delete,
+            DeletionPlan::DeleteSnapshot,
+        ),
+        (
+            PrunedBy::FailedHistory,
+            DeletionPolicy::Retain,
+            DeletionPlan::RetainSnapshot,
+        ),
+        (
+            PrunedBy::FailedHistory,
+            DeletionPolicy::Orphan,
+            DeletionPlan::OrphanSnapshot,
+        ),
+        // The loud downgrade: a policy-cascade prune under an effective
+        // `Delete` policy NEVER contacts the repository.
+        (
+            PrunedBy::PolicyCascade,
+            DeletionPolicy::Delete,
+            DeletionPlan::RetainSnapshotOnPolicyDelete,
+        ),
+        (
+            PrunedBy::PolicyCascade,
+            DeletionPolicy::Retain,
+            DeletionPlan::RetainSnapshot,
+        ),
+        (
+            PrunedBy::PolicyCascade,
+            DeletionPolicy::Orphan,
+            DeletionPlan::OrphanSnapshot,
+        ),
+    ];
+    for (kind, policy, expected) in cases {
+        let a = pruned(kind);
+        // Every operator prune bypasses BOTH the schedule cascade guard and
+        // the breaker — set both to what would otherwise divert the
+        // decision, so this test also proves the prune path short-circuits
+        // them for every kind, not just Retention/FailedHistory.
+        let plan = plan_deletion(DeletionFacts {
+            policy,
+            owner: OwnerState::GoneOrReplaced,
+            cascade: ScheduleDeletePolicy::Retain,
+            breaker: BreakerState::Held,
+            ..base_facts(&a)
+        });
+        assert_eq!(plan, expected, "{kind:?}/{policy:?}");
+    }
+}
+
+#[test]
+fn policy_cascade_stamp_bypasses_schedule_cascade_guard_not_just_the_breaker() {
+    // A composite of the two "bypass" mechanisms: a policy-cascade stamp
+    // must resolve via the prune path (RetainSnapshotOnPolicyDelete), NOT
+    // the schedule cascade guard, even when the owner is gone/replaced and
+    // the schedule cascade is set to Retain (which would otherwise produce
+    // the DIFFERENT plan RetainSnapshotOnScheduleDelete).
+    let a = pruned(PrunedBy::PolicyCascade);
+    let plan = plan_deletion(DeletionFacts {
+        policy: DeletionPolicy::Delete,
+        owner: OwnerState::GoneOrReplaced,
+        cascade: ScheduleDeletePolicy::Retain,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::RetainSnapshotOnPolicyDelete);
+}
+
+#[test]
+fn skip_cleanup_annotation_wins_over_a_policy_cascade_stamp() {
+    // Decision step 1 (skip-cleanup) is absolute — it wins even over an
+    // operator prune stamp.
+    let a = ann(&[
+        (
+            PRUNED_BY_ANNOTATION,
+            PrunedBy::PolicyCascade.annotation_value(),
+        ),
+        (SKIP_SNAPSHOT_CLEANUP_ANNOTATION, "true"),
+    ]);
+    let plan = plan_deletion(DeletionFacts {
+        policy: DeletionPolicy::Delete,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::OrphanSnapshot);
+}
+
 #[test]
 fn unknown_pruned_by_value_treated_external() {
     let a = ann(&[(PRUNED_BY_ANNOTATION, "garbage")]);
@@ -1837,6 +1942,19 @@ fn counts_toward_breaker_cascade_retained_is_false() {
     }));
 }
 
+#[test]
+fn counts_toward_breaker_policy_cascade_stamp_is_false() {
+    // Locks the new PrunedBy::PolicyCascade variant into the existing
+    // early-return short-circuit (any valid pruned-by stamp never counts
+    // toward the breaker) — the M3 finalizer must never see this stamp
+    // inflate a repository's pending count.
+    let a = pruned(PrunedBy::PolicyCascade);
+    assert!(!counts_toward_breaker(DeletionFacts {
+        policy: DeletionPolicy::Delete,
+        ..base_facts(&a)
+    }));
+}
+
 // -- breaker_stores_ready / parse_mass_deletion_ack ------------------------
 
 #[test]
@@ -1965,6 +2083,47 @@ fn hold_message_carries_counts_repo_ack_command_and_escape_hatch() {
     assert!(
         msg.contains(SKIP_SNAPSHOT_CLEANUP_ANNOTATION),
         "escape hatch: {msg}"
+    );
+}
+
+// -- policy_cascade_retained_message (RetainSnapshotOnPolicyDelete executor) --
+
+#[test]
+fn policy_cascade_retained_message_names_cr_retained_state_and_opt_in() {
+    let msg = policy_cascade_retained_message("backups", "nightly-1", true);
+    assert!(msg.contains("backups/nightly-1"), "cr name: {msg}");
+    assert!(
+        msg.contains("RETAINED in the repository"),
+        "states retained: {msg}"
+    );
+    assert!(
+        msg.contains("rediscoverable/adoptable"),
+        "states rediscoverable: {msg}"
+    );
+    assert!(
+        msg.contains("spec.deletion.onPolicyDelete: Delete"),
+        "names the opt-in: {msg}"
+    );
+}
+
+#[test]
+fn policy_cascade_retained_message_cancelled_mid_flight_names_no_completed_snapshot() {
+    // A live child cascaded before its mover Job ever finished: there is no
+    // kopia snapshot to "retain" — the message must say so, not lie about a
+    // snapshot that never existed.
+    let msg = policy_cascade_retained_message("backups", "nightly-2", false);
+    assert!(
+        msg.contains("never completed") && msg.contains("cancelled mid-flight"),
+        "states not-completed: {msg}"
+    );
+    assert!(!msg.contains("RETAINED in the repository"), "{msg}");
+    assert!(
+        msg.contains("rediscoverable/adoptable"),
+        "still states rediscoverable: {msg}"
+    );
+    assert!(
+        msg.contains("spec.deletion.onPolicyDelete: Delete"),
+        "still names the opt-in: {msg}"
     );
 }
 

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -2165,6 +2165,41 @@ fn hold_message_carries_counts_repo_ack_command_and_escape_hatch() {
     );
 }
 
+// -- schedule_cascade_retained_message (RetainSnapshotOnScheduleDelete executor) --
+
+#[test]
+fn schedule_cascade_retained_message_names_cr_and_opt_in() {
+    let msg = schedule_cascade_retained_message("backups", "nightly-1");
+    assert!(msg.contains("backups/nightly-1"), "cr name: {msg}");
+    assert!(msg.contains("RETAINED"), "states retained: {msg}");
+    assert!(
+        msg.contains("spec.deletion.onScheduleDelete: Delete"),
+        "names the opt-in: {msg}"
+    );
+}
+
+#[test]
+fn schedule_cascade_retained_message_does_not_promise_a_refresh_interval() {
+    // Regression: the message used to promise rediscovery "within the
+    // repository's catalog refresh interval", which is misleading now that
+    // periodicRefresh defaults off — nothing runs on a timer unless the user
+    // opted in. The real triggers are a catalog scan (bootstrap, spec change,
+    // or a recreated policy's scan request), followed by default auto-adoption.
+    let msg = schedule_cascade_retained_message("backups", "nightly-1");
+    assert!(
+        !msg.contains("within the repository's catalog refresh interval"),
+        "must not promise a timer-driven refresh: {msg}"
+    );
+    assert!(
+        msg.contains("next catalog scan"),
+        "names the real trigger: {msg}"
+    );
+    assert!(
+        msg.contains("auto-adopted"),
+        "states the post-rediscovery outcome: {msg}"
+    );
+}
+
 // -- policy_cascade_retained_message (RetainSnapshotOnPolicyDelete executor) --
 
 #[test]

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -1309,6 +1309,55 @@ fn ns_terminating_delete_optin_bypasses_guard_but_not_breaker() {
 }
 
 #[test]
+fn ns_terminating_delete_optin_overrides_policy_cascade_stamp() {
+    // Failure-1 regression guard (PR #272): during namespace teardown the
+    // SnapshotPolicy cleanup finalizer stamps its live children `pruned-by:
+    // policy-cascade` (the default `onPolicyDelete: Retain`). That IMPLICIT stamp
+    // must NOT override an EXPLICIT `onNamespaceDelete: Delete` opt-in — the
+    // stamped child resolves as an ordinary external destructive deletion, so a
+    // `deletionPolicy: Delete` snapshot IS reclaimed, not quietly retained. On
+    // HEAD (before the fix) this returned RetainSnapshotOnPolicyDelete: the bug.
+    let a = pruned(PrunedBy::PolicyCascade);
+    let allowed = plan_deletion(DeletionFacts {
+        ns_terminating: true,
+        ns_policy: Some(NamespaceDeletePolicy::Delete),
+        breaker: BreakerState::Allowed,
+        ..base_facts(&a)
+    });
+    assert_eq!(allowed, DeletionPlan::DeleteSnapshot);
+
+    // Still subject to the mass-deletion breaker, exactly like an unstamped
+    // external delete under the same opt-in.
+    let held = plan_deletion(DeletionFacts {
+        ns_terminating: true,
+        ns_policy: Some(NamespaceDeletePolicy::Delete),
+        breaker: BreakerState::Held,
+        ..base_facts(&a)
+    });
+    assert_eq!(held, DeletionPlan::HoldSnapshotDeletion);
+}
+
+#[test]
+fn ns_terminating_policy_cascade_stays_nondestructive_under_default_ns_policy() {
+    // The complement to the opt-in override: a `policy-cascade`-stamped child in
+    // a terminating namespace under the DEFAULT ns policy (Orphan) or an
+    // unresolved repository (None) stays non-destructive — the fix must not make
+    // the default namespace-delete path start reclaiming data. Effective policy
+    // is Delete (base_facts), so this proves the ns policy, not the stamp, wins.
+    // (Passes on HEAD too — the ns-terminating Orphan/None arms short-circuit to
+    // OrphanSnapshot before any prune check; this pins that invariant is kept.)
+    let a = pruned(PrunedBy::PolicyCascade);
+    for ns_policy in [None, Some(NamespaceDeletePolicy::Orphan)] {
+        let plan = plan_deletion(DeletionFacts {
+            ns_terminating: true,
+            ns_policy,
+            ..base_facts(&a)
+        });
+        assert_eq!(plan, DeletionPlan::OrphanSnapshot, "{ns_policy:?}");
+    }
+}
+
+#[test]
 fn breaker_never_holds_retain_or_orphan() {
     let a = BTreeMap::new();
     for policy in [DeletionPolicy::Retain, DeletionPolicy::Orphan] {

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -1358,6 +1358,27 @@ fn ns_terminating_policy_cascade_stays_nondestructive_under_default_ns_policy() 
 }
 
 #[test]
+fn ns_terminating_retention_prune_keeps_prune_semantics_never_held() {
+    // A genuine OPERATOR prune (Retention/FailedHistory) in a terminating
+    // namespace under `onNamespaceDelete: Delete` keeps its prune semantics: it
+    // deletes on effective `Delete` and is NEVER held by the breaker, even with
+    // the breaker tripping. `plan_ns_delete` routes it to `plan_prune`, not
+    // `plan_external`, so the ns-teardown opt-in does not turn retention into a
+    // breaker-gated mass deletion — retention must keep working during an
+    // incident. This is the invariant the PolicyCascade fix must not disturb.
+    for kind in [PrunedBy::Retention, PrunedBy::FailedHistory] {
+        let a = pruned(kind);
+        let plan = plan_deletion(DeletionFacts {
+            ns_terminating: true,
+            ns_policy: Some(NamespaceDeletePolicy::Delete),
+            breaker: BreakerState::Held,
+            ..base_facts(&a)
+        });
+        assert_eq!(plan, DeletionPlan::DeleteSnapshot, "{kind:?} never held");
+    }
+}
+
+#[test]
 fn breaker_never_holds_retain_or_orphan() {
     let a = BTreeMap::new();
     for policy in [DeletionPolicy::Retain, DeletionPolicy::Orphan] {
@@ -2071,16 +2092,76 @@ fn counts_toward_breaker_cascade_retained_is_false() {
 }
 
 #[test]
-fn counts_toward_breaker_policy_cascade_stamp_is_false() {
-    // Locks the new PrunedBy::PolicyCascade variant into the existing
-    // early-return short-circuit (any valid pruned-by stamp never counts
-    // toward the breaker) — the M3 finalizer must never see this stamp
-    // inflate a repository's pending count.
+fn counts_toward_breaker_policy_cascade_stamp_is_false_in_live_namespace() {
+    // In a LIVE namespace a `policy-cascade` stamp is quiet-retained
+    // (RetainSnapshotOnPolicyDelete), never a destructive delete, so it does not
+    // count toward the breaker — even though `PolicyCascade` (unlike
+    // Retention/FailedHistory) is no longer blanket-exempted. The plan check,
+    // not a stamp short-circuit, is what excludes it here.
     let a = pruned(PrunedBy::PolicyCascade);
     assert!(!counts_toward_breaker(DeletionFacts {
         policy: DeletionPolicy::Delete,
         ..base_facts(&a)
     }));
+}
+
+#[test]
+fn counts_toward_breaker_policy_cascade_stamp_is_true_under_ns_teardown_delete() {
+    // The gap this fix closes (PR #272): during a namespace teardown with the
+    // explicit `onNamespaceDelete: Delete` opt-in, a `policy-cascade`-stamped
+    // child resolves to an external destructive DeleteSnapshot
+    // (plan_ns_delete → plan_external), so it MUST count toward the per-repo
+    // mass-deletion breaker exactly like an unstamped external child — otherwise
+    // a large teardown that stamps all its children mass-deletes kopia data with
+    // NO breaker hold and NO ack. On HEAD this returned false (any pruned-by was
+    // blanket-exempt), silently nullifying the breaker in the common case.
+    let a = pruned(PrunedBy::PolicyCascade);
+    assert!(counts_toward_breaker(DeletionFacts {
+        policy: DeletionPolicy::Delete,
+        ns_terminating: true,
+        ns_policy: Some(NamespaceDeletePolicy::Delete),
+        ..base_facts(&a)
+    }));
+}
+
+#[test]
+fn counts_toward_breaker_retention_prune_stays_exempt_even_under_ns_teardown_delete() {
+    // The stamp-exemption exists for OPERATOR prunes: Retention (and
+    // FailedHistory) are bounded, deliberate, steady-state deletes that must
+    // keep working during an incident and are NEVER held. That exemption holds
+    // EVERYWHERE — including a terminating namespace under `Delete` — so an
+    // operator prune never trips the breaker.
+    for kind in [PrunedBy::Retention, PrunedBy::FailedHistory] {
+        let a = pruned(kind);
+        assert!(
+            !counts_toward_breaker(DeletionFacts {
+                policy: DeletionPolicy::Delete,
+                ns_terminating: true,
+                ns_policy: Some(NamespaceDeletePolicy::Delete),
+                ..base_facts(&a)
+            }),
+            "{kind:?} must stay breaker-exempt under ns-teardown Delete"
+        );
+    }
+}
+
+#[test]
+fn counts_toward_breaker_policy_cascade_stamp_is_false_under_ns_teardown_orphan() {
+    // Complement to the Delete case: under the DEFAULT ns policy (Orphan) or an
+    // unresolved repository (None), a terminating `policy-cascade` child plans
+    // OrphanSnapshot — non-destructive — so it must NOT count toward the breaker.
+    let a = pruned(PrunedBy::PolicyCascade);
+    for ns_policy in [None, Some(NamespaceDeletePolicy::Orphan)] {
+        assert!(
+            !counts_toward_breaker(DeletionFacts {
+                policy: DeletionPolicy::Delete,
+                ns_terminating: true,
+                ns_policy,
+                ..base_facts(&a)
+            }),
+            "{ns_policy:?}"
+        );
+    }
 }
 
 // -- breaker_stores_ready / parse_mass_deletion_ack ------------------------

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -1340,6 +1340,84 @@ fn orphaned_ownerref_children_get_their_own_policy() {
     }
 }
 
+// -- Adopted origin: deletion planning (M5) -------------------------------
+//
+// `Origin::Adopted` rows run through `plan_deletion` exactly like a produced
+// (Scheduled/Manual) row once `effective_deletion_policy` has resolved their
+// policy — unlike Discovered, they are NOT forced to Retain. These lock that
+// in end-to-end: `effective_deletion_policy(_, Origin::Adopted)` feeding
+// `plan_deletion`/`counts_toward_breaker`.
+
+#[test]
+fn adopted_external_delete_with_no_schedule_owner_deletes() {
+    // Adopted rows are NOT forced-Retain like Discovered: an external delete
+    // with no schedule owner and the breaker allowed deletes exactly like a
+    // produced row's would.
+    let a = BTreeMap::new();
+    let policy = effective_deletion_policy(None, Origin::Adopted);
+    assert_eq!(policy, DeletionPolicy::Delete);
+    let plan = plan_deletion(DeletionFacts {
+        policy,
+        owner: OwnerState::NoScheduleOwner,
+        breaker: BreakerState::Allowed,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::DeleteSnapshot);
+}
+
+#[test]
+fn adopted_external_delete_counts_toward_and_is_held_by_the_breaker() {
+    // Adopted external deletes count toward the per-repo mass-deletion breaker
+    // exactly like produced ones — the breaker doesn't special-case origin.
+    let a = BTreeMap::new();
+    let policy = effective_deletion_policy(None, Origin::Adopted);
+
+    assert!(counts_toward_breaker(DeletionFacts {
+        policy,
+        owner: OwnerState::NoScheduleOwner,
+        ..base_facts(&a)
+    }));
+
+    // Over threshold + unacked ⇒ held, never silently deleted.
+    let plan = plan_deletion(DeletionFacts {
+        policy,
+        owner: OwnerState::NoScheduleOwner,
+        breaker: BreakerState::Held,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::HoldSnapshotDeletion);
+}
+
+#[test]
+fn adopted_retention_prune_deletes_never_held() {
+    // Retention is the whole point of adoption: an operator retention prune on
+    // an adopted row deletes even with the breaker Held (operator prunes always
+    // bypass the breaker, same as any produced row).
+    let a = pruned(PrunedBy::Retention);
+    let policy = effective_deletion_policy(Some(DeletionPolicy::Delete), Origin::Adopted);
+    let plan = plan_deletion(DeletionFacts {
+        policy,
+        owner: OwnerState::NoScheduleOwner,
+        breaker: BreakerState::Held,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::DeleteSnapshot);
+}
+
+#[test]
+fn adopted_policy_cascade_prune_retains_kopia_data() {
+    // A SnapshotPolicy-deletion cascade keeps kopia data even for an adopted
+    // row: the loud downgrade (RetainSnapshotOnPolicyDelete) fires for Adopted
+    // exactly as it does for a produced row under an effective Delete policy.
+    let a = pruned(PrunedBy::PolicyCascade);
+    let policy = effective_deletion_policy(None, Origin::Adopted);
+    let plan = plan_deletion(DeletionFacts {
+        policy,
+        ..base_facts(&a)
+    });
+    assert_eq!(plan, DeletionPlan::RetainSnapshotOnPolicyDelete);
+}
+
 // -- table test: every meaningful row of the decision matrix -------------
 
 /// One row of the decision matrix: the facts that matter for that row plus
@@ -2430,6 +2508,116 @@ fn produced_honors_explicit_spec_policy() {
         effective_deletion_policy(Some(DeletionPolicy::Retain), Origin::Scheduled),
         DeletionPolicy::Retain
     );
+}
+
+#[test]
+fn adopted_defaults_to_delete_like_produced_not_retain() {
+    // M5: an adopted row is managed like any produced backup (Scheduled/Manual),
+    // NOT forced to Retain like Discovered — retention is the whole point of
+    // adoption, so the default must be Delete when the spec leaves it unset.
+    assert_eq!(
+        effective_deletion_policy(None, Origin::Adopted),
+        DeletionPolicy::Delete
+    );
+    assert_eq!(
+        effective_deletion_policy(Some(DeletionPolicy::Orphan), Origin::Adopted),
+        DeletionPolicy::Orphan
+    );
+}
+
+// --- resolve_origin: status-first precedence over the origin label (M5) ----
+
+/// A bare `Snapshot` with `status.origin`/the origin label set as given, for
+/// exercising [`resolve_origin`]'s precedence. `None`/`None` mirrors a raw
+/// `kubectl create` (no status yet, no label stamped).
+fn backup_with_origin(status_origin: Option<Origin>, label: Option<&str>) -> Snapshot {
+    let mut backup = dummy_backup();
+    if let Some(o) = status_origin {
+        backup.status = Some(kopiur_api::snapshot::SnapshotStatus {
+            origin: Some(o),
+            ..Default::default()
+        });
+    }
+    if let Some(l) = label {
+        backup
+            .labels_mut()
+            .insert(crate::consts::ORIGIN_LABEL.to_string(), l.to_string());
+    }
+    backup
+}
+
+#[test]
+fn resolve_origin_defaults_to_manual_with_no_status_or_label() {
+    assert_eq!(
+        resolve_origin(&backup_with_origin(None, None)),
+        Origin::Manual
+    );
+}
+
+#[test]
+fn resolve_origin_status_wins_over_a_conflicting_label() {
+    // status.origin is canonical: a stale/mismatched `discovered` label (e.g.
+    // from before an M6 adoption re-stamped status) must never demote an
+    // already-adopted row back to Discovered.
+    let backup = backup_with_origin(Some(Origin::Adopted), Some("discovered"));
+    assert_eq!(resolve_origin(&backup), Origin::Adopted);
+}
+
+#[test]
+fn resolve_origin_reads_adopted_from_the_label_when_status_is_unset() {
+    // Label-only adoption (status not yet stamped, e.g. mid-reconcile) still
+    // resolves to Adopted — the label is the fallback, not just Discovered's.
+    let backup = backup_with_origin(None, Some("adopted"));
+    assert_eq!(resolve_origin(&backup), Origin::Adopted);
+}
+
+// --- needs_terminal_pin: shared idempotence gate for the Discovered/Adopted
+// steady-state pin arms (M5) -------------------------------------------------
+//
+// `reconcile_inner`'s `pin_discovered_row`/`pin_adopted_row` are thin async IO
+// wrappers around a `snapshot_ready_status` patch; the one piece of actual
+// decision logic they contain — whether a patch is needed at all this pass —
+// is this pure predicate, extracted so the "only pin when unset/divergent,
+// never re-patch once converged" idempotence is unit-tested without a cluster.
+// The wrapper functions' IO (the patch calls, `ensure_finalizer`, the terminal
+// requeue) is exercised live by the M8 e2e suite, not here.
+
+#[test]
+fn needs_terminal_pin_true_when_phase_unset() {
+    assert!(super::plan::needs_terminal_pin(
+        None,
+        SnapshotPhase::Discovered
+    ));
+    assert!(super::plan::needs_terminal_pin(
+        None,
+        SnapshotPhase::Succeeded
+    ));
+}
+
+#[test]
+fn needs_terminal_pin_true_when_phase_diverges_from_target() {
+    assert!(super::plan::needs_terminal_pin(
+        Some(SnapshotPhase::Pending),
+        SnapshotPhase::Succeeded
+    ));
+    assert!(super::plan::needs_terminal_pin(
+        Some(SnapshotPhase::Succeeded),
+        SnapshotPhase::Discovered
+    ));
+}
+
+#[test]
+fn needs_terminal_pin_false_once_converged() {
+    // The idempotence both `pin_discovered_row` and `pin_adopted_row` rely on:
+    // once the observed phase matches the arm's own target, no further patch.
+    assert!(!super::plan::needs_terminal_pin(
+        Some(SnapshotPhase::Discovered),
+        SnapshotPhase::Discovered
+    ));
+    assert!(!super::plan::needs_terminal_pin(
+        Some(SnapshotPhase::Succeeded),
+        SnapshotPhase::Succeeded
+    ));
 }
 
 fn job_with_status(status: Option<k8s_openapi::api::batch::v1::JobStatus>) -> Job {

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -236,6 +236,8 @@ fn sample_policy() -> kopiur_api::SnapshotPolicy {
             hooks: None,
             mover: None,
             credential_projection: None,
+            deletion: None,
+            adoption: None,
         },
     )
 }
@@ -445,6 +447,8 @@ fn config_with_source(name: &str, source: kopiur_api::snapshot_policy::Source) -
             hooks: None,
             mover: None,
             credential_projection: None,
+            deletion: None,
+            adoption: None,
         },
     )
 }

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -2786,6 +2786,42 @@ fn needs_terminal_pin_false_once_converged() {
     ));
 }
 
+#[test]
+fn adopted_row_has_provenance_gates_the_succeeded_pin() {
+    use kopiur_api::common::ResolvedIdentity;
+    use kopiur_api::snapshot::{SnapshotInfo, SnapshotStatus};
+    // I1: a user-applied BARE `origin: adopted` label with NO `status.snapshot`
+    // resolves `Adopted` (label fallback) but carries NO controller-written
+    // provenance — `pin_adopted_row` must NOT pin it `Succeeded`. A phantom
+    // Succeeded row would enter GFS retention (displacing a real snapshot) and set
+    // `has_history` (suppressing a recreated policy's scan). On HEAD
+    // `pin_adopted_row` pinned ANY Adopted-resolving row.
+    let forged = backup_with_origin(None, Some("adopted"));
+    assert_eq!(resolve_origin(&forged), Origin::Adopted);
+    assert!(
+        !super::plan::adopted_row_has_provenance(&forged),
+        "a bare origin:adopted label carries no provenance"
+    );
+    // A genuine adopted row (adopt_one wrote `status.snapshot`) IS pinned.
+    let mut genuine = dummy_backup();
+    genuine.status = Some(SnapshotStatus {
+        origin: Some(Origin::Adopted),
+        snapshot: Some(SnapshotInfo {
+            kopia_snapshot_id: "k-abc".into(),
+            identity: ResolvedIdentity {
+                username: "u".into(),
+                hostname: "h".into(),
+                source_path: Some("/d".into()),
+            },
+        }),
+        ..Default::default()
+    });
+    assert!(
+        super::plan::adopted_row_has_provenance(&genuine),
+        "a controller-written adopted row carries provenance"
+    );
+}
+
 fn job_with_status(status: Option<k8s_openapi::api::batch::v1::JobStatus>) -> Job {
     Job {
         status,

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -414,6 +414,7 @@ fn resolved_s3_repo() -> io::ResolvedRepository {
         owner_ref: Default::default(),
         deletion_protection: None,
         mass_deletion_ack: None,
+        catalog: None,
     }
 }
 

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -63,6 +63,14 @@ pub fn retention_view(b: &Snapshot) -> Option<SnapshotRetentionView> {
     if status.phase != Some(SnapshotPhase::Succeeded) {
         return None;
     }
+    // PROVENANCE (defense in depth): a `Succeeded` row only participates in GFS
+    // when it carries CONTROLLER-WRITTEN provenance (`status.snapshot`, the kopia
+    // id the operator produced or adopted). This closes the phantom-Succeeded
+    // displacement even if a phase were ever pinned without one — a forged bare
+    // `origin: adopted` label whose creationTimestamp fallback would otherwise
+    // claim a GFS bucket and displace a real snapshot into the retention delete
+    // set. Every genuine produced/adopted row has `status.snapshot`.
+    status.snapshot.as_ref()?;
     let end_time = status
         .timing
         .as_ref()
@@ -919,7 +927,19 @@ fn own_snapshot_ids_and_history(
         {
             ids.insert(info.kopia_snapshot_id.clone());
         }
-        if retention_view(b).is_some() || crate::snapshot::resolve_origin(b) == Origin::Adopted {
+        // The `Adopted` arm requires the SAME controller-written provenance
+        // (`status.snapshot`) as `retention_view` — a forged bare `origin: adopted`
+        // label with no status must NOT count as history, or it would suppress a
+        // recreated policy's one on-demand scan. (`retention_view` already requires
+        // provenance, so a genuine adopted row that has converged to `Succeeded` is
+        // caught by the first arm; this arm additionally counts an interim
+        // controller-written adopted row before its phase pins.)
+        let adopted_with_provenance = crate::snapshot::resolve_origin(b) == Origin::Adopted
+            && b.status
+                .as_ref()
+                .and_then(|s| s.snapshot.as_ref())
+                .is_some();
+        if retention_view(b).is_some() || adopted_with_provenance {
             has_history = true;
         }
     }
@@ -944,11 +964,31 @@ async fn execute_adoptions(
     Ok(count)
 }
 
+/// **Pure.** Whether the object found at the adopted row's name on a create-409
+/// is really THIS candidate's adopted row (a prior wave that crashed before the
+/// status patch), and not a name-collision STRANGER. Requires the matching
+/// `SNAPSHOT_ID_LABEL` AND a catalog origin label (`adopted`/`discovered`). On a
+/// mismatch [`adopt_one`] skips the status patch (and the discovered-row delete)
+/// rather than clobber a stranger's status.
+fn adopted_row_matches_candidate(existing: &Snapshot, snapshot_id: &str) -> bool {
+    let labels = existing.labels();
+    let id_matches = labels
+        .get(crate::consts::SNAPSHOT_ID_LABEL)
+        .map(String::as_str)
+        == Some(snapshot_id);
+    let origin = labels.get(crate::consts::ORIGIN_LABEL).map(String::as_str);
+    let origin_is_catalog = origin == Some(Origin::Adopted.label_value())
+        || origin == Some(Origin::Discovered.label_value());
+    id_matches && origin_is_catalog
+}
+
 /// Adopt one discovered row (inv. 4): CREATE the adopted row FIRST in the
 /// POLICY's namespace, ENSURE its status, THEN delete the discovered row in ITS
 /// OWN namespace. On create-409 (a prior wave already created it) DO NOT
 /// early-return — fall through to re-ensure the status so a crash between create
-/// and status-patch is healed. Every step is 404/409-tolerant.
+/// and status-patch is healed, but FIRST verify the occupant is really this
+/// candidate's adopted row ([`adopted_row_matches_candidate`]): a name-collision
+/// stranger must never have its status overwritten. Every step is 404/409-tolerant.
 async fn adopt_one(
     ctx: &Context,
     config: &SnapshotPolicy,
@@ -962,9 +1002,25 @@ async fn adopt_one(
 
     match policy_api.create(&PostParams::default(), &adopted).await {
         Ok(_) => {}
-        // Already exists (a prior wave crashed after create) — ensure status, do
-        // NOT early-return.
-        Err(kube::Error::Api(ae)) if ae.code == 409 => {}
+        // Already exists (a prior wave crashed after create) — verify it is really
+        // OUR adopted row before re-ensuring status; do NOT early-return on the
+        // happy path.
+        Err(kube::Error::Api(ae)) if ae.code == 409 => match policy_api.get_opt(&cr_name).await? {
+            Some(existing) if adopted_row_matches_candidate(&existing, &candidate.snapshot_id) => {}
+            Some(_) => {
+                tracing::warn!(
+                    policy = %config.name_any(),
+                    adopted = %cr_name,
+                    discovered = %candidate.name,
+                    "adopted-row name is occupied by an object that is not this candidate's \
+                     adopted row (label mismatch); skipping to avoid overwriting a stranger's status"
+                );
+                return Ok(());
+            }
+            // 409 then vanished (a concurrent delete): nothing to adopt this pass,
+            // re-planned on the next reconcile.
+            None => return Ok(()),
+        },
         Err(e) => return Err(Error::Kube(e)),
     }
     io::patch_status(&policy_api, &cr_name, serde_json::to_value(&status)?).await?;
@@ -1260,6 +1316,108 @@ mod tests {
             del,
             ["d23".to_string(), "d22".to_string()].into_iter().collect()
         );
+    }
+
+    // -- I1: provenance gates on adopted / retention rows ---------------------
+
+    #[test]
+    fn retention_view_requires_controller_written_provenance() {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::Time;
+        // A Succeeded row with NO status.snapshot must NOT participate in GFS. This
+        // is the exact shape a HEAD `pin_adopted_row` would mint for a forged
+        // `origin: adopted` label: phase pinned Succeeded, no provenance. Its
+        // creationTimestamp fallback would otherwise claim a GFS bucket and displace
+        // a real snapshot into the (breaker-exempt) retention delete set.
+        let mut phantom = succeeded_backup("phantom", at(2026, 5, 24));
+        let s = phantom.status.as_mut().unwrap();
+        s.snapshot = None; // strip controller-written provenance
+        s.timing = None; // force the creationTimestamp fallback path
+        phantom.metadata.creation_timestamp = Some(Time(
+            k8s_openapi::jiff::Timestamp::from_second(1_700_000_000).unwrap(),
+        ));
+        assert!(
+            retention_view(&phantom).is_none(),
+            "a Succeeded row without status.snapshot never enters GFS (HEAD returned \
+             Some via the creationTimestamp fallback)"
+        );
+        // A genuine produced/adopted row (status.snapshot present) still enters GFS.
+        assert!(retention_view(&succeeded_backup("real", at(2026, 5, 24))).is_some());
+    }
+
+    #[test]
+    fn has_history_requires_provenance_for_a_bare_adopted_label() {
+        // A forged BARE `origin: adopted` label row (no status at all) must NOT
+        // count as history — counting it would suppress a delete-then-recreated
+        // policy's one on-demand catalog scan. On HEAD the `origin == Adopted` arm
+        // set has_history from the label alone.
+        let mut forged = succeeded_backup("forged", at(2026, 5, 24));
+        forged.status = None; // bare row: label only, no controller-written status
+        let mut labels = BTreeMap::new();
+        labels.insert(
+            crate::consts::ORIGIN_LABEL.to_string(),
+            Origin::Adopted.label_value().to_string(),
+        );
+        forged.metadata.labels = Some(labels);
+        assert_eq!(crate::snapshot::resolve_origin(&forged), Origin::Adopted);
+        let (_ids, has_history) = own_snapshot_ids_and_history(&[forged]);
+        assert!(
+            !has_history,
+            "a bare origin:adopted label with no status.snapshot is not history"
+        );
+
+        // A genuine adopted row (status.snapshot present) DOES count as history.
+        let (_ids, has_history) =
+            own_snapshot_ids_and_history(&[backup_with_origin("genuine", Origin::Adopted)]);
+        assert!(has_history, "a controller-written adopted row is history");
+    }
+
+    #[test]
+    fn adopted_row_matches_candidate_guards_name_collision_strangers() {
+        let row = |id: Option<&str>, origin: Option<&str>| {
+            let mut b = Snapshot::new(
+                "occupant",
+                SnapshotSpec {
+                    policy_ref: None,
+                    tags: None,
+                    failure_policy: None,
+                    deletion_policy: None,
+                    on_schedule_delete: None,
+                    pin: false,
+                    description: None,
+                },
+            );
+            let mut labels = BTreeMap::new();
+            if let Some(id) = id {
+                labels.insert(crate::consts::SNAPSHOT_ID_LABEL.to_string(), id.to_string());
+            }
+            if let Some(o) = origin {
+                labels.insert(crate::consts::ORIGIN_LABEL.to_string(), o.to_string());
+            }
+            b.metadata.labels = Some(labels);
+            b
+        };
+        // Our adopted row (a prior wave's crash-before-status-patch) → matches.
+        assert!(adopted_row_matches_candidate(
+            &row(Some("abc"), Some("adopted")),
+            "abc"
+        ));
+        // A discovered-origin occupant at the name is also a catalog row → matched.
+        assert!(adopted_row_matches_candidate(
+            &row(Some("abc"), Some("discovered")),
+            "abc"
+        ));
+        // Wrong snapshot id → stranger (name collision on the first-16 id prefix).
+        assert!(!adopted_row_matches_candidate(
+            &row(Some("xyz"), Some("adopted")),
+            "abc"
+        ));
+        // Non-catalog origin (a produced snapshot) → stranger.
+        assert!(!adopted_row_matches_candidate(
+            &row(Some("abc"), Some("scheduled")),
+            "abc"
+        ));
+        // Missing labels entirely → stranger.
+        assert!(!adopted_row_matches_candidate(&row(None, None), "abc"));
     }
 
     /// Mark a Snapshot terminating, optionally with a valid `pruned-by` stamp.

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -18,10 +18,10 @@ use kube::api::ListParams;
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 
-use kopiur_api::common::Retention;
+use kopiur_api::common::{PolicyDeletePolicy, Retention};
 use kopiur_api::retention::{SnapshotLike, select_kept};
 use kopiur_api::snapshot::PrunedBy;
-use kopiur_api::{Snapshot, SnapshotPolicy, validate};
+use kopiur_api::{Origin, Snapshot, SnapshotPolicy, validate};
 
 use crate::consts::CONFIG_LABEL;
 use crate::context::Context;
@@ -126,6 +126,99 @@ pub fn partition_retention_prune(
         }
     }
     (to_delete, to_stamp_only)
+}
+
+/// The plan for cascading a `SnapshotPolicy` deletion onto the `Snapshot` CRs
+/// carrying its config label (wired to the policy finalizer in M3; nothing
+/// calls this yet). **Pure** — no IO, no repository contact of its own.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct PolicyCascadePlan {
+    /// `PolicyDeletePolicy::Retain`, live children: stamp `pruned-by:
+    /// policy-cascade` then delete the CR (the kopia snapshot is NEVER
+    /// touched — the stamp is what routes the Snapshot finalizer to
+    /// [`crate::snapshot::DeletionPlan::RetainSnapshotOnPolicyDelete`] instead
+    /// of a real repository delete, even when the Snapshot's own
+    /// `deletionPolicy` is `Delete`).
+    pub stamp_and_delete: Vec<String>,
+    /// `PolicyDeletePolicy::Retain`, terminating children with NO valid
+    /// `pruned-by` stamp: an in-flight external (or breaker-held) deletion,
+    /// reclassified into a quiet retain drain by stamping the annotation ONLY
+    /// (already terminating — there is nothing left to delete). This is the
+    /// finalizer-release guarantee: a breaker-held terminating child must
+    /// resolve to "no work" here, or the M3 policy finalizer would wedge
+    /// forever waiting on a mass-deletion ack that will never come once the
+    /// policy itself is gone.
+    pub stamp_only: Vec<String>,
+    /// `PolicyDeletePolicy::Delete`, live children: a bare UNSTAMPED delete —
+    /// each child's own `deletionPolicy` applies as an ordinary EXTERNAL
+    /// deletion, subject to the per-repository mass-deletion breaker. NEVER
+    /// stamped: stamping here would launder an external-classified deletion
+    /// past the breaker.
+    pub delete_only: Vec<String>,
+}
+
+/// **Pure.** Decide how a `SnapshotPolicy` deletion cascades onto its
+/// `children` `Snapshot` CRs under the policy's effective `mode`
+/// ([`kopiur_api::snapshot_policy::effective_on_policy_delete`]).
+///
+/// Rules, in order:
+/// 1. **Origin filter** (exhaustive over [`Origin`], status-first via
+///    [`crate::snapshot::resolve_origin`]): `Discovered` is NEVER included in
+///    any set — a hand-labeled discovered CR must not churn just because a
+///    policy it merely resembles was deleted. `Adopted | Scheduled | Manual`
+///    are cascaded — all three are operator-managed rows.
+/// 2. **Terminating exclusion**: only a child with
+///    `metadata.deletionTimestamp.is_none()` (live) may enter
+///    `stamp_and_delete` or `delete_only`. A terminating child is handled by
+///    `stamp_only` (Retain mode, unstamped) or left alone entirely (every
+///    other case) — never re-deleted.
+/// 3. **Exhaustive match on `(terminating, mode)`** (2×2, no catch-all):
+///    - `(live, Retain)` → `stamp_and_delete`.
+///    - `(live, Delete)` → `delete_only`.
+///    - `(terminating, Retain)` → `stamp_only` iff no valid `pruned-by` stamp
+///      is already present (an already-stamped terminating child is already
+///      draining correctly — nothing to do).
+///    - `(terminating, Delete)` → nothing (already terminating; `Delete` mode
+///      never stamps).
+pub fn plan_policy_cascade(children: &[Snapshot], mode: PolicyDeletePolicy) -> PolicyCascadePlan {
+    let mut plan = PolicyCascadePlan::default();
+    for child in children {
+        if cascade_eligible(child) {
+            classify_policy_cascade_child(child, mode, &mut plan);
+        }
+    }
+    plan
+}
+
+/// Step 1 of [`plan_policy_cascade`]: exhaustive over [`Origin`]. Only
+/// `Discovered` is excluded — the operator did not create that kopia
+/// snapshot and must never churn it on a policy's say-so.
+fn cascade_eligible(child: &Snapshot) -> bool {
+    match crate::snapshot::resolve_origin(child) {
+        Origin::Discovered => false,
+        Origin::Adopted | Origin::Scheduled | Origin::Manual => true,
+    }
+}
+
+/// Steps 2-3 of [`plan_policy_cascade`]: exhaustive over `(terminating,
+/// mode)` for one already-eligible child.
+fn classify_policy_cascade_child(
+    child: &Snapshot,
+    mode: PolicyDeletePolicy,
+    plan: &mut PolicyCascadePlan,
+) {
+    let name = child.name_any();
+    let terminating = child.metadata.deletion_timestamp.is_some();
+    match (terminating, mode) {
+        (false, PolicyDeletePolicy::Retain) => plan.stamp_and_delete.push(name),
+        (false, PolicyDeletePolicy::Delete) => plan.delete_only.push(name),
+        (true, PolicyDeletePolicy::Retain) => {
+            if crate::snapshot::pruned_by(child.annotations()).is_none() {
+                plan.stamp_only.push(name);
+            }
+        }
+        (true, PolicyDeletePolicy::Delete) => {}
+    }
 }
 
 /// Count the most-recent run of consecutive `Failed` backups before the latest
@@ -707,6 +800,122 @@ mod tests {
         // Terminating + no pruned-by → stamp only (reclassify draining prune).
         assert_eq!(to_stamp_only, vec!["term-unstamped".to_string()]);
         // Terminating + already stamped, and the absent one, are in neither set.
+    }
+
+    // -- plan_policy_cascade (M2 — pure decision layer; wired to a finalizer in M3) --
+
+    /// A `Succeeded` Snapshot with the given `origin` (status-first, matching
+    /// `resolve_origin`'s precedence).
+    fn backup_with_origin(name: &str, origin: Origin) -> Snapshot {
+        let mut b = succeeded_backup(name, at(2026, 5, 24));
+        if let Some(s) = b.status.as_mut() {
+            s.origin = Some(origin);
+        }
+        b
+    }
+
+    #[test]
+    fn plan_policy_cascade_retain_mode_mixed_population() {
+        let children = vec![
+            backup_with_origin("live-produced", Origin::Scheduled),
+            backup_with_origin("live-adopted", Origin::Adopted),
+            backup_with_origin("live-discovered", Origin::Discovered),
+            terminating(backup_with_origin("term-unstamped", Origin::Manual), false),
+            terminating(backup_with_origin("term-stamped", Origin::Scheduled), true),
+        ];
+        let plan = plan_policy_cascade(&children, PolicyDeletePolicy::Retain);
+        let stamp_and_delete: BTreeSet<String> = plan.stamp_and_delete.into_iter().collect();
+        assert_eq!(
+            stamp_and_delete,
+            ["live-produced".to_string(), "live-adopted".to_string()]
+                .into_iter()
+                .collect(),
+            "discovered is excluded; adopted is cascaded like produced"
+        );
+        assert_eq!(plan.stamp_only, vec!["term-unstamped".to_string()]);
+        assert!(
+            plan.delete_only.is_empty(),
+            "Retain mode never bare-deletes"
+        );
+    }
+
+    #[test]
+    fn plan_policy_cascade_delete_mode_mixed_population() {
+        let children = vec![
+            backup_with_origin("live-produced", Origin::Scheduled),
+            backup_with_origin("live-adopted", Origin::Adopted),
+            backup_with_origin("live-discovered", Origin::Discovered),
+            terminating(backup_with_origin("term-unstamped", Origin::Manual), false),
+            terminating(backup_with_origin("term-stamped", Origin::Scheduled), true),
+        ];
+        let plan = plan_policy_cascade(&children, PolicyDeletePolicy::Delete);
+        let delete_only: BTreeSet<String> = plan.delete_only.into_iter().collect();
+        assert_eq!(
+            delete_only,
+            ["live-produced".to_string(), "live-adopted".to_string()]
+                .into_iter()
+                .collect(),
+            "discovered is excluded; adopted is cascaded like produced, bare-unstamped"
+        );
+        assert!(plan.stamp_and_delete.is_empty(), "Delete mode never stamps");
+        assert!(
+            plan.stamp_only.is_empty(),
+            "Delete mode never touches terminating children"
+        );
+    }
+
+    #[test]
+    fn plan_policy_cascade_excludes_discovered_from_every_set_live_and_terminating() {
+        // Defensive: a hand-labeled discovered CR must not churn just because a
+        // policy it merely resembles was deleted — neither live nor terminating.
+        let children = vec![
+            backup_with_origin("live-discovered", Origin::Discovered),
+            terminating(
+                backup_with_origin("term-discovered", Origin::Discovered),
+                false,
+            ),
+        ];
+        for mode in [PolicyDeletePolicy::Retain, PolicyDeletePolicy::Delete] {
+            let plan = plan_policy_cascade(&children, mode);
+            assert!(plan.stamp_and_delete.is_empty(), "{mode:?}");
+            assert!(plan.stamp_only.is_empty(), "{mode:?}");
+            assert!(plan.delete_only.is_empty(), "{mode:?}");
+        }
+    }
+
+    #[test]
+    fn plan_policy_cascade_empty_input_is_empty_plan() {
+        for mode in [PolicyDeletePolicy::Retain, PolicyDeletePolicy::Delete] {
+            let plan = plan_policy_cascade(&[], mode);
+            assert_eq!(plan, PolicyCascadePlan::default(), "{mode:?}");
+        }
+    }
+
+    #[test]
+    fn plan_policy_cascade_only_terminating_children_yields_no_live_work_in_either_mode() {
+        // The release-condition guarantee: a population of ONLY breaker-held
+        // terminating children must yield empty stamp_and_delete AND empty
+        // delete_only in BOTH modes, or the M3 finalizer would wait forever on
+        // a mass-deletion ack that can never come once the policy is gone.
+        let children = vec![
+            terminating(
+                backup_with_origin("held-unstamped", Origin::Scheduled),
+                false,
+            ),
+            terminating(backup_with_origin("held-stamped", Origin::Adopted), true),
+        ];
+        for mode in [PolicyDeletePolicy::Retain, PolicyDeletePolicy::Delete] {
+            let plan = plan_policy_cascade(&children, mode);
+            assert!(plan.stamp_and_delete.is_empty(), "{mode:?}");
+            assert!(plan.delete_only.is_empty(), "{mode:?}");
+        }
+        // Retain mode still performs its documented non-blocking side effect
+        // (stamping the unstamped one so its finalizer drains quietly); Delete
+        // mode touches nothing in this population at all.
+        let retain_plan = plan_policy_cascade(&children, PolicyDeletePolicy::Retain);
+        assert_eq!(retain_plan.stamp_only, vec!["held-unstamped".to_string()]);
+        let delete_plan = plan_policy_cascade(&children, PolicyDeletePolicy::Delete);
+        assert!(delete_plan.stamp_only.is_empty());
     }
 
     #[test]

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -23,10 +23,11 @@ use kopiur_api::retention::{SnapshotLike, select_kept};
 use kopiur_api::snapshot::PrunedBy;
 use kopiur_api::{Origin, Snapshot, SnapshotPolicy, validate};
 
-use crate::consts::CONFIG_LABEL;
+use crate::consts::{CONFIG_LABEL, POLICY_CLEANUP_FINALIZER};
 use crate::context::Context;
 use crate::error::{Error, Result, error_policy_for};
 use crate::io;
+use crate::metrics::PolicyCascadeMode;
 
 /// A minimal view of a `Snapshot` for retention selection: its CR name (the id
 /// used in delete decisions) and its snapshot end time (the GFS bucketing key).
@@ -129,8 +130,9 @@ pub fn partition_retention_prune(
 }
 
 /// The plan for cascading a `SnapshotPolicy` deletion onto the `Snapshot` CRs
-/// carrying its config label (wired to the policy finalizer in M3; nothing
-/// calls this yet). **Pure** — no IO, no repository contact of its own.
+/// carrying its config label, executed by [`handle_policy_deletion`] (the
+/// [`POLICY_CLEANUP_FINALIZER`](crate::consts::POLICY_CLEANUP_FINALIZER) body).
+/// **Pure** — no IO, no repository contact of its own.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct PolicyCascadePlan {
     /// `PolicyDeletePolicy::Retain`, live children: stamp `pruned-by:
@@ -221,6 +223,164 @@ fn classify_policy_cascade_child(
     }
 }
 
+/// Cap on combined cascade actions ([`PolicyCascadePlan::stamp_and_delete`] +
+/// [`PolicyCascadePlan::stamp_only`] + [`PolicyCascadePlan::delete_only`])
+/// executed by [`handle_policy_deletion`] in a single reconcile pass, so a
+/// policy with a very large child population can't balloon one reconcile's
+/// IO. Each pass re-LISTs and re-plans, so remaining work is simply picked up
+/// on the next pass.
+const POLICY_CASCADE_BATCH: usize = 50;
+
+/// One pass's execution slice of a [`PolicyCascadePlan`]: which prefix of each
+/// set to act on, in preference order (`stamp_and_delete`, then `stamp_only`,
+/// then `delete_only`), capped at `cap` combined actions. **Pure** — split out
+/// so the batching/ordering itself is unit-tested without a cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PolicyCascadeBatch<'a> {
+    stamp_and_delete: &'a [String],
+    stamp_only: &'a [String],
+    delete_only: &'a [String],
+}
+
+/// **Pure.** See [`PolicyCascadeBatch`].
+fn slice_policy_cascade_batch(plan: &PolicyCascadePlan, cap: usize) -> PolicyCascadeBatch<'_> {
+    let sd_take = plan.stamp_and_delete.len().min(cap);
+    let so_take = plan.stamp_only.len().min(cap - sd_take);
+    let do_take = plan.delete_only.len().min(cap - sd_take - so_take);
+    PolicyCascadeBatch {
+        stamp_and_delete: &plan.stamp_and_delete[..sd_take],
+        stamp_only: &plan.stamp_only[..so_take],
+        delete_only: &plan.delete_only[..do_take],
+    }
+}
+
+/// Thin IO: execute one pass's [`slice_policy_cascade_batch`] over `plan`
+/// (capped at [`POLICY_CASCADE_BATCH`]). Every step is idempotent and
+/// 404-tolerant, so a crash mid-pass simply re-runs safely on the next
+/// reconcile. Each set's action is its own tiny helper (complexity ratchet:
+/// keeps this orchestrator a flat sequence of calls).
+async fn execute_policy_cascade_pass(
+    ctx: &Context,
+    backup_api: &Api<Snapshot>,
+    namespace: &str,
+    plan: &PolicyCascadePlan,
+) -> Result<()> {
+    let batch = slice_policy_cascade_batch(plan, POLICY_CASCADE_BATCH);
+    execute_stamp_and_delete(ctx, backup_api, namespace, batch.stamp_and_delete).await?;
+    execute_stamp_only(backup_api, namespace, batch.stamp_only).await?;
+    execute_delete_only(ctx, backup_api, namespace, batch.delete_only).await?;
+    Ok(())
+}
+
+/// `PolicyCascadeBatch::stamp_and_delete` half of [`execute_policy_cascade_pass`]:
+/// stamp `pruned-by: policy-cascade` then delete (Retain mode).
+async fn execute_stamp_and_delete(
+    ctx: &Context,
+    backup_api: &Api<Snapshot>,
+    namespace: &str,
+    names: &[String],
+) -> Result<()> {
+    for cr_name in names {
+        io::annotate_then_delete_snapshot(backup_api, cr_name, PrunedBy::PolicyCascade).await?;
+        ctx.metrics
+            .inc_policy_cascade_children_deleted(namespace, PolicyCascadeMode::Retain);
+        tracing::info!(namespace, snapshot = %cr_name, "policy cascade: stamped pruned-by then deleted (Retain mode)");
+    }
+    Ok(())
+}
+
+/// `PolicyCascadeBatch::stamp_only` half of [`execute_policy_cascade_pass`]:
+/// reclassify an in-flight terminating child (no delete — it is already
+/// terminating). Not counted by `kopiur_policy_cascade_children_deleted` (see
+/// its description) since nothing is deleted here.
+async fn execute_stamp_only(
+    backup_api: &Api<Snapshot>,
+    namespace: &str,
+    names: &[String],
+) -> Result<()> {
+    for cr_name in names {
+        io::stamp_pruned_by(backup_api, cr_name, PrunedBy::PolicyCascade).await?;
+        tracing::info!(namespace, snapshot = %cr_name, "policy cascade: reclassified an in-flight terminating child (stamp only)");
+    }
+    Ok(())
+}
+
+/// `PolicyCascadeBatch::delete_only` half of [`execute_policy_cascade_pass`]:
+/// a bare unstamped delete (Delete mode, external classification).
+async fn execute_delete_only(
+    ctx: &Context,
+    backup_api: &Api<Snapshot>,
+    namespace: &str,
+    names: &[String],
+) -> Result<()> {
+    for cr_name in names {
+        io::delete_snapshot(backup_api, cr_name).await?;
+        ctx.metrics
+            .inc_policy_cascade_children_deleted(namespace, PolicyCascadeMode::Delete);
+        tracing::info!(namespace, snapshot = %cr_name, "policy cascade: bare deleted (Delete mode, external classification)");
+    }
+    Ok(())
+}
+
+/// Drive the `SnapshotPolicy` deletion-cascade finalizer body: LIST this
+/// policy's `Snapshot` children (by [`CONFIG_LABEL`]), plan the cascade via
+/// [`plan_policy_cascade`], execute one pass ([`execute_policy_cascade_pass`]),
+/// and release the finalizer once a pass's plan is **entirely empty** (no
+/// `stamp_and_delete`, `stamp_only`, or `delete_only` work at all).
+///
+/// A plan whose ONLY work is `stamp_only` still executes-then-requeues rather
+/// than releasing in the same pass: the next pass re-LISTs, observes those
+/// children now stamped (so `classify_policy_cascade_child`'s `(terminating,
+/// Retain)` arm no longer selects them — a valid `pruned-by` stamp is already
+/// present), and its plan is then genuinely empty, releasing at that point.
+/// This costs at most one extra ~2s pass and is what keeps a breaker-held
+/// terminating child from EVER wedging finalizer removal — M2's planner
+/// already guarantees such a child produces no `stamp_and_delete`/`delete_only`
+/// work, so this never waits on a mass-deletion ack that will never come once
+/// the policy itself is gone.
+async fn handle_policy_deletion(
+    ctx: &Context,
+    api: &Api<SnapshotPolicy>,
+    config: &SnapshotPolicy,
+    namespace: &str,
+    name: &str,
+) -> Result<Action> {
+    // Nothing to clean up if our finalizer isn't present (e.g. a CR created
+    // and deleted before this version's finalizer was ever stamped).
+    if !config
+        .finalizers()
+        .iter()
+        .any(|f| f == POLICY_CLEANUP_FINALIZER)
+    {
+        return Ok(Action::await_change());
+    }
+
+    let backup_api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), namespace);
+    let lp = ListParams::default().labels(&format!("{CONFIG_LABEL}={name}"));
+    let children = backup_api.list(&lp).await?.items;
+    let mode =
+        kopiur_api::snapshot_policy::effective_on_policy_delete(config.spec.deletion.as_ref());
+    let plan = plan_policy_cascade(&children, mode);
+
+    if plan.stamp_and_delete.is_empty() && plan.stamp_only.is_empty() && plan.delete_only.is_empty()
+    {
+        io::remove_finalizer(api, config, POLICY_CLEANUP_FINALIZER).await?;
+        tracing::info!(policy = %name, ?mode, "policy deletion cascade complete; finalizer released");
+        return Ok(Action::await_change());
+    }
+
+    tracing::info!(
+        policy = %name,
+        ?mode,
+        stamp_and_delete = plan.stamp_and_delete.len(),
+        stamp_only = plan.stamp_only.len(),
+        delete_only = plan.delete_only.len(),
+        "policy deletion cascade: executing pass"
+    );
+    execute_policy_cascade_pass(ctx, &backup_api, namespace, &plan).await?;
+    Ok(Action::requeue(std::time::Duration::from_secs(2)))
+}
+
 /// Count the most-recent run of consecutive `Failed` backups before the latest
 /// `Succeeded` one (the `kopiur_snapshot_consecutive_failures` gauge). Only
 /// terminal backups (Succeeded/Failed) count; ordering is by `endTime` (falling
@@ -280,6 +440,30 @@ pub async fn reconcile(config: Arc<SnapshotPolicy>, ctx: Arc<Context>) -> Result
     result
 }
 
+/// `reconcile_inner`'s deletion/finalizer front-matter, extracted to a single
+/// call (complexity ratchet: `reconcile_inner` only gains calls). `Some(action)`
+/// means the caller must return it immediately without reconciling further;
+/// `None` means the policy is live and finalized — proceed as normal.
+async fn handle_policy_lifecycle(
+    ctx: &Context,
+    api: &Api<SnapshotPolicy>,
+    config: &SnapshotPolicy,
+    namespace: &str,
+    name: &str,
+) -> Result<Option<Action>> {
+    if config.metadata.deletion_timestamp.is_some() {
+        return Ok(Some(
+            handle_policy_deletion(ctx, api, config, namespace, name).await?,
+        ));
+    }
+    // Ensure the cleanup finalizer before anything else runs, so the deletion
+    // branch above is guaranteed to observe it later.
+    if io::ensure_finalizer(api, config, POLICY_CLEANUP_FINALIZER).await? {
+        return Ok(Some(Action::requeue(std::time::Duration::from_secs(1))));
+    }
+    Ok(None)
+}
+
 async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Action> {
     let errs = validate::validate_backup_config(&config.spec);
     if let Some(first) = errs.into_iter().next() {
@@ -292,6 +476,14 @@ async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Actio
     let name = config.name_any();
     let generation = config.metadata.generation;
     let api: Api<SnapshotPolicy> = Api::namespaced(ctx.client.clone(), &namespace);
+
+    // Deletion trumps suspend: a suspended policy that is deleted still
+    // cascades onto its Snapshot children, so this is checked BEFORE the
+    // suspend branch below.
+    if let Some(action) = handle_policy_lifecycle(ctx, &api, config, &namespace, &name).await? {
+        return Ok(action);
+    }
+
     let existing = config
         .status
         .as_ref()
@@ -802,7 +994,7 @@ mod tests {
         // Terminating + already stamped, and the absent one, are in neither set.
     }
 
-    // -- plan_policy_cascade (M2 — pure decision layer; wired to a finalizer in M3) --
+    // -- plan_policy_cascade (pure decision layer; executed by the M3 finalizer) --
 
     /// A `Succeeded` Snapshot with the given `origin` (status-first, matching
     /// `resolve_origin`'s precedence).
@@ -916,6 +1108,68 @@ mod tests {
         assert_eq!(retain_plan.stamp_only, vec!["held-unstamped".to_string()]);
         let delete_plan = plan_policy_cascade(&children, PolicyDeletePolicy::Delete);
         assert!(delete_plan.stamp_only.is_empty());
+    }
+
+    // -- slice_policy_cascade_batch (M3 — the per-pass execution slice) --
+
+    fn names(prefix: &str, ids: &[&str]) -> Vec<String> {
+        ids.iter().map(|id| format!("{prefix}{id}")).collect()
+    }
+
+    #[test]
+    fn slice_policy_cascade_batch_takes_everything_when_cap_covers_the_whole_plan() {
+        let plan = PolicyCascadePlan {
+            stamp_and_delete: names("sd", &["1", "2"]),
+            stamp_only: names("so", &["1", "2"]),
+            delete_only: names("do", &["1", "2"]),
+        };
+        let batch = slice_policy_cascade_batch(&plan, 50);
+        assert_eq!(batch.stamp_and_delete, plan.stamp_and_delete.as_slice());
+        assert_eq!(batch.stamp_only, plan.stamp_only.as_slice());
+        assert_eq!(batch.delete_only, plan.delete_only.as_slice());
+    }
+
+    #[test]
+    fn slice_policy_cascade_batch_prefers_stamp_and_delete_then_stamp_only_then_delete_only() {
+        let plan = PolicyCascadePlan {
+            stamp_and_delete: names("sd", &["1", "2"]),
+            stamp_only: names("so", &["1", "2"]),
+            delete_only: names("do", &["1", "2"]),
+        };
+        // Cap smaller than stamp_and_delete alone → only a truncated prefix of
+        // stamp_and_delete; stamp_only/delete_only get nothing this pass.
+        let tight = slice_policy_cascade_batch(&plan, 1);
+        assert_eq!(tight.stamp_and_delete, &["sd1".to_string()]);
+        assert!(tight.stamp_only.is_empty());
+        assert!(tight.delete_only.is_empty());
+
+        // Cap exactly covers stamp_and_delete plus part of stamp_only.
+        let mid = slice_policy_cascade_batch(&plan, 3);
+        assert_eq!(mid.stamp_and_delete, plan.stamp_and_delete.as_slice());
+        assert_eq!(mid.stamp_only, &["so1".to_string()]);
+        assert!(mid.delete_only.is_empty());
+
+        // Cap covers everything but the last delete_only entry.
+        let almost_all = slice_policy_cascade_batch(&plan, 5);
+        assert_eq!(
+            almost_all.stamp_and_delete,
+            plan.stamp_and_delete.as_slice()
+        );
+        assert_eq!(almost_all.stamp_only, plan.stamp_only.as_slice());
+        assert_eq!(almost_all.delete_only, &["do1".to_string()]);
+    }
+
+    #[test]
+    fn slice_policy_cascade_batch_zero_cap_takes_nothing() {
+        let plan = PolicyCascadePlan {
+            stamp_and_delete: names("sd", &["1"]),
+            stamp_only: names("so", &["1"]),
+            delete_only: names("do", &["1"]),
+        };
+        let batch = slice_policy_cascade_batch(&plan, 0);
+        assert!(batch.stamp_and_delete.is_empty());
+        assert!(batch.stamp_only.is_empty());
+        assert!(batch.delete_only.is_empty());
     }
 
     #[test]

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -14,7 +14,7 @@
 use std::sync::Arc;
 
 use chrono::{DateTime, Utc};
-use kube::api::ListParams;
+use kube::api::{DeleteParams, ListParams, PostParams};
 use kube::runtime::controller::Action;
 use kube::{Api, ResourceExt};
 
@@ -642,6 +642,25 @@ async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Actio
         .await?;
     }
 
+    // §5 (M6): auto-adopt discovered snapshots whose resolved identity matches
+    // this recipe. Runs AFTER the retention block (inv. 6) and consumes a
+    // SEPARATE cluster-wide LIST — the retention pass above already acted on the
+    // `backups` LIST taken before adoption, so one reconcile never both adopts
+    // and prunes the same rows (the newly-adopted rows are first seen by the
+    // NEXT pass's retention). `Some(requeue)` after a wave / scan request.
+    let adoption_requeue = run_adoption(
+        ctx,
+        &api,
+        config,
+        &namespace,
+        &name,
+        &repo,
+        &resolved,
+        &backups,
+        current.as_ref(),
+    )
+    .await?;
+
     // Final status: Ready (the policy is reconciled and its repo is Ready), the
     // observedGeneration, and the §3 lastSuccessfulSnapshot. Only set the timestamp
     // when known so we never thrash it with null.
@@ -724,12 +743,299 @@ async fn reconcile_inner(config: &SnapshotPolicy, ctx: &Context) -> Result<Actio
     // requeue on the shorter of the steady cadence and the verify cadence so a due
     // verification fires on time.
     let steady = std::time::Duration::from_secs(300);
-    match crate::verification::verify_step(config, ctx, &repo, &namespace, has_successful_snapshot)
-        .await?
+    let base = match crate::verification::verify_step(
+        config,
+        ctx,
+        &repo,
+        &namespace,
+        has_successful_snapshot,
+    )
+    .await?
     {
-        Some(verify_requeue) => Ok(Action::requeue(steady.min(verify_requeue))),
-        None => Ok(Action::requeue(steady)),
+        Some(verify_requeue) => steady.min(verify_requeue),
+        None => steady,
+    };
+    // A fresh adoption wave / scan request pulls the next reconcile in sooner
+    // (belt — the policy/repository watches usually re-trigger before this).
+    let requeue = match adoption_requeue {
+        Some(a) => base.min(a),
+        None => base,
+    };
+    Ok(Action::requeue(requeue))
+}
+
+/// Run one auto-adoption pass for a live `SnapshotPolicy` (M6, fixes #210),
+/// AFTER the retention block (inv. 6). `reconcile_inner` only gains the call.
+///
+/// Returns `Some(requeue)` when this pass adopted rows OR stamped an on-demand
+/// catalog-scan request (a belt requeue so the wave settles promptly); `None`
+/// means nothing happened — fall through to the normal steady-state return.
+///
+/// `backups` is the retention pass's `CONFIG_LABEL` child LIST, reused here to
+/// derive this policy's own kopia ids + whether it has any history (never
+/// re-LISTed). The discovered candidates come from a SEPARATE cluster-wide LIST.
+#[allow(clippy::too_many_arguments)]
+async fn run_adoption(
+    ctx: &Context,
+    api: &Api<SnapshotPolicy>,
+    config: &SnapshotPolicy,
+    namespace: &str,
+    name: &str,
+    repo: &io::ResolvedRepository,
+    resolved: &kopiur_api::snapshot_policy::ResolvedPolicy,
+    backups: &[Snapshot],
+    current: Option<&serde_json::Value>,
+) -> Result<Option<std::time::Duration>> {
+    use kopiur_api::common::{SnapshotAdoption, effective_adoption};
+
+    // 1. Gate: only when the effective adoption policy (policy → repo → default)
+    //    is Adopt. An unresolved identity (nothing to match against) is inert.
+    if effective_adoption(config.spec.adoption, repo.catalog.as_ref()) != SnapshotAdoption::Adopt {
+        return Ok(None);
     }
+    let Some(policy_identity) = resolved.identity.as_ref() else {
+        return Ok(None);
+    };
+
+    // 2. LIST discovered candidates cluster-wide (inv. 1), scoped to THIS repo.
+    let repo_uid = repo.owner_ref.uid.as_str();
+    let candidates = list_adoption_candidates(ctx, repo_uid).await?;
+
+    // 3. Own kopia ids + history from the retention child LIST (no re-LIST).
+    let (own_ids, has_history) = own_snapshot_ids_and_history(backups);
+    let scan_requested_identity = config
+        .status
+        .as_ref()
+        .and_then(|s| s.adoption.as_ref())
+        .and_then(|a| a.scan_requested_identity.as_deref());
+    let repo_cluster = repo
+        .identity_defaults
+        .as_ref()
+        .and_then(|d| d.cluster.as_deref());
+
+    // 4. Plan (pure).
+    let plan = crate::adoption::plan_adoption(
+        SnapshotAdoption::Adopt,
+        policy_identity,
+        repo_cluster,
+        candidates,
+        &own_ids,
+        has_history,
+        scan_requested_identity,
+    );
+
+    // 5. Execute adoptions (inv. 4: create → ensure-status → delete discovered).
+    let adopted = execute_adoptions(ctx, config, namespace, repo_uid, &plan.adopt).await?;
+
+    // A single token for this pass: stamped on the repository AND recorded in
+    // `status.adoption` so the two agree.
+    let now = Utc::now().to_rfc3339();
+    let identity_str = kopiur_api::identity_string(policy_identity);
+
+    // 6. On-demand catalog-scan request (stamp + Normal event).
+    if plan.request_scan {
+        io::request_catalog_scan(&ctx.client, &config.spec.repository, namespace, &now).await?;
+        io::publish_normal_event(
+            ctx,
+            config,
+            crate::consts::ADOPTION_SCAN_REQUESTED_REASON,
+            crate::consts::AWAIT_CATALOG_SCAN_ACTION,
+            &format!(
+                "requested an on-demand catalog scan on repository {} so newly-recreated \
+                 snapshots matching identity {identity_str} materialize for adoption",
+                config.spec.repository.name
+            ),
+        )
+        .await;
+    }
+
+    // 7. Adoption-wave observability (metric + Normal event).
+    if adopted > 0 {
+        ctx.metrics.inc_snapshots_adopted(namespace, name, adopted);
+        io::publish_normal_event(
+            ctx,
+            config,
+            crate::consts::SNAPSHOTS_ADOPTED_REASON,
+            crate::consts::REVIEW_ADOPTION_ACTION,
+            &crate::adoption::adoption_event_message(adopted, &identity_str),
+        )
+        .await;
+        tracing::info!(policy = %name, adopted, identity = %identity_str, "auto-adopted discovered snapshots");
+    }
+
+    // 8. `status.adoption` summary (guarded, prior-carrying — only touched when
+    //    there is activity, so a steady-state pass writes nothing).
+    if adopted > 0 || plan.request_scan {
+        write_adoption_status(
+            api,
+            name,
+            current,
+            config,
+            adopted,
+            plan.request_scan,
+            &now,
+            &identity_str,
+        )
+        .await?;
+        return Ok(Some(std::time::Duration::from_secs(30)));
+    }
+    Ok(None)
+}
+
+/// LIST this repository's discovered rows cluster-wide (inv. 1) via the install
+/// scope, selected by `origin: discovered` + the repository UID, and distill
+/// them into [`crate::adoption::AdoptionCandidate`]s.
+async fn list_adoption_candidates(
+    ctx: &Context,
+    repo_uid: &str,
+) -> Result<Vec<crate::adoption::AdoptionCandidate>> {
+    let api: Api<Snapshot> = crate::controllers::scoped_api(&ctx.client, &ctx.watch_scope);
+    let lp = ListParams::default().labels(&format!(
+        "{}={},{}={repo_uid}",
+        crate::consts::ORIGIN_LABEL,
+        Origin::Discovered.label_value(),
+        crate::consts::REPOSITORY_UID_LABEL,
+    ));
+    let rows = api.list(&lp).await?.items;
+    Ok(crate::adoption::adoption_candidates(repo_uid, &rows))
+}
+
+/// **Pure.** From this policy's `CONFIG_LABEL` children: the set of kopia ids
+/// they already carry (so an adopted row is never re-adopted), and whether the
+/// policy has any HISTORY — a retention-visible (`Succeeded`) row or an already-
+/// `Adopted` row. "No history" is what lets a brand-new / recreated policy ask
+/// for exactly one on-demand scan.
+fn own_snapshot_ids_and_history(
+    backups: &[Snapshot],
+) -> (std::collections::BTreeSet<String>, bool) {
+    let mut ids = std::collections::BTreeSet::new();
+    let mut has_history = false;
+    for b in backups {
+        if let Some(info) = b
+            .status
+            .as_ref()
+            .and_then(|s| s.snapshot.as_ref())
+            .filter(|i| !i.kopia_snapshot_id.is_empty())
+        {
+            ids.insert(info.kopia_snapshot_id.clone());
+        }
+        if retention_view(b).is_some() || crate::snapshot::resolve_origin(b) == Origin::Adopted {
+            has_history = true;
+        }
+    }
+    (ids, has_history)
+}
+
+/// Execute the planned adoptions in order, returning how many succeeded. Each is
+/// idempotent and 404/409-tolerant ([`adopt_one`]), so a crash mid-pass re-runs
+/// safely next reconcile.
+async fn execute_adoptions(
+    ctx: &Context,
+    config: &SnapshotPolicy,
+    namespace: &str,
+    repo_uid: &str,
+    adopt: &[crate::adoption::AdoptionCandidate],
+) -> Result<u64> {
+    let mut count = 0u64;
+    for candidate in adopt {
+        adopt_one(ctx, config, namespace, repo_uid, candidate).await?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Adopt one discovered row (inv. 4): CREATE the adopted row FIRST in the
+/// POLICY's namespace, ENSURE its status, THEN delete the discovered row in ITS
+/// OWN namespace. On create-409 (a prior wave already created it) DO NOT
+/// early-return — fall through to re-ensure the status so a crash between create
+/// and status-patch is healed. Every step is 404/409-tolerant.
+async fn adopt_one(
+    ctx: &Context,
+    config: &SnapshotPolicy,
+    namespace: &str,
+    repo_uid: &str,
+    candidate: &crate::adoption::AdoptionCandidate,
+) -> Result<()> {
+    let (adopted, status) = crate::adoption::build_adopted_snapshot(config, repo_uid, candidate);
+    let cr_name = adopted.name_any();
+    let policy_api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), namespace);
+
+    match policy_api.create(&PostParams::default(), &adopted).await {
+        Ok(_) => {}
+        // Already exists (a prior wave crashed after create) — ensure status, do
+        // NOT early-return.
+        Err(kube::Error::Api(ae)) if ae.code == 409 => {}
+        Err(e) => return Err(Error::Kube(e)),
+    }
+    io::patch_status(&policy_api, &cr_name, serde_json::to_value(&status)?).await?;
+
+    // Delete the discovered row in ITS OWN namespace, 404-tolerant.
+    let disc_api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), &candidate.namespace);
+    match disc_api
+        .delete(&candidate.name, &DeleteParams::default())
+        .await
+    {
+        Ok(_) => {}
+        Err(kube::Error::Api(ae)) if ae.code == 404 => {}
+        Err(e) => return Err(Error::Kube(e)),
+    }
+    tracing::info!(
+        policy = %config.name_any(),
+        adopted = %cr_name,
+        discovered = %candidate.name,
+        "adopted a discovered snapshot"
+    );
+    Ok(())
+}
+
+/// Merge-patch `status.adoption` with the pass's summary, carrying prior values
+/// forward for the fields this pass did not touch so [`io::patch_status_if_changed`]
+/// stays a no-op in steady state.
+#[allow(clippy::too_many_arguments)]
+async fn write_adoption_status(
+    api: &Api<SnapshotPolicy>,
+    name: &str,
+    current: Option<&serde_json::Value>,
+    config: &SnapshotPolicy,
+    adopted: u64,
+    request_scan: bool,
+    now: &str,
+    identity: &str,
+) -> Result<()> {
+    use kopiur_api::snapshot_policy::AdoptionSummary;
+    let prior = config.status.as_ref().and_then(|s| s.adoption.as_ref());
+    let prior_total = prior.and_then(|a| a.total_adopted).unwrap_or(0);
+    let summary = AdoptionSummary {
+        last_adoption_at: if adopted > 0 {
+            Some(now.to_string())
+        } else {
+            prior.and_then(|a| a.last_adoption_at.clone())
+        },
+        last_adopted_count: if adopted > 0 {
+            Some(adopted as u32)
+        } else {
+            prior.and_then(|a| a.last_adopted_count)
+        },
+        total_adopted: Some(prior_total + adopted),
+        scan_requested_at: if request_scan {
+            Some(now.to_string())
+        } else {
+            prior.and_then(|a| a.scan_requested_at.clone())
+        },
+        scan_requested_identity: if request_scan {
+            Some(identity.to_string())
+        } else {
+            prior.and_then(|a| a.scan_requested_identity.clone())
+        },
+    };
+    io::patch_status_if_changed(
+        api,
+        name,
+        current,
+        serde_json::json!({ "adoption": summary }),
+    )
+    .await?;
+    Ok(())
 }
 
 /// The RFC3339 `endTime` of the most recent `Succeeded` `Snapshot` produced by

--- a/crates/controller/src/snapshot_schedule.rs
+++ b/crates/controller/src/snapshot_schedule.rs
@@ -896,11 +896,23 @@ fn slot_fire_blocked_by_terminating(existing: Option<&Snapshot>) -> bool {
     existing.is_some_and(|s| s.metadata.deletion_timestamp.is_some())
 }
 
+/// **Pure.** Whether `policy` is safe to fire a scheduled `Snapshot` against —
+/// it must not be mid-deletion. A `SnapshotPolicy` carrying a
+/// `metadata.deletionTimestamp` is treated EXACTLY like an absent one by
+/// [`policy_default_deletion_policy`]: firing into it would create a
+/// `Snapshot` after the policy's own deletion-cascade finalizer
+/// ([`crate::snapshot_policy::plan_policy_cascade`]) may already have LISTed
+/// its children, stranding a child the cascade never accounts for.
+fn policy_usable(policy: &SnapshotPolicy) -> bool {
+    policy.metadata.deletion_timestamp.is_none()
+}
+
 /// GET the target policy and return its `spec.defaultDeletionPolicy` (issue #238).
 /// Honors a cross-namespace `policyRef.namespace` exactly like
 /// [`policy_repo_timezone_default`], and — like it — returns an **error** rather
-/// than a value on a read failure or a missing policy, so the caller skips/retries
-/// the fire instead of firing with a wrong default.
+/// than a value on a read failure, a missing policy, or a TERMINATING policy
+/// ([`policy_usable`]), so the caller skips/retries the fire instead of firing
+/// with a wrong default or into a policy that is cascading its own children away.
 ///
 /// This must NOT degrade to `None` on a transient GET failure: `None` reaches the
 /// mutating webhook, which stamps the origin default `Delete`, so an apiserver blip
@@ -910,6 +922,10 @@ fn slot_fire_blocked_by_terminating(existing: Option<&Snapshot>) -> bool {
 /// safer than persisting the wrong retention semantics. A genuine `None` here means
 /// the policy exists but sets no default — then the webhook `Delete` default is
 /// correct — never "we couldn't read it."
+///
+/// Known residual (not eliminated here): a TOCTOU window between this check and
+/// the apply in [`create_scheduled_backup`] — the policy could start terminating
+/// in between, and a late-fired child dangles, bounded by `failedJobsHistoryLimit`.
 async fn policy_default_deletion_policy(
     client: &kube::Client,
     policy_ref: &PolicyRef,
@@ -920,6 +936,12 @@ async fn policy_default_deletion_policy(
     let policy = api.get_opt(&policy_ref.name).await?.ok_or_else(|| {
         Error::MissingDependency(format!("SnapshotPolicy {policy_ns}/{}", policy_ref.name))
     })?;
+    if !policy_usable(&policy) {
+        return Err(Error::MissingDependency(format!(
+            "SnapshotPolicy {policy_ns}/{} is being deleted",
+            policy_ref.name
+        )));
+    }
     Ok(policy.spec.default_deletion_policy)
 }
 
@@ -1228,6 +1250,78 @@ mod tests {
                 "a missing policy must be MissingDependency, got {r:?}"
             );
         }
+
+        #[tokio::test]
+        async fn terminating_policy_is_missing_dependency() {
+            // A policy mid-deletion must be treated EXACTLY like an absent one —
+            // never fire a Snapshot into a recipe whose own deletion cascade may
+            // already have LISTed (and so will never account for) this child.
+            let body = serde_json::json!({
+                "apiVersion": kopiur_api::consts::API_VERSION,
+                "kind": "SnapshotPolicy",
+                "metadata": {
+                    "name": "test-pvc",
+                    "namespace": "default",
+                    "deletionTimestamp": "2024-01-01T00:00:00Z",
+                },
+                "spec": { "repository": { "name": "repo" } },
+            });
+            let client = mock_client(StatusCode::OK, body);
+            let r = policy_default_deletion_policy(&client, &pref(), "default").await;
+            assert!(
+                matches!(r, Err(Error::MissingDependency(_))),
+                "a terminating policy must be MissingDependency, got {r:?}"
+            );
+        }
+    }
+
+    /// A minimal `SnapshotPolicy` fixture with an optional deletionTimestamp,
+    /// for [`policy_usable`].
+    fn policy_fixture(terminating: bool) -> SnapshotPolicy {
+        let mut p = SnapshotPolicy::new(
+            "pg",
+            kopiur_api::SnapshotPolicySpec {
+                repository: kopiur_api::common::RepositoryRef {
+                    kind: Default::default(),
+                    name: "repo".into(),
+                    namespace: None,
+                },
+                identity: None,
+                sources: vec![],
+                copy_method: Default::default(),
+                volume_snapshot_class_name: None,
+                staging: None,
+                group_by: None,
+                retention: None,
+                default_deletion_policy: None,
+                compression: None,
+                files: None,
+                extra_args: vec![],
+                error_handling: None,
+                upload: None,
+                verification: None,
+                preflight: None,
+                suspend: false,
+                hooks: None,
+                mover: None,
+                credential_projection: None,
+                deletion: None,
+                adoption: None,
+            },
+        );
+        if terminating {
+            p.metadata.deletion_timestamp =
+                Some(k8s_openapi::apimachinery::pkg::apis::meta::v1::Time(
+                    k8s_openapi::jiff::Timestamp::from_second(1_700_000_000).unwrap(),
+                ));
+        }
+        p
+    }
+
+    #[test]
+    fn policy_usable_true_when_live_false_when_terminating() {
+        assert!(policy_usable(&policy_fixture(false)));
+        assert!(!policy_usable(&policy_fixture(true)));
     }
 
     #[test]

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -1048,6 +1048,8 @@ mod tests {
                 hooks: None,
                 mover: None,
                 credential_projection: None,
+                deletion: None,
+                adoption: None,
             },
         )
     }

--- a/crates/controller/src/verification.rs
+++ b/crates/controller/src/verification.rs
@@ -1079,6 +1079,7 @@ mod tests {
             mode: RepositoryMode::ReadWrite,
             deletion_protection: None,
             mass_deletion_ack: None,
+            catalog: None,
         }
     }
 

--- a/crates/controller/tests/integration.rs
+++ b/crates/controller/tests/integration.rs
@@ -140,6 +140,8 @@ fn sample_backup_config(name: &str) -> SnapshotPolicy {
             hooks: None,
             mover: None,
             credential_projection: None,
+            deletion: None,
+            adoption: None,
         },
     )
 }

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -104,7 +104,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune; do
+  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune adopt-prune adopt-ignore polcasc-retain polcasc-delete polcasc-simul; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -102,6 +102,17 @@ pub const REPO_SUBPATHS: &[&str] = &[
     // Final-review flagship counterexample (mass_deletion.rs scenario 9): a held
     // external wave must not be swept into a concurrent breaker-exempt prune's batch.
     "massdel-heldprune",
+    // Policy-cascade + adoption scenarios (feat/policy-cascade-adoption, M8). Each
+    // needs its OWN kopia repository so adoption/retention/cascade counts never leak
+    // between scenarios. adoption.rs: the #210 adopt-then-prune acceptance test
+    // (`adopt-prune`) and the adoption opt-out (`adopt-ignore`); mass_deletion.rs
+    // scenarios 10-12: policy-cascade retain (`polcasc-retain`), breaker-gated opt-in
+    // delete (`polcasc-delete`), and simultaneous schedule+policy delete (`polcasc-simul`).
+    "adopt-prune",
+    "adopt-ignore",
+    "polcasc-retain",
+    "polcasc-delete",
+    "polcasc-simul",
 ];
 /// The in-pod mount path for an isolated per-scenario repo: the PVC root is mounted
 /// here and `kopia --path` points here, so the kopia repo IS this dir (one repo per
@@ -285,6 +296,12 @@ pub const BUCKETS: &[&str] = &[
     "kopiur-mc-d2",
     "kopiur-mc-e",
     "kopiur-mc-f",
+    // ClusterRepository cross-namespace adoption (M8, crates/e2e/tests/adoption.rs,
+    // `cluster_repository_adoption_cross_namespace`): a foreign-seeded snapshot whose
+    // identity hostname places its discovered row in the WORKLOAD namespace while the
+    // adopting SnapshotPolicy lives in the OPERATOR namespace — the cluster-wide-LIST
+    // adoption guard.
+    "kopiur-adopt-crepo",
 ];
 
 /// The anonymous-policy bucket for the workload-identity scenario (see

--- a/crates/e2e/tests/adoption.rs
+++ b/crates/e2e/tests/adoption.rs
@@ -1,0 +1,1062 @@
+//! e2e: the **snapshot-adoption** story end-to-end (fixes #210) — a discovered
+//! catalog entry whose kopia identity matches a live `SnapshotPolicy` is
+//! *adopted* (re-attached as an `origin: adopted` `Snapshot` carrying the policy's
+//! config label), then governed by GFS retention like any produced backup, instead
+//! of sitting in the catalog forever.
+//!
+//! Scenario 1 (`policy_recreate_adopts_and_prunes_history`) is THE #210 acceptance
+//! test: it delete-then-recreates a policy over real backdated history and proves
+//! the recreated policy hands-off (a) requests an on-demand catalog scan, (b)
+//! rediscovers the retained kopia snapshots, (c) adopts the identity-matching ones,
+//! and (e) — the assertion that would have FAILED before this branch — actually
+//! prunes kopia-side history down to the recreated policy's `keepLatest: 1`, while a
+//! NON-matching seeded snapshot stays a forced-Retain `discovered` row (its kopia
+//! data untouched). Scenario 2 proves the `catalog.adoption: Ignore` opt-out leaves
+//! matching rows discovered. Scenario 3 proves cross-namespace `ClusterRepository`
+//! adoption (the cluster-wide-LIST guard).
+//!
+//! Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; skip gracefully off-cluster.
+
+#![cfg(all(unix, feature = "e2e"))]
+
+mod common;
+
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
+
+use kube::api::{DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use kube::{Api, Client, ResourceExt};
+
+use k8s_openapi::api::events::v1::Event as EventsV1;
+
+use kopiur_api::consts::{CONFIG_LABEL, ORIGIN_LABEL, REPOSITORY_UID_LABEL, SCHEDULE_LABEL};
+use kopiur_api::{ClusterRepository, Repository, Snapshot, SnapshotPolicy, SnapshotSchedule};
+use kopiur_e2e::builders::SeedStep;
+use kopiur_e2e::{E2E_NAMESPACE, Need, World, consts, default_timeout, poll_interval, wait_until};
+
+use common::{
+    cr, ensure_repo, observed_snapshot_count, repository_json, snapshot_json, snapshot_policy_json,
+    status_json, wait_phase,
+};
+
+// --- Wire-contract literals mirrored from the CONTROLLER crate --------------------
+// The e2e crate does not depend on `kopiur-controller`, so the on-demand catalog-scan
+// annotation and the adoption Event reason are DELIBERATE literals here — the same
+// pattern `common::WORK_SPEC_ENV` / the batch-delete labels use: an accidental rename
+// in the controller must fail THIS suite at runtime (these are a wire contract these
+// scenarios read). `crate::consts::{CATALOG_SCAN_REQUESTED_ANNOTATION, SNAPSHOTS_ADOPTED_REASON}`.
+const CATALOG_SCAN_REQUESTED_ANNOTATION: &str =
+    "kopiur.home-operations.com/catalog-scan-requested-at";
+const SNAPSHOTS_ADOPTED_REASON: &str = "SnapshotsAdopted";
+
+// --- shared helpers ---------------------------------------------------------------
+
+/// A `SnapshotSchedule` firing `policy` on `cron` with `runOnCreate`.
+fn schedule_json(name: &str, policy: &str, cron: &str) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotSchedule",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "policyRef": { "name": policy },
+            "schedule": { "cron": cron, "runOnCreate": true }
+        }
+    })
+}
+
+/// The kopia snapshot id recorded on a `Snapshot` (`status.snapshot.kopiaSnapshotID`),
+/// or `""` if absent.
+fn kopia_id(s: &Snapshot) -> String {
+    serde_json::to_value(s)
+        .unwrap_or_default()
+        .pointer("/status/snapshot/kopiaSnapshotID")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// The `status.origin` recorded on a `Snapshot`, or `""` if absent.
+fn status_origin(s: &Snapshot) -> String {
+    serde_json::to_value(s)
+        .unwrap_or_default()
+        .pointer("/status/origin")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+/// The `username@hostname:sourcePath` identity recorded on a discovered/adopted row.
+fn row_identity(s: &Snapshot) -> String {
+    let v = serde_json::to_value(s).unwrap_or_default();
+    let id = v
+        .pointer("/status/snapshot/identity")
+        .cloned()
+        .unwrap_or_default();
+    format!(
+        "{}@{}:{}",
+        id.get("username").and_then(|x| x.as_str()).unwrap_or(""),
+        id.get("hostname").and_then(|x| x.as_str()).unwrap_or(""),
+        id.get("sourcePath").and_then(|x| x.as_str()).unwrap_or(""),
+    )
+}
+
+/// This repository's discovered rows in `ns`, via the dedup labels the catalog scan
+/// stamps (`origin=discovered` + the repository UID).
+async fn discovered_rows(client: &Client, ns: &str, repo_uid: &str) -> Vec<Snapshot> {
+    let api: Api<Snapshot> = Api::namespaced(client.clone(), ns);
+    let selector = format!("{ORIGIN_LABEL}=discovered,{REPOSITORY_UID_LABEL}={repo_uid}");
+    api.list(&ListParams::default().labels(&selector))
+        .await
+        .map(|l| l.items)
+        .unwrap_or_default()
+}
+
+/// A policy's config-labeled `Snapshot` CRs in `ns`.
+async fn config_labeled(client: &Client, ns: &str, policy: &str) -> Vec<Snapshot> {
+    let api: Api<Snapshot> = Api::namespaced(client.clone(), ns);
+    api.list(&ListParams::default().labels(&format!("{CONFIG_LABEL}={policy}")))
+        .await
+        .map(|l| l.items)
+        .unwrap_or_default()
+}
+
+/// Whether an `events.k8s.io/v1` Event with `reason` regarding `kind`/`name` exists
+/// in `ns`. The event outlives the object, so it stays queryable after a CR delete.
+async fn event_exists(client: &Client, ns: &str, reason: &str, kind: &str, name: &str) -> bool {
+    let events: Api<EventsV1> = Api::namespaced(client.clone(), ns);
+    let list = match events.list(&ListParams::default()).await {
+        Ok(l) => l,
+        Err(_) => return false,
+    };
+    list.items.iter().any(|e| {
+        e.reason.as_deref() == Some(reason)
+            && e.regarding
+                .as_ref()
+                .is_some_and(|r| r.kind.as_deref() == Some(kind) && r.name.as_deref() == Some(name))
+    })
+}
+
+/// The repository's live `catalog-scan-requested-at` annotation value, if any.
+async fn scan_requested_annotation(repos: &Api<Repository>, name: &str) -> Option<String> {
+    repos
+        .get_opt(name)
+        .await
+        .ok()
+        .flatten()
+        .and_then(|r| {
+            r.annotations()
+                .get(CATALOG_SCAN_REQUESTED_ANNOTATION)
+                .cloned()
+        })
+        .filter(|v| !v.is_empty())
+}
+
+// --- Scenario 1: the #210 adopt-then-prune acceptance test ------------------------
+
+const S1_SUBPATH: &str = "adopt-prune";
+
+/// THE #210 ACCEPTANCE TEST. A filesystem repo + policy + schedule produce ≥3 REAL
+/// distinct kopia snapshots; a fourth is seeded under a NON-matching identity (the
+/// negative control). The schedule AND policy are deleted — every config-labeled CR
+/// drains, the policy finalizer releases (cascade guard), and kopia is UNCHANGED
+/// (safe-default Retain). The policy is then recreated with the SAME identity and a
+/// tight `keepLatest: 1`; hands-off it (a) stamps `catalog-scan-requested-at`, (b)
+/// rediscovers, (c) adopts the ≥3 matching rows (`origin=adopted`, config-labeled,
+/// Succeeded), (d) records `lastAdoptedCount>=3` + a `SnapshotsAdopted` event, and
+/// (e) — the assertion that would have FAILED before this branch, because adoption
+/// did not exist and the rows would sit as immortal `discovered` entries — prunes
+/// kopia history for the identity down to 1, while the non-matching control stays a
+/// forced-Retain `discovered` row with its kopia snapshot intact.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn policy_recreate_adopts_and_prunes_history() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, S1_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let schedules: Api<SnapshotSchedule> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-adopt-repo";
+    const POLICY: &str = "e2e-adopt-pol";
+    const NEG_POLICY: &str = "e2e-adopt-neg-pol";
+    const SCHED: &str = "e2e-adopt-sched";
+    const NEG_SNAP: &str = "e2e-adopt-neg-1";
+
+    // A fast catalog refresh so rediscovery doesn't wait an hour; maintenance off to
+    // cut Job churn. No deletionProtection — adoption/prune are operator-internal.
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                S1_SUBPATH,
+                serde_json::json!({
+                    "maintenance": { "enabled": false },
+                    "catalog": { "periodicRefresh": true, "refreshInterval": "30s" }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+
+    // Main recipe: generous retention so no scheduled snapshot is GFS-pruned during
+    // seeding; `defaultDeletionPolicy: Delete` so the adopted rows (later) actually
+    // delete their kopia data on prune — the #210 proof.
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create main SnapshotPolicy");
+
+    // The schedule that produces the history (honors "policy + schedule"; deleting it
+    // with the policy also regression-guards the cascade).
+    schedules
+        .create(
+            &PostParams::default(),
+            &cr::<SnapshotSchedule>(schedule_json(SCHED, POLICY, "* * * * *")),
+        )
+        .await
+        .expect("create SnapshotSchedule");
+
+    // Collect ≥3 Succeeded scheduled snapshots carrying DISTINCT kopia ids.
+    let sched_selector = format!("{SCHEDULE_LABEL}={SCHED}");
+    let distinct_ids = wait_until(
+        "schedule produces ≥3 Succeeded snapshots with distinct kopia ids",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let sel = sched_selector.clone();
+            async move {
+                let list = backups
+                    .list(&ListParams::default().labels(&sel))
+                    .await?
+                    .items;
+                let ids: BTreeSet<String> = list
+                    .iter()
+                    .filter(|b| {
+                        serde_json::to_value(b)
+                            .unwrap_or_default()
+                            .pointer("/status/phase")
+                            .and_then(|p| p.as_str())
+                            == Some("Succeeded")
+                    })
+                    .map(kopia_id)
+                    .filter(|id| !id.is_empty())
+                    .collect();
+                Ok((ids.len() >= 3).then_some(ids))
+            }
+        },
+    )
+    .await
+    .expect("the schedule should produce ≥3 Succeeded snapshots with distinct kopia ids");
+    assert!(
+        distinct_ids.len() >= 3,
+        "need ≥3 distinct kopia snapshots; got {distinct_ids:?}"
+    );
+
+    // Freeze production, then let any in-flight run settle so the counts are stable.
+    schedules
+        .patch(
+            SCHED,
+            &PatchParams::default(),
+            &Patch::Merge(&serde_json::json!({ "spec": { "schedule": { "suspend": true } } })),
+        )
+        .await
+        .expect("suspend schedule to freeze the produced set");
+    // Wait until EVERY scheduled snapshot is in a TERMINAL phase — so no in-flight
+    // mover run can still add a kopia snapshot after we count, keeping the produced
+    // set and `kopia_before` stable (a fixed sleep can race a slow kind mover Job).
+    wait_until(
+        "all scheduled snapshots reach a terminal phase after suspend",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let sel = sched_selector.clone();
+            async move {
+                let list = backups
+                    .list(&ListParams::default().labels(&sel))
+                    .await?
+                    .items;
+                let all_terminal = list.iter().all(|b| {
+                    matches!(
+                        serde_json::to_value(b)
+                            .unwrap_or_default()
+                            .pointer("/status/phase")
+                            .and_then(|p| p.as_str()),
+                        Some("Succeeded") | Some("Failed")
+                    )
+                });
+                Ok(all_terminal.then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("scheduled snapshots should settle to terminal phases after suspend");
+
+    // Backdate the produced snapshots across DISTINCT days (reuse the retention
+    // primitive) so the original history spans GFS buckets — proving the seeded set
+    // is real, calendar-spread history and not a degenerate same-instant burst.
+    let produced: Vec<Snapshot> = backups
+        .list(&ListParams::default().labels(&sched_selector))
+        .await
+        .expect("list produced snapshots")
+        .items
+        .into_iter()
+        .filter(|b| {
+            serde_json::to_value(b)
+                .unwrap_or_default()
+                .pointer("/status/phase")
+                .and_then(|p| p.as_str())
+                == Some("Succeeded")
+        })
+        .collect();
+    for (i, b) in produced.iter().enumerate() {
+        let day = format!("2026-03-{:02}T10:00:00Z", i + 1);
+        let patch = serde_json::json!({ "status": { "timing": { "endTime": day } } });
+        backups
+            .patch_status(
+                &b.name_any(),
+                &PatchParams::default(),
+                &Patch::Merge(&patch),
+            )
+            .await
+            .unwrap_or_else(|e| panic!("backdate {} endTime: {e}", b.name_any()));
+    }
+    let produced_count = produced.len();
+
+    // The NEGATIVE CONTROL: one snapshot under a NON-matching identity. A second
+    // policy whose name (⇒ username default) differs gives a distinct kopia identity
+    // over the same repo; its snapshot must NEVER be adopted by the main policy.
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                NEG_POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create negative-control SnapshotPolicy");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                NEG_SNAP,
+                NEG_POLICY,
+                serde_json::json!({ "deletionPolicy": "Retain" }),
+            )),
+        )
+        .await
+        .expect("create negative-control Snapshot");
+    wait_phase(&backups, NEG_SNAP, "Succeeded")
+        .await
+        .expect("negative-control Snapshot should Succeed");
+    let neg_identity = row_identity(
+        &backups
+            .get(NEG_SNAP)
+            .await
+            .expect("get negative-control Snapshot"),
+    );
+
+    // kopia holds the (≥3) produced snapshots + the 1 negative-control snapshot. Use
+    // `>=` (not exact): all produced snapshots share the policy identity and are ALL
+    // adopted-then-pruned to 1 later, so the load-bearing proof is the FINAL count
+    // (`== 2`) and the UNCHANGED-across-delete count — not the exact starting value.
+    let kopia_before = observed_snapshot_count(&client, "e2e-adopt-verify-1", S1_SUBPATH).await;
+    assert!(
+        kopia_before >= (produced_count + 1) as i64 && kopia_before >= 4,
+        "kopia should hold the {produced_count} produced + 1 negative-control snapshot (≥4) before deletion; got {kopia_before}"
+    );
+
+    // --- Delete the schedule AND both policies (the cascade + finalizer guard) ---
+    schedules
+        .delete(SCHED, &DeleteParams::default())
+        .await
+        .expect("delete the SnapshotSchedule");
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the main SnapshotPolicy");
+    policies
+        .delete(NEG_POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the negative-control SnapshotPolicy");
+
+    // Every config-labeled CR (both policies) drains, and BOTH policy CRs are gone —
+    // the finalizer released (the cascade did not wedge). Generous deadline (kind).
+    wait_until(
+        "schedule + both policies + all their config-labeled Snapshot CRs drain",
+        Duration::from_secs(360),
+        poll_interval(),
+        || async {
+            let main_children = config_labeled(&client, E2E_NAMESPACE, POLICY).await;
+            let neg_children = config_labeled(&client, E2E_NAMESPACE, NEG_POLICY).await;
+            let pol_gone = policies.get_opt(POLICY).await?.is_none();
+            let neg_gone = policies.get_opt(NEG_POLICY).await?.is_none();
+            let sched_gone = schedules.get_opt(SCHED).await?.is_none();
+            Ok((main_children.is_empty()
+                && neg_children.is_empty()
+                && pol_gone
+                && neg_gone
+                && sched_gone)
+                .then_some(()))
+        },
+    )
+    .await
+    .expect("the policy-deletion cascade must drain every config-labeled CR and RELEASE both policy finalizers");
+
+    // kopia UNCHANGED — the safe-default Retain cascade kept every snapshot.
+    let kopia_after_delete =
+        observed_snapshot_count(&client, "e2e-adopt-verify-2", S1_SUBPATH).await;
+    assert_eq!(
+        kopia_after_delete, kopia_before,
+        "a Retain-cascade policy+schedule delete MUST NOT touch kopia data; before={kopia_before} after={kopia_after_delete}"
+    );
+
+    // --- Recreate the SAME policy with a tight keepLatest: 1 + default adoption ---
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 1 } }),
+            )),
+        )
+        .await
+        .expect("recreate the main SnapshotPolicy");
+
+    let repo_uid = repos
+        .get(REPO)
+        .await
+        .expect("get Repository")
+        .uid()
+        .expect("Repository uid");
+
+    // (a) the recreated policy requests an on-demand catalog scan on its repository.
+    wait_until(
+        "recreated policy stamps catalog-scan-requested-at on its repository",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(scan_requested_annotation(&repos, REPO).await.map(|_| ())) },
+    )
+    .await
+    .expect(
+        "the recreated policy must request an on-demand catalog scan (`catalog-scan-requested-at`)",
+    );
+
+    // (b) discovered rows materialize — proven by the persistent NEGATIVE CONTROL row
+    // (never adopted, so it does not vanish under us like the matching rows do).
+    wait_until(
+        "the catalog rediscovers the non-matching (negative-control) snapshot as a discovered row",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let client = client.clone();
+            let repo_uid = repo_uid.clone();
+            let neg_identity = neg_identity.clone();
+            async move {
+                let rows = discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await;
+                Ok(rows
+                    .iter()
+                    .any(|r| row_identity(r) == neg_identity)
+                    .then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("catalog rediscovery must materialize the retained snapshots as discovered rows");
+
+    // (c)+(e, CR side) retention converges: EXACTLY ONE config-labeled CR remains,
+    // and it is an `origin=adopted` / Succeeded row — the adopted history, pruned to
+    // keepLatest: 1. (Before this branch there was no adoption: the matching rows
+    // would remain immortal `discovered` entries and config-labeled would stay 0.)
+    let survivor = wait_until(
+        "adopted history converges to exactly one config-labeled Succeeded row",
+        Duration::from_secs(420),
+        poll_interval(),
+        || {
+            let client = client.clone();
+            async move {
+                let rows = config_labeled(&client, E2E_NAMESPACE, POLICY).await;
+                if rows.len() != 1 {
+                    return Ok(None);
+                }
+                let r = &rows[0];
+                let terminal = serde_json::to_value(r)
+                    .unwrap_or_default()
+                    .pointer("/status/phase")
+                    .and_then(|p| p.as_str())
+                    == Some("Succeeded")
+                    && r.metadata.deletion_timestamp.is_none();
+                Ok(terminal.then(|| r.clone()))
+            }
+        },
+    )
+    .await
+    .expect("GFS retention over the ADOPTED rows must converge to exactly one config-labeled CR");
+    assert_eq!(
+        survivor.labels().get(ORIGIN_LABEL).map(String::as_str),
+        Some("adopted"),
+        "the surviving config-labeled row must carry the `origin: adopted` LABEL: {}",
+        survivor.name_any()
+    );
+    assert_eq!(
+        status_origin(&survivor),
+        "adopted",
+        "the surviving row must carry `status.origin: adopted`: {}",
+        survivor.name_any()
+    );
+
+    // (d) the policy recorded the adoption wave: lastAdoptedCount ≥ 3 + the event.
+    wait_until(
+        "policy records status.adoption.lastAdoptedCount ≥ 3",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = status_json(&policies, POLICY).await;
+            Ok(s.pointer("/adoption/lastAdoptedCount")
+                .and_then(|v| v.as_i64())
+                .filter(|&n| n >= 3)
+                .map(|_| ()))
+        },
+    )
+    .await
+    .expect("status.adoption.lastAdoptedCount must record the ≥3 adopted snapshots");
+    assert!(
+        event_exists(
+            &client,
+            E2E_NAMESPACE,
+            SNAPSHOTS_ADOPTED_REASON,
+            "SnapshotPolicy",
+            POLICY
+        )
+        .await,
+        "a `SnapshotsAdopted` Normal event must be published on the recreated policy"
+    );
+
+    // (e, kopia side) THE #210 ASSERTION: kopia history is pruned to exactly the
+    // policy identity's kept snapshot (1) PLUS the untouched negative control (1) —
+    // total 2. Before this branch adoption did not exist, so the ≥3 matching kopia
+    // snapshots would remain forever (kopia count would stay at `kopia_before` ≥ 4);
+    // that this dropped to 2 proves the adopted rows are now GFS-governed and their
+    // kopia data was really deleted. (config-labeled == 1 above ⇒ the pruned adopted
+    // CRs' finalizers already released ⇒ their kopia snapshot-deletes completed.)
+    let kopia_final = observed_snapshot_count(&client, "e2e-adopt-verify-3", S1_SUBPATH).await;
+    assert_eq!(
+        kopia_final, 2,
+        "kopia must hold exactly 1 (policy-identity, pruned from {produced_count}) + 1 (negative \
+         control) = 2 snapshots after adoption+retention; got {kopia_final} (was {kopia_before})"
+    );
+    assert!(
+        (kopia_final as usize) < kopia_before as usize,
+        "the adopted history MUST have been pruned kopia-side (the #210 fix): before={kopia_before} after={kopia_final}"
+    );
+
+    // The negative control endures: still a forced-Retain `discovered` row, and its
+    // kopia snapshot is one of the surviving 2.
+    let disc = discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await;
+    let neg_rows: Vec<&Snapshot> = disc
+        .iter()
+        .filter(|r| row_identity(r) == neg_identity)
+        .collect();
+    assert_eq!(
+        neg_rows.len(),
+        1,
+        "the non-matching seeded snapshot must remain a single `discovered` row: {neg_identity}"
+    );
+    let neg = neg_rows[0];
+    assert_eq!(
+        serde_json::to_value(neg)
+            .unwrap_or_default()
+            .pointer("/spec/deletionPolicy")
+            .and_then(|x| x.as_str()),
+        Some("Retain"),
+        "the negative-control discovered row must be FORCED deletionPolicy Retain"
+    );
+    assert_eq!(
+        status_origin(neg),
+        "discovered",
+        "the negative-control row must stay `discovered` (never adopted by a non-matching identity)"
+    );
+
+    // Cleanup: discovered rows are forced-Retain (deleting them leaves kopia intact);
+    // remove Snapshot CRs BEFORE the Repository (finalizers need it).
+    for r in config_labeled(&client, E2E_NAMESPACE, POLICY).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    for r in discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    let _ = policies.delete(POLICY, &DeleteParams::default()).await;
+    let _ = wait_until(
+        "snapshot CRs drain before repo teardown",
+        Duration::from_secs(120),
+        poll_interval(),
+        || async {
+            let live = backups
+                .list(&ListParams::default().labels(&format!("{REPOSITORY_UID_LABEL}={repo_uid}")))
+                .await?
+                .items;
+            Ok(live.is_empty().then_some(()))
+        },
+    )
+    .await;
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// --- Scenario 2: the adoption opt-out keeps matching rows discovered --------------
+
+const S2_SUBPATH: &str = "adopt-ignore";
+
+/// With `catalog.adoption: Ignore` on the repository, a discovered snapshot whose
+/// identity matches a live policy is LEFT ALONE: after the same delete→recreate flow
+/// it re-materializes as a `discovered` row and STAYS discovered — no adopted rows,
+/// no repeated on-demand scan-request stamping (the annotation is never stamped by an
+/// inert adoption pass), and the policy's `status.adoption` records no adoptions.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn adoption_opt_out_stays_discovered() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, S2_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-adopt-ignore-repo";
+    const POLICY: &str = "e2e-adopt-ignore-pol";
+    const SNAP: &str = "e2e-adopt-ignore-1";
+
+    // The opt-out lives on the repository (`catalog.adoption: Ignore`); a fast refresh
+    // so rediscovery is prompt; maintenance off.
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                S2_SUBPATH,
+                serde_json::json!({
+                    "maintenance": { "enabled": false },
+                    "catalog": { "adoption": "Ignore", "periodicRefresh": true, "refreshInterval": "30s" }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository with catalog.adoption: Ignore");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy");
+
+    // One matching snapshot, then delete the policy → the CR cascades (Retain) →
+    // kopia retained → rediscovered.
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                SNAP,
+                POLICY,
+                serde_json::json!({ "deletionPolicy": "Delete" }),
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+    wait_phase(&backups, SNAP, "Succeeded")
+        .await
+        .expect("Snapshot should Succeed");
+    let policy_identity = row_identity(&backups.get(SNAP).await.expect("get Snapshot"));
+
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the SnapshotPolicy");
+    wait_until(
+        "the policy + its config-labeled CR drain",
+        Duration::from_secs(240),
+        poll_interval(),
+        || async {
+            let children = config_labeled(&client, E2E_NAMESPACE, POLICY).await;
+            let gone = policies.get_opt(POLICY).await?.is_none();
+            Ok((children.is_empty() && gone).then_some(()))
+        },
+    )
+    .await
+    .expect("the policy and its config-labeled CR must drain");
+
+    let repo_uid = repos
+        .get(REPO)
+        .await
+        .expect("get Repository")
+        .uid()
+        .expect("Repository uid");
+
+    // Recreate the policy with the SAME identity. With repo `adoption: Ignore` and no
+    // per-policy override, the effective adoption is Ignore → the pass is inert.
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("recreate the SnapshotPolicy");
+
+    // The matching snapshot re-materializes as a discovered row (via periodicRefresh).
+    wait_until(
+        "the matching snapshot re-materializes as a discovered row",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let client = client.clone();
+            let repo_uid = repo_uid.clone();
+            let policy_identity = policy_identity.clone();
+            async move {
+                let rows = discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await;
+                Ok(rows
+                    .iter()
+                    .any(|r| row_identity(r) == policy_identity)
+                    .then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("the retained snapshot must re-materialize as a discovered row");
+
+    // Settle window: for ~60s the matching row STAYS discovered — never adopted, no
+    // adopted rows appear, the scan-request annotation is never stamped, and
+    // status.adoption records no adoptions. Poll the invariants throughout.
+    let settle_deadline = Instant::now() + Duration::from_secs(60);
+    loop {
+        // No adopted rows for this repo, ever.
+        let adopted: Vec<Snapshot> = {
+            let api: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+            api.list(&ListParams::default().labels(&format!(
+                "{ORIGIN_LABEL}=adopted,{REPOSITORY_UID_LABEL}={repo_uid}"
+            )))
+            .await
+            .map(|l| l.items)
+            .unwrap_or_default()
+        };
+        assert!(
+            adopted.is_empty(),
+            "adoption is opted OUT — no `origin: adopted` rows may ever appear: {:?}",
+            adopted.iter().map(|a| a.name_any()).collect::<Vec<_>>()
+        );
+        // The matching row is still present AND still discovered.
+        let disc = discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await;
+        assert!(
+            disc.iter().any(|r| row_identity(r) == policy_identity),
+            "the matching row must STAY a discovered row under the opt-out"
+        );
+        // The adoption pass never stamps an on-demand scan request in Ignore mode.
+        assert!(
+            scan_requested_annotation(&repos, REPO).await.is_none(),
+            "an Ignore-mode adoption pass must NOT stamp `catalog-scan-requested-at`"
+        );
+        if Instant::now() >= settle_deadline {
+            break;
+        }
+        tokio::time::sleep(poll_interval()).await;
+    }
+
+    // status.adoption records no adoptions (never written by an inert pass).
+    let s = status_json(&policies, POLICY).await;
+    assert!(
+        s.pointer("/adoption/lastAdoptedCount")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0)
+            == 0,
+        "status.adoption must record no adoptions under the opt-out; got {s}"
+    );
+
+    // Cleanup.
+    for r in discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    let _ = policies.delete(POLICY, &DeleteParams::default()).await;
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// --- Scenario 3: cross-namespace ClusterRepository adoption -----------------------
+
+const S3_BUCKET: &str = "kopiur-adopt-crepo";
+
+/// Run a foreign kopia seeder to completion.
+async fn run_seeder(client: &Client, name: &str, steps: &[SeedStep<'_>]) {
+    kopiur_e2e::apply::run_foreign_seeder(client, E2E_NAMESPACE, name, steps)
+        .await
+        .expect("foreign kopia seeder");
+}
+
+/// CROSS-NAMESPACE adoption for a `ClusterRepository` — the cluster-wide-LIST guard.
+/// A foreign snapshot's identity hostname places its `discovered` row in the WORKLOAD
+/// namespace, while the adopting `SnapshotPolicy` lives in the OPERATOR namespace (a
+/// hostname override matches the foreign identity). Adoption must find the discovered
+/// row cluster-wide and create the adopted row in the POLICY's namespace — a
+/// policy-namespaced LIST would miss it. After a delete→recreate the adoption
+/// re-converges cross-namespace.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + MinIO + built images + helm install"]
+async fn cluster_repository_adoption_cross_namespace() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    // WorkloadNs implies Minio; Filesystem gives the operator-namespace source PVC the
+    // policy references (its sourcePath is overridden, so only the name is needed).
+    world
+        .ensure(&[Need::WorkloadNs, Need::Filesystem])
+        .await
+        .expect("provision MinIO + workload namespace + operator source PVC");
+    let client: Client = world.client().clone();
+
+    let crepos: Api<ClusterRepository> = Api::all(client.clone());
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const CREPO: &str = "e2e-adopt-crepo";
+    const POLICY: &str = "app"; // username default = policy name = "app"
+
+    // Foreign writer: one snapshot under identity `app@<workload-ns>:/data/app`. The
+    // hostname is the workload namespace, so the ClusterRepository places its
+    // discovered row THERE.
+    run_seeder(
+        &client,
+        "e2e-adopt-crepo-seed",
+        &[
+            SeedStep::WipeBucket { bucket: S3_BUCKET },
+            SeedStep::WriteFile {
+                dir: "app",
+                file: "f.txt",
+                content: "cross-ns-adopt",
+            },
+            SeedStep::CreateRepo {
+                bucket: S3_BUCKET,
+                username: "app",
+                hostname: consts::WORKLOAD_NS,
+            },
+            SeedStep::Snapshot { dir: "app" },
+        ],
+    )
+    .await;
+
+    // Adopt-only ClusterRepository, open to all namespaces (so the OPERATOR-namespace
+    // policy is tenancy-allowed AND the WORKLOAD-namespace placement is allowed), fast
+    // refresh, maintenance off.
+    crepos
+        .create(
+            &PostParams::default(),
+            &cr(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "ClusterRepository",
+                "metadata": { "name": CREPO },
+                "spec": {
+                    "backend": { "s3": {
+                        "bucket": S3_BUCKET,
+                        "endpoint": consts::MINIO_ENDPOINT,
+                        "region": "us-east-1",
+                        "tls": { "disableTls": true },
+                        "auth": { "secretRef": {
+                            "name": consts::SECRET_S3_CREDS, "namespace": E2E_NAMESPACE
+                        } }
+                    }},
+                    "encryption": { "passwordSecretRef": {
+                        "name": consts::SECRET_S3_CREDS,
+                        "namespace": E2E_NAMESPACE,
+                        "key": "KOPIA_PASSWORD"
+                    }},
+                    "create": { "enabled": false },
+                    "maintenance": { "enabled": false },
+                    "allowedNamespaces": { "all": true },
+                    "catalog": { "periodicRefresh": true, "refreshInterval": "30s" }
+                }
+            })),
+        )
+        .await
+        .expect("create adopting ClusterRepository");
+    wait_phase(&crepos, CREPO, "Ready")
+        .await
+        .expect("adopting ClusterRepository should reach Ready");
+
+    let crepo_uid = crepos
+        .get(CREPO)
+        .await
+        .expect("get ClusterRepository")
+        .uid()
+        .expect("ClusterRepository uid");
+    let want_identity = format!("app@{}:/data/app", consts::WORKLOAD_NS);
+
+    // The discovered row lands in the WORKLOAD namespace (identity hostname).
+    wait_until(
+        "the foreign snapshot is discovered in the WORKLOAD namespace",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let client = client.clone();
+            let crepo_uid = crepo_uid.clone();
+            let want = want_identity.clone();
+            async move {
+                let rows = discovered_rows(&client, consts::WORKLOAD_NS, &crepo_uid).await;
+                Ok(rows.iter().any(|r| row_identity(r) == want).then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("the discovered row must be placed in the workload namespace by identity hostname");
+
+    // The adopting policy lives in the OPERATOR namespace, but a hostname override +
+    // sourcePathOverride make its resolved identity EXACTLY the foreign one — so it
+    // adopts the WORKLOAD-namespace row cross-namespace (the cluster-wide-LIST fix).
+    let policy_json = |name: &str| -> serde_json::Value {
+        snapshot_policy_json(
+            E2E_NAMESPACE,
+            name,
+            "ClusterRepository",
+            CREPO,
+            serde_json::json!({
+                "identity": { "hostname": consts::WORKLOAD_NS },
+                "sources": [ { "pvc": { "name": consts::PVC_SRC }, "sourcePathOverride": "/data/app" } ],
+                "retention": { "keepLatest": 20 }
+            }),
+        )
+    };
+
+    // Assert cross-namespace adoption converges: an `origin=adopted` row appears in the
+    // POLICY's (operator) namespace with the foreign identity, twice (create, then
+    // delete→recreate).
+    let assert_adopts = |round: &'static str| {
+        let client = client.clone();
+        let want = want_identity.clone();
+        async move {
+            wait_until(
+                &format!("[{round}] adopted row appears in the POLICY (operator) namespace"),
+                Duration::from_secs(420),
+                poll_interval(),
+                || {
+                    let client = client.clone();
+                    let want = want.clone();
+                    async move {
+                        let rows = config_labeled(&client, E2E_NAMESPACE, POLICY).await;
+                        let adopted = rows.iter().find(|r| {
+                            r.labels().get(ORIGIN_LABEL).map(String::as_str) == Some("adopted")
+                                && status_origin(r) == "adopted"
+                                && row_identity(r) == want
+                        });
+                        Ok(adopted.cloned())
+                    }
+                },
+            )
+            .await
+            .unwrap_or_else(|e| panic!("[{round}] cross-namespace adoption must converge: {e}"))
+        }
+    };
+
+    policies
+        .create(&PostParams::default(), &cr(policy_json(POLICY)))
+        .await
+        .expect("create the adopting SnapshotPolicy in the operator namespace");
+    let first = assert_adopts("create").await;
+    assert_eq!(
+        first.namespace().as_deref(),
+        Some(E2E_NAMESPACE),
+        "the adopted row must live in the POLICY's namespace ({E2E_NAMESPACE}), not the discovered row's"
+    );
+
+    // Delete the policy (Retain cascade) → the adopted row is released, kopia retained,
+    // rediscovered (back in the workload namespace). Recreate → adoption re-converges.
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the adopting SnapshotPolicy");
+    wait_until(
+        "the policy + its adopted child drain",
+        Duration::from_secs(240),
+        poll_interval(),
+        || async {
+            let children = config_labeled(&client, E2E_NAMESPACE, POLICY).await;
+            let gone = policies.get_opt(POLICY).await?.is_none();
+            Ok((children.is_empty() && gone).then_some(()))
+        },
+    )
+    .await
+    .expect("the policy and its adopted child must drain");
+
+    policies
+        .create(&PostParams::default(), &cr(policy_json(POLICY)))
+        .await
+        .expect("recreate the adopting SnapshotPolicy");
+    let second = assert_adopts("recreate").await;
+    assert_eq!(
+        second.namespace().as_deref(),
+        Some(E2E_NAMESPACE),
+        "after delete→recreate, cross-namespace adoption must again land the adopted row in the policy namespace"
+    );
+
+    // Cleanup (best-effort; cluster-scoped objects persist across reused clusters).
+    for r in config_labeled(&client, E2E_NAMESPACE, POLICY).await {
+        let _ = Api::<Snapshot>::namespaced(client.clone(), E2E_NAMESPACE)
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    let _ = policies.delete(POLICY, &DeleteParams::default()).await;
+    let _ = crepos.delete(CREPO, &DeleteParams::default()).await;
+}

--- a/crates/e2e/tests/credential_projection.rs
+++ b/crates/e2e/tests/credential_projection.rs
@@ -534,14 +534,20 @@ async fn projected_copies_do_not_accumulate_across_runs() {
     let _ = crepos.delete(crepo, &DeleteParams::default()).await;
 }
 
-/// **The stuck-finalizer guard (#255).** Delete the `SnapshotPolicy` BEFORE the
-/// `Snapshot` it produced, and a `deletionPolicy: Delete` Snapshot must still finish
-/// deleting.
+/// **The stuck-finalizer guard (#255), now via the policy-cascade Delete mode.** Delete
+/// the `SnapshotPolicy` and let its `onPolicyDelete: Delete` cascade remove the child,
+/// and a `deletionPolicy: Delete` Snapshot must still finish deleting its kopia snapshot
+/// with the recipe already gone.
 ///
-/// This is the ordering every other scenario in this file avoids: they delete the
-/// Snapshot first, then the policy, which keeps the recipe alive for exactly as long as
-/// the delete path needs it. Nothing forces a user to be so considerate. Once the run
-/// succeeds its projected copy is reaped, so the delete Job must re-project — and the
+/// On this branch a config-labeled child is owned by the policy-deletion cascade, so the
+/// old flow (delete the policy, then explicitly delete the Snapshot) no longer applies:
+/// under the default `onPolicyDelete: Retain` the cascade would quiet-RELEASE the child
+/// without a kopia delete (a different guarantee). Setting `onPolicyDelete: Delete` makes
+/// the cascade issue an UNSTAMPED external delete for the child — the same external
+/// deletion a bare `kubectl delete snapshot` would, but triggered BY the policy's own
+/// removal — so this one scenario exercises BOTH #255 and the cascade Delete path
+/// end-to-end. Nothing forces a user to delete the Snapshot before the policy. Once the
+/// run succeeds its projected copy is reaped, so the delete Job must re-project — and the
 /// opt-in that authorizes that lives ONLY on the recipe. Reading an absent recipe as
 /// "projection off" sent the delete Job hunting for the ClusterRepository's canonical
 /// Secret name in the workload namespace, which projection exists precisely because
@@ -581,13 +587,16 @@ async fn snapshot_deletion_survives_a_policy_deleted_first() {
         .await
         .expect("ClusterRepository should bootstrap to Ready");
 
+    // onPolicyDelete: Delete — deleting the policy issues an UNSTAMPED external delete
+    // for the config-labeled child (not the default quiet-retain cascade), so the child's
+    // finalizer runs the real kopia delete with the recipe gone: the #255 property, now
+    // reached through the cascade's Delete mode.
+    let mut cfg_spec = backup_config_json(PROJECTION_NS, cfg, crepo, true);
+    cfg_spec["spec"]["deletion"] = serde_json::json!({ "onPolicyDelete": "Delete" });
     configs
-        .create(
-            &PostParams::default(),
-            &cr(backup_config_json(PROJECTION_NS, cfg, crepo, true)),
-        )
+        .create(&PostParams::default(), &cr(cfg_spec))
         .await
-        .expect("create projection-on SnapshotPolicy");
+        .expect("create projection-on SnapshotPolicy with onPolicyDelete: Delete");
     // deletionPolicy: Delete is what arms the cleanup finalizer — the whole point.
     let mut backup_spec = backup_json(PROJECTION_NS, backup, cfg);
     backup_spec["spec"]["deletionPolicy"] = serde_json::json!("Delete");
@@ -630,11 +639,12 @@ async fn snapshot_deletion_survives_a_policy_deleted_first() {
     .await
     .expect("the projected copy must be reaped once the run is terminal");
 
-    // The reporter's ordering: recipe first...
+    // Delete ONLY the recipe. Its `onPolicyDelete: Delete` cascade issues an unstamped
+    // external delete for the config-labeled child — the test never touches the Snapshot.
     configs
         .delete(cfg, &DeleteParams::default())
         .await
-        .expect("delete the SnapshotPolicy BEFORE the Snapshot");
+        .expect("delete the SnapshotPolicy (its Delete cascade removes the child)");
     wait_until(
         &format!("SnapshotPolicy {cfg} gone"),
         default_timeout(),
@@ -642,16 +652,16 @@ async fn snapshot_deletion_survives_a_policy_deleted_first() {
         || async { Ok(configs.get_opt(cfg).await?.is_none().then_some(())) },
     )
     .await
-    .expect("the SnapshotPolicy should delete cleanly");
+    .expect("the SnapshotPolicy should delete cleanly once its cascade drains");
 
-    // ...then the Snapshot, which must re-project creds against the pinned opt-in,
-    // run its delete Job, and release the finalizer.
-    backups
-        .delete(backup, &DeleteParams::default())
-        .await
-        .expect("delete Snapshot");
+    // The child is removed by the cascade, with the recipe already gone: it must
+    // re-project creds against the PINNED opt-in, run its delete Job, and release the
+    // finalizer. A released `snapshot-cleanup` finalizer (CR gone) is the kopia-side
+    // proof — a `deletionPolicy: Delete` external deletion under the breaker threshold
+    // resolves to DeleteSnapshot, so the finalizer only clears once the real kopia
+    // snapshot delete succeeded (an orphan/retain would never contact the repo).
     wait_until(
-        &format!("{backup} removed after the cleanup finalizer ran"),
+        &format!("{backup} removed by the onPolicyDelete cascade"),
         default_timeout(),
         poll_interval(),
         || async { Ok(backups.get_opt(backup).await?.is_none().then_some(())) },
@@ -661,7 +671,9 @@ async fn snapshot_deletion_survives_a_policy_deleted_first() {
         "the Snapshot must finish deleting with its SnapshotPolicy already gone — before \
          #255 it hung on kopiur.home-operations.com/snapshot-cleanup forever, because the \
          delete path read the absent recipe as 'projection off' and then demanded a \
-         namespace-local Secret that projection was the only thing supplying",
+         namespace-local Secret that projection was the only thing supplying. Here the \
+         cascade's Delete mode is what issues the external delete, so this also covers the \
+         policy-cascade Delete path end-to-end",
     );
 
     let _ = crepos.delete(crepo, &DeleteParams::default()).await;

--- a/crates/e2e/tests/mass_deletion.rs
+++ b/crates/e2e/tests/mass_deletion.rs
@@ -2168,29 +2168,38 @@ async fn policy_cascade_delete_cleans_crs_keeps_kopia() {
     wait_phase(&backups, SEED_SNAP, "Succeeded")
         .await
         .expect("seed Snapshot should Succeed");
-    backups
-        .delete(SEED_SNAP, &DeleteParams::default())
+    // Retire the SEED POLICY (Retain cascade keeps the child's kopia snapshot) BEFORE
+    // the snapshot re-catalogs. This is load-bearing: a LIVE identity-matching policy
+    // would AUTO-ADOPT the re-cataloged snapshot (flipping it out of `discovered`), so
+    // the seed policy must be gone first for the seed to persist as the untouched
+    // `discovered` control. A terminating policy never runs the adoption path.
+    policies
+        .delete(SEED_POL, &DeleteParams::default())
         .await
-        .expect("delete the seed Snapshot CR (Retain ⇒ kopia kept ⇒ rediscovered)");
+        .expect("delete the seed SnapshotPolicy (Retain cascade ⇒ kopia kept ⇒ rediscovered)");
     let seed_row = wait_until(
-        "the seed snapshot re-catalogs as a discovered row",
+        "the seed snapshot re-catalogs as a discovered row once the seed policy is retired",
         default_timeout(),
         poll_interval(),
         || {
             let backups = backups.clone();
+            let policies = policies.clone();
             let repo_uid = repo_uid.clone();
             async move {
+                // Only accept the discovered row once SEED_POL is fully gone, so no
+                // live matcher can adopt it out from under this control.
+                if policies.get_opt(SEED_POL).await?.is_some() {
+                    return Ok(None);
+                }
                 let rows = repo_discovered_rows(&backups, &repo_uid).await;
                 Ok(rows.into_iter().next())
             }
         },
     )
     .await
-    .expect("the seed snapshot must re-catalog as a discovered row");
+    .expect("the seed snapshot must re-catalog as a discovered row (no live policy to adopt it)");
     let seed_disc_name = seed_row.name_any();
     let seed_uid = seed_row.uid().expect("seed discovered row uid");
-    // Retire the seed policy so nothing live matches the seed identity.
-    let _ = policies.delete(SEED_POL, &DeleteParams::default()).await;
 
     // Schedule-produced child.
     schedules

--- a/crates/e2e/tests/mass_deletion.rs
+++ b/crates/e2e/tests/mass_deletion.rs
@@ -71,7 +71,7 @@ use k8s_openapi::api::core::v1::Pod;
 use k8s_openapi::api::events::v1::Event as EventsV1;
 
 use kopiur_api::consts::{
-    ALLOW_MASS_DELETION_ANNOTATION, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
+    ALLOW_MASS_DELETION_ANNOTATION, CONFIG_LABEL, MANAGED_BY_LABEL, MANAGED_BY_VALUE,
     MASS_DELETION_HELD_CONDITION, OP_LABEL, ORIGIN_LABEL, PRUNED_BY_ANNOTATION,
     REPOSITORY_UID_LABEL, SCHEDULE_LABEL, SNAPSHOT_CLEANUP_FINALIZER,
 };
@@ -2028,5 +2028,724 @@ async fn batch_delete_retries_after_repo_outage() {
     );
 
     let _ = policies.delete(POLICY, &DeleteParams::default()).await;
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// --- Policy-cascade scenarios (feat/policy-cascade-adoption, M8) ----------------
+// The SnapshotPolicy-deletion cascade is the sibling of the schedule-deletion cascade
+// (scenario 1): deleting a `SnapshotPolicy` cascades onto the `Snapshot` CRs carrying
+// its config label, governed by `spec.deletion.onPolicyDelete` (safe-default `Retain`,
+// opt-in `Delete`). These prove the Retain cascade keeps kopia + re-catalogs (10), the
+// `Delete` opt-in is breaker-gated WITHOUT wedging the policy finalizer (11), and a
+// simultaneous schedule+policy delete drains cleanly to Retain (12).
+
+/// This policy's config-labeled `Snapshot` children.
+async fn config_children(backups: &Api<Snapshot>, policy: &str) -> Vec<Snapshot> {
+    backups
+        .list(&ListParams::default().labels(&format!("{CONFIG_LABEL}={policy}")))
+        .await
+        .map(|l| l.items)
+        .unwrap_or_default()
+}
+
+/// This repository's discovered rows (`origin=discovered` + the repository UID).
+async fn repo_discovered_rows(backups: &Api<Snapshot>, repo_uid: &str) -> Vec<Snapshot> {
+    backups
+        .list(&ListParams::default().labels(&format!(
+            "{ORIGIN_LABEL}=discovered,{REPOSITORY_UID_LABEL}={repo_uid}"
+        )))
+        .await
+        .map(|l| l.items)
+        .unwrap_or_default()
+}
+
+// --- Scenario 10: policy-cascade (Retain) cleans CRs, keeps kopia, re-catalogs --
+
+const POLCASC_RETAIN_SUBPATH: &str = "polcasc-retain";
+
+/// Deleting a `SnapshotPolicy` whose `onPolicyDelete` is the safe-default `Retain`
+/// removes EVERY `Snapshot` CR carrying its config label — a schedule-produced one AND
+/// a MANUAL one created by plain apply with only a `spec.policyRef` (proving the M0
+/// webhook config-label stamp end-to-end) — WITHOUT hanging the policy finalizer or
+/// touching kopia. Each cascaded CR fires a `SnapshotRetainedOnPolicyDelete` Warning;
+/// the retained kopia snapshots re-catalog as `discovered`; and a pre-existing
+/// (different-identity) discovered row is untouched throughout.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn policy_cascade_delete_cleans_crs_keeps_kopia() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, POLCASC_RETAIN_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let schedules: Api<SnapshotSchedule> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-polcasc-retain-repo";
+    const POLICY: &str = "e2e-polcasc-retain-pol";
+    const SCHED: &str = "e2e-polcasc-retain-sched";
+    const SEED_POL: &str = "e2e-polcasc-retain-seed-pol";
+    const SEED_SNAP: &str = "e2e-polcasc-retain-seed-1";
+    const MANUAL: &str = "e2e-polcasc-retain-manual";
+
+    // Fast catalog refresh so rediscovery is prompt; maintenance off. NO
+    // deletionProtection — the Retain cascade never counts against the breaker.
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                POLCASC_RETAIN_SUBPATH,
+                serde_json::json!({
+                    "maintenance": { "enabled": false },
+                    "catalog": { "periodicRefresh": true, "refreshInterval": "30s" }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+    let repo_uid = repos
+        .get(REPO)
+        .await
+        .expect("get Repository")
+        .uid()
+        .expect("Repository uid");
+
+    // Main policy: onPolicyDelete unset ⇒ Retain default; generous retention.
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create main SnapshotPolicy");
+
+    // Pre-existing DISCOVERED row (different identity): a seed policy produces one
+    // snapshot; deleting its CR (Retain) re-catalogs it as a discovered row, then the
+    // seed policy is removed so NO live policy matches its identity (it must never be
+    // adopted or cascaded — it is the untouched control).
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                SEED_POL,
+                "Repository",
+                REPO,
+                serde_json::json!({ "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create seed SnapshotPolicy");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                SEED_SNAP,
+                SEED_POL,
+                serde_json::json!({ "deletionPolicy": "Retain" }),
+            )),
+        )
+        .await
+        .expect("create seed Snapshot");
+    wait_phase(&backups, SEED_SNAP, "Succeeded")
+        .await
+        .expect("seed Snapshot should Succeed");
+    backups
+        .delete(SEED_SNAP, &DeleteParams::default())
+        .await
+        .expect("delete the seed Snapshot CR (Retain ⇒ kopia kept ⇒ rediscovered)");
+    let seed_row = wait_until(
+        "the seed snapshot re-catalogs as a discovered row",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let repo_uid = repo_uid.clone();
+            async move {
+                let rows = repo_discovered_rows(&backups, &repo_uid).await;
+                Ok(rows.into_iter().next())
+            }
+        },
+    )
+    .await
+    .expect("the seed snapshot must re-catalog as a discovered row");
+    let seed_disc_name = seed_row.name_any();
+    let seed_uid = seed_row.uid().expect("seed discovered row uid");
+    // Retire the seed policy so nothing live matches the seed identity.
+    let _ = policies.delete(SEED_POL, &DeleteParams::default()).await;
+
+    // Schedule-produced child.
+    schedules
+        .create(
+            &PostParams::default(),
+            &cr::<SnapshotSchedule>(schedule_json(SCHED, POLICY, "* * * * *")),
+        )
+        .await
+        .expect("create SnapshotSchedule");
+    let sched_selector = format!("{SCHEDULE_LABEL}={SCHED}");
+    wait_until(
+        "the schedule produces ≥1 Succeeded snapshot",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let sel = sched_selector.clone();
+            async move {
+                let list = backups
+                    .list(&ListParams::default().labels(&sel))
+                    .await?
+                    .items;
+                let ok = list.iter().any(|b| {
+                    serde_json::to_value(b)
+                        .unwrap_or_default()
+                        .pointer("/status/phase")
+                        .and_then(|p| p.as_str())
+                        == Some("Succeeded")
+                });
+                Ok(ok.then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("the schedule should produce a Succeeded snapshot");
+    // Freeze production so counts are stable across the cascade.
+    schedules
+        .patch(
+            SCHED,
+            &PatchParams::default(),
+            &Patch::Merge(&serde_json::json!({ "spec": { "schedule": { "suspend": true } } })),
+        )
+        .await
+        .expect("suspend schedule");
+
+    // MANUAL snapshot by plain apply with ONLY a policyRef (no config label): the
+    // admission webhook must STAMP the config label so it is GFS/cascade-visible.
+    let created: Snapshot = backups
+        .create(
+            &PostParams::default(),
+            &cr::<Snapshot>(serde_json::json!({
+                "apiVersion": "kopiur.home-operations.com/v1alpha1",
+                "kind": "Snapshot",
+                "metadata": { "name": MANUAL, "namespace": E2E_NAMESPACE },
+                "spec": { "policyRef": { "name": POLICY }, "deletionPolicy": "Delete" }
+            })),
+        )
+        .await
+        .expect("create the manual Snapshot with only a policyRef");
+    assert_eq!(
+        created.labels().get(CONFIG_LABEL).map(String::as_str),
+        Some(POLICY),
+        "the admission webhook must STAMP the config label on a policyRef-only manual Snapshot \
+         (M0), or it would be invisible to GFS retention and the policy cascade"
+    );
+    wait_phase(&backups, MANUAL, "Succeeded")
+        .await
+        .expect("the manual Snapshot should Succeed");
+
+    // The config-labeled child set the cascade must clean (scheduled + manual).
+    let child_names: Vec<String> = config_children(&backups, POLICY)
+        .await
+        .iter()
+        .map(|b| b.name_any())
+        .collect();
+    assert!(
+        child_names.len() >= 2 && child_names.iter().any(|n| n == MANUAL),
+        "expected ≥2 config-labeled children (scheduled + the stamped manual); got {child_names:?}"
+    );
+
+    let kopia_before = observed_snapshot_count(
+        &client,
+        "e2e-polcasc-retain-verify-1",
+        POLCASC_RETAIN_SUBPATH,
+    )
+    .await;
+    assert!(
+        kopia_before >= 3,
+        "kopia should hold the scheduled + manual + seed snapshots (≥3) before the cascade; got {kopia_before}"
+    );
+
+    // Delete ONLY the main policy.
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the main SnapshotPolicy (the cascade trigger)");
+
+    // Drain: every config-labeled child gone AND the policy finalizer released, while
+    // the pre-existing discovered row endures with its ORIGINAL uid throughout (a
+    // cascade wrongly touching it would delete/replace it).
+    let deadline = Instant::now() + Duration::from_secs(300);
+    loop {
+        let seed_now = backups
+            .get_opt(&seed_disc_name)
+            .await
+            .expect("get seed discovered row");
+        assert!(
+            seed_now
+                .as_ref()
+                .and_then(|s| s.uid())
+                .is_some_and(|u| u == seed_uid),
+            "the pre-existing discovered row must be UNTOUCHED by the policy cascade (same uid) \
+             throughout the drain"
+        );
+        let children = config_children(&backups, POLICY).await;
+        let policy_gone = policies
+            .get_opt(POLICY)
+            .await
+            .expect("get policy")
+            .is_none();
+        if children.is_empty() && policy_gone {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "the policy cascade must drain every config-labeled child and RELEASE the policy \
+             finalizer; still {} child(ren), policy_gone={policy_gone}",
+            children.len()
+        );
+        tokio::time::sleep(poll_interval()).await;
+    }
+
+    // Each vanished child fired a `SnapshotRetainedOnPolicyDelete` Warning.
+    for name in &child_names {
+        assert!(
+            snapshot_warning_event_exists(
+                &client,
+                E2E_NAMESPACE,
+                name,
+                "SnapshotRetainedOnPolicyDelete"
+            )
+            .await,
+            "cascade-retained snapshot {name} must get a SnapshotRetainedOnPolicyDelete Warning"
+        );
+    }
+
+    // kopia UNCHANGED — the Retain cascade kept every snapshot.
+    let kopia_after = observed_snapshot_count(
+        &client,
+        "e2e-polcasc-retain-verify-2",
+        POLCASC_RETAIN_SUBPATH,
+    )
+    .await;
+    assert_eq!(
+        kopia_after, kopia_before,
+        "a Retain-cascade policy delete MUST NOT touch kopia data; before={kopia_before} after={kopia_after}"
+    );
+
+    // The retained kopia snapshots re-catalog as discovered rows (the child set + the
+    // untouched seed row).
+    wait_until(
+        "the cascade-retained snapshots re-catalog as discovered rows",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let repo_uid = repo_uid.clone();
+            let want = child_names.len() as i64 + 1;
+            async move {
+                let rows = repo_discovered_rows(&backups, &repo_uid).await;
+                Ok((rows.len() as i64 >= want).then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("the retained snapshots must re-materialize as discovered rows");
+    // The pre-existing discovered row still endures (final check).
+    assert!(
+        backups
+            .get_opt(&seed_disc_name)
+            .await
+            .expect("get seed row")
+            .and_then(|s| s.uid())
+            .is_some_and(|u| u == seed_uid),
+        "the pre-existing discovered row must survive the whole cascade untouched"
+    );
+
+    // Cleanup: discovered rows are forced-Retain; remove Snapshot CRs before the repo.
+    for r in repo_discovered_rows(&backups, &repo_uid).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    let _ = schedules.delete(SCHED, &DeleteParams::default()).await;
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// --- Scenario 11: policy-cascade Delete opt-in is breaker-gated -----------------
+
+const POLCASC_DELETE_SUBPATH: &str = "polcasc-delete";
+
+/// The `onPolicyDelete: Delete` opt-in cascades EXTERNAL deletions, so it is subject
+/// to the per-repository mass-deletion breaker. Deleting a policy whose ≥3 children
+/// exceed the repo threshold HOLDS them (`DeletionHeld=True`, no kopia data touched),
+/// yet the POLICY CR's finalizer still RELEASES (a terminating breaker-held child must
+/// resolve to "no work" — the finalizer must never wedge waiting on an ack that would
+/// never come once the policy is gone). The `allow-mass-deletion` ack then drains the
+/// wave and really deletes the kopia snapshots.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn policy_cascade_opt_in_delete_is_breaker_gated() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, POLCASC_DELETE_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-polcasc-delete-repo";
+    const POLICY: &str = "e2e-polcasc-delete-pol";
+    const NAMES: [&str; 3] = [
+        "e2e-polcasc-delete-1",
+        "e2e-polcasc-delete-2",
+        "e2e-polcasc-delete-3",
+    ];
+
+    // threshold: 2 → the 3 cascaded external deletions trip the breaker. Fast refresh
+    // so the repo's MassDeletionHeld condition appears promptly; maintenance off.
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                POLCASC_DELETE_SUBPATH,
+                serde_json::json!({
+                    "deletionProtection": { "threshold": 2 },
+                    "maintenance": { "enabled": false },
+                    "catalog": { "periodicRefresh": true, "refreshInterval": "30s" }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository with a threshold-2 breaker");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+
+    // The opt-in: spec.deletion.onPolicyDelete: Delete.
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({
+                    "deletion": { "onPolicyDelete": "Delete" },
+                    "retention": { "keepLatest": 20 }
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy with onPolicyDelete: Delete");
+
+    // Three config-labeled manual children (deletionPolicy Delete), all Succeeded.
+    seed_manual_snapshots(&backups, POLICY, &NAMES).await;
+    let kopia_before = observed_snapshot_count(
+        &client,
+        "e2e-polcasc-delete-verify-1",
+        POLCASC_DELETE_SUBPATH,
+    )
+    .await;
+    assert_eq!(
+        kopia_before, 3,
+        "the three children must all exist in kopia before the cascade, got {kopia_before}"
+    );
+
+    // Delete the policy → the Delete-mode cascade bare-deletes the 3 children as
+    // EXTERNAL deletions → the breaker HOLDS them.
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the SnapshotPolicy (Delete-cascade trigger)");
+
+    // (a) all three children go terminating with DeletionHeld=True / MassDeletionBreaker.
+    for n in NAMES {
+        let cond = wait_condition(&backups, n, "DeletionHeld", "True")
+            .await
+            .unwrap_or_else(|e| panic!("{n} must be HELD by the mass-deletion breaker: {e}"));
+        assert_eq!(
+            cond.get("reason").and_then(|r| r.as_str()),
+            Some("MassDeletionBreaker"),
+            "{n} DeletionHeld reason must be MassDeletionBreaker: {cond}"
+        );
+    }
+
+    // (b) the POLICY finalizer RELEASES even though its children are held — the
+    // load-bearing anti-wedge guarantee (a terminating held child ⇒ no cascade work).
+    wait_until(
+        "the policy finalizer releases despite breaker-held children",
+        Duration::from_secs(150),
+        poll_interval(),
+        || async { Ok(policies.get_opt(POLICY).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect(
+        "the SnapshotPolicy CR must be released even while its Delete-cascaded children are HELD",
+    );
+
+    // (c) the children are STILL held after the policy is gone, and kopia is untouched.
+    for n in NAMES {
+        let s = backups
+            .get_opt(n)
+            .await
+            .expect("get held child")
+            .unwrap_or_else(|| panic!("held child {n} must still exist"));
+        assert!(
+            s.meta().deletion_timestamp.is_some() && snapshot_is_held(&s),
+            "held child {n} must stay terminating + DeletionHeld after the policy released"
+        );
+    }
+    let kopia_held = observed_snapshot_count(
+        &client,
+        "e2e-polcasc-delete-verify-2",
+        POLCASC_DELETE_SUBPATH,
+    )
+    .await;
+    assert_eq!(
+        kopia_held, kopia_before,
+        "NO kopia data may be deleted while the cascaded wave is HELD; before={kopia_before} held={kopia_held}"
+    );
+
+    // (d) ack via the repository annotation → the wave drains and REALLY deletes kopia.
+    let held_msg = status_json(&backups, NAMES[0])
+        .await
+        .get("conditions")
+        .and_then(|c| c.as_array())
+        .and_then(|a| {
+            a.iter()
+                .find(|c| c.get("type").and_then(|t| t.as_str()) == Some("DeletionHeld"))
+        })
+        .and_then(|c| c.get("message").and_then(|m| m.as_str()))
+        .map(str::to_string)
+        .unwrap_or_default();
+    let ack_value = parse_ack_value(&held_msg)
+        .unwrap_or_else(|| panic!("the held message must carry an ack value: {held_msg}"));
+    repos
+        .patch(
+            REPO,
+            &PatchParams::default(),
+            &Patch::Merge(&serde_json::json!({
+                "metadata": { "annotations": { ALLOW_MASS_DELETION_ANNOTATION: ack_value } }
+            })),
+        )
+        .await
+        .expect("acknowledge the mass-deletion wave on the repository");
+    wait_all_drained(&backups, &NAMES, Duration::from_secs(180)).await;
+    let kopia_after = observed_snapshot_count(
+        &client,
+        "e2e-polcasc-delete-verify-3",
+        POLCASC_DELETE_SUBPATH,
+    )
+    .await;
+    assert_eq!(
+        kopia_after,
+        kopia_before - 3,
+        "the acked cascade must delete all 3 kopia snapshots; before={kopia_before} after={kopia_after}"
+    );
+
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// --- Scenario 12: simultaneous schedule + policy delete drains to Retain --------
+
+const POLCASC_SIMUL_SUBPATH: &str = "polcasc-simul";
+
+/// Deleting a `SnapshotSchedule` and its `SnapshotPolicy` back-to-back (both at their
+/// safe-default `Retain`) must NOT wedge: every produced `Snapshot` CR drains (no
+/// stuck finalizer under the overlapping cascades), the kopia data is intact, and NO
+/// `SnapshotDeleteBatch` Job ever fires (nothing is deleted kopia-side).
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn schedule_and_policy_simultaneous_delete_drains_to_retain() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, POLCASC_SIMUL_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let schedules: Api<SnapshotSchedule> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-polcasc-simul-repo";
+    const POLICY: &str = "e2e-polcasc-simul-pol";
+    const SCHED: &str = "e2e-polcasc-simul-sched";
+
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                POLCASC_SIMUL_SUBPATH,
+                serde_json::json!({ "maintenance": { "enabled": false } }),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({ "defaultDeletionPolicy": "Delete", "retention": { "keepLatest": 20 } }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy");
+    schedules
+        .create(
+            &PostParams::default(),
+            &cr::<SnapshotSchedule>(schedule_json(SCHED, POLICY, "* * * * *")),
+        )
+        .await
+        .expect("create SnapshotSchedule");
+
+    // Wait for ≥2 Succeeded scheduled children, then freeze the produced set.
+    let sched_selector = format!("{SCHEDULE_LABEL}={SCHED}");
+    wait_until(
+        "the schedule produces ≥2 Succeeded snapshots",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let sel = sched_selector.clone();
+            async move {
+                let list = backups
+                    .list(&ListParams::default().labels(&sel))
+                    .await?
+                    .items;
+                let n = list
+                    .iter()
+                    .filter(|b| {
+                        serde_json::to_value(b)
+                            .unwrap_or_default()
+                            .pointer("/status/phase")
+                            .and_then(|p| p.as_str())
+                            == Some("Succeeded")
+                    })
+                    .count();
+                Ok((n >= 2).then_some(()))
+            }
+        },
+    )
+    .await
+    .expect("the schedule should produce ≥2 Succeeded snapshots");
+    schedules
+        .patch(
+            SCHED,
+            &PatchParams::default(),
+            &Patch::Merge(&serde_json::json!({ "spec": { "schedule": { "suspend": true } } })),
+        )
+        .await
+        .expect("suspend schedule to freeze the produced set");
+    tokio::time::sleep(Duration::from_secs(12)).await;
+
+    let children: Vec<Snapshot> = config_children(&backups, POLICY).await;
+    let child_names: Vec<String> = children.iter().map(|b| b.name_any()).collect();
+    let child_uids: BTreeSet<String> = children.iter().filter_map(|b| b.uid()).collect();
+    assert!(
+        child_uids.len() >= 2,
+        "need ≥2 produced children to prove a clean multi-child drain; got {child_names:?}"
+    );
+
+    let kopia_before =
+        observed_snapshot_count(&client, "e2e-polcasc-simul-verify-1", POLCASC_SIMUL_SUBPATH).await;
+    assert!(
+        kopia_before >= 2,
+        "kopia should hold ≥2 snapshots before the simultaneous delete; got {kopia_before}"
+    );
+
+    // Delete the schedule and the policy back-to-back (schedule then policy): both
+    // cascades (Retain) now race over the SAME children — neither may wedge a finalizer.
+    schedules
+        .delete(SCHED, &DeleteParams::default())
+        .await
+        .expect("delete the SnapshotSchedule");
+    policies
+        .delete(POLICY, &DeleteParams::default())
+        .await
+        .expect("delete the SnapshotPolicy");
+
+    // Every child drains (no stuck finalizer), and BOTH parents are gone.
+    let names_ref: Vec<&str> = child_names.iter().map(String::as_str).collect();
+    wait_all_drained(&backups, &names_ref, Duration::from_secs(300)).await;
+    wait_until(
+        "the schedule and policy CRs are both released",
+        Duration::from_secs(120),
+        poll_interval(),
+        || async {
+            let sched_gone = schedules.get_opt(SCHED).await?.is_none();
+            let pol_gone = policies.get_opt(POLICY).await?.is_none();
+            Ok((sched_gone && pol_gone).then_some(()))
+        },
+    )
+    .await
+    .expect("both the schedule and policy finalizers must release under the overlapping cascades");
+
+    // NO DeleteSnapshot activity: no batch delete Job ever covered these children, and
+    // the kopia data is intact (both cascades were Retain).
+    let my_batches = my_batch_jobs(&jobs, &child_uids).await;
+    assert!(
+        my_batches.is_empty(),
+        "a Retain double-cascade must launch NO SnapshotDeleteBatch Job; found {:?}",
+        my_batches.iter().map(|j| j.name_any()).collect::<Vec<_>>()
+    );
+    let kopia_after =
+        observed_snapshot_count(&client, "e2e-polcasc-simul-verify-2", POLCASC_SIMUL_SUBPATH).await;
+    assert_eq!(
+        kopia_after, kopia_before,
+        "a simultaneous Retain schedule+policy delete MUST keep all kopia data; before={kopia_before} after={kopia_after}"
+    );
+
+    // Cleanup: the retained kopia snapshots may re-catalog as discovered rows; remove
+    // any Snapshot CRs before the repo.
+    let repo_uid = repos
+        .get(REPO)
+        .await
+        .ok()
+        .and_then(|r| r.uid())
+        .unwrap_or_default();
+    for r in repo_discovered_rows(&backups, &repo_uid).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
     let _ = repos.delete(REPO, &DeleteParams::default()).await;
 }

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -965,6 +965,8 @@ fn policy_args_from_policy_maps_all_flattened_knobs() {
         hooks: None,
         mover: None,
         credential_projection: None,
+        deletion: None,
+        adoption: None,
     };
     let p = PolicyArgsSpec::from_policy(&spec);
     assert_eq!(p.compression.as_deref(), Some("zstd"));
@@ -1036,6 +1038,8 @@ fn empty_policy_spec() -> kopiur_api::SnapshotPolicySpec {
         hooks: None,
         mover: None,
         credential_projection: None,
+        deletion: None,
+        adoption: None,
     }
 }
 

--- a/crates/webhook/src/handlers.rs
+++ b/crates/webhook/src/handlers.rs
@@ -16,7 +16,7 @@
 use kopiur_api as api;
 
 use api::cluster_repository::ClusterRepositorySpec;
-use api::common::{DeletionPolicy, RepositoryKind, RepositoryRef};
+use api::common::{DeletionPolicy, PolicyRef, RepositoryKind, RepositoryRef};
 use api::error::ValidationError;
 use api::maintenance::MaintenanceSpec;
 use api::repository::RepositorySpec;
@@ -34,6 +34,7 @@ use kube::Client;
 use kube::core::DynamicObject;
 use kube::core::admission::{AdmissionRequest, AdmissionResponse, Operation};
 use serde_json::{Value, json};
+use std::collections::BTreeMap;
 
 /// The finalizer that ties a kopia snapshot's lifecycle to its `Snapshot` CR (ADR §4.5).
 /// Single definition shared with the controller via `kopiur-api` so the two can't drift.
@@ -337,7 +338,92 @@ fn handle_snapshot(
     // Every Snapshot carries the snapshot-cleanup finalizer (ADR §4.5).
     ensure_finalizer_ops(&obj.metadata, &mut ops);
 
+    // Stamp CONFIG_LABEL on CREATE only. Today the label is stamped by the schedule
+    // controller and by the CLI's `snapshot now` — but a raw-`kubectl apply`'d manual
+    // Snapshot with `spec.policyRef` never gets it, making it invisible to GFS
+    // retention, the policy fan-out watch, and the SnapshotPolicy deletion cascade
+    // (all of which select a policy's children by this label). Deliberately no
+    // controller-side backfill of pre-existing CRs: retro-labeling would make a
+    // previously-immortal raw-applied manual Snapshot GFS-prunable — silent data loss.
+    if req.operation == Operation::Create
+        && let Some(value) = config_label_stamp(
+            origin,
+            spec.policy_ref.as_ref(),
+            obj.metadata
+                .namespace
+                .as_deref()
+                .or(req.namespace.as_deref())
+                .unwrap_or_default(),
+            obj.metadata.labels.as_ref(),
+        )
+    {
+        ops.push(config_label_op(&obj.metadata, &value));
+    }
+
     with_patch(resp, ops)
+}
+
+/// Decide whether a `Snapshot` referencing a `SnapshotPolicy` should have
+/// `CONFIG_LABEL` stamped on it, and the value to stamp. Pure (no IO), so it
+/// unit-tests without a cluster.
+///
+/// Fires only when ALL hold:
+/// - `origin` is `Manual` or `Scheduled` — never `Discovered`: a catalog-materialized
+///   Snapshot never ran through a policy, so a `policyRef` on one (if any) doesn't
+///   earn the label.
+/// - `policy_ref` is present with a nonempty name.
+/// - The ref targets the Snapshot's OWN namespace (absent/empty `namespace`, or equal
+///   to `cr_namespace`). The stamped label value is a bare policy name with no
+///   namespace component, so a cross-namespace ref must not mint a label that
+///   collides with a same-named LOCAL policy.
+/// - The label isn't already present, regardless of its value (idempotent: never
+///   overwrite an existing value).
+fn config_label_stamp(
+    origin: Origin,
+    policy_ref: Option<&PolicyRef>,
+    cr_namespace: &str,
+    existing_labels: Option<&BTreeMap<String, String>>,
+) -> Option<String> {
+    match origin {
+        Origin::Discovered => return None,
+        Origin::Manual | Origin::Scheduled => {}
+    }
+
+    let policy_ref = policy_ref?;
+    if policy_ref.name.is_empty() {
+        return None;
+    }
+
+    if let Some(ns) = policy_ref.namespace.as_deref()
+        && !ns.is_empty()
+        && ns != cr_namespace
+    {
+        return None;
+    }
+
+    if existing_labels.is_some_and(|labels| labels.contains_key(api::consts::CONFIG_LABEL)) {
+        return None;
+    }
+
+    Some(policy_ref.name.clone())
+}
+
+/// Build the JSON-patch op that stamps `CONFIG_LABEL = value` on a `Snapshot`,
+/// mirroring `set_spec_field`'s absent-parent handling: if `metadata.labels` is
+/// absent, add the whole map; otherwise add just the key (an RFC 6902 `add` on an
+/// existing map sets/creates that one member without clobbering siblings). Only
+/// called once `config_label_stamp` has already confirmed the key is absent.
+fn config_label_op(meta: &ObjectMeta, value: &str) -> PatchOperation {
+    match &meta.labels {
+        None => PatchOperation::Add(AddOperation {
+            path: PointerBuf::from_tokens(["metadata", "labels"]),
+            value: json!({ api::consts::CONFIG_LABEL: value }),
+        }),
+        Some(_) => PatchOperation::Add(AddOperation {
+            path: PointerBuf::from_tokens(["metadata", "labels", api::consts::CONFIG_LABEL]),
+            value: json!(value),
+        }),
+    }
 }
 
 /// Resolve a `Snapshot`'s origin from the `kopiur.home-operations.com/origin` label (canonical) or
@@ -772,6 +858,132 @@ fn set_spec_field(data: &Value, field: &str, value: Value) -> PatchOperation {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    // --- config_label_stamp (pure) ---------------------------------------------
+
+    fn policy_ref(name: &str, namespace: Option<&str>) -> PolicyRef {
+        PolicyRef {
+            name: name.to_string(),
+            namespace: namespace.map(str::to_string),
+        }
+    }
+
+    fn labels(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn manual_same_ns_ref_with_no_labels_map_stamps() {
+        let r = policy_ref("nightly", None);
+        assert_eq!(
+            config_label_stamp(Origin::Manual, Some(&r), "billing", None),
+            Some("nightly".to_string())
+        );
+    }
+
+    #[test]
+    fn manual_ref_with_existing_labels_map_missing_key_stamps() {
+        let r = policy_ref("nightly", None);
+        let existing = labels(&[("some-other", "label")]);
+        assert_eq!(
+            config_label_stamp(Origin::Manual, Some(&r), "billing", Some(&existing)),
+            Some("nightly".to_string())
+        );
+    }
+
+    #[test]
+    fn label_already_present_is_a_no_op_regardless_of_value() {
+        let r = policy_ref("nightly", None);
+        let existing = labels(&[(api::consts::CONFIG_LABEL, "some-other-policy")]);
+        assert_eq!(
+            config_label_stamp(Origin::Manual, Some(&r), "billing", Some(&existing)),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_cross_namespace_ref_is_a_no_op() {
+        let r = policy_ref("nightly", Some("other-ns"));
+        assert_eq!(
+            config_label_stamp(Origin::Manual, Some(&r), "billing", None),
+            None
+        );
+    }
+
+    #[test]
+    fn explicit_same_namespace_ref_still_stamps() {
+        let r = policy_ref("nightly", Some("billing"));
+        assert_eq!(
+            config_label_stamp(Origin::Manual, Some(&r), "billing", None),
+            Some("nightly".to_string())
+        );
+    }
+
+    #[test]
+    fn absent_policy_ref_is_a_no_op() {
+        assert_eq!(
+            config_label_stamp(Origin::Manual, None, "billing", None),
+            None
+        );
+    }
+
+    #[test]
+    fn discovered_origin_is_a_no_op_even_with_a_ref() {
+        let r = policy_ref("nightly", None);
+        assert_eq!(
+            config_label_stamp(Origin::Discovered, Some(&r), "billing", None),
+            None
+        );
+    }
+
+    #[test]
+    fn scheduled_origin_with_ref_stamps_same_as_manual() {
+        // Harmless idempotent parity with the schedule controller, which already
+        // stamps this label itself — this codepath is a no-op there in practice.
+        let r = policy_ref("nightly", None);
+        assert_eq!(
+            config_label_stamp(Origin::Scheduled, Some(&r), "billing", None),
+            Some("nightly".to_string())
+        );
+    }
+
+    // --- config_label_op (ops-building) -----------------------------------------
+
+    fn add_op(op: PatchOperation) -> AddOperation {
+        match op {
+            PatchOperation::Add(add) => add,
+            other => panic!("expected an Add op, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn config_label_op_creates_the_labels_map_when_absent() {
+        let meta = ObjectMeta::default();
+        let op = add_op(config_label_op(&meta, "nightly"));
+        assert_eq!(op.path.to_string(), "/metadata/labels");
+        assert_eq!(
+            op.value,
+            json!({ "kopiur.home-operations.com/config": "nightly" })
+        );
+    }
+
+    #[test]
+    fn config_label_op_adds_just_the_key_when_the_map_already_exists() {
+        let meta = ObjectMeta {
+            labels: Some(labels(&[("some-other", "label")])),
+            ..Default::default()
+        };
+        let op = add_op(config_label_op(&meta, "nightly"));
+        // The slash in the label key must be RFC 6901 ("~1") escaped.
+        assert_eq!(
+            op.path.to_string(),
+            "/metadata/labels/kopiur.home-operations.com~1config"
+        );
+        assert_eq!(op.value, json!("nightly"));
+    }
 
     /// Build a CREATE `AdmissionRequest` for the given kind/spec, the way the API
     /// server would. No cluster needed — Repository/ClusterRepository validation is

--- a/crates/webhook/src/handlers.rs
+++ b/crates/webhook/src/handlers.rs
@@ -428,8 +428,27 @@ fn config_label_op(meta: &ObjectMeta, value: &str) -> PatchOperation {
     }
 }
 
-/// Resolve a `Snapshot`'s origin from the `kopiur.home-operations.com/origin` label (canonical) or
-/// `status.origin`, defaulting to `manual` for user-created backups with no marker.
+/// Resolve a `Snapshot`'s origin from `status.origin` (canonical) or the
+/// `kopiur.home-operations.com/origin` label (CREATE-time fallback, before any
+/// status has ever been written), defaulting to `manual` for user-created
+/// backups with no marker. Mirrors the controller's `resolve_origin`
+/// (`crates/controller/src/snapshot/plan.rs`) — status-first, NOT label-first.
+///
+/// This ordering is load-bearing with adoption in play (M1+): the label lives on
+/// `metadata`, which a user can edit freely, while `status` is a subresource only
+/// the controller can write. A label-first resolution would let a user flip a
+/// `discovered` row's label to `adopted` and unlock `deletionPolicy: Delete` at
+/// admission while the controller still treats the row as `discovered` (forced
+/// `Retain`) — an admitted spec the controller's own reconcile invariants
+/// disagree with. Status-first closes that gap.
+///
+/// Audit-verified safe for the cases that predate this flip: at CREATE,
+/// `status.origin` is always absent (a brand-new object has no status yet), so
+/// the label fallback preserves every existing admission default exactly.
+/// Already-`discovered` rows carry `status.origin` (stamped by the catalog scan),
+/// so they were never depending on the label winning. `produced` (scheduled/
+/// manual) rows get `status.origin` written shortly after creation and their
+/// admission-time defaulting never depended on which arm won either.
 fn backup_origin(meta: &ObjectMeta, data: &Value) -> Origin {
     let from_label = meta
         .labels
@@ -440,7 +459,7 @@ fn backup_origin(meta: &ObjectMeta, data: &Value) -> Origin {
         .get("status")
         .and_then(|s| s.get("origin"))
         .and_then(|v| v.as_str());
-    match from_label.or(from_status) {
+    match from_status.or(from_label) {
         Some("discovered") => Origin::Discovered,
         Some("scheduled") => Origin::Scheduled,
         Some("adopted") => Origin::Adopted,

--- a/crates/webhook/src/handlers.rs
+++ b/crates/webhook/src/handlers.rs
@@ -326,7 +326,7 @@ fn handle_snapshot(
     if spec.deletion_policy.is_none() {
         let default = match origin {
             Origin::Discovered => DeletionPolicy::Retain,
-            Origin::Scheduled | Origin::Manual => DeletionPolicy::Delete,
+            Origin::Scheduled | Origin::Manual | Origin::Adopted => DeletionPolicy::Delete,
         };
         ops.push(set_spec_field(
             &obj.data,
@@ -368,9 +368,11 @@ fn handle_snapshot(
 /// unit-tests without a cluster.
 ///
 /// Fires only when ALL hold:
-/// - `origin` is `Manual` or `Scheduled` — never `Discovered`: a catalog-materialized
-///   Snapshot never ran through a policy, so a `policyRef` on one (if any) doesn't
-///   earn the label.
+/// - `origin` is `Manual`, `Scheduled`, or `Adopted` — never `Discovered`: a
+///   catalog-materialized Snapshot never ran through a policy, so a `policyRef`
+///   on one (if any) doesn't earn the label. `Adopted` is the managed-row
+///   exception: it was deliberately re-attached to a `SnapshotPolicy`, so it
+///   earns the label exactly like a produced Snapshot.
 /// - `policy_ref` is present with a nonempty name.
 /// - The ref targets the Snapshot's OWN namespace (absent/empty `namespace`, or equal
 ///   to `cr_namespace`). The stamped label value is a bare policy name with no
@@ -386,7 +388,7 @@ fn config_label_stamp(
 ) -> Option<String> {
     match origin {
         Origin::Discovered => return None,
-        Origin::Manual | Origin::Scheduled => {}
+        Origin::Manual | Origin::Scheduled | Origin::Adopted => {}
     }
 
     let policy_ref = policy_ref?;
@@ -441,6 +443,7 @@ fn backup_origin(meta: &ObjectMeta, data: &Value) -> Origin {
     match from_label.or(from_status) {
         Some("discovered") => Origin::Discovered,
         Some("scheduled") => Origin::Scheduled,
+        Some("adopted") => Origin::Adopted,
         // A user `kubectl create`-ing a Snapshot with no origin marker is manual.
         _ => Origin::Manual,
     }

--- a/crates/webhook/src/identity_collision.rs
+++ b/crates/webhook/src/identity_collision.rs
@@ -284,6 +284,8 @@ mod tests {
             hooks: None,
             mover: None,
             credential_projection: None,
+            deletion: None,
+            adoption: None,
         }
     }
 

--- a/crates/webhook/src/routes.rs
+++ b/crates/webhook/src/routes.rs
@@ -296,6 +296,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn manual_backup_create_stamps_config_label_alongside_other_defaults() {
+        // A raw-`kubectl apply`'d manual Snapshot with `policyRef` (no ORIGIN_LABEL,
+        // no pre-existing config label) must get CONFIG_LABEL stamped on CREATE,
+        // alongside the existing finalizer/deletionPolicy defaults.
+        let body = review_body(
+            "Snapshot",
+            "billing",
+            "u",
+            json!({ "policyRef": { "name": "nightly" } }),
+        );
+        let (_s, v) = post_review(body).await;
+        assert_eq!(v["response"]["allowed"], true);
+        let patch = decode_patch(&v);
+        let has_label = patch.iter().any(|op| {
+            op["op"] == "add"
+                && op["path"] == "/metadata/labels"
+                && op["value"]["kopiur.home-operations.com/config"] == "nightly"
+        });
+        let has_dp = patch.iter().any(|op| {
+            op["op"] == "add" && op["path"] == "/spec/deletionPolicy" && op["value"] == "Delete"
+        });
+        let has_fin = patch.iter().any(|op| {
+            op["op"] == "add"
+                && op["path"] == "/metadata/finalizers"
+                && op["value"][0] == "kopiur.home-operations.com/snapshot-cleanup"
+        });
+        assert!(has_label, "expected config label stamp: {patch:?}");
+        assert!(has_dp, "expected Delete default: {patch:?}");
+        assert!(has_fin, "expected finalizer add: {patch:?}");
+    }
+
+    #[tokio::test]
+    async fn manual_backup_update_does_not_stamp_config_label() {
+        // CONFIG_LABEL stamping is CREATE-only by design (no controller-side
+        // backfill of pre-existing CRs — see `handlers::config_label_stamp`).
+        let mut body = review_body(
+            "Snapshot",
+            "billing",
+            "u",
+            json!({ "policyRef": { "name": "nightly" } }),
+        );
+        body["request"]["operation"] = json!("UPDATE");
+        let (_s, v) = post_review(body).await;
+        assert_eq!(v["response"]["allowed"], true);
+        let patch = decode_patch(&v);
+        // The origin-aware deletionPolicy default applies regardless of operation,
+        // so the patch is non-empty — proving this isn't a vacuous check.
+        assert!(
+            patch.iter().any(|op| op["path"] == "/spec/deletionPolicy"),
+            "expected a non-empty patch to make this a meaningful assertion: {patch:?}"
+        );
+        let touches_labels = patch.iter().any(|op| {
+            op["path"]
+                .as_str()
+                .is_some_and(|p| p.starts_with("/metadata/labels"))
+        });
+        assert!(
+            !touches_labels,
+            "UPDATE must not stamp the config label: {patch:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn deleting_backup_is_not_refinalized() {
         // Regression: the mutating webhook re-added the snapshot-cleanup finalizer
         // on EVERY admission, including the UPDATE the controller issues to REMOVE

--- a/crates/webhook/src/routes.rs
+++ b/crates/webhook/src/routes.rs
@@ -428,6 +428,92 @@ mod tests {
         );
     }
 
+    // --- backup_origin: status-first resolution (M4) ---------------------------
+    //
+    // `backup_origin` flipped from label-first to status-first to match the
+    // controller's `resolve_origin` (crates/controller/src/snapshot/plan.rs).
+    // These pin the status arm winning at UPDATE, the label surviving as the
+    // CREATE-time fallback, and — the actual hardening — a label flip NOT
+    // overriding an existing `status.origin` (the "origin-flip attack").
+
+    #[tokio::test]
+    async fn adopted_status_update_with_delete_is_admitted() {
+        let mut body = review_body(
+            "Snapshot",
+            "billing",
+            "u",
+            json!({ "deletionPolicy": "Delete" }),
+        );
+        body["request"]["operation"] = json!("UPDATE");
+        body["request"]["object"]["status"] = json!({ "origin": "adopted" });
+        let (_s, v) = post_review(body).await;
+        assert_eq!(
+            v["response"]["allowed"], true,
+            "adopted rows may carry any deletionPolicy: {v:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn discovered_status_update_with_delete_is_denied() {
+        let mut body = review_body(
+            "Snapshot",
+            "billing",
+            "u",
+            json!({ "deletionPolicy": "Delete" }),
+        );
+        body["request"]["operation"] = json!("UPDATE");
+        body["request"]["object"]["status"] = json!({ "origin": "discovered" });
+        let (_s, v) = post_review(body).await;
+        assert_eq!(v["response"]["allowed"], false);
+        let msg = v["response"]["status"]["message"].as_str().unwrap();
+        assert!(msg.contains("Retain"), "msg was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn label_flip_to_adopted_does_not_override_discovered_status() {
+        // The origin-flip attack this hardening closes: a user cannot unlock
+        // `deletionPolicy: Delete` on a catalog-discovered row by editing the
+        // metadata LABEL — only the controller-owned `status.origin` (which still
+        // says `discovered`) governs. Label-first would have admitted this.
+        let mut body = review_body(
+            "Snapshot",
+            "billing",
+            "u",
+            json!({ "deletionPolicy": "Delete" }),
+        );
+        body["request"]["operation"] = json!("UPDATE");
+        body["request"]["object"]["status"] = json!({ "origin": "discovered" });
+        body["request"]["object"]["metadata"]["labels"] =
+            json!({ "kopiur.home-operations.com/origin": "adopted" });
+        let (_s, v) = post_review(body).await;
+        assert_eq!(
+            v["response"]["allowed"], false,
+            "status-first must win over a flipped label: {v:?}"
+        );
+        let msg = v["response"]["status"]["message"].as_str().unwrap();
+        assert!(msg.contains("Retain"), "msg was: {msg}");
+    }
+
+    #[tokio::test]
+    async fn create_with_only_the_discovered_label_still_resolves_discovered() {
+        // No `status` at all on CREATE (a brand-new object never has one yet) — the
+        // label fallback must still resolve `discovered` and default `Retain`,
+        // byte-identical to pre-M4 behavior.
+        let mut body = review_body("Snapshot", "billing", "u", json!({}));
+        body["request"]["object"]["metadata"]["labels"] =
+            json!({ "kopiur.home-operations.com/origin": "discovered" });
+        let (_s, v) = post_review(body).await;
+        assert_eq!(v["response"]["allowed"], true);
+        let patch = decode_patch(&v);
+        let has_retain = patch
+            .iter()
+            .any(|op| op["path"] == "/spec/deletionPolicy" && op["value"] == "Retain");
+        assert!(
+            has_retain,
+            "expected Retain default via the label fallback: {patch:?}"
+        );
+    }
+
     #[tokio::test]
     async fn restore_identity_without_repository_denied() {
         let spec = json!({

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2630,6 +2631,15 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
                     nullable: true
                     type: string
                   scanRequestHonored:

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -544,6 +544,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2618,6 +2630,17 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
                     nullable: true
                     type: string
                 type: object

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -248,6 +248,7 @@ spec:
                 - scheduled
                 - manual
                 - discovered
+                - adopted
                 nullable: true
                 type: string
               phase:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -2629,6 +2629,15 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
+                    nullable: true
+                    type: string
                   scanRequestHonored:
                     description: |-
                       The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
@@ -5558,6 +5567,15 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
                     nullable: true
                     type: string
                   scanRequestHonored:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -541,6 +541,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2617,6 +2629,17 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
+                    nullable: true
+                    type: string
                 type: object
               conditions:
                 description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
@@ -3437,6 +3460,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -5525,6 +5560,17 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
+                    nullable: true
+                    type: string
                 type: object
               conditions:
                 description: Standard Kubernetes conditions (e.g. `Connected`, `MaintenanceOwned`).
@@ -5791,6 +5837,18 @@ spec:
           spec:
             description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
+              adoption:
+                description: |-
+                  Whether a discovered snapshot whose resolved identity matches a live
+                  `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                  policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                  retention governs it and eventually prunes it, instead of it sitting in the
+                  catalog forever as an immortal `discovered` row.
+                enum:
+                - Adopt
+                - Ignore
+                nullable: true
+                type: string
               compression:
                 description: Compression algorithm + per-extension opt-outs.
                 nullable: true
@@ -5833,6 +5891,20 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              deletion:
+                description: Deletion semantics for the `Snapshot` CRs carrying this recipe's config label.
+                nullable: true
+                properties:
+                  onPolicyDelete:
+                    default: Retain
+                    description: |-
+                      Consulted by the Snapshot finalizer when the deletion is external and the
+                      owning `SnapshotPolicy` is gone. Absent resolves to `Retain`.
+                    enum:
+                    - Retain
+                    - Delete
+                    type: string
+                type: object
               errorHandling:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
@@ -6956,6 +7028,40 @@ spec:
             description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
+              adoption:
+                description: Summary of automatic adoption of discovered snapshots into this recipe.
+                nullable: true
+                properties:
+                  lastAdoptedCount:
+                    description: Number of discovered `Snapshot` CRs adopted by the last adoption pass.
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  lastAdoptionAt:
+                    description: RFC3339 timestamp of the last adoption pass that adopted at least one snapshot.
+                    nullable: true
+                    type: string
+                  scanRequestedAt:
+                    description: |-
+                      RFC3339 token echoing an in-flight on-demand adoption scan request for
+                      this policy's identity; cleared once honored.
+                    nullable: true
+                    type: string
+                  scanRequestedIdentity:
+                    description: |-
+                      The resolved kopia identity the requested scan was scoped to, pinned at
+                      request time so a later identity-changing edit can't retarget an
+                      in-flight scan.
+                    nullable: true
+                    type: string
+                  totalAdopted:
+                    description: Running total of `Snapshot` CRs ever adopted into this recipe.
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               conditions:
                 description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:
@@ -7315,6 +7421,7 @@ spec:
                 - scheduled
                 - manual
                 - discovered
+                - adopted
                 nullable: true
                 type: string
               phase:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -2693,6 +2693,15 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
+                    nullable: true
+                    type: string
                   scanRequestHonored:
                     description: |-
                       The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -593,6 +593,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2679,6 +2691,17 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -2629,6 +2629,15 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
+                    nullable: true
+                    type: string
                   scanRequestHonored:
                     description: |-
                       The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -541,6 +541,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2615,6 +2627,17 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -39,6 +39,18 @@ spec:
           spec:
             description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
+              adoption:
+                description: |-
+                  Whether a discovered snapshot whose resolved identity matches a live
+                  `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                  policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                  retention governs it and eventually prunes it, instead of it sitting in the
+                  catalog forever as an immortal `discovered` row.
+                enum:
+                - Adopt
+                - Ignore
+                nullable: true
+                type: string
               compression:
                 description: Compression algorithm + per-extension opt-outs.
                 nullable: true
@@ -81,6 +93,20 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              deletion:
+                description: Deletion semantics for the `Snapshot` CRs carrying this recipe's config label.
+                nullable: true
+                properties:
+                  onPolicyDelete:
+                    default: Retain
+                    description: |-
+                      Consulted by the Snapshot finalizer when the deletion is external and the
+                      owning `SnapshotPolicy` is gone. Absent resolves to `Retain`.
+                    enum:
+                    - Retain
+                    - Delete
+                    type: string
+                type: object
               errorHandling:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
@@ -1204,6 +1230,40 @@ spec:
             description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
+              adoption:
+                description: Summary of automatic adoption of discovered snapshots into this recipe.
+                nullable: true
+                properties:
+                  lastAdoptedCount:
+                    description: Number of discovered `Snapshot` CRs adopted by the last adoption pass.
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  lastAdoptionAt:
+                    description: RFC3339 timestamp of the last adoption pass that adopted at least one snapshot.
+                    nullable: true
+                    type: string
+                  scanRequestedAt:
+                    description: |-
+                      RFC3339 token echoing an in-flight on-demand adoption scan request for
+                      this policy's identity; cleared once honored.
+                    nullable: true
+                    type: string
+                  scanRequestedIdentity:
+                    description: |-
+                      The resolved kopia identity the requested scan was scoped to, pinned at
+                      request time so a later identity-changing edit can't retarget an
+                      in-flight scan.
+                    nullable: true
+                    type: string
+                  totalAdopted:
+                    description: Running total of `Snapshot` CRs ever adopted into this recipe.
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               conditions:
                 description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -245,6 +245,7 @@ spec:
                 - scheduled
                 - manual
                 - discovered
+                - adopted
                 nullable: true
                 type: string
               phase:

--- a/deploy/examples/35-policy-deletion-cascade.yaml
+++ b/deploy/examples/35-policy-deletion-cascade.yaml
@@ -1,0 +1,100 @@
+# Example 35 — SnapshotPolicy.spec.deletion.onPolicyDelete: what happens to a
+# recipe's Snapshots when the SnapshotPolicy itself is deleted
+#
+# A SnapshotPolicy owns a policy-cleanup finalizer that cascades onto every
+# Snapshot CR carrying its config label (kopiur.home-operations.com/config)
+# the moment the SnapshotPolicy is deleted. spec.deletion.onPolicyDelete picks
+# the mode:
+#
+# - Retain (the default — shown below): every child CR is stamped
+#   `pruned-by: policy-cascade` and removed, but NO kopia snapshot is ever
+#   deleted, even for a child whose own deletionPolicy was Delete (a
+#   SnapshotRetainedOnPolicyDelete Warning Event fires on each one, naming
+#   why). The kopia data survives in the repository, is rediscovered as
+#   `origin: discovered` on the next catalog scan, and — since adoption
+#   defaults on — is automatically re-attached the moment a SnapshotPolicy
+#   with a matching identity exists again (including this same policy,
+#   re-created; see example 36).
+#
+# - Delete (opt-in, commented out below): each child CR is deleted UNSTAMPED,
+#   so its own deletionPolicy applies exactly like any other external
+#   deletion — a Delete child's kopia snapshot really is removed. That still
+#   passes through the repository's mass-deletion breaker
+#   (spec.deletionProtection.threshold, default 10): deleting a whole
+#   recipe's worth of Snapshots at once is exactly the bulk-deletion pattern
+#   the breaker exists to catch, so a large policy will likely trip it and
+#   need the kopiur.home-operations.com/allow-mass-deletion ack before the
+#   held deletions proceed (see example 34 / docs/repositories.md
+#   "deletionProtection").
+#
+# Field shapes verified against crates/api (externally-tagged backend:
+# `backend.s3`, not `backend: { kind: S3 }`).
+#
+# See docs/backups.md ("What happens when the policy is deleted") and
+# docs/scenarios/adopt-existing-repo.md ("Delete a policy, then recreate it").
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nas-primary-creds
+  namespace: billing
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: "REPLACE_ME"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_ME"
+  KOPIA_PASSWORD: "choose-something-long-and-random"
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: nas-primary
+  namespace: billing
+spec:
+  backend:
+    s3:
+      bucket: my-backups
+      prefix: prod/
+      endpoint: s3.us-east-1.amazonaws.com
+      region: us-east-1
+      auth:
+        secretRef:
+          name: nas-primary-creds
+  encryption:
+    passwordSecretRef:
+      name: nas-primary-creds
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+  # The mass-deletion circuit breaker every Delete-mode cascade below still
+  # passes through — see the Delete variant's comments further down.
+  deletionProtection:
+    threshold: 10 # default; `0` disables it
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: postgres-data
+  namespace: billing
+spec:
+  repository:
+    kind: Repository
+    name: nas-primary
+  sources:
+    - pvc:
+        name: postgres-data
+  retention:
+    keepDaily: 14
+    keepWeekly: 4
+  # Deletion semantics for the Snapshots THIS policy's config label governs.
+  deletion:
+    # Fail-safe default (shown explicitly here — omitting `deletion`
+    # entirely, or the whole block, resolves to the same thing): deleting
+    # this SnapshotPolicy removes its Snapshot CRs but keeps every kopia
+    # snapshot in the repository. Nothing is lost — see the header comment.
+    onPolicyDelete: Retain
+
+    # Opt-in cascade instead: uncomment to make deleting this SnapshotPolicy
+    # really delete its Snapshots' kopia data too (each child's own
+    # deletionPolicy applies as an ordinary external deletion, subject to
+    # the repository's deletionProtection breaker above).
+    # onPolicyDelete: Delete

--- a/deploy/examples/36-policy-recreate-adoption.yaml
+++ b/deploy/examples/36-policy-recreate-adoption.yaml
@@ -1,0 +1,115 @@
+# Example 36 — Recreating a deleted SnapshotPolicy: catalog.adoption + the
+# automatic delete -> recreate -> adopt -> retention-resumes flow
+#
+# Pairs with example 35 (SnapshotPolicy.spec.deletion.onPolicyDelete: Retain,
+# the default): after that cascade removes a policy's Snapshot CRs but keeps
+# every kopia snapshot in the repository, re-applying THIS SAME manifest is
+# how the history comes back and retention resumes pruning it. Step by step:
+#
+# 1. `kubectl delete snapshotschedule postgres-data-nightly` then
+#    `kubectl delete snapshotpolicy postgres-data` (or a GitOps prune removing
+#    both at once — see docs/backups.md "Retain-wins-ties"). The policy's
+#    Snapshot CRs are cleaned up; every kopia snapshot survives, un-cataloged.
+# 2. `kubectl apply -f` this file again (a genuinely fresh SnapshotPolicy has
+#    no Snapshot CRs carrying its config label — no history yet). Its first
+#    reconcile finds zero adoption candidates for its resolved identity
+#    (nothing has been rediscovered yet) and, because it has no history and
+#    hasn't already asked for this identity, requests an on-demand catalog
+#    scan on the repository (an AdoptionScanRequested Normal Event fires on
+#    the SnapshotPolicy) instead of waiting for a spec change or the
+#    (off-by-default) periodicRefresh timer.
+# 3. The repository reconciler honors that request and re-scans, which
+#    re-materializes the kept kopia snapshots as `origin: discovered` rows
+#    (status.catalog.scanRequestHonored advances to match the request).
+# 4. The SnapshotPolicy's next reconcile sees those discovered rows, matches
+#    them by EXACT identity (username + hostname + sourcePath — never a
+#    fuzzy/partial match), and adopts them: a SnapshotsAdopted Normal Event
+#    fires, each becomes an `origin: adopted` Snapshot CR carrying this
+#    policy's config label, and the matching `origin: discovered` rows are
+#    removed (recreate-then-delete, never a re-label, so a crash mid-wave
+#    just re-runs next pass).
+# 5. Adopted rows are now GFS-governed exactly like produced ones — the SAME
+#    spec.retention below prunes them once they age out of the window. This
+#    is by design, not a bug: see docs/backups.md "Retention" and
+#    "troubleshooting.md" if backups you didn't expect to lose disappear
+#    right after a recreate.
+#
+# On a repository SHARED by many namespaces/policies, this scan-request is
+# bounded: many policies recreated at once each stamp the SAME repository
+# annotation, but the repository only ever needs to run ONE scan to satisfy
+# all of them (a fresh scan re-materializes everything at once) — it is not
+# one scan per policy.
+#
+# Field shapes verified against crates/api (externally-tagged backend:
+# `backend.s3`, not `backend: { kind: S3 }`).
+#
+# See docs/repositories.md ("The catalog — discovered snapshots"),
+# docs/backups.md ("What happens when the policy is deleted"), and
+# docs/scenarios/adopt-existing-repo.md ("Delete a policy, then recreate it").
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nas-primary-creds
+  namespace: billing
+type: Opaque
+stringData:
+  AWS_ACCESS_KEY_ID: "REPLACE_ME"
+  AWS_SECRET_ACCESS_KEY: "REPLACE_ME"
+  KOPIA_PASSWORD: "choose-something-long-and-random"
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: nas-primary
+  namespace: billing
+spec:
+  backend:
+    s3:
+      bucket: my-backups
+      prefix: prod/
+      endpoint: s3.us-east-1.amazonaws.com
+      region: us-east-1
+      auth:
+        secretRef:
+          name: nas-primary-creds
+  encryption:
+    passwordSecretRef:
+      name: nas-primary-creds
+      key: KOPIA_PASSWORD
+  create:
+    enabled: true
+  catalog:
+    # Whether a discovered snapshot whose identity matches a live
+    # SnapshotPolicy is automatically re-attached to it. Adopt is the
+    # effective default even with this whole `catalog` block omitted; shown
+    # explicitly here since it's the field this example is about. A
+    # per-policy `spec.adoption` (see the SnapshotPolicy below) overrides
+    # this per-repository setting.
+    adoption: Adopt # Adopt (default) | Ignore
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: SnapshotPolicy
+metadata:
+  name: postgres-data
+  namespace: billing
+spec:
+  repository:
+    kind: Repository
+    name: nas-primary
+  sources:
+    - pvc:
+        name: postgres-data
+  # GFS retention — applies identically to produced AND adopted Snapshots.
+  # Recreating this policy and letting adoption run is only useful if this
+  # window is wide enough to actually keep the history you're recovering.
+  retention:
+    keepDaily: 14
+    keepWeekly: 4
+  # Per-policy override of automatic adoption for discovered snapshots whose
+  # resolved identity matches THIS recipe. Absent (the normal case) inherits
+  # the repository's `catalog.adoption` above. Set explicitly here only if
+  # this one recipe should behave differently from its repository's default
+  # — e.g. a policy you deliberately want to start a fresh lineage under
+  # rather than re-absorb a foreign/prior history:
+  # adoption: Ignore

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -2693,6 +2693,15 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
+                    nullable: true
+                    type: string
                   scanRequestHonored:
                     description: |-
                       The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -593,6 +593,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2679,6 +2691,17 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -2629,6 +2629,15 @@ spec:
                     description: RFC 3339 timestamp of the last catalog refresh.
                     nullable: true
                     type: string
+                  scanRequestAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF
+                      a pending `catalog-scan-requested-at` token (i.e. the token arm was the
+                      reason the attempt fired). Used only to rate-limit token-driven attempts
+                      on a Ready-but-unreachable repository — it is never compared against the
+                      token for retirement (that's `scanRequestHonored`, by equality).
+                    nullable: true
+                    type: string
                   scanRequestHonored:
                     description: |-
                       The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -541,6 +541,18 @@ spec:
                 description: 'Bounds materialization of `origin: discovered` `Snapshot` CRs from the kopia catalog.'
                 nullable: true
                 properties:
+                  adoption:
+                    description: |-
+                      Whether a discovered snapshot whose resolved identity matches a live
+                      `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                      policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                      retention governs it and eventually prunes it, instead of it sitting in the
+                      catalog forever as an immortal `discovered` row.
+                    enum:
+                    - Adopt
+                    - Ignore
+                    nullable: true
+                    type: string
                   fallbackNamespace:
                     description: Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only).
                     nullable: true
@@ -2615,6 +2627,17 @@ spec:
                     type: integer
                   lastRefreshAt:
                     description: RFC 3339 timestamp of the last catalog refresh.
+                    nullable: true
+                    type: string
+                  scanRequestHonored:
+                    description: |-
+                      The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at`
+                      annotation last honored by a completed catalog scan. Compared by
+                      **equality** against the live annotation to decide whether a requested
+                      on-demand scan is still pending — deliberately NOT a timestamp comparison
+                      against `lastRefreshAt` (a periodic refresh completing after the request
+                      was made would otherwise look like it honored the request even though it
+                      started before the annotation was set).
                     nullable: true
                     type: string
                 type: object

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -39,6 +39,18 @@ spec:
           spec:
             description: 'What to back up: sources, identity, retention, policy, hooks.'
             properties:
+              adoption:
+                description: |-
+                  Whether a discovered snapshot whose resolved identity matches a live
+                  `SnapshotPolicy` is automatically adopted — re-attached (stamped with that
+                  policy's config label, `status.origin` flipped to `Adopted`) so GFS
+                  retention governs it and eventually prunes it, instead of it sitting in the
+                  catalog forever as an immortal `discovered` row.
+                enum:
+                - Adopt
+                - Ignore
+                nullable: true
+                type: string
               compression:
                 description: Compression algorithm + per-extension opt-outs.
                 nullable: true
@@ -81,6 +93,20 @@ spec:
                 - Orphan
                 nullable: true
                 type: string
+              deletion:
+                description: Deletion semantics for the `Snapshot` CRs carrying this recipe's config label.
+                nullable: true
+                properties:
+                  onPolicyDelete:
+                    default: Retain
+                    description: |-
+                      Consulted by the Snapshot finalizer when the deletion is external and the
+                      owning `SnapshotPolicy` is gone. Absent resolves to `Retain`.
+                    enum:
+                    - Retain
+                    - Delete
+                    type: string
+                type: object
               errorHandling:
                 description: 'Backup-side error handling: let a snapshot complete-with-errors instead of failing outright.'
                 nullable: true
@@ -1204,6 +1230,40 @@ spec:
             description: Observed state of a `SnapshotPolicy`.
             nullable: true
             properties:
+              adoption:
+                description: Summary of automatic adoption of discovered snapshots into this recipe.
+                nullable: true
+                properties:
+                  lastAdoptedCount:
+                    description: Number of discovered `Snapshot` CRs adopted by the last adoption pass.
+                    format: uint32
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                  lastAdoptionAt:
+                    description: RFC3339 timestamp of the last adoption pass that adopted at least one snapshot.
+                    nullable: true
+                    type: string
+                  scanRequestedAt:
+                    description: |-
+                      RFC3339 token echoing an in-flight on-demand adoption scan request for
+                      this policy's identity; cleared once honored.
+                    nullable: true
+                    type: string
+                  scanRequestedIdentity:
+                    description: |-
+                      The resolved kopia identity the requested scan was scoped to, pinned at
+                      request time so a later identity-changing edit can't retarget an
+                      in-flight scan.
+                    nullable: true
+                    type: string
+                  totalAdopted:
+                    description: Running total of `Snapshot` CRs ever adopted into this recipe.
+                    format: uint64
+                    minimum: 0.0
+                    nullable: true
+                    type: integer
+                type: object
               conditions:
                 description: Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`).
                 items:

--- a/deploy/helm/kopiur/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/crds/snapshots.yaml
@@ -245,6 +245,7 @@ spec:
                 - scheduled
                 - manual
                 - discovered
+                - adopted
                 nullable: true
                 type: string
               phase:

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -179,6 +179,10 @@ If you set `retention:` but leave every bucket unset or `0`, GFS would prune **e
 kopia's `snapshot create` normally applies its own retention after every backup, and with nothing configured it falls back to kopia's defaults (`keepLatest: 10`, etc.) — values a wide `retention:` window above would blow right past, deleting backups behind Kopiur's back. Kopiur pins kopia's own retention to effectively-infinite on every identity it manages, so `retention:` above is the only thing that ever deletes a backup.
 ///
 
+/// note | Adopted rows are governed exactly like produced ones
+A discovered snapshot that gets [auto-adopted](repositories.md#the-catalog--discovered-snapshots) into a `SnapshotPolicy` (`origin: adopted`) carries `status.phase: Succeeded` from the moment it's created, so it is immediately visible to this same GFS window — that's the entire point of adoption: instead of sitting in the catalog forever as an immortal `discovered` row, it now ages out and gets pruned like any snapshot the policy produced itself. A `pin: true` carried over from the discovered row stays exempt, same as any pinned produced backup.
+///
+
 ### How many `Snapshot` CRs will I have?
 
 Kopiur keeps **one `Snapshot` CR per retained snapshot per source** — the CR _is_ the backup's lifecycle handle (finalizer + `deletionPolicy`), so the live CR count equals the retained snapshot count **by design**. It is set by _retention_, not by how often you schedule: a faster schedule fills the GFS window sooner but never exceeds it. Three independent populations add up:
@@ -602,6 +606,51 @@ This guard exists because Kubernetes' own ownerReference garbage collection dele
 The guard only ever fires for **external** deletions — one of Kopiur's own retention/`failedJobsHistoryLimit` prunes always honors the Snapshot's real `deletionPolicy` regardless of the schedule's state (retention must keep working even if a schedule was just deleted). It also only fires while the schedule is genuinely gone/replaced: a live schedule deleting its own stale children (e.g. `failedJobsHistoryLimit` pruning) is an operator prune, not this path.
 
 Editing `spec.deletion.onScheduleDelete` on a **live** schedule propagates to its existing produced Snapshots (a best-effort patch on every reconcile, skipping any child already `Terminating`) — so flipping the knob doesn't only affect *future* firings, and you don't have to touch each child by hand.
+
+#### What happens when the policy is deleted
+
+`SnapshotPolicy.spec.deletion.onPolicyDelete` is the recipe-level counterpart to the schedule guard above — what happens to a **recipe's** `Snapshot` CRs (the ones carrying its config label, `kopiur.home-operations.com/config`) when the `SnapshotPolicy` itself is deleted. A `policy-cleanup` finalizer on the `SnapshotPolicy` drives the cascade before the CR is actually removed:
+
+```yaml
+spec:
+    deletion:
+        onPolicyDelete: Delete # default: Retain
+```
+
+| Value                | What happens to the policy's `Snapshot` CRs once the `SnapshotPolicy` is deleted                                                                                                                                                        |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Retain` _(default)_  | Every CR is stamped `pruned-by: policy-cascade` and removed — but **every kopia snapshot stays in the repository**. A `SnapshotRetainedOnPolicyDelete` Warning Event fires on each one whose own `deletionPolicy` was `Delete` (the loud downgrade). Nothing is lost: the data is rediscovered as `origin: discovered` on the next catalog scan, and — since adoption defaults on — automatically re-attached the moment a `SnapshotPolicy` with a matching identity exists (including this same policy, re-created). |
+| `Delete`              | Opt-in cascade: each CR is deleted **unstamped**, so its own `deletionPolicy` applies exactly like any other external deletion — `Delete` really does call `kopia snapshot delete`, subject to the repository's [mass-deletion breaker](repositories.md#deletionprotection--the-mass-deletion-circuit-breaker) (the `allow-mass-deletion` ack) below. |
+
+/// warning | Behavior change: previously-dangling CRs are now cleaned up
+
+Before this cascade existed, deleting a `SnapshotPolicy` left its `Snapshot` CRs behind with no owner — they just sat there (still retention-governed by nothing, since the recipe that pruned them was gone). Now `Retain` (the default) actively **removes** those CRs the moment the policy goes, while still keeping every kopia snapshot in the repository. If you relied on the old dangling-CR behavior to keep the CRs themselves around after deleting a policy, that no longer happens — the data survives, the CRs don't.
+
+///
+
+Two things make `Retain` a genuinely safe default rather than a "kopia data now, CRs later" half-measure:
+
+- **Retain-wins-ties.** If a `SnapshotSchedule` and its `SnapshotPolicy` are deleted **at once** (a GitOps prune removing a whole recipe bundle), the policy-cascade's `pruned-by: policy-cascade` stamp bypasses the schedule-deletion cascade guard above — the pair always drains to `Retain`'s CR-removed/kopia-kept outcome, never a race between the two guards. A `Snapshot` that was `Running` at the time is **cancelled**: its CR (and the mover Job it owns) is deleted mid-run, so no kopia snapshot manifest for that run ever exists to retain — any content the interrupted run had already uploaded is unreferenced and reclaimed by the repository's ordinary [full maintenance](maintenance.md) garbage collection, the same as any other interrupted kopia backup.
+- **Discovered rows are never touched.** The cascade only ever acts on `Adopted`/`Scheduled`/`Manual` children — an `origin: discovered` `Snapshot` never churns just because a policy it resembles (even one you hand-labeled it with) was deleted.
+
+Escape hatches, same as the schedule cascade:
+
+- **`kopiur.home-operations.com/skip-snapshot-cleanup`** on an individual `Snapshot` releases just that CR without contacting the repository, overriding the cascade entirely — same lever as [above](#what-delete-needs-to-succeed).
+- **Removing the config label** (`kopiur.home-operations.com/config`) from a `Snapshot` detaches it from the policy before you delete the policy — the cascade lists children by that label, so an unlabeled CR is simply invisible to it (and to retention).
+
+/// note | A manually-applied `Snapshot` only joins retention/cascade if it carries the config label
+
+The mutating webhook stamps the config label automatically on any **new** `Manual`/`Scheduled` `Snapshot` that names a `policyRef` at CREATE time. A `Snapshot` `kubectl apply`'d **before** this behavior shipped keeps today's behavior unchanged — it stays outside GFS retention and outside the deletion cascade, because Kopiur deliberately does not retro-label pre-existing CRs (turning a previously-immortal raw-applied Snapshot GFS-prunable behind your back would be a silent-data-loss footgun). Add the label yourself (`kopiur.home-operations.com/config: <policy-name>`) to opt an old CR in.
+
+///
+
+Both modes, side by side:
+
+```yaml
+--8<-- "deploy/examples/35-policy-deletion-cascade.yaml"
+```
+
+See [Adopt an existing repo → Delete a policy, then recreate it](scenarios/adopt-existing-repo.md#delete-a-policy-then-recreate-it) for the full delete→recreate→adopt walkthrough.
 
 #### How a deletion actually runs — batched, not one Job per Snapshot
 

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -615,6 +615,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `discoveredBackupCount` | integer | — | How many `Snapshot` CRs were materialized from the catalog scan. |
 | `foreignSnapshotCount` | integer | — | Snapshots in the last complete listing classified as another cluster's (see `catalog.foreignSnapshots`); never materialized under `Ignore`. As of `catalog.lastRefreshAt` — enable `periodicRefresh` to keep it current. |
 | `lastRefreshAt` | string | — | RFC 3339 timestamp of the last catalog refresh. |
+| `scanRequestAttemptAt` | string | — | RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF a pending `catalog-scan-requested-at` token (i.e. the token arm was the reason the attempt fired). Used only to rate-limit token-driven attempts on a Ready-but-unreachable repository — it is never compared against the token for retirement (that's `scanRequestHonored`, by equality). |
 | `scanRequestHonored` | string | — | The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at` annotation last honored by a completed catalog scan. Compared by **equality** against the live annotation to decide whether a requested on-demand scan is still pending — deliberately NOT a timestamp comparison against `lastRefreshAt` (a periodic refresh completing after the request was made would otherwise look like it honored the request even though it started before the annotation was set). |
 
 #### `status.conditions[]` { #repository-status-conditions }
@@ -1301,6 +1302,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `discoveredBackupCount` | integer | — | How many `Snapshot` CRs were materialized from the catalog scan. |
 | `foreignSnapshotCount` | integer | — | Snapshots in the last complete listing classified as another cluster's (see `catalog.foreignSnapshots`); never materialized under `Ignore`. As of `catalog.lastRefreshAt` — enable `periodicRefresh` to keep it current. |
 | `lastRefreshAt` | string | — | RFC 3339 timestamp of the last catalog refresh. |
+| `scanRequestAttemptAt` | string | — | RFC 3339 timestamp of the last bootstrap/scan attempt initiated BECAUSE OF a pending `catalog-scan-requested-at` token (i.e. the token arm was the reason the attempt fired). Used only to rate-limit token-driven attempts on a Ready-but-unreachable repository — it is never compared against the token for retirement (that's `scanRequestHonored`, by equality). |
 | `scanRequestHonored` | string | — | The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at` annotation last honored by a completed catalog scan. Compared by **equality** against the live annotation to decide whether a requested on-demand scan is still pending — deliberately NOT a timestamp comparison against `lastRefreshAt` (a periodic refresh completing after the request was made would otherwise look like it honored the request even though it started before the annotation was set). |
 
 #### `status.conditions[]` { #clusterrepository-status-conditions }

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -324,6 +324,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `adoption` | enum: Adopt \| Ignore | — | Whether a discovered snapshot whose resolved identity matches a live `SnapshotPolicy` is automatically adopted — re-attached (stamped with that policy's config label, `status.origin` flipped to `Adopted`) so GFS retention governs it and eventually prunes it, instead of it sitting in the catalog forever as an immortal `discovered` row. |
 | `fallbackNamespace` | string | — | Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only). |
 | `foreignSnapshots` | enum: Ignore \| Fallback | — | How catalog discovery treats snapshots written by ANOTHER cluster. `status.catalog.foreignSnapshotCount` counts an identity hostname carrying a different `.&lt;cluster&gt;` suffix ALWAYS, under either value below, plus — under `Ignore` only — a bare hostname naming no allowed namespace here. Under `Fallback`, that same disallowed bare host is NOT counted foreign: it materializes into `catalog.fallbackNamespace` exactly like a disallowed `OwnCluster` host would, so it is placed rather than dropped-and-counted (see `classify_hostname`/`decide_cluster_placement`). Meaningful only when `identityDefaults.cluster` is set: without a cluster identity there is no notion of "foreign" and the legacy hostname-names-a-namespace placement applies (validators enforce this). |
 | `periodicRefresh` | boolean | — | Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs current (re-list snapshots; for object-store / volume-backed repos this recycles the bootstrap Job every `refreshInterval`). **Off by default** — the repository still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup failure, but does not re-run on a timer. Enable it if you rely on discovered snapshots reflecting changes made outside this operator. |
@@ -614,6 +615,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `discoveredBackupCount` | integer | — | How many `Snapshot` CRs were materialized from the catalog scan. |
 | `foreignSnapshotCount` | integer | — | Snapshots in the last complete listing classified as another cluster's (see `catalog.foreignSnapshots`); never materialized under `Ignore`. As of `catalog.lastRefreshAt` — enable `periodicRefresh` to keep it current. |
 | `lastRefreshAt` | string | — | RFC 3339 timestamp of the last catalog refresh. |
+| `scanRequestHonored` | string | — | The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at` annotation last honored by a completed catalog scan. Compared by **equality** against the live annotation to decide whether a requested on-demand scan is still pending — deliberately NOT a timestamp comparison against `lastRefreshAt` (a periodic refresh completing after the request was made would otherwise look like it honored the request even though it started before the annotation was set). |
 
 #### `status.conditions[]` { #repository-status-conditions }
 
@@ -1000,6 +1002,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `adoption` | enum: Adopt \| Ignore | — | Whether a discovered snapshot whose resolved identity matches a live `SnapshotPolicy` is automatically adopted — re-attached (stamped with that policy's config label, `status.origin` flipped to `Adopted`) so GFS retention governs it and eventually prunes it, instead of it sitting in the catalog forever as an immortal `discovered` row. |
 | `fallbackNamespace` | string | — | Where to materialize discovered `Snapshot`s with no allowed-namespace mapping (ClusterRepository only). |
 | `foreignSnapshots` | enum: Ignore \| Fallback | — | How catalog discovery treats snapshots written by ANOTHER cluster. `status.catalog.foreignSnapshotCount` counts an identity hostname carrying a different `.&lt;cluster&gt;` suffix ALWAYS, under either value below, plus — under `Ignore` only — a bare hostname naming no allowed namespace here. Under `Fallback`, that same disallowed bare host is NOT counted foreign: it materializes into `catalog.fallbackNamespace` exactly like a disallowed `OwnCluster` host would, so it is placed rather than dropped-and-counted (see `classify_hostname`/`decide_cluster_placement`). Meaningful only when `identityDefaults.cluster` is set: without a cluster identity there is no notion of "foreign" and the legacy hostname-names-a-namespace placement applies (validators enforce this). |
 | `periodicRefresh` | boolean | — | Opt-in: periodically re-scan the repository to keep discovered `Snapshot` CRs current (re-list snapshots; for object-store / volume-backed repos this recycles the bootstrap Job every `refreshInterval`). **Off by default** — the repository still bootstraps once, re-bootstraps on a spec change, and re-probes on a backup failure, but does not re-run on a timer. Enable it if you rely on discovered snapshots reflecting changes made outside this operator. |
@@ -1298,6 +1301,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `discoveredBackupCount` | integer | — | How many `Snapshot` CRs were materialized from the catalog scan. |
 | `foreignSnapshotCount` | integer | — | Snapshots in the last complete listing classified as another cluster's (see `catalog.foreignSnapshots`); never materialized under `Ignore`. As of `catalog.lastRefreshAt` — enable `periodicRefresh` to keep it current. |
 | `lastRefreshAt` | string | — | RFC 3339 timestamp of the last catalog refresh. |
+| `scanRequestHonored` | string | — | The RFC3339 token VALUE of the `kopiur.home-operations.com/catalog-scan-requested-at` annotation last honored by a completed catalog scan. Compared by **equality** against the live annotation to decide whether a requested on-demand scan is still pending — deliberately NOT a timestamp comparison against `lastRefreshAt` (a periodic refresh completing after the request was made would otherwise look like it honored the request even though it started before the annotation was set). |
 
 #### `status.conditions[]` { #clusterrepository-status-conditions }
 
@@ -1376,10 +1380,12 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `repository` | [object](#snapshotpolicy-spec-repository) | **required** | Discriminated reference to a `Repository` or `ClusterRepository`. |
+| `adoption` | enum: Adopt \| Ignore | — | Whether a discovered snapshot whose resolved identity matches a live `SnapshotPolicy` is automatically adopted — re-attached (stamped with that policy's config label, `status.origin` flipped to `Adopted`) so GFS retention governs it and eventually prunes it, instead of it sitting in the catalog forever as an immortal `discovered` row. |
 | `compression` | [object](#snapshotpolicy-spec-compression) | — | Compression algorithm + per-extension opt-outs. |
 | `copyMethod` | enum: Snapshot \| Clone \| Direct | `Snapshot` | How the source volume is captured before kopia reads it: `Snapshot` (default), `Direct`, or `Clone`. |
 | `credentialProjection` | [object](#snapshotpolicy-spec-credentialprojection) | — | Opt-in credential-Secret projection into each backup mover's namespace (default off). |
 | `defaultDeletionPolicy` | enum: Delete \| Retain \| Orphan | `Delete` | Lifecycle of the underlying kopia snapshot when its `Snapshot` CR is deleted. Produced backups default to `Delete`; discovered snapshots are forced to `Retain`. |
+| `deletion` | [object](#snapshotpolicy-spec-deletion) | — | Deletion semantics for the `Snapshot` CRs carrying this recipe's config label. |
 | `errorHandling` | [object](#snapshotpolicy-spec-errorhandling) | — | Backup-side error handling: let a snapshot complete-with-errors instead of failing outright. |
 | `extraArgs` | []string | — | Escape hatch for kopia flags not yet modeled. |
 | `files` | [object](#snapshotpolicy-spec-files) | — | Paths/patterns kopia should skip while snapshotting. |
@@ -1416,6 +1422,12 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enabled` | boolean | `false` | Copy the repository's credential Secret(s) into the namespace of each mover Job; off by default. |
+
+#### `spec.deletion` { #snapshotpolicy-spec-deletion }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `onPolicyDelete` | enum: Retain \| Delete | `Retain` | Consulted by the Snapshot finalizer when the deletion is external and the owning `SnapshotPolicy` is gone. Absent resolves to `Retain`. |
 
 #### `spec.errorHandling` { #snapshotpolicy-spec-errorhandling }
 
@@ -1698,12 +1710,23 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `adoption` | [object](#snapshotpolicy-status-adoption) | — | Summary of automatic adoption of discovered snapshots into this recipe. |
 | `conditions` | [][object](#snapshotpolicy-status-conditions) | — | Standard Kubernetes conditions (e.g. `RepositoryReachable`, `GroupSnapshotSupported`). |
 | `lastSuccessfulSnapshot` | string | — | RFC3339 timestamp of the most recent successful child `Snapshot` from this recipe. |
 | `lastVerified` | string | — | RFC3339 timestamp of the most recent successful verification (any tier). |
 | `observedGeneration` | integer | — | `metadata.generation` last reconciled, for staleness detection. |
 | `resolved` | [object](#snapshotpolicy-status-resolved) | — | What would be passed to kopia — pinned at admission. |
 | `retention` | [object](#snapshotpolicy-status-retention) | — | Summary of GFS retention pruning against this config's `Snapshot` CRs. |
+
+#### `status.adoption` { #snapshotpolicy-status-adoption }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `lastAdoptedCount` | integer | —<br><sub>min 0</sub> | Number of discovered `Snapshot` CRs adopted by the last adoption pass. |
+| `lastAdoptionAt` | string | — | RFC3339 timestamp of the last adoption pass that adopted at least one snapshot. |
+| `scanRequestedAt` | string | — | RFC3339 token echoing an in-flight on-demand adoption scan request for this policy's identity; cleared once honored. |
+| `scanRequestedIdentity` | string | — | The resolved kopia identity the requested scan was scoped to, pinned at request time so a later identity-changing edit can't retarget an in-flight scan. |
+| `totalAdopted` | integer | —<br><sub>min 0</sub> | Running total of `Snapshot` CRs ever adopted into this recipe. |
 
 #### `status.conditions[]` { #snapshotpolicy-status-conditions }
 
@@ -1790,7 +1813,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | `job` | [object](#snapshot-status-job) | — | The mover Job backing this run; absent for discovered. |
 | `logTail` | string | — | The last lines of the run's output, written by the mover at the terminal transition. |
 | `observedGeneration` | integer | — | `metadata.generation` last reconciled, for staleness detection. |
-| `origin` | enum: scheduled \| manual \| discovered | — | How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy default: `discovered` backups are forced to `Retain` because the operator did not create those snapshots. |
+| `origin` | enum: scheduled \| manual \| discovered \| adopted | — | How a `Snapshot` came to exist. Canonical value mirrored from the `kopiur.home-operations.com/origin` label. Origin drives the deletion-policy default: `discovered` backups are forced to `Retain` because the operator did not create those snapshots. |
 | `phase` | enum: Pending \| Running \| Succeeded \| Failed \| Deleting \| Discovered | — | Lifecycle phase of a `Snapshot`. |
 | `pinned` | boolean | — | The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile. |
 | `preflightSince` | string | — | RFC 3339 timestamp of the first reconcile where the repository was `Ready` but a `spec.preflight` check was failing. The one-shot anchor for the preflight `timeout` deadline (so the budget covers preflight only, not the earlier repository-not-Ready wait). Cleared once every preflight check passes, so a later failing episode gets a fresh budget rather than a stale anchor. |

--- a/docs/repositories.md
+++ b/docs/repositories.md
@@ -211,6 +211,7 @@ spec:
             perIdentity: 100 # keep the newest N rows per username@hostname:path (0 = no rows)
             maxAgeDays: 90 # no rows for snapshots older than this
         fallbackNamespace: backups # ClusterRepository only — see below
+        adoption: Adopt # Adopt (default) | Ignore — see below
 ```
 
 `retain` bounds the **CR rows, never the data**: a row "expired" by `perIdentity`/`maxAgeDays` is just a deleted CR — the kopia snapshot stays in the repository and remains restorable via [`Restore.source.identity`](restores.md#restoring-a-snapshot-kopiur-didnt-create).
@@ -220,6 +221,23 @@ spec:
 A namespaced `Repository` materializes rows in its own namespace. A **`ClusterRepository`** places each row in the namespace named by the snapshot identity's **hostname** — when that namespace exists and passes the `allowedNamespaces` gate — so an adopted shared repository's snapshots land next to the workloads they belong to. Identities whose hostname maps to no allowed namespace go to `catalog.fallbackNamespace`; with no fallback configured they are skipped, and the `ClusterRepository` gets a Warning Event (`DiscoveredSnapshotUnplaced`) naming the hostnames and the fix.
 
 ///
+
+### `catalog.adoption` — automatically re-attaching discovered snapshots
+
+A discovered row can stop being a dead end. When a `discovered` snapshot's kopia identity **exactly** matches a live `SnapshotPolicy`'s resolved identity (`username` AND `hostname` AND `sourcePath`, never a partial match), the policy **adopts** it: a fresh `origin: adopted` `Snapshot` CR is created in the policy's namespace carrying the policy's config label, and the discovered row is deleted. The adopted row is now GFS-governed exactly like a produced backup — see [Backups → Retention](backups.md#retention--how-long-backups-are-kept-gfs) — instead of sitting in the catalog forever.
+
+```yaml
+spec:
+    catalog:
+        adoption: Ignore # Adopt (default) | Ignore
+```
+
+- **Resolution order**: `SnapshotPolicy.spec.adoption`, if set, always wins over the repository's `catalog.adoption`; an unset policy field inherits the repository's setting; both unset defaults to `Adopt`. Set it on the repository to change the default for every policy against it, or on one policy to carve out an exception.
+- **`Ignore`** turns adoption off (at whichever level it's set) — discovered rows keep accumulating and bounded only by `catalog.retain`, and you restore from them directly instead ([Restores → discovered snapshots](restores.md#restoring-a-snapshot-kopiur-didnt-create)).
+- **A brand-new or delete-then-recreated policy nudges the catalog.** A `SnapshotPolicy` with no adoption history yet, that finds nothing to adopt on its first pass, requests an on-demand catalog scan on its repository (an `AdoptionScanRequested` Normal Event names the identity) instead of waiting on a spec change or the periodic-refresh timer — this is what makes "delete a policy, then re-apply it" self-heal without you manually forcing a re-scan. It fires exactly once per (policy, identity): a scan that turns up nothing stays quiet after that. See [Adopt an existing repo → Delete a policy, then recreate it](scenarios/adopt-existing-repo.md#delete-a-policy-then-recreate-it) for the full walkthrough.
+- **The request is bounded, even on a repository shared by many policies.** Several policies recreated at once each stamp the SAME `catalog-scan-requested-at` annotation on the repository — but the repository only ever needs to run one scan to satisfy all of them (a fresh listing re-materializes every match at once), so a burst of simultaneous requests costs one scan, not one per policy.
+- **`status.catalog.discoveredBackupCount` is transiently stale right after an adoption wave.** It's written by the catalog scan (the `Repository`/`ClusterRepository` reconciler); adoption runs in a **separate** reconcile pass (the `SnapshotPolicy`) that deletes discovered rows without touching that count. Expect it to over-count by however many rows were just adopted until the next scan corrects it — it is not wrong, just one scan behind.
+- **Foreign-cluster snapshots are never adopted**, even on an exact identity match — see [`identityDefaults.cluster`](#identitydefaultscluster--sharing-one-repository-across-clusters).
 
 ## `moverDefaults` — one place to configure every mover
 

--- a/docs/scenarios/adopt-existing-repo.md
+++ b/docs/scenarios/adopt-existing-repo.md
@@ -103,8 +103,88 @@ adopt-smoke-test   Completed   45s
 A `Ready` repo, an `OWNED` maintenance lease, and a `Completed` smoke-test restore
 mean the repository is fully adopted.
 
+## Delete a policy, then recreate it
+
+Adoption isn't only for a repository you're onboarding for the first time — it's
+also how Kopiur heals itself after **you** delete a `SnapshotPolicy` and bring it
+back. This is the scenario end-to-end, continuing from the `postgres-data`
+recipe above once it's been backing up for a while:
+
+```mermaid
+flowchart LR
+  DEL[Delete SnapshotSchedule + SnapshotPolicy] --> CLEAN[Snapshot CRs removed<br/>kopia data kept, Retain]
+  CLEAN --> REAPPLY[kubectl apply the SAME SnapshotPolicy]
+  REAPPLY --> SCAN[No history yet -> requests<br/>an on-demand catalog scan]
+  SCAN --> DISC[Repository re-scans -><br/>origin=discovered rows]
+  DISC --> ADOPT[Exact identity match -><br/>origin=adopted, config-labeled]
+  ADOPT --> RET[GFS retention resumes]
+```
+
+1. **Delete the schedule, then the policy** (or let a GitOps prune remove both at
+   once — either order drains to the same outcome; see
+   [Backups → Retain-wins-ties](../backups.md#what-happens-when-the-policy-is-deleted)).
+   With the default `onPolicyDelete: Retain`, the `policy-cleanup` finalizer
+   removes every `Snapshot` CR carrying the policy's config label — but **every
+   kopia snapshot stays in the repository**. Nothing is deleted kopia-side.
+
+   ```console
+   $ kubectl delete snapshotschedule postgres-data-nightly -n billing
+   $ kubectl delete snapshotpolicy postgres-data -n billing
+   ```
+
+2. **Re-apply the same `SnapshotPolicy`** (same name, same `identity`/sources —
+   shown below). A freshly-created policy has no
+   `Snapshot` CRs carrying its config label yet — no history. Its first
+   reconcile finds nothing to adopt (the old snapshots haven't been rediscovered
+   yet) and, because it has no history and hasn't already asked for this exact
+   identity, requests an **on-demand catalog scan** on the repository instead of
+   waiting for a spec change or the (off-by-default) periodic-refresh timer. An
+   `AdoptionScanRequested` Normal Event fires on the `SnapshotPolicy` naming the
+   identity it's waiting on.
+3. **The repository honors the scan request** and re-lists the backend, which
+   re-materializes the kept kopia snapshots as `origin: discovered` rows —
+   exactly like the very first adoption above, just triggered on demand instead
+   of by the initial bootstrap.
+4. **The policy adopts them on its next reconcile**: it matches discovered rows
+   by **exact structured identity** — `username` AND `hostname` AND
+   `sourcePath` must ALL match its own resolved identity, never a
+   partial/fuzzy match — creates an `origin: adopted` `Snapshot` CR (carrying
+   the config label) for each one, and removes the matching discovered rows. A
+   `SnapshotsAdopted` Normal Event fires naming the count and identity.
+5. **Retention resumes.** Adopted rows are GFS-governed exactly like produced
+   ones — `spec.retention` starts pruning them the moment they age out of the
+   window. If you recreated the policy with a **narrower** retention window
+   than before, expect some of the just-adopted history to be pruned on the
+   very next reconcile — that's [by design](../backups.md#retention--how-long-backups-are-kept-gfs),
+   not a bug (see [Troubleshooting](../troubleshooting.md#my-old-snapshots-were-pruned-after-i-recreated-a-policy)
+   if this surprises you).
+
+```yaml
+--8<-- "deploy/examples/36-policy-recreate-adoption.yaml"
+```
+
+/// note | Opting out, and the one case adoption never touches
+
+Automatic adoption is on by default at both levels — turn it off with
+`SnapshotPolicy.spec.adoption: Ignore` (this recipe only) or
+`Repository`/`ClusterRepository` `spec.catalog.adoption: Ignore` (every policy
+against this repository); the per-policy field wins when both are set. Either
+way, `origin: discovered` rows keep accumulating and are never auto-attached —
+you restore from them directly instead (as in the section above).
+
+On a repository **shared across clusters** (`identityDefaults.cluster` set),
+adoption never crosses cluster boundaries: a discovered row whose hostname
+classifies as another cluster's is refused even on an otherwise-exact identity
+match — the same [foreign-snapshot rule](../repositories.md#identitydefaultscluster--sharing-one-repository-across-clusters)
+that keeps two clusters' maintenance leases from fighting also keeps one
+cluster from silently absorbing another's backup history.
+
+///
+
 ## See also
 
 - [Restores → discovered snapshots](../restores.md#restoring-a-snapshot-kopiur-didnt-create) and [example 07](../examples.md#example-07--restore-a-discovered-backup) — the two ways to restore foreign snapshots.
 - [Maintenance](../maintenance.md) and [example 08](../examples.md#example-08--maintenance) — ownership leases and takeover policy in full.
 - [Backups → identity](../backups.md#identity--what-kopia-records-usernamehostnamepath) — matching the foreign writer's identity.
+- [Backups → What happens when the policy is deleted](../backups.md#what-happens-when-the-policy-is-deleted) — the `onPolicyDelete` cascade this scenario relies on.
+- [Repositories → The catalog](../repositories.md#the-catalog--discovered-snapshots) — the `catalog.adoption` knob and scan-request mechanics in full.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -361,6 +361,44 @@ $ kubectl get snapshotschedule <name> -n <ns> \
 - If the operator was down across a slot and `startingDeadlineSeconds` elapsed, that slot is skipped on purpose (no late stampede).
 - Repeated failures show up as `status.consecutiveFailures`; the failing `Snapshot` CRs (bounded by `failedJobsHistoryLimit`) carry the reason.
 
+## My old snapshots were pruned after I recreated a policy
+
+You deleted a `SnapshotPolicy` (or it was deleted-and-recreated by GitOps), and
+some of the backup history you expected to keep is now gone.
+
+**What happened**: this is [automatic adoption](repositories.md#catalogadoption--automatically-re-attaching-discovered-snapshots) plus GFS retention working exactly as designed, not a bug. With `onPolicyDelete: Retain` (the default), deleting the policy kept every kopia snapshot in the repository — nothing was lost at that point. Re-applying the policy triggered a catalog scan, which rediscovered them, which triggered adoption, which re-attached them as `origin: adopted` `Snapshot` CRs governed by the SAME `spec.retention` window as any produced backup. If that window is narrower than the effective age of the history you just got back (or narrower than the window the OLD policy used), some of the newly-adopted rows are outside it on the very first reconcile — and GFS prunes them immediately, same as it would any other out-of-window snapshot.
+
+**The paper trail**: a `SnapshotsAdopted` Normal Event on the `SnapshotPolicy` names exactly how many rows were adopted and under which identity, right before retention's own prune events show what went out the other side:
+
+```console
+$ kubectl describe snapshotpolicy <name> -n <ns> | grep -A3 SnapshotsAdopted
+```
+
+**Fix**: widen `spec.retention` on the recreated policy to cover the history you want kept — retention decisions are made fresh on every reconcile, so a wider window applied even after the fact stops future prunes from taking the remaining rows (it does not undo already-deleted CRs; if `Delete` already ran, the kopia snapshot is really gone). If you don't want a recreated policy to inherit history at all, opt out (see below) **before** re-applying it.
+
+**Both opt-outs**, if this isn't the behavior you want going forward:
+
+- `SnapshotPolicy.spec.adoption: Ignore` — this recipe never adopts, regardless of the repository's setting.
+- `Repository`/`ClusterRepository` `spec.catalog.adoption: Ignore` — no policy against this repository adopts.
+
+## Adoption didn't happen
+
+You expected a recreated (or brand-new) `SnapshotPolicy` to pick up matching
+`origin: discovered` snapshots, and it didn't.
+
+| Check                                                                                                    | How                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Adoption is actually on.** The effective mode is `SnapshotPolicy.spec.adoption` if set, else the repository's `spec.catalog.adoption`, else `Adopt`. | `kubectl get snapshotpolicy <name> -n <ns> -o jsonpath='{.spec.adoption}'` and the same on the `Repository`/`ClusterRepository` — either explicitly `Ignore` is a full stop.                                                            |
+| **The identity really matches — exactly.** Adoption never partial-matches: `username` AND `hostname` AND `sourcePath` on the discovered row must ALL equal the policy's resolved identity. | Compare `status.resolved.identity` on the `SnapshotPolicy` against `status.snapshot.identity` on the `Snapshot` you expected adopted. Any one field differing (a typo'd `identity.hostname`, a different `sourcePathOverride`) is a silent non-match — no error, it's simply not a candidate. |
+| **It isn't a foreign-cluster row.** On a repository with [`identityDefaults.cluster`](repositories.md#identitydefaultscluster--sharing-one-repository-across-clusters) set, a discovered row whose hostname classifies as another cluster's is refused even on an otherwise-exact identity match — by design. | Check the repository's `identityDefaults.cluster` and whether the discovered row's hostname belongs to a different cluster. |
+| **The scan request isn't stuck pending against an unreachable repo.** A brand-new/recreated policy with nothing to adopt yet stamps `kopiur.home-operations.com/catalog-scan-requested-at` on the repository and waits for it to be honored. | `kubectl get repository <name> -n <ns> -o jsonpath='{.metadata.annotations.kopiur\.home-operations\.com/catalog-scan-requested-at}{"  honored="}{.status.catalog.scanRequestHonored}{"\n"}'` — if the annotation value and `scanRequestHonored` **differ**, the scan hasn't completed yet (repository not `Ready`, or a launch backoff against a flaky backend — see [Repository never reaches Ready](#repository-never-reaches-ready)). If they're **equal**, the scan already ran; the discovered row genuinely wasn't there or didn't match. |
+| **Enough time has passed for the next reconcile.** Adoption runs on the `SnapshotPolicy`'s own reconcile loop, which fires again once the scan is honored — it isn't instantaneous with the scan completing. | Give it the same ~30s window a normal reconcile takes, then re-check for a `SnapshotsAdopted` Event. |
+
+If every row above checks out and adoption still didn't fire, the discovered
+`Snapshot` may simply not exist yet — confirm it with
+`kubectl get snapshots -n <ns> -l kopiur.home-operations.com/origin=discovered`
+before assuming adoption is broken.
+
 ## CRDs or CRs disappeared after upgrading to 0.6.0
 
 Upgrading **from 0.5.x to 0.6.0** moves the CRDs into Helm's `crds/` directory. On


### PR DESCRIPTION
## Summary

Two features that close the policy lifecycle gap described in #210: deleting a policy now cleans up its Snapshot CRs (keeping the kopia data), and recreating the policy adopts that history back so retention resumes governing it.

### 1. SnapshotPolicy deletion cascade

Deleting a `SnapshotPolicy` now removes its config-labeled Snapshot CRs via a new `policy-cleanup` finalizer:

- **Default `spec.deletion.onPolicyDelete: Retain`** — the CRs are removed, every kopia snapshot survives (rediscoverable on the next catalog scan, adoptable on recreation). The cascade stamps `pruned-by: policy-cascade`, so children release quietly with zero repository contact.
- **Opt-in `Delete`** — each CR's own `deletionPolicy` applies, issued as *external* deletions so the mass-deletion breaker (#265) gates bulk waves behind the `allow-mass-deletion` ack. Deliberately unstamped: a policy delete with `Delete` is exactly the kro-incident shape the breaker exists for.
- Retain-wins-ties for simultaneous schedule+policy deletion (GitOps prune); a terminating policy can no longer be fired against by its schedule (skip+retry); breaker-held children never wedge policy removal.

### 2. Auto-adoption of discovered snapshots (fixes #210)

Discovered snapshots whose **exact resolved identity** (structured `username`/`hostname`/`sourcePath` comparison) matches a live `SnapshotPolicy` are adopted automatically: the row is recreated in the policy's namespace as `origin: adopted`, `phase: Succeeded`, config-labeled — indistinguishable from produced snapshots to retention, deletion, batching, catalog dedup, and the breaker. GFS retention then governs and prunes the old history per `spec.retention`, ending the "pre-DR history occupies storage forever" failure mode.

- **On by default**; opt out per policy (`spec.adoption: Ignore`) or per repository (`spec.catalog.adoption: Ignore`).
- **Foreign-cluster snapshots in shared repositories are never adopted** — three independent guards (structured identity equality with cluster-scoped hostnames, foreign rows are never materialized as discovered under `Ignore`, and a hard `HostClass::ForeignCluster` refusal).
- The delete→recreate flow converges hands-off: the policy reconciler stamps a `catalog-scan-requested-at` token on the repository; scans retire it by token equality (`status.catalog.scanRequestHonored`), and launch attempts are rate-limited (`scanRequestAttemptAt`) so a Ready-but-unreachable repo never churns bootstrap Jobs.
- Loudly surfaced, not gated: `SnapshotsAdopted` / `AdoptionScanRequested` / `SnapshotRetainedOnPolicyDelete` events, `status.adoption` summary on the policy, and `kopiur_snapshots_adopted` + cascade counters.

### Hardening that rode along

- Webhook now resolves Snapshot origin **status-first**: flipping a discovered row's origin *label* can no longer unlock `deletionPolicy: Delete` at admission.
- New policy-referencing manual Snapshots get the config label at admission, making them visible to retention and the cascade. Deliberately **no retro-backfill**: labeling pre-existing raw-applied Snapshots would silently make previously-immortal history prunable.
- The `SnapshotRetainedOnScheduleDelete` event no longer promises rediscovery "within the catalog refresh interval" (misleading with periodic refresh off).

## BREAKING CHANGE

Deleting a `SnapshotPolicy` now removes its config-labeled Snapshot CRs by default (`onPolicyDelete: Retain` — kopia snapshots are kept and rediscoverable/adoptable). Previously the CRs were left dangling.

## Test coverage

- **Hermetic**: new unit/serde coverage across api/controller/webhook — cascade planner matrix (terminating exclusion, origin filter, release condition), the 9-cell `PrunedBy × DeletionPolicy` prune table, scan-request predicate matrix (equality retirement, launch backoff, no-token regression pins), full adoption matrix (identity near-misses, foreign refusal, 409-heal, knob precedence), webhook origin-flip denials.
- **e2e** (6 new scenarios): the #210 acceptance test (produce → delete schedule+policy → CRs gone, kopia intact → recreate with `keepLatest: 1` → scan request → discovered → adopted → retention prunes kopia-side to exactly 1, with a non-matching-identity negative control), ClusterRepository cross-namespace adoption, adoption opt-out, cascade default-Retain (incl. webhook-labeled manual Snapshot), breaker-gated opt-in `Delete` (hold → ack → drain), and the schedule+policy simultaneous-delete race.
- Every milestone landed with `cargo test --workspace`, `clippy -D warnings`, `gen-check`, and the cognitive-complexity ratchet (29/29, unchanged) green. Each milestone was independently review-gated; one Critical (object-store scan-request honoring) was caught in review and fixed with a regression test (`734b2f8`).

Local fresh-kind validation of the new e2e binaries is running; CI's e2e suite is the authoritative gate for this PR.

Closes #210
