### PR TITLE
fix(probe): stamp the health probe at launch so it stops recycling its Job (#273)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -118,10 +118,10 @@ jobs:
             bins: "lifecycle"
             backends: false # Filesystem only — skip the backend-image preload
           - shard: restore
-            bins: "restore"
+            bins: "restore leak_cleanup"
             backends: false # Filesystem only — the restore class needs no object store
           - shard: backends
-            bins: "backends"
+            bins: "backends ttl_rerun"
             backends: true
           - shard: cross-ns
             bins: "cross_namespace credential_projection"
@@ -129,11 +129,36 @@ jobs:
           - shard: misc
             bins: "object_store cache_and_events terminal_failure webhook observability"
             backends: true
+          # Reconcile-quiescence guards. Both watch for CHURN over a fixed window —
+          # steady_state a 45s quiet window on status/resourceVersion, health_probe a
+          # 180s window on bootstrap-Job UIDs (the #273 regression guard) — so this
+          # shard must not share a cluster with a binary that restarts the operator
+          # (mass_deletion) or floods the apiserver. steady_state runs FIRST, on the
+          # cleanest cluster: its own bound is eroded by leftover CRs' requeue ticks.
+          # backends: true for health_probe's MinIO buckets; steady_state is
+          # Filesystem-only and rides along.
+          - shard: quiescence
+            bins: "steady_state health_probe"
+            backends: true
+          # Mass-deletion protection + the batched delete dispatcher. Own shard:
+          # throttle_caps_concurrent_batch_jobs patches the controller Deployment's
+          # KOPIUR_MAX_CONCURRENT_DELETE_JOBS and waits out a rollout — it restores the
+          # env on exit, but the restart inside that window must not race another
+          # binary's reconciles. Filesystem-only (isolated repo subpaths per scenario).
+          - shard: mass-deletion
+            bins: "mass_deletion"
+            backends: false
+          # kubectl-kopiur plugin (the `run` task builds kopiur-cli before the suite)
+          # + multi-cluster shared-repository scenarios. Both S3-backed, both large,
+          # neither mutates the install.
+          - shard: cli-multicluster
+            bins: "cli multi_cluster"
+            backends: true
           # Workload identity (auth.workloadIdentity): full S3 pipeline with NO
           # static keys via the anonymous-policy bucket + kopia's ambient chain,
           # plus the Job-shape and missing-SA-condition assertions.
           - shard: workload-identity
-            bins: "workload_identity"
+            bins: "workload_identity import"
             backends: true
           # ADR-0004/0005 reshape scenarios (Filesystem only). Split in two so the
           # cron-driven verify/replication waits don't push one shard past the job
@@ -148,7 +173,7 @@ jobs:
           # httpRequest hook reuses the WebDAV fixture as its receiver, so this
           # shard preloads the backend images.
           - shard: hooks-retention
-            bins: "hooks retention policy_knobs"
+            bins: "hooks retention policy_knobs adoption"
             backends: true
           - shard: reshape-async
             bins: "verification replication"
@@ -164,7 +189,7 @@ jobs:
           # securityContext-compatibility pipeline: pvcConsumer auto-derive + the
           # SecurityContextCompatible reconcile condition. Filesystem only.
           - shard: security-context-compat
-            bins: "security_context_compat"
+            bins: "security_context_compat colocation preflight"
             backends: false
           # Leader election (--leader-elect, chart default): Lease held by the
           # controller pod, single holder at 2 replicas, failover on holder

--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -476,6 +476,16 @@ pub struct RepositoryHealthStatus {
     /// RFC 3339 timestamp of the first failure in the current failing streak.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub first_failure_at: Option<String>,
+    /// RFC 3339 timestamp at which the last backend health probe was *launched*
+    /// (the bootstrap Job created for it), cleared when its result is finalized.
+    ///
+    /// This is the **launch-side** rate limit, and it is what makes the probe
+    /// terminate. `lastProbeAt` is written only at *finalize*, so gating the
+    /// launch on that alone recycles the bootstrap Job forever: the gate destroys
+    /// every Job whose completion would have cleared it (#273). Never compared
+    /// against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub probe_attempt_at: Option<String>,
 }
 
 /// Aggregate repository storage figures from the last catalog scan.

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -35,8 +35,8 @@ use kopiur_mover::workspec::{
 
 use crate::catalog;
 use crate::consts::{
-    API_VERSION, BOOTSTRAP_JOB_DEADLINE_SECS, CLUSTER_REPOSITORY_LABEL,
-    CLUSTER_REPOSITORY_UID_LABEL, REPOSITORY_BOOTSTRAPPED_CONDITION, SERVER_CLEANUP_FINALIZER,
+    API_VERSION, CLUSTER_REPOSITORY_LABEL, CLUSTER_REPOSITORY_UID_LABEL,
+    REPOSITORY_BOOTSTRAPPED_CONDITION, SERVER_CLEANUP_FINALIZER,
 };
 use crate::context::Context;
 use crate::error::{Error, Result, TERMINAL_HEARTBEAT, error_policy_for};
@@ -860,29 +860,50 @@ async fn bootstrap_cluster_via_mover(
         .is_some();
     let probe_enabled =
         kopiur_api::repository::RepositoryHealthProbeSpec::enabled(repo.spec.health.as_ref());
-    let probe_due = health::health_probe_due(
+    let already_ready = repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
+    let probe_attempt_at = repo
+        .status
+        .as_ref()
+        .and_then(|s| s.health.as_ref())
+        .and_then(|h| h.probe_attempt_at.clone());
+    let probe = health::probe_action(
+        already_ready,
         bootstrapped_before,
         probe_enabled,
         repo.status
             .as_ref()
             .and_then(|s| s.health.as_ref())
             .and_then(|h| h.last_probe_at.as_deref()),
+        probe_attempt_at.as_deref(),
         kopiur_api::repository::RepositoryHealthProbeSpec::effective_interval(
             repo.spec.health.as_ref(),
         ),
+        health::probe_attempt_timeout(health::bootstrap_deadline_seconds(
+            repo.spec
+                .bootstrap
+                .as_ref()
+                .and_then(|b| b.failure_policy.as_ref())
+                .and_then(|fp| fp.active_deadline_seconds),
+        )),
         chrono::Utc::now(),
     );
     let spec_changed =
         repo.metadata.generation != repo.status.as_ref().and_then(|s| s.observed_generation);
+    // This finished Job IS the probe's own result (we launched it and stamped
+    // `probeAttemptAt`) — interpret it gently and consume it exactly once. Keying on
+    // `awaits_result()` rather than `probe_enabled` alone stops a Job left by a STRICT
+    // launch from being re-read as a probe, which fabricated `lastHealthyAt` and could
+    // route a real bootstrap failure into the alert-only `finalize_cluster_probe_failure`
+    // (hard-coded `phase: Ready`), resurrecting a terminally-`Failed` repository.
     // `!reverify`: a reverify nudge keeps its strict semantics (flip to `Failed` on a
-    // connect failure) and is never downgraded to an alert-only probe. The probe is a
-    // separate, timer-driven concern (`probe_due`).
-    let probe_run = probe_enabled && bootstrapped_before && !spec_changed && !reverify;
-    let keep_ready_on_launch = probe_enabled && bootstrapped_before && !reverify && !spec_changed;
+    // connect failure) and is never downgraded to an alert-only probe.
+    let probe_run = probe.awaits_result() && !spec_changed && !reverify;
+    // The LAUNCH-side twin of `probe_run`: keep the phase `Ready` while the probe
+    // connects, and stamp `probeAttemptAt` so its result is recognised when it lands.
+    let probe_style_launch =
+        probe_enabled && bootstrapped_before && already_ready && !reverify && !spec_changed;
 
     if let Some(job) = job_api.get_opt(&job_name).await? {
-        let already_ready =
-            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
         return match crate::snapshot::job_terminal_state(&job) {
             // Still running. A catalog-refresh re-run of an already-Ready repo
             // keeps its phase — flapping Ready→Initializing every refresh would
@@ -901,14 +922,17 @@ async fn bootstrap_cluster_via_mover(
             // Finished — unless the result is stale (catalog refresh due, the spec
             // changed, or a health probe is due since it was taken), in which case
             // recycle the Job so the next reconcile re-runs the bootstrap for a FRESH
-            // connect. `probe_due` is essential — without it the first probe would
-            // re-read the lingering first-bootstrap result and report healthy without
-            // ever re-connecting.
+            // connect. `probe.launches()` is essential — without it the first probe
+            // would re-read the lingering first-bootstrap result and report healthy
+            // without ever re-connecting. It is deliberately `launches()`, NOT "a probe
+            // is enabled": once the probe's own Job is launched, `probe_action` returns
+            // `AwaitingResult` and this arm stands down so the result can be finalized.
+            // Recycling then too is the #273 livelock.
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
                 if reverify
-                    || probe_due
+                    || probe.launches()
                     || catalog::bootstrap_recycle_due(
                         already_ready,
                         repo.metadata.generation,
@@ -941,7 +965,7 @@ async fn bootstrap_cluster_via_mover(
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
     if !(reverify
-        || probe_due
+        || probe.launches()
         || catalog::bootstrap_create_due(
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
             repo.metadata.generation,
@@ -1133,13 +1157,13 @@ async fn bootstrap_cluster_via_mover(
         image_pull_policy: ctx.mover_pull_policy(),
         // Bound the bootstrap Job so a pod that never schedules (missing mover SA,
         // image-pull failure) becomes terminal-`Failed` instead of hanging — then
-        // `finalize_cluster_bootstrap` runs and surfaces a Warning Event.
+        // `finalize_cluster_bootstrap` runs and surfaces a Warning Event. Shared with
+        // `health::probe_attempt_timeout`, so the bound on a probe Job's life and the
+        // gate that waits for its result can never disagree.
         limits: JobLimits {
-            active_deadline_seconds: Some(
-                bootstrap_fp
-                    .and_then(|fp| fp.active_deadline_seconds)
-                    .unwrap_or(BOOTSTRAP_JOB_DEADLINE_SECS),
-            ),
+            active_deadline_seconds: Some(health::bootstrap_deadline_seconds(
+                bootstrap_fp.and_then(|fp| fp.active_deadline_seconds),
+            )),
             backoff_limit: bootstrap_fp
                 .and_then(|fp| fp.backoff_limit)
                 .unwrap_or(JobLimits::default().backoff_limit),
@@ -1169,13 +1193,27 @@ async fn bootstrap_cluster_via_mover(
     io::apply_mover_objects(&ctx.client, &job_ns, &job_name, Some(&cm), &job).await?;
     // Stamp the reverify token (loop guard): this request is now honored. A
     // health-probe re-run keeps the phase `Ready` so backups/replication aren't paused.
-    let mut create_status = if keep_ready_on_launch {
+    let mut create_status = if probe_style_launch {
         serde_json::json!({ "backend": backend.kind_str() })
     } else {
         serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() })
     };
     if let Some(token) = reverify_token {
         create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    // Launch-side probe stamp (#273) — the loop guard that lets the probe terminate.
+    // `lastProbeAt` is only written at FINALIZE, so gating the recycle on it alone
+    // deletes every Job whose completion would have cleared it. Stamping here means the
+    // next pass reads `AwaitingResult` and lets the finished Job be finalized.
+    //
+    // `now` for a probe-style launch, an explicit `null` otherwise, so a STRICT relaunch
+    // actively clears a stale stamp instead of inheriting it.
+    if probe_enabled || probe_attempt_at.is_some() {
+        create_status["health"] = health::probe_attempt_health_patch(
+            probe_style_launch
+                .then(|| chrono::Utc::now().to_rfc3339())
+                .as_deref(),
+        );
     }
     // Rate-limit backoff for the scan-request token: stamped BEFORE the outcome is
     // known (a probe-style failure never lands in `run_cluster_catalog_scan`, so
@@ -1585,7 +1623,11 @@ async fn finalize_cluster_probe_failure(
         current.as_ref(),
         serde_json::json!({
             "phase": "Ready",
-            "health": upd.health,
+            // NOT `upd.health` directly: `skip_serializing_if = "Option::is_none"` would
+            // ELIDE the `None` for `probeAttemptAt`, leaving the launch stamp in the
+            // stored object — so the repo would stay `AwaitingResult` and the next
+            // finished Job would read as a probe. This emits the explicit RFC 7386 null.
+            "health": health::probe_failure_health_patch(&upd.health),
             "conditions": conditions,
         }),
     )

--- a/crates/controller/src/health.rs
+++ b/crates/controller/src/health.rs
@@ -227,6 +227,135 @@ pub fn health_probe_due(
     enabled && bootstrapped_before && crate::catalog::refresh_due(last_probe_at, interval, now)
 }
 
+/// Extra headroom over the bootstrap Job's own deadline before a stamped
+/// `probeAttemptAt` is treated as abandoned. Covers the gap between the Job going
+/// terminal and the controller finalizing it (a restart, a requeue backoff).
+pub const PROBE_ATTEMPT_GRACE_SECS: i64 = 60;
+
+/// The bootstrap Job's `activeDeadlineSeconds`: the user's override, else
+/// [`crate::consts::BOOTSTRAP_JOB_DEADLINE_SECS`]. One definition shared by the Job
+/// builder and [`probe_attempt_timeout`], so the launch bound and the gate that
+/// waits on it can never disagree.
+pub fn bootstrap_deadline_seconds(active_deadline_seconds: Option<i64>) -> i64 {
+    active_deadline_seconds.unwrap_or(crate::consts::BOOTSTRAP_JOB_DEADLINE_SECS)
+}
+
+/// How long a stamped `probeAttemptAt` still means "a probe Job is in flight".
+///
+/// Derived from the Job's own deadline rather than the probe interval: the
+/// interval floor is 30s (and the e2e uses exactly that), so a slow backend would
+/// be declared abandoned mid-flight. A bootstrap Job cannot outlive its
+/// `activeDeadlineSeconds`, so that plus a grace window is the true upper bound.
+pub fn probe_attempt_timeout(active_deadline_seconds: i64) -> std::time::Duration {
+    std::time::Duration::from_secs(
+        active_deadline_seconds
+            .saturating_add(PROBE_ATTEMPT_GRACE_SECS)
+            .max(1) as u64,
+    )
+}
+
+/// Whether a probe Job launched at `attempt_at` is still plausibly in flight.
+///
+/// **Fails OPEN**: an absent or unparseable stamp reads as "not pending", so a
+/// malformed value can never wedge the probe forever. This controller is the only
+/// writer of the field, mirroring [`crate::catalog::scan_requested_due`]'s
+/// reasoning.
+pub fn probe_attempt_pending(
+    attempt_at: Option<&str>,
+    timeout: std::time::Duration,
+    now: DateTime<Utc>,
+) -> bool {
+    let Some(raw) = attempt_at else {
+        return false;
+    };
+    let Ok(started) = DateTime::parse_from_rfc3339(raw) else {
+        return false;
+    };
+    let Ok(timeout) = chrono::Duration::from_std(timeout) else {
+        return false;
+    };
+    started.with_timezone(&Utc) + timeout > now
+}
+
+/// What the backend health probe wants from this reconcile pass.
+///
+/// A closed enum so both reconcilers stay symmetric and a new variant cannot
+/// compile until every arm accounts for it (CLAUDE.md "type-safety end-to-end").
+/// It replaces the bare `probe_due` bool, whose single value had to serve two
+/// incompatible questions — "should I launch a probe?" and "is this finished Job
+/// my probe's result?" — which is precisely how #273 happened.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProbeAction {
+    /// Nothing to do: disabled, never bootstrapped, not `Ready`, or not yet due.
+    Idle,
+    /// A probe is due and none is in flight — (re)launch the bootstrap Job.
+    Launch,
+    /// A probe Job was launched and its result has not been finalized yet. The
+    /// finished Job MUST be allowed through to `finalize_*` — recycling it here is
+    /// the #273 livelock.
+    AwaitingResult,
+}
+
+impl ProbeAction {
+    /// Whether this pass should launch (or recycle-then-relaunch) a probe Job.
+    pub fn launches(self) -> bool {
+        match self {
+            Self::Launch => true,
+            Self::Idle | Self::AwaitingResult => false,
+        }
+    }
+
+    /// Whether a finished bootstrap Job observed on this pass is *this probe's*
+    /// result, and must therefore be finalized as a probe rather than recycled.
+    pub fn awaits_result(self) -> bool {
+        match self {
+            Self::AwaitingResult => true,
+            Self::Idle | Self::Launch => false,
+        }
+    }
+}
+
+/// Decide what the probe wants from this pass.
+///
+/// **The #273 fix, and the mirror image of [`crate::catalog::scan_requested_pending`].**
+/// That doc comment warns against using the *rate-limited launch* predicate at
+/// *finalize* time. This is the converse hazard: `lastProbeAt` is a *finalize-side*
+/// stamp, and gating the *launch-side* recycle on it alone means the gate deletes
+/// every Job whose completion would have cleared it — so `finalize_*` (the only
+/// writer of `lastProbeAt`) is unreachable and the probe recycles its Job forever.
+/// The launch-side stamp `probeAttemptAt` is what breaks that cycle.
+///
+/// `phase_is_ready` is load-bearing twice over. It stops a probe from racing a real
+/// (re-)bootstrap — mirroring [`crate::catalog::bootstrap_recycle_due`]'s own
+/// `if !phase_is_ready { return false }` guard, which the probe arm was missing —
+/// and it stops a terminally-`Failed` repository's lingering Job from being re-read
+/// as a probe, which would flip it back to `Ready` (see `finalize_probe_failure`).
+/// It does NOT weaken [`health_probe_due`]'s deliberate "keyed on
+/// `bootstrapped_before`, not `phase == Ready`" property: a repository that has
+/// raised an alert *stays* `Ready` by design, so it keeps probing.
+#[allow(clippy::too_many_arguments)]
+pub fn probe_action(
+    phase_is_ready: bool,
+    bootstrapped_before: bool,
+    enabled: bool,
+    last_probe_at: Option<&str>,
+    probe_attempt_at: Option<&str>,
+    interval: std::time::Duration,
+    attempt_timeout: std::time::Duration,
+    now: DateTime<Utc>,
+) -> ProbeAction {
+    if !(enabled && bootstrapped_before && phase_is_ready) {
+        return ProbeAction::Idle;
+    }
+    if probe_attempt_pending(probe_attempt_at, attempt_timeout, now) {
+        return ProbeAction::AwaitingResult;
+    }
+    if health_probe_due(bootstrapped_before, enabled, last_probe_at, interval, now) {
+        return ProbeAction::Launch;
+    }
+    ProbeAction::Idle
+}
+
 /// How a failing probe is classified — the load-bearing distinction the user
 /// demanded before anything destructive is ever even *suggested*.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -287,6 +416,7 @@ pub fn reconcile_probe_success(
             last_healthy_at: Some(now.to_string()),
             consecutive_probe_failures: None,
             first_failure_at: None,
+            probe_attempt_at: None,
         },
         event: None,
     }
@@ -304,6 +434,42 @@ pub fn probe_success_health_patch(now: &str) -> serde_json::Value {
         "lastHealthyAt": now,
         "consecutiveProbeFailures": serde_json::Value::Null,
         "firstFailureAt": serde_json::Value::Null,
+        // Retire the launch-side attempt stamp: this probe's result is now recorded,
+        // so the next pass must read `Idle`/`Launch`, never `AwaitingResult` (#273).
+        "probeAttemptAt": serde_json::Value::Null,
+    })
+}
+
+/// The `status.health` merge-patch fragment for a **failing** probe.
+///
+/// [`reconcile_probe_failure`] returns a typed [`RepositoryHealthStatus`], and every
+/// field is `skip_serializing_if = "Option::is_none"` — so serializing it directly
+/// can never CLEAR `probeAttemptAt`; the `None` is simply elided and the stale stamp
+/// survives in the stored object, leaving the repository stuck `AwaitingResult` until
+/// the timeout and making the *next* finished Job read as a probe. Emits the explicit
+/// RFC 7386 null the merge needs. Success twin: [`probe_success_health_patch`].
+pub fn probe_failure_health_patch(health: &RepositoryHealthStatus) -> serde_json::Value {
+    let mut value = serde_json::to_value(health).unwrap_or_else(|_| serde_json::json!({}));
+    value["probeAttemptAt"] = serde_json::Value::Null;
+    value
+}
+
+/// The `status.health` merge-patch fragment written when a bootstrap Job is
+/// **launched**: stamps `probeAttemptAt` for a probe-style launch, or explicitly
+/// clears it for any other launch.
+///
+/// Clearing is not optional. A strict relaunch (spec change, reverify) that merely
+/// *left* a stale stamp alone would have its result re-read as a probe on the next
+/// pass — fabricating `lastHealthyAt` from a connect no probe requested, and (worse)
+/// routing a genuine bootstrap failure into the alert-only `finalize_probe_failure`,
+/// which hard-codes `phase: Ready`. Writing `now | null` at the single launch site
+/// kills that whole class at the source.
+pub fn probe_attempt_health_patch(launched_at: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "probeAttemptAt": match launched_at {
+            Some(now) => serde_json::Value::String(now.to_string()),
+            None => serde_json::Value::Null,
+        },
     })
 }
 
@@ -345,6 +511,9 @@ pub fn reconcile_probe_failure(
         last_healthy_at: prior.and_then(|h| h.last_healthy_at.clone()),
         consecutive_probe_failures: Some(consecutive),
         first_failure_at: Some(first_failure_at),
+        // Retired by the caller through `probe_failure_health_patch`, which emits the
+        // explicit null this `None` cannot express through a merge patch.
+        probe_attempt_at: None,
     };
 
     let threshold = failure_threshold.max(1);
@@ -567,6 +736,330 @@ mod tests {
         // (and stayed Ready) keeps probing — `bootstrapped_before` stays true.
     }
 
+    // ---- #273: the launch-side attempt stamp -------------------------------
+
+    /// The attempt timeout used throughout these tests: the default Job deadline
+    /// (120s) plus the grace window (60s) = 180s.
+    fn attempt_timeout() -> std::time::Duration {
+        probe_attempt_timeout(bootstrap_deadline_seconds(None))
+    }
+
+    #[test]
+    fn probe_action_truth_table() {
+        let interval = std::time::Duration::from_secs(1800);
+        let to = attempt_timeout();
+        let action = |ready, boot, enabled, last: Option<&str>, attempt: Option<&str>, now| {
+            probe_action(ready, boot, enabled, last, attempt, interval, to, now)
+        };
+
+        // Ready + enabled + bootstrapped + never probed + no attempt → launch.
+        assert_eq!(
+            action(true, true, true, None, None, t(10_000)),
+            ProbeAction::Launch
+        );
+        // THE #273 ASSERTION: with a fresh attempt stamped, the pass must NOT launch
+        // (i.e. must not recycle) — it must wait for that Job's result. On the buggy
+        // code this state did not exist and the Job was recycled forever.
+        assert_eq!(
+            action(
+                true,
+                true,
+                true,
+                None,
+                Some(&t(9_950).to_rfc3339()),
+                t(10_000)
+            ),
+            ProbeAction::AwaitingResult
+        );
+        // The liveness escape: once the attempt is older than the timeout (a crashed
+        // controller, a TTL-reaped Job, a result ConfigMap that never materialised),
+        // the probe must become launchable again rather than wedging forever.
+        assert_eq!(
+            action(
+                true,
+                true,
+                true,
+                None,
+                Some(&t(9_000).to_rfc3339()),
+                t(10_000)
+            ),
+            ProbeAction::Launch
+        );
+        // Fail-open: an unparseable stamp must never wedge the probe.
+        assert_eq!(
+            action(true, true, true, None, Some("not-a-timestamp"), t(10_000)),
+            ProbeAction::Launch
+        );
+        // Timer not elapsed → idle.
+        assert_eq!(
+            action(
+                true,
+                true,
+                true,
+                Some(&t(9_000).to_rfc3339()),
+                None,
+                t(10_000)
+            ),
+            ProbeAction::Idle
+        );
+        // Timer elapsed → launch again (the probe re-fires on cadence).
+        assert_eq!(
+            action(true, true, true, Some(&t(0).to_rfc3339()), None, t(10_000)),
+            ProbeAction::Launch
+        );
+        // Disabled / never bootstrapped → idle regardless.
+        assert_eq!(
+            action(true, true, false, None, None, t(10_000)),
+            ProbeAction::Idle
+        );
+        assert_eq!(
+            action(true, false, true, None, None, t(10_000)),
+            ProbeAction::Idle
+        );
+    }
+
+    /// A repository that is NOT `Ready` must never produce probe activity, even when
+    /// every other input says a probe is due.
+    ///
+    /// Two distinct hazards. (1) A probe must not race a real (re-)bootstrap: without
+    /// this guard a spec change opens a second livelock — the generation arm recycles
+    /// the fresh strict result before it can write `observedGeneration`. (2) A
+    /// terminally-`Failed` repository's lingering Job must not be re-read as a probe:
+    /// `finalize_probe_failure` hard-codes `phase: Ready`, so that would silently
+    /// resurrect a failed repository and open every downstream `repository_ready` gate.
+    #[test]
+    fn a_repository_that_is_not_ready_never_probes() {
+        let interval = std::time::Duration::from_secs(1800);
+        let to = attempt_timeout();
+        // Due by every other measure, but not Ready.
+        assert_eq!(
+            probe_action(false, true, true, None, None, interval, to, t(10_000)),
+            ProbeAction::Idle
+        );
+        // Even with a fresh attempt stamped, a non-Ready repo never claims the result.
+        let upd = probe_action(
+            false,
+            true,
+            true,
+            None,
+            Some(&t(9_950).to_rfc3339()),
+            interval,
+            to,
+            t(10_000),
+        );
+        assert_eq!(upd, ProbeAction::Idle);
+        assert!(
+            !upd.awaits_result(),
+            "a Failed/Initializing repository must never treat a finished Job as its \
+             probe result — finalize_probe_failure would flip it back to Ready"
+        );
+    }
+
+    /// #273 encoded as an executable regression: drive the pure predicates through the
+    /// real reconcile sequence and assert it CONVERGES.
+    ///
+    /// On the buggy code the cycle was: due → recycle Job → recreate → completes →
+    /// still due (nothing ever stamped `lastProbeAt`, because the recycle returned
+    /// before `finalize_*`) → recycle → … forever. The launch-side stamp is what makes
+    /// the middle state (`AwaitingResult`) reachable, and therefore the timer clearable.
+    #[test]
+    fn probe_attempt_stamp_breaks_the_recycle_livelock() {
+        let interval = std::time::Duration::from_secs(1800);
+        let to = attempt_timeout();
+
+        // Pass 1 — a Ready, bootstrapped repo with the probe on and nothing recorded.
+        let mut last_probe_at: Option<String> = None;
+        let mut probe_attempt_at: Option<String> = None;
+        let first = probe_action(
+            true,
+            true,
+            true,
+            last_probe_at.as_deref(),
+            probe_attempt_at.as_deref(),
+            interval,
+            to,
+            t(10_000),
+        );
+        assert_eq!(first, ProbeAction::Launch);
+
+        // The reconciler launches the Job and stamps the attempt (create-site write).
+        probe_attempt_at = Some(t(10_000).to_rfc3339());
+
+        // Pass 2 — the Job is running/finished. This MUST NOT be another Launch, or the
+        // finished Job is recycled and we are back in the livelock.
+        let second = probe_action(
+            true,
+            true,
+            true,
+            last_probe_at.as_deref(),
+            probe_attempt_at.as_deref(),
+            interval,
+            to,
+            t(10_020),
+        );
+        assert_eq!(
+            second,
+            ProbeAction::AwaitingResult,
+            "#273: a launched probe must be awaited, not relaunched — relaunching \
+             destroys the result that would stamp lastProbeAt"
+        );
+        assert!(
+            second.awaits_result() && !second.launches(),
+            "the finished Job must reach finalize_*, which is the only writer of \
+             lastProbeAt"
+        );
+
+        // `finalize_*` runs: stamps lastProbeAt and CLEARS the attempt.
+        last_probe_at = Some(t(10_020).to_rfc3339());
+        probe_attempt_at = None;
+
+        // Pass 3 — converged. Quiet until the interval elapses.
+        assert_eq!(
+            probe_action(
+                true,
+                true,
+                true,
+                last_probe_at.as_deref(),
+                probe_attempt_at.as_deref(),
+                interval,
+                to,
+                t(10_030),
+            ),
+            ProbeAction::Idle,
+            "#273: the steady state after a completed probe must be quiet — a Launch \
+             here means the bootstrap Job churns forever"
+        );
+        // ... and re-fires exactly once the interval has passed.
+        assert_eq!(
+            probe_action(
+                true,
+                true,
+                true,
+                last_probe_at.as_deref(),
+                probe_attempt_at.as_deref(),
+                interval,
+                to,
+                t(10_020 + 1800),
+            ),
+            ProbeAction::Launch,
+            "the probe must still re-fire on cadence — fixing the loop must not mean \
+             never probing again"
+        );
+    }
+
+    /// A finished Job that no probe launched must never be claimed as a probe result.
+    /// This is what used to fabricate `lastHealthyAt` from a connect nobody requested.
+    #[test]
+    fn a_job_no_probe_launched_is_never_read_as_a_probe() {
+        let interval = std::time::Duration::from_secs(1800);
+        let to = attempt_timeout();
+        // No attempt stamped (the Job came from a spec-change re-bootstrap or a
+        // reverify) → the pass never claims its result.
+        let action = probe_action(
+            true,
+            true,
+            true,
+            Some(&t(9_990).to_rfc3339()),
+            None,
+            interval,
+            to,
+            t(10_000),
+        );
+        assert!(!action.awaits_result());
+    }
+
+    #[test]
+    fn probe_attempt_timeout_outlives_the_job_deadline() {
+        // The window must exceed the Job's own deadline, or an attempt is declared
+        // abandoned while its Job is still legitimately running.
+        let default = probe_attempt_timeout(bootstrap_deadline_seconds(None));
+        assert!(
+            default
+                > std::time::Duration::from_secs(crate::consts::BOOTSTRAP_JOB_DEADLINE_SECS as u64),
+            "the attempt window must outlive the Job deadline it waits on"
+        );
+        // A user raising activeDeadlineSeconds for a slow backend widens it too.
+        assert!(probe_attempt_timeout(bootstrap_deadline_seconds(Some(900))) > default);
+        assert_eq!(
+            bootstrap_deadline_seconds(None),
+            crate::consts::BOOTSTRAP_JOB_DEADLINE_SECS
+        );
+        assert_eq!(bootstrap_deadline_seconds(Some(42)), 42);
+    }
+
+    #[test]
+    fn probe_attempt_pending_truth_table() {
+        let to = std::time::Duration::from_secs(180);
+        assert!(!probe_attempt_pending(None, to, t(10_000)), "absent");
+        assert!(
+            !probe_attempt_pending(Some("garbage"), to, t(10_000)),
+            "unparseable must fail OPEN so a bad value cannot wedge the probe"
+        );
+        assert!(probe_attempt_pending(
+            Some(&t(9_950).to_rfc3339()),
+            to,
+            t(10_000)
+        ));
+        assert!(!probe_attempt_pending(
+            Some(&t(9_000).to_rfc3339()),
+            to,
+            t(10_000)
+        ));
+    }
+
+    #[test]
+    fn probe_attempt_health_patch_stamps_or_clears() {
+        let now = t(200).to_rfc3339();
+        assert_eq!(
+            probe_attempt_health_patch(Some(&now))["probeAttemptAt"].as_str(),
+            Some(now.as_str())
+        );
+        // A strict relaunch must CLEAR, and an empty object would not — the merge
+        // patch needs an explicit null or the stale stamp survives.
+        let cleared = probe_attempt_health_patch(None);
+        assert!(
+            cleared["probeAttemptAt"].is_null(),
+            "must be an explicit null, got {cleared:?}"
+        );
+    }
+
+    #[test]
+    fn probe_failure_health_patch_clears_the_attempt_stamp() {
+        // The trap: `RepositoryHealthStatus` fields are `skip_serializing_if =
+        // "Option::is_none"`, so serializing the typed struct directly ELIDES the
+        // `None` and the launch stamp survives in the stored object — leaving the repo
+        // stuck `AwaitingResult` and making the next finished Job read as a probe.
+        let health = RepositoryHealthStatus {
+            last_probe_at: Some(t(100).to_rfc3339()),
+            last_healthy_at: Some(t(50).to_rfc3339()),
+            consecutive_probe_failures: Some(2),
+            first_failure_at: Some(t(80).to_rfc3339()),
+            probe_attempt_at: Some(t(90).to_rfc3339()),
+        };
+        let raw = serde_json::to_value(&health).unwrap();
+        assert_eq!(
+            raw["probeAttemptAt"].as_str(),
+            Some(t(90).to_rfc3339().as_str()),
+            "sanity: the typed struct round-trips the stamp"
+        );
+
+        let patch = probe_failure_health_patch(&health);
+        assert!(
+            patch["probeAttemptAt"].is_null(),
+            "the failure patch must emit an explicit null to retire the attempt"
+        );
+        // ... while preserving everything the debounce depends on.
+        assert_eq!(
+            patch["lastProbeAt"].as_str(),
+            Some(t(100).to_rfc3339().as_str())
+        );
+        assert_eq!(patch["consecutiveProbeFailures"].as_i64(), Some(2));
+        assert_eq!(
+            patch["firstFailureAt"].as_str(),
+            Some(t(80).to_rfc3339().as_str())
+        );
+    }
+
     // ---- Part B: probe failure debounce + classification -------------------
 
     fn reachable_cond(status: &str, reason: &str) -> Condition {
@@ -588,6 +1081,7 @@ mod tests {
             last_healthy_at: Some(t(0).to_rfc3339()),
             consecutive_probe_failures: Some(n),
             first_failure_at: Some(t(0).to_rfc3339()),
+            probe_attempt_at: None,
         }
     }
 
@@ -753,6 +1247,13 @@ mod tests {
             patch["firstFailureAt"].is_null(),
             "must be explicit null so the merge clears it, got {:?}",
             patch["firstFailureAt"]
+        );
+        // #273: the launch-side attempt stamp must be retired here too. If it survives,
+        // the next pass still reads `AwaitingResult` and the probe never re-fires.
+        assert!(
+            patch["probeAttemptAt"].is_null(),
+            "must be explicit null so the merge retires the attempt, got {:?}",
+            patch["probeAttemptAt"]
         );
     }
 }

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -32,7 +32,7 @@ use kopiur_mover::workspec::{
 };
 
 use crate::catalog;
-use crate::consts::{API_VERSION, BOOTSTRAP_JOB_DEADLINE_SECS, REPOSITORY_BOOTSTRAPPED_CONDITION};
+use crate::consts::{API_VERSION, REPOSITORY_BOOTSTRAPPED_CONDITION};
 use crate::context::Context;
 use crate::error::{Error, Result, TERMINAL_HEARTBEAT, error_policy_for};
 use crate::health;
@@ -774,36 +774,54 @@ async fn bootstrap_via_mover(
         .is_some();
     let probe_enabled =
         kopiur_api::repository::RepositoryHealthProbeSpec::enabled(repo.spec.health.as_ref());
-    let probe_due = health::health_probe_due(
+    let already_ready = repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
+    let probe_attempt_at = repo
+        .status
+        .as_ref()
+        .and_then(|s| s.health.as_ref())
+        .and_then(|h| h.probe_attempt_at.clone());
+    let probe = health::probe_action(
+        already_ready,
         bootstrapped_before,
         probe_enabled,
         repo.status
             .as_ref()
             .and_then(|s| s.health.as_ref())
             .and_then(|h| h.last_probe_at.as_deref()),
+        probe_attempt_at.as_deref(),
         kopiur_api::repository::RepositoryHealthProbeSpec::effective_interval(
             repo.spec.health.as_ref(),
         ),
+        health::probe_attempt_timeout(health::bootstrap_deadline_seconds(
+            repo.spec
+                .bootstrap
+                .as_ref()
+                .and_then(|b| b.failure_policy.as_ref())
+                .and_then(|fp| fp.active_deadline_seconds),
+        )),
         chrono::Utc::now(),
     );
     let spec_changed =
         repo.metadata.generation != repo.status.as_ref().and_then(|s| s.observed_generation);
-    // A re-run of an already-bootstrapped, probe-enabled repo on the SAME spec is a
-    // probe: interpret it gently (stay `Ready`) and process the job exactly once
-    // (`finalize_bootstrap` deletes it). A spec change is a real re-bootstrap of new
-    // config and keeps the strict `Failed`-on-error semantics.
-    // `!reverify`: a reverify nudge (a failed backup's forced re-probe) must keep its
-    // strict semantics — flip the phase to `Failed` on a connect failure — and must
-    // NOT be downgraded to an alert-only probe. The probe is a separate, timer-driven
-    // concern (`probe_due`).
-    let probe_run = probe_enabled && bootstrapped_before && !spec_changed && !reverify;
-    // When LAUNCHING such a re-run, do not flip the phase to `Initializing` (that
-    // would fail the `repository_ready` gate and pause backups) — keep `Ready`.
-    let keep_ready_on_launch = probe_enabled && bootstrapped_before && !reverify && !spec_changed;
+    // This finished Job IS the probe's own result (we launched it and stamped
+    // `probeAttemptAt`): interpret it gently (stay `Ready`) and consume it exactly
+    // once (`finalize_bootstrap` deletes it). Keying on `awaits_result()` rather than
+    // on `probe_enabled` alone is what stops a Job left behind by a STRICT launch
+    // from being re-read as a probe — which used to fabricate `lastHealthyAt` from a
+    // connect no probe requested and, worse, route a genuine bootstrap failure into
+    // the alert-only `finalize_probe_failure` (hard-coded `phase: Ready`), silently
+    // resurrecting a terminally-`Failed` repository.
+    // `!reverify`/`!spec_changed`: those are real re-bootstraps of new config and keep
+    // the strict `Failed`-on-error semantics; they are never downgraded to an alert.
+    let probe_run = probe.awaits_result() && !spec_changed && !reverify;
+    // The LAUNCH-side twin of `probe_run`: this launch is a probe-style re-run, so
+    // (a) don't flip the phase to `Initializing` (that would fail the
+    // `repository_ready` gate and pause backups) and (b) stamp `probeAttemptAt` so the
+    // result is recognised as a probe when it lands.
+    let probe_style_launch =
+        probe_enabled && bootstrapped_before && already_ready && !reverify && !spec_changed;
 
     if let Some(job) = job_api.get_opt(&job_name).await? {
-        let already_ready =
-            repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready);
         return match crate::snapshot::job_terminal_state(&job) {
             // Still running: surface Initializing and poll. A catalog-refresh
             // re-run of an already-Ready repo keeps its phase — flapping
@@ -822,14 +840,19 @@ async fn bootstrap_via_mover(
             // Complete or backoff-exhausted: read the structured result — unless
             // the result is stale (catalog refresh due, the spec changed, or a health
             // probe is due) since it was taken: then recycle the Job so the next
-            // reconcile re-runs the bootstrap for a FRESH connect. `probe_due` is
-            // essential — without it the first probe would re-read the lingering
+            // reconcile re-runs the bootstrap for a FRESH connect. `probe.launches()`
+            // is essential — without it the first probe would re-read the lingering
             // first-bootstrap result and report healthy without ever re-connecting.
+            // It is deliberately `launches()`, NOT "a probe is enabled": once we have
+            // launched the probe's own Job, `probe_action` returns `AwaitingResult` and
+            // this arm stands down so `finalize_bootstrap` can consume it. Recycling
+            // then too is the #273 livelock — it destroys the very result that would
+            // have stamped `lastProbeAt` and cleared the gate.
             Some(success) => {
                 let interval =
                     CatalogBounds::effective_refresh_interval(repo.spec.catalog.as_ref());
                 if reverify
-                    || probe_due
+                    || probe.launches()
                     || catalog::bootstrap_recycle_due(
                         already_ready,
                         repo.metadata.generation,
@@ -863,7 +886,7 @@ async fn bootstrap_via_mover(
     // due, or spec changed) — re-creating unconditionally would pin the refresh
     // cadence to the Job TTL instead of `catalog.refreshInterval`.
     if !(reverify
-        || probe_due
+        || probe.launches()
         || catalog::bootstrap_create_due(
             repo.status.as_ref().and_then(|s| s.phase) == Some(RepositoryPhase::Ready),
             repo.metadata.generation,
@@ -1064,12 +1087,12 @@ async fn bootstrap_via_mover(
         // image-pull failure) otherwise never reaches a `Failed` condition, so the
         // controller never finalizes and the repository hangs `Initializing` with
         // no Event. The deadline forces it terminal so `finalize_bootstrap` runs.
+        // Shared with `health::probe_attempt_timeout`, so the bound on a probe Job's
+        // life and the gate that waits for its result can never disagree.
         limits: JobLimits {
-            active_deadline_seconds: Some(
-                bootstrap_fp
-                    .and_then(|fp| fp.active_deadline_seconds)
-                    .unwrap_or(BOOTSTRAP_JOB_DEADLINE_SECS),
-            ),
+            active_deadline_seconds: Some(health::bootstrap_deadline_seconds(
+                bootstrap_fp.and_then(|fp| fp.active_deadline_seconds),
+            )),
             backoff_limit: bootstrap_fp
                 .and_then(|fp| fp.backoff_limit)
                 .unwrap_or(JobLimits::default().backoff_limit),
@@ -1099,16 +1122,34 @@ async fn bootstrap_via_mover(
     io::apply_mover_objects(&ctx.client, namespace, &job_name, Some(&cm), &job).await?;
     // Stamp the reverify token (loop guard): this request is now honored.
     // A health-probe re-run of an already-`Ready` repo keeps its phase `Ready`
-    // (`keep_ready_on_launch`) so backups/replication are never paused while the
+    // (`probe_style_launch`) so backups/replication are never paused while the
     // probe connects; only a first bootstrap or a spec-change re-bootstrap shows
     // `Initializing`.
-    let mut create_status = if keep_ready_on_launch {
+    let mut create_status = if probe_style_launch {
         serde_json::json!({ "backend": backend.kind_str() })
     } else {
         serde_json::json!({ "phase": "Initializing", "backend": backend.kind_str() })
     };
     if let Some(token) = reverify_token {
         create_status["lastReverifyAt"] = serde_json::Value::String(token.to_string());
+    }
+    // Launch-side probe stamp (#273) — the loop guard that lets the probe terminate.
+    // `lastProbeAt` is only written at FINALIZE, so it cannot bound the launch: gating
+    // the recycle on it alone deletes every Job whose completion would have cleared
+    // it. Stamping here means the next pass reads `AwaitingResult` and lets the
+    // finished Job through to `finalize_bootstrap`.
+    //
+    // Written as `now` for a probe-style launch and as an explicit `null` otherwise, so
+    // a STRICT relaunch actively clears a stale stamp rather than inheriting it — a
+    // stamp left over from an abandoned probe would make this strict result read as a
+    // probe. Skipped entirely when there is nothing to say, keeping the patch a no-op
+    // for repositories that never enable the probe.
+    if probe_enabled || probe_attempt_at.is_some() {
+        create_status["health"] = health::probe_attempt_health_patch(
+            probe_style_launch
+                .then(|| chrono::Utc::now().to_rfc3339())
+                .as_deref(),
+        );
     }
     // Rate-limit backoff for the scan-request token: stamped BEFORE the outcome is
     // known (a probe-style failure never lands in `run_catalog_scan`, so the
@@ -1574,7 +1615,12 @@ async fn finalize_probe_failure(
         current.as_ref(),
         serde_json::json!({
             "phase": "Ready",
-            "health": upd.health,
+            // NOT `upd.health` directly: every field is `skip_serializing_if =
+            // "Option::is_none"`, so the typed `None` for `probeAttemptAt` would be
+            // ELIDED from this merge patch and the launch stamp would survive — leaving
+            // the repo stuck `AwaitingResult` and making the next finished Job read as a
+            // probe. `probe_failure_health_patch` emits the explicit RFC 7386 null.
+            "health": health::probe_failure_health_patch(&upd.health),
             "conditions": conditions,
         }),
     )

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -278,6 +278,12 @@ pub const BUCKETS: &[&str] = &[
     // opt-in probe raises RepositoryVanished without recreating. Isolated so the
     // wipe can't clobber another scenario's repository.
     "kopiur-health-probe",
+    // #273 bootstrap-Job churn guards (crates/e2e/tests/health_probe.rs). One bucket
+    // per kind so the `Repository` and `ClusterRepository` guards never share a kopia
+    // repository — and so neither can be clobbered by the wipe scenario above, whose
+    // in-binary ordering is not guaranteed.
+    BUCKET_PROBE_CHURN_REPO,
+    BUCKET_PROBE_CHURN_CREPO,
     // RepositoryReplication to an S3 destination (crates/e2e/tests/replication.rs,
     // the #200 regression guard): a filesystem source mirrors here, so `sync-to`
     // only succeeds if the destination backend's OWN S3 credentials are injected.
@@ -307,6 +313,11 @@ pub const BUCKETS: &[&str] = &[
 /// The anonymous-policy bucket for the workload-identity scenario (see
 /// [`BUCKETS`]); `mc anonymous set public` is applied to exactly this bucket.
 pub const WI_BUCKET: &str = "kopiur-wi";
+
+/// Bucket for the `Repository` arm of the #273 bootstrap-Job churn guard.
+pub const BUCKET_PROBE_CHURN_REPO: &str = "kopiur-probe-churn-repo";
+/// Bucket for the `ClusterRepository` arm of the #273 bootstrap-Job churn guard.
+pub const BUCKET_PROBE_CHURN_CREPO: &str = "kopiur-probe-churn-crepo";
 
 // --- SFTP backend (in-cluster atmoz/sftp server, key-based auth) ---------------
 // kopia's SFTP backend has no env-var credential form, so the mover materializes

--- a/crates/e2e/src/lib.rs
+++ b/crates/e2e/src/lib.rs
@@ -185,3 +185,95 @@ pub async fn apply_secret(
     .await?;
     Ok(())
 }
+
+/// Guard: every e2e test binary must actually be RUN by CI.
+///
+/// This exists because 11 of 37 binaries were wired into no shard at all —
+/// including `health_probe` and `steady_state`, the two most relevant to #273,
+/// which is exactly why that bug shipped: the regression test for it had been
+/// written, committed, and never once executed.
+///
+/// A *misspelled* `--test <name>` fails loudly (cargo errors on an unknown
+/// target). A binary in NO shard fails silently, forever. This is the only thing
+/// that catches the silent case.
+///
+/// Deliberately hermetic and in `src/` rather than `tests/`: it must run under the
+/// ordinary `cargo test --workspace` job, with no cluster and no `feature = "e2e"`.
+/// Putting it in `tests/` would make the coverage guard itself need wiring — the
+/// exact trap it exists to prevent.
+#[cfg(test)]
+mod shard_coverage {
+    use std::collections::BTreeSet;
+    use std::path::PathBuf;
+
+    fn repo_root() -> PathBuf {
+        // CARGO_MANIFEST_DIR is <root>/crates/e2e.
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .expect("workspace root resolves")
+    }
+
+    /// Every `--test` target: `crates/e2e/tests/*.rs` (a directory like `common/`
+    /// is a shared module, not a binary).
+    fn test_binaries() -> BTreeSet<String> {
+        let dir = repo_root().join("crates/e2e/tests");
+        std::fs::read_dir(&dir)
+            .unwrap_or_else(|e| panic!("read {}: {e}", dir.display()))
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                (path.extension()? == "rs")
+                    .then(|| path.file_stem()?.to_str().map(str::to_string))
+                    .flatten()
+            })
+            .collect()
+    }
+
+    /// Every binary named in a `bins: "..."` value in the e2e workflow matrix.
+    /// The values are single-line and double-quoted, so this needs no YAML parser.
+    fn sharded_binaries() -> BTreeSet<String> {
+        let path = repo_root().join(".github/workflows/e2e.yaml");
+        let yaml = std::fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        yaml.lines()
+            .filter_map(|line| {
+                let rest = line.trim().strip_prefix("bins:")?.trim();
+                let inner = rest.strip_prefix('"')?.strip_suffix('"')?;
+                Some(inner.split_whitespace().map(str::to_string))
+            })
+            .flatten()
+            .collect()
+    }
+
+    #[test]
+    fn every_e2e_test_binary_runs_in_some_ci_shard() {
+        let binaries = test_binaries();
+        assert!(
+            binaries.len() > 10,
+            "sanity: expected to discover many test binaries, found {binaries:?}"
+        );
+        let sharded = sharded_binaries();
+
+        let orphans: Vec<_> = binaries.difference(&sharded).cloned().collect();
+        assert!(
+            orphans.is_empty(),
+            "these e2e test binaries are in NO shard's `bins:`, so CI never runs them \
+             — they are dead code and cannot catch a regression: {orphans:?}\n\
+             Fix: add each to a `matrix.include` entry's `bins:` in \
+             .github/workflows/e2e.yaml. Set `backends: true` if the binary uses \
+             Need::Minio/WorkloadNs/ProjectionNs (WorkloadNs and ProjectionNs imply \
+             Minio), and `csi: true` if it needs VolumeSnapshots. Give it its own \
+             shard if it restarts or reshapes the operator."
+        );
+
+        // The reverse direction: a `bins:` entry naming a binary that no longer
+        // exists makes `cargo test --test <name>` fail the whole shard.
+        let phantom: Vec<_> = sharded.difference(&binaries).cloned().collect();
+        assert!(
+            phantom.is_empty(),
+            "these names appear in a shard's `bins:` but have no \
+             crates/e2e/tests/<name>.rs — `cargo test --test <name>` will fail the \
+             shard: {phantom:?}"
+        );
+    }
+}

--- a/crates/e2e/tests/cli.rs
+++ b/crates/e2e/tests/cli.rs
@@ -1605,27 +1605,49 @@ async fn cli_migrate_volsync_kopia() {
         )
     };
     let want_identity = format!("{}@{}:{}", VSK_IDENTITY.0, VSK_IDENTITY.1, VSK_IDENTITY.2);
-    let discovered_selector = format!(
-        "kopiur.home-operations.com/origin=discovered,\
-         kopiur.home-operations.com/repository-uid={repo_uid}"
-    );
+    // Select on the repository only, NOT on `origin=discovered`.
+    //
+    // The catalog materializes the seeded snapshot as `discovered`, but `migrate`
+    // also emits a SnapshotPolicy pinning this exact fork identity — so policy
+    // auto-adoption (#272) immediately re-attaches the row and flips its origin to
+    // `adopted`. Both are correct outcomes of a successful migration, and which one
+    // you observe is a race against the adoption pass; pinning `discovered` made this
+    // assertion silently unsatisfiable the moment #272 landed.
+    //
+    // What is actually load-bearing here is the IDENTITY surviving the migration
+    // intact, which is asserted below and holds under either origin.
+    let repo_selector = format!("kopiur.home-operations.com/repository-uid={repo_uid}");
+    // Origin is read from the LABEL, not `spec.origin`: the label is what the catalog
+    // and the adoption pass both stamp (and what a selector could filter on), while
+    // `spec.origin` is elided from the serialized object for these rows.
+    let origin_of = |s: &Snapshot| {
+        s.metadata
+            .labels
+            .as_ref()
+            .and_then(|l| l.get("kopiur.home-operations.com/origin"))
+            .cloned()
+            .unwrap_or_default()
+    };
     wait_until(
-        "the seeded fork snapshot is discovered with its identity intact",
+        "the seeded fork snapshot surfaces with its identity intact",
         default_timeout(),
         poll_interval(),
         || async {
             let rows = snapshots
-                .list(&ListParams::default().labels(&discovered_selector))
+                .list(&ListParams::default().labels(&repo_selector))
                 .await?
                 .items;
             Ok(rows
                 .iter()
-                .any(|s| identity_of(s) == want_identity)
+                .any(|s| {
+                    identity_of(s) == want_identity
+                        && matches!(origin_of(s).as_str(), "discovered" | "adopted")
+                })
                 .then_some(()))
         },
     )
     .await
-    .expect("discovered Snapshot with the fork identity");
+    .expect("Snapshot carrying the fork identity (discovered, or adopted by the migrated policy)");
 
     // --- 5. History continuity: the next snapshot through the translated
     // policy records the SAME identity the fork was writing.

--- a/crates/e2e/tests/health_probe.rs
+++ b/crates/e2e/tests/health_probe.rs
@@ -12,11 +12,15 @@
 
 #![cfg(all(unix, feature = "e2e"))]
 
-use k8s_openapi::api::core::v1::Pod;
-use kube::Api;
-use kube::api::{DeleteParams, PostParams};
+use std::collections::BTreeSet;
+use std::time::{Duration, Instant};
 
-use kopiur_api::Repository;
+use k8s_openapi::api::batch::v1::Job;
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{DeleteParams, PostParams};
+use kube::{Api, ResourceExt};
+
+use kopiur_api::{ClusterRepository, Repository};
 use kopiur_e2e::builders::{self, SeedStep};
 use kopiur_e2e::{
     E2E_NAMESPACE, Need, World, consts, default_timeout, poll_interval, wait, wait_until,
@@ -111,6 +115,34 @@ async fn probe_alerts_on_wipe_but_stays_ready_and_never_recreates() {
         .map(str::to_string)
         .expect("Ready repository pins a uniqueId");
 
+    // 1b. #273: the probe must actually FIRE, and keep firing on its 30s cadence.
+    //     The churn guards below prove the bootstrap Job stops being recreated; this
+    //     proves that was not achieved by simply never probing again. On the buggy
+    //     code `lastProbeAt` was never written at all, because the recycle branch
+    //     returned before `finalize_*` — the only writer of it.
+    let read_last_probe_at = || async {
+        Ok(status_value(&repos.get(repo).await?)
+            .pointer("/health/lastProbeAt")
+            .and_then(|v| v.as_str())
+            .map(str::to_string))
+    };
+    let first_probe_at = wait_until(
+        &format!("{repo} status.health.lastProbeAt is stamped"),
+        default_timeout(),
+        poll_interval(),
+        read_last_probe_at,
+    )
+    .await
+    .expect("the probe must finalize and stamp lastProbeAt (#273)");
+    wait_until(
+        &format!("{repo} status.health.lastProbeAt advances"),
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(read_last_probe_at().await?.filter(|t| *t != first_probe_at)) },
+    )
+    .await
+    .expect("the probe must re-fire on its 30s cadence, not stamp once and stop");
+
     // 2. Wipe the backend out-of-band: delete every object in the bucket so the
     //    kopia format blob is gone (the backend itself stays reachable).
     let wipe = builders::foreign_kopia_pod(
@@ -162,4 +194,300 @@ async fn probe_alerts_on_wipe_but_stays_ready_and_never_recreates() {
     let _ = pods
         .delete("e2e-health-probe-wipe", &DeleteParams::default())
         .await;
+}
+
+// ---------------------------------------------------------------------------
+// #273 — the bootstrap-Job churn guard.
+//
+// `probe_due` was derived from `status.health.lastProbeAt`, but the finished-Job
+// branch deleted the Job and returned BEFORE `finalize_*` — the only writer of
+// `lastProbeAt`. So the gate destroyed every Job whose completion would have
+// cleared it: the `<name>-bootstrap` Job was recreated every ~15-25s forever,
+// `status.health` stayed permanently empty, and `BackendReachable` was never
+// written. Only Job-based backends (object stores, server, volume-backed
+// filesystem) were affected; bare-path filesystem repos connect in-process.
+//
+// The fix is a launch-side attempt stamp (`status.health.probeAttemptAt`), so
+// these guards assert BOTH halves of the contract: the Job stops churning, AND
+// the probe still actually completes and publishes. A "fix" that simply stopped
+// probing would pass the first assertion and fail the rest.
+// ---------------------------------------------------------------------------
+
+/// Probe cadence for the churn guards.
+///
+/// Deliberately far longer than [`CHURN_WINDOW`]: a CORRECT operator legitimately
+/// creates and destroys one mover Job *per interval*, so the assertion has to
+/// separate "one Job per interval" from "a Job every few seconds". At the 30s
+/// webhook floor (`crates/api/src/validate/repository.rs`) the correct rate
+/// (1/30s) and the buggy rate (~1/20s) differ by under 2x and the guard would be a
+/// coin flip. At 10m they differ by ~30x.
+const CHURN_PROBE_INTERVAL: &str = "10m";
+const CHURN_PROBE_INTERVAL_SECS: u64 = 600;
+
+/// How long the `<name>-bootstrap` Job is watched, measured from `Ready`.
+const CHURN_WINDOW: Duration = Duration::from_secs(180);
+
+/// Distinct `<name>-bootstrap` Job UIDs a CORRECT operator may produce inside
+/// [`CHURN_WINDOW`]:
+///
+/// ```text
+///   ceil(window / interval)   periodic probes that may legitimately fire
+/// + 1                         the FIRST probe, always immediately due:
+///                             `refresh_due(None, ..)` is true until
+///                             `status.health.lastProbeAt` is first stamped
+/// + 1                         the initial bootstrap Job, still present when the
+///                             window opens (`finalize_*` deletes it only for a
+///                             probe run)
+/// ```
+///
+/// = `ceil(180/600) + 2` = 3. A correct run observes exactly 2; the buggy code
+/// produces 9-12 and is still climbing when the window closes.
+const MAX_BOOTSTRAP_JOB_UIDS: usize =
+    (CHURN_WINDOW.as_secs() as usize).div_ceil(CHURN_PROBE_INTERVAL_SECS as usize) + 2;
+
+/// The `spec.health` block shared by both churn guards.
+fn churn_health_spec() -> serde_json::Value {
+    serde_json::json!({
+        "probe": { "enabled": true, "interval": CHURN_PROBE_INTERVAL, "failureThreshold": 1 }
+    })
+}
+
+/// Sample the `<name>-bootstrap` Job's `metadata.uid` every [`poll_interval`] for
+/// `window`, returning every DISTINCT uid seen.
+///
+/// A missing Job (the gap between a delete and the next create) and a transient API
+/// error both count as "no sample". Under-sampling can only LOWER the count, so it
+/// can never turn a correct run red — it only makes the guard more forgiving of the
+/// bug, never the reverse.
+async fn distinct_bootstrap_job_uids(
+    jobs: &Api<Job>,
+    job_name: &str,
+    window: Duration,
+) -> BTreeSet<String> {
+    let deadline = Instant::now() + window;
+    let mut seen = BTreeSet::new();
+    while Instant::now() < deadline {
+        if let Ok(Some(job)) = jobs.get_opt(job_name).await
+            && let Some(uid) = job.uid()
+        {
+            seen.insert(uid);
+        }
+        tokio::time::sleep(poll_interval()).await;
+    }
+    seen
+}
+
+/// Delete a leftover CR of the same name and wait for it to go (reused clusters).
+async fn clear_leftover<K>(api: &Api<K>, name: &str)
+where
+    K: kube::Resource + Clone + serde::de::DeserializeOwned + std::fmt::Debug,
+    <K as kube::Resource>::DynamicType: Default,
+{
+    if api.get_opt(name).await.expect("query leftover").is_some() {
+        let _ = api.delete(name, &DeleteParams::default()).await;
+        wait_until(
+            &format!("leftover {name} is gone"),
+            default_timeout(),
+            poll_interval(),
+            || async { Ok(api.get_opt(name).await?.is_none().then_some(())) },
+        )
+        .await
+        .expect("leftover CR should delete");
+    }
+}
+
+/// Assert the shared post-`Ready` contract: bounded Job churn, a stamped
+/// `lastProbeAt` that post-dates `Ready`, `BackendReachable=True`, and an
+/// unchanged `Ready` phase.
+async fn assert_probe_finalizes_without_churn(
+    jobs: &Api<Job>,
+    job_name: &str,
+    ready_at: chrono::DateTime<chrono::Utc>,
+    status_now: impl AsyncFn() -> serde_json::Value,
+) {
+    // THE #273 ASSERTION. Buggy: ~9-12 UIDs. Fixed: exactly 2.
+    let uids = distinct_bootstrap_job_uids(jobs, job_name, CHURN_WINDOW).await;
+    assert!(
+        uids.len() <= MAX_BOOTSTRAP_JOB_UIDS,
+        "#273 bootstrap-Job hot-loop: {} distinct {job_name} Jobs in {CHURN_WINDOW:?} at \
+         probe interval {CHURN_PROBE_INTERVAL} (bound {MAX_BOOTSTRAP_JOB_UIDS}) — the probe \
+         is recycling its Job without ever finalizing it, so status.health.lastProbeAt is \
+         never stamped and the probe stays permanently due. UIDs: {uids:?}",
+        uids.len()
+    );
+
+    // ... and it must be a probe that actually RAN, not a probe switched off. Both of
+    // these are written only by the finalize path, which is unreachable on buggy code.
+    let probed_at = wait_until(
+        "status.health.lastProbeAt is stamped",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            Ok(status_now()
+                .await
+                .pointer("/health/lastProbeAt")
+                .and_then(|v| v.as_str())
+                .map(str::to_string))
+        },
+    )
+    .await
+    .expect(
+        "a probe must FINALIZE and stamp status.health.lastProbeAt — it is the only input \
+         to the probe timer, so an unstamped probe re-fires forever (#273)",
+    );
+    let probed_at = chrono::DateTime::parse_from_rfc3339(&probed_at)
+        .expect("lastProbeAt is RFC 3339")
+        .with_timezone(&chrono::Utc);
+    assert!(
+        probed_at >= ready_at,
+        "lastProbeAt {probed_at} predates Ready ({ready_at}) — that is the initial \
+         bootstrap being re-read, not a probe that connected"
+    );
+
+    let s = status_now().await;
+    assert_eq!(
+        condition(&s, "BackendReachable", "status").as_deref(),
+        Some("True"),
+        "a completed healthy probe must publish BackendReachable=True; status: {s}"
+    );
+    assert_eq!(
+        s.get("phase").and_then(|p| p.as_str()),
+        Some("Ready"),
+        "a healthy probe must never move the phase"
+    );
+}
+
+/// #273: a probe-enabled `Repository` on an object store must FINALIZE its probe
+/// instead of recycling the `<name>-bootstrap` Job forever.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn probe_finalizes_instead_of_recreating_the_bootstrap_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Minio])
+        .await
+        .expect("provision MinIO + buckets");
+    let client = world.client().clone();
+
+    let name = "e2e-probe-churn";
+    let job_name = format!("{name}-bootstrap");
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    clear_leftover(&repos, name).await;
+    let mut spec = probe_repository_json(name, consts::BUCKET_PROBE_CHURN_REPO);
+    spec["spec"]["health"] = churn_health_spec();
+    repos
+        .create(
+            &PostParams::default(),
+            &serde_json::from_value(spec).expect("Repository JSON deserializes"),
+        )
+        .await
+        .expect("create Repository");
+
+    wait_until(
+        &format!("{name} Ready"),
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = status_value(&repos.get(name).await?);
+            Ok((s.get("phase").and_then(|p| p.as_str()) == Some("Ready")).then_some(()))
+        },
+    )
+    .await
+    .expect("repository becomes Ready");
+    let ready_at = chrono::Utc::now();
+
+    assert_probe_finalizes_without_churn(&jobs, &job_name, ready_at, async || {
+        status_value(&repos.get(name).await.expect("get Repository"))
+    })
+    .await;
+
+    let _ = repos.delete(name, &DeleteParams::default()).await;
+}
+
+/// #273 on the kind the issue was actually reported against. `cluster_repository.rs`
+/// is a hand-copied twin of `repository.rs`, so the guard must cover both or the
+/// reported path stays unguarded.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn cluster_repository_probe_finalizes_instead_of_recreating_the_bootstrap_job() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Minio])
+        .await
+        .expect("provision MinIO + buckets");
+    let client = world.client().clone();
+
+    let name = "e2e-probe-churn-crepo";
+    let job_name = format!("{name}-bootstrap");
+    let repos: Api<ClusterRepository> = Api::all(client.clone());
+    // A ClusterRepository's bootstrap Job lands in the credential Secret's namespace,
+    // which the spec below pins to E2E_NAMESPACE.
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    clear_leftover(&repos, name).await;
+    let cr = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "ClusterRepository",
+        "metadata": { "name": name },
+        "spec": {
+            "backend": { "s3": {
+                "bucket": consts::BUCKET_PROBE_CHURN_CREPO,
+                "endpoint": consts::MINIO_ENDPOINT,
+                "region": "us-east-1",
+                "tls": { "disableTls": true },
+                "auth": { "secretRef": { "name": consts::SECRET_S3_CREDS, "namespace": E2E_NAMESPACE } }
+            }},
+            "encryption": {
+                "passwordSecretRef": {
+                    "name": consts::SECRET_S3_CREDS,
+                    "namespace": E2E_NAMESPACE,
+                    "key": "KOPIA_PASSWORD"
+                }
+            },
+            "create": { "enabled": true },
+            "allowedNamespaces": { "all": true },
+            "maintenance": { "enabled": false },
+            "health": churn_health_spec(),
+        }
+    });
+    repos
+        .create(
+            &PostParams::default(),
+            &serde_json::from_value(cr).expect("ClusterRepository JSON deserializes"),
+        )
+        .await
+        .expect("create ClusterRepository");
+
+    wait_until(
+        &format!("{name} Ready"),
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let s = cluster_status_value(&repos.get(name).await?);
+            Ok((s.get("phase").and_then(|p| p.as_str()) == Some("Ready")).then_some(()))
+        },
+    )
+    .await
+    .expect("cluster repository becomes Ready");
+    let ready_at = chrono::Utc::now();
+
+    assert_probe_finalizes_without_churn(&jobs, &job_name, ready_at, async || {
+        cluster_status_value(&repos.get(name).await.expect("get ClusterRepository"))
+    })
+    .await;
+
+    let _ = repos.delete(name, &DeleteParams::default()).await;
+}
+
+fn cluster_status_value(repo: &ClusterRepository) -> serde_json::Value {
+    serde_json::to_value(repo)
+        .ok()
+        .and_then(|v| v.get("status").cloned())
+        .unwrap_or_default()
 }

--- a/crates/e2e/tests/leak_cleanup.rs
+++ b/crates/e2e/tests/leak_cleanup.rs
@@ -646,8 +646,24 @@ async fn sweep_reaps_legacy_projected_secret_but_not_stable_or_live_copies() {
         "app.kubernetes.io/managed-by": "kopiur",
         "app.kubernetes.io/component": "credentials"
     });
-    let projected_from =
-        serde_json::json!({ "kopiur.home-operations.com/projected-from": "kopiur-e2e/repo-pw" });
+    // The creds kernels refuse to reap anything younger than
+    // `sweep::CREDS_MIN_AGE_FLOOR_SECS` (15m), a HARD floor that deliberately
+    // overrides the harness's 30s `KOPIUR_WORK_SPEC_SWEEP_MIN_AGE_SECS` — it exists so
+    // an admin who zeroes that shared knob cannot hand the creds kernels a zero-width
+    // guard on the project→create-Job window. A fixture created just now can therefore
+    // never age into eligibility inside `default_timeout()` (420s), so stamp
+    // `projected-at` in the past instead: `sweep::creds_age_secs` prefers that
+    // annotation over `creationTimestamp` (which the apiserver owns and we cannot
+    // backdate). An hour is comfortably past the floor.
+    //
+    // Every fixture below carries the SAME backdated stamp, so the two controls are a
+    // real control: they survive the pass that reaps the orphan because of the marker
+    // and the in-use guard, not merely because they were too young to be considered.
+    let projected_at = (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339();
+    let projected_from = serde_json::json!({
+        "kopiur.home-operations.com/projected-from": "kopiur-e2e/repo-pw",
+        "kopiur.home-operations.com/projected-at": projected_at,
+    });
     let orphan = serde_json::json!({
         "apiVersion": "v1",
         "kind": "Secret",
@@ -719,9 +735,10 @@ async fn sweep_reaps_legacy_projected_secret_but_not_stable_or_live_copies() {
     });
     let _ = jobs.create(&PostParams::default(), &cr(live_job)).await;
 
-    // The sweep reaps the orphan once it ages past the harness min-age (30s) —
-    // the wait must also absorb the sweep's fixed 60s first-pass delay after
-    // leader election plus the 15s cadence, all well inside default_timeout().
+    // The sweep reaps the orphan on its next pass: the backdated `projected-at` above
+    // already puts it past the creds floor, so the wait only has to absorb the sweep's
+    // fixed 60s first-pass delay after leader election plus the 15s cadence — well
+    // inside default_timeout().
     wait_until(
         "legacy projected credential Secret swept",
         default_timeout(),

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
-assertion_line: 24
 expression: "body(&artifacts, \"repositories\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -2710,6 +2709,18 @@ spec:
                     description: |-
                       RFC 3339 timestamp of the last completed probe (success or failure); drives
                       the `health_probe_due` timer so the probe re-fires on cadence.
+                    nullable: true
+                    type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -2708,6 +2708,18 @@ spec:
                       the `health_probe_due` timer so the probe re-fires on cadence.
                     nullable: true
                     type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+                    nullable: true
+                    type: string
                 type: object
               lastReverifyAt:
                 description: |-
@@ -5646,6 +5658,18 @@ spec:
                     description: |-
                       RFC 3339 timestamp of the last completed probe (success or failure); drives
                       the `health_probe_due` timer so the probe re-fires on cadence.
+                    nullable: true
+                    type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
                     nullable: true
                     type: string
                 type: object

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -2772,6 +2772,18 @@ spec:
                       the `health_probe_due` timer so the probe re-fires on cadence.
                     nullable: true
                     type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+                    nullable: true
+                    type: string
                 type: object
               lastReverifyAt:
                 description: |-

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -2708,6 +2708,18 @@ spec:
                       the `health_probe_due` timer so the probe re-fires on cadence.
                     nullable: true
                     type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+                    nullable: true
+                    type: string
                 type: object
               lastReverifyAt:
                 description: |-

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -2772,6 +2772,18 @@ spec:
                       the `health_probe_due` timer so the probe re-fires on cadence.
                     nullable: true
                     type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+                    nullable: true
+                    type: string
                 type: object
               lastReverifyAt:
                 description: |-

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -2708,6 +2708,18 @@ spec:
                       the `health_probe_due` timer so the probe re-fires on cadence.
                     nullable: true
                     type: string
+                  probeAttemptAt:
+                    description: |-
+                      RFC 3339 timestamp at which the last backend health probe was *launched*
+                      (the bootstrap Job created for it), cleared when its result is finalized.
+
+                      This is the **launch-side** rate limit, and it is what makes the probe
+                      terminate. `lastProbeAt` is written only at *finalize*, so gating the
+                      launch on that alone recycles the bootstrap Job forever: the gate destroys
+                      every Job whose completion would have cleared it (#273). Never compared
+                      against `lastProbeAt` — see `kopiur_controller::health::probe_action`.
+                    nullable: true
+                    type: string
                 type: object
               lastReverifyAt:
                 description: |-

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -637,6 +637,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `firstFailureAt` | string | — | RFC 3339 timestamp of the first failure in the current failing streak. |
 | `lastHealthyAt` | string | — | RFC 3339 timestamp of the last *successful* probe (backend reachable, repo present). |
 | `lastProbeAt` | string | — | RFC 3339 timestamp of the last completed probe (success or failure); drives the `health_probe_due` timer so the probe re-fires on cadence. |
+| `probeAttemptAt` | string | — | RFC 3339 timestamp at which the last backend health probe was *launched* (the bootstrap Job created for it), cleared when its result is finalized.<br>This is the **launch-side** rate limit, and it is what makes the probe terminate. `lastProbeAt` is written only at *finalize*, so gating the launch on that alone recycles the bootstrap Job forever: the gate destroys every Job whose completion would have cleared it (#273). Never compared against `lastProbeAt` — see `kopiur_controller::health::probe_action`. |
 
 #### `status.parameters` { #repository-status-parameters }
 
@@ -1324,6 +1325,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `firstFailureAt` | string | — | RFC 3339 timestamp of the first failure in the current failing streak. |
 | `lastHealthyAt` | string | — | RFC 3339 timestamp of the last *successful* probe (backend reachable, repo present). |
 | `lastProbeAt` | string | — | RFC 3339 timestamp of the last completed probe (success or failure); drives the `health_probe_due` timer so the probe re-fires on cadence. |
+| `probeAttemptAt` | string | — | RFC 3339 timestamp at which the last backend health probe was *launched* (the bootstrap Job created for it), cleared when its result is finalized.<br>This is the **launch-side** rate limit, and it is what makes the probe terminate. `lastProbeAt` is written only at *finalize*, so gating the launch on that alone recycles the bootstrap Job forever: the gate destroys every Job whose completion would have cleared it (#273). Never compared against `lastProbeAt` — see `kopiur_controller::health::probe_action`. |
 
 #### `status.parameters` { #clusterrepository-status-parameters }
 

--- a/docs/repository-health.md
+++ b/docs/repository-health.md
@@ -134,6 +134,32 @@ backend) before you act.
 
 ///
 
+/// note | How a probe run is tracked
+
+On an object-store, server, or volume-backed backend a probe re-connects by
+running the repository's `<name>-bootstrap` mover Job, so kopiur tracks each run
+across two reconciles:
+
+- `status.health.probeAttemptAt` is stamped when the Job is **launched** and
+  cleared when its result is finalized. While it is set, the finished Job is
+  recognised as *that probe's* result rather than a stale one to recycle.
+- `status.health.lastProbeAt` is stamped when the run **finishes** (success or
+  failure) and drives the interval timer.
+
+A probe consumes its Job exactly once, so a healthy repository creates and
+destroys **one** mover Job per `interval` — if you see the bootstrap Job
+recreated every few seconds, that is [#273][issue-273], fixed in v0.7.6.
+
+A probe also stands aside while a real (re-)bootstrap is in flight: a repository
+that is not `Ready` (a spec change is being applied, or the bootstrap has failed)
+does not probe, and its `BackendReachable` condition holds its last value until
+the repository is `Ready` again. `phase: Failed` is the louder signal in that
+window.
+
+[issue-273]: https://github.com/home-operations/kopiur/issues/273
+
+///
+
 ## Backup preflight (opt-in)
 
 The readiness gate above is a single hard-coded precondition: *the repository is


### PR DESCRIPTION
Fixes #273.

## The bug

With `spec.health.probe.enabled: true`, the `<name>-bootstrap` Job is created and
destroyed every few seconds, forever, even though every run succeeds.

It turns out to be a livelock. The recycle gate and the only writer of the probe timer
are mutually exclusive:

1. `probe_due` was derived from `status.health.lastProbeAt`, and
   `catalog::refresh_due(None, ..)` returns `true`, so the probe became due the instant
   a repository pinned its `uniqueId`.
2. The finished-Job branch deleted the Job and returned *before* `finalize_*`.
3. `finalize_*` is the only writer of `lastProbeAt`.
4. The no-Job branch had `probe_due` in its OR, so it immediately re-created the Job.

Every Job whose completion would have cleared the gate got destroyed by that same gate.
`finalize_*` was unreachable, so `status.health` stayed permanently empty and
`BackendReachable` was never published.

Worth calling out: this feature has never worked. `git log -S"|| probe_due"` shows the
recycle gate and `crates/e2e/tests/health_probe.rs` landed in the same commit
(`d5b9eb2`, 2026-06-23). That test asserts `RepositoryVanished`, which goes through
`finalize_probe_failure`, sitting behind the same gate. It could not have passed.

Blast radius is every backend whose bootstrap runs as a mover Job: object stores,
server, and volume-backed filesystem. Bare-path filesystem repos connect in-process and
never enter this branch, which is why only object-store users hit it. `Repository` and
`ClusterRepository` were affected identically. The preflight CEL vars
`repository.lastHealthyKnown` and `lastHealthyAgeSeconds` were also permanently unset,
since both are fed by stamps that were never written.

## The fix

Add a launch-side attempt stamp, `status.health.probeAttemptAt`, mirroring the existing
`catalog.scanRequestAttemptAt` precedent, and replace the `probe_due` bool with a closed
enum:

```rust
pub enum ProbeAction { Idle, Launch, AwaitingResult }
```

A launched probe is now awaited rather than relaunched, so its result reaches
`finalize_*` and clears the timer. The stamp is bounded by the Job's own
`activeDeadlineSeconds` plus a grace window, so a controller restart mid-flight or a
TTL-reaped Job self-heals instead of wedging the probe forever.

The underlying reason one bool was not enough: it was answering two incompatible
questions, "should I launch a probe?" and "is this finished Job my probe's result?".
Booleans compose into unrepresentable states silently, and no exhaustive `match` can
police them. The enum puts that decision back under the compiler.

### Two related defects, fixed here too

Both are only reachable once the livelock is gone, so deferring them would have shipped
a regression:

* `probe_run` was not gated on the probe having launched anything, so a finished Job
  left behind by a spec-change re-bootstrap or a reverify was later re-read as a
  "probe". It stamped `lastProbeAt` and `lastHealthyAt` with no fresh backend connect,
  fabricating freshness that preflight CEL gates trust.
* That same path routed a genuine bootstrap failure into the alert-only
  `finalize_probe_failure`, which hard-codes `phase: Ready`. A terminally-failed
  repository would silently report `Ready` again and open every downstream
  `repository_ready` gate. Probe activity now requires `phase == Ready`, which is the
  guard `bootstrap_recycle_due` already had and the probe arm was missing.

The failure path also needed `probe_failure_health_patch`. It serialized the typed
`RepositoryHealthStatus` directly, and `skip_serializing_if = "Option::is_none"` would
have elided the `None` from the RFC 7386 merge patch, leaving the stamp set.

## Why this shipped, and the CI gap it exposed

`.github/workflows/e2e.yaml` is the only e2e workflow, and its shard matrix was running
26 of 37 test binaries. `health_probe` was one of 11 orphans that no shard ever ran,
alongside `steady_state`, which is the dedicated guard for the reconcile-hot-loop bug
class:

```
adoption, cli, colocation, health_probe, import, leak_cleanup,
mass_deletion, multi_cluster, preflight, steady_state, ttl_rerun
```

All 11 are now wired in, as 2 new shards plus 3 folds into shards with headroom. There
is also a new hermetic guard, `kopiur_e2e::shard_coverage`, that fails
`cargo test --workspace` if any `crates/e2e/tests/*.rs` binary is in no shard's `bins:`,
or if a `bins:` entry names a binary that no longer exists. A misspelled `--test` name
already failed loudly; a binary in no shard failed silently and indefinitely. I verified
the guard bites by unwiring `health_probe` and watching it fail.

## Tests

Unit, in `health.rs`:

* `probe_action` truth table, including the liveness escape and fail-open behaviour on
  an unparseable stamp.
* `probe_attempt_stamp_breaks_the_recycle_livelock` drives the pure predicates through
  the real reconcile sequence and asserts it converges (`Launch`, `AwaitingResult`,
  `Idle`) and then re-fires on cadence.
* `a_repository_that_is_not_ready_never_probes` pins the failed-to-Ready guard.
* Both explicit-null patches are pinned so the merge-patch clearing cannot rot.

e2e, in `health_probe.rs`:

* `probe_finalizes_instead_of_recreating_the_bootstrap_job` and its `ClusterRepository`
  twin count distinct `<name>-bootstrap` Job UIDs over a 180s window at a 10m probe
  interval. A correct operator produces 2, the bug produces 9 to 12. The long interval
  is deliberate: at the 30s webhook floor the correct rate (1 per 30s) and the buggy
  rate (about 1 per 20s) differ by under 2x, and the assertion would be a coin flip.
* Both scenarios also assert the probe actually completed, via `lastProbeAt` being
  stamped and post-dating `Ready` plus `BackendReachable=True`, so a "fix" that simply
  stopped probing would fail them.
* The pre-existing `probe_alerts_on_wipe_but_stays_ready_and_never_recreates` gains a
  cadence assertion, and per the analysis above, this PR is what makes it pass for the
  first time.

## Verification

I ran the e2e suite twice against a real kind cluster: once with the fix, and once with
only the controller logic reverted (keeping the new tests), to confirm the guards
actually catch the bug.

Observed on the `ClusterRepository` scenario, sampling the bootstrap Job every 5s:

| | Reverted (buggy) | With the fix |
|---|---|---|
| Distinct bootstrap Job UIDs in ~80s | 14 | 0 (consumed, then stays gone) |
| `status.health.lastProbeAt` | never set | stamped, then quiet until the interval |
| Cumulative "recycling finished bootstrap Job" events | 102 | 1 |

The single recycle on the fixed run is the legitimate one: the initial bootstrap Job is
recycled once so the first probe gets a fresh connect.

Test results:

* Reverted: `test result: FAILED. 0 passed; 3 failed`. Both churn guards fail on the
  UID-count assertion, and the wipe scenario fails on the new `lastProbeAt` assertion.
* With the fix: `test result: ok. 3 passed; 0 failed` in 486s.

`fmt-check`, `clippy`, `gen-check`, `complexity-check` (29/29, no new offenders), and
`cargo test --workspace --locked` are all green.
