### PR TITLE
fix(release): use the generic updater for Chart.yaml + stamp README badges

### DIFF
--- a/deploy/helm/kopiur/README.md
+++ b/deploy/helm/kopiur/README.md
@@ -1,6 +1,8 @@
 # kopiur
 
-![Version: 0.8.0](https://img.shields.io/badge/Version-0.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.8.0](https://img.shields.io/badge/AppVersion-0.8.0-informational?style=flat-square)
+![Version](https://img.shields.io/static/v1?label=Version&message=0.8.0&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message=0.8.0&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 Kopiur — a Kopia-native Kubernetes backup operator written in Rust.
 Installs the controller, admission webhook, the 8 kopiur.home-operations.com/v1alpha1 CRDs,

--- a/deploy/helm/kopiur/README.md.gotmpl
+++ b/deploy/helm/kopiur/README.md.gotmpl
@@ -1,6 +1,14 @@
 {{ template "chart.header" . }}
 
-{{ template "chart.badgesSection" . }}
+{{- /* Hand-rolled badges instead of chart.badgesSection so release-please can
+stamp the version: its generic updater replaces only the first semver on an
+annotated line and would swallow a `-color` suffix as a prerelease, so each
+version badge uses the static/v1 query form (version followed by `&`), keeps
+the version out of its alt text, and carries its own annotation. Keeps the
+committed README in sync with the stamped Chart.yaml. */}}
+![Version](https://img.shields.io/static/v1?label=Version&message={{ .Version }}&color=informational&style=flat-square) <!-- x-release-please-version -->
+![Type: {{ .Type }}](https://img.shields.io/badge/Type-{{ .Type }}-informational?style=flat-square)
+![AppVersion](https://img.shields.io/static/v1?label=AppVersion&message={{ .AppVersion }}&color=informational&style=flat-square) <!-- x-release-please-version -->
 
 {{ template "chart.description" . }}
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,10 @@
       "include-v-in-tag": false,
       "include-v-in-release-name": false,
       "always-update": true,
-      "extra-files": ["deploy/helm/kopiur/Chart.yaml"]
+      "extra-files": [
+        { "type": "generic", "path": "deploy/helm/kopiur/Chart.yaml" },
+        "deploy/helm/kopiur/README.md"
+      ]
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
Ports home-operations/tuppr#415 (plus the README-badge stamping from home-operations/tuppr#414): the pending 0.8.1 release PR (#274) mangles `Chart.yaml` - comments and `x-release-please-version` annotations stripped, the `description` block scalar rewritten (`|-` → `>-`), and `appVersion` left at 0.8.0.

## Root cause

release-please picks the updater for a plain-string `extra-files` entry by file extension (`src/strategies/base.ts`, `extraFileUpdates`). A `.yaml` path gets `CompositeUpdater(GenericYaml('$.version'), Generic)`: `GenericYaml` parses and re-serializes the whole document to set `$.version`, destroying comments/annotations and formatting, and the follow-up `Generic` pass then finds no annotations - so `appVersion` never gets stamped.

## Changes

1. **Typed extra-files entry for Chart.yaml** - `{ "type": "generic", "path": "deploy/helm/kopiur/Chart.yaml" }` forces pure line-level annotation replacement: comments survive and both `version` and `appVersion` get stamped.
2. **The chart README version badges are stamped too** (added to `extra-files`). The lint workflow's `helm-docs-check` gate would otherwise fail on every release PR - and on `main` after merge - because the badges are generated from the bumped `Chart.yaml`. Two constraints from the generic updater shape the badge markup:
   - It replaces only the **first** semver occurrence per annotated line, so the version is kept out of the badge alt text (one occurrence per line).
   - Its semver regex would swallow a shields.io path-style `-informational` color suffix as a prerelease (`Version-0.8.0-informational` → `Version-0.8.1`, corrupting the URL), so the version badges use the `static/v1?label=...&message=0.8.0&color=...` query form, where the version is delimited by `&`.

Verified end to end by simulating the updater's exact regex/replacement on `Chart.yaml` + `README.md` and confirming `helm-docs` regeneration is byte-identical afterwards. `helm-docs-check`, helm lint, and all 75 chart unit tests pass.

## Follow-up

Once this merges, release-please will rebuild the #274 branch on its next run and the release PR should come out clean - #274 should not be merged in its current form.
