### PR TITLE
ci(tests): cap debuginfo at line-tables-only so the compile-check fits runner disk

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,6 +31,12 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # Full debuginfo overflows the standard runner disk: the all-features
+  # compile-check links every gated e2e/integration test binary against the
+  # whole dep tree, and with debug=2 that plus the restored cache exceeds the
+  # ~14GB free ("No space left on device" → ld SIGBUS, 2026-07-24 twice).
+  # line-tables-only keeps file:line backtraces for test failures.
+  CARGO_PROFILE_DEV_DEBUG: "line-tables-only"
   # renovate: datasource=github-releases depName=helm-unittest/helm-unittest
   HELM_UNITTEST_VERSION: "v1.1.1"
 
@@ -55,7 +61,9 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: tests
+          # -v2: the debuginfo profile changed (CARGO_PROFILE_DEV_DEBUG above);
+          # a restored full-debug cache would double disk during the rebuild.
+          shared-key: tests-v2
 
       - name: Build workspace
         run: mise run build
@@ -86,7 +94,8 @@ jobs:
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
-          shared-key: integration
+          # -v2: see the tests cache note — debuginfo profile changed.
+          shared-key: integration-v2
 
       - name: Create kind cluster
         uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0


### PR DESCRIPTION
## Problem

The `Rust Tests` job died twice on 2026-07-24 (release-0.8.1 branch, `ci/renovate-reactive`) with:

```
error: failed to build archive ...: No space left on device (os error 28)
collect2: fatal error: ld terminated with signal 7 [Bus error], core dumped
```

The SIGBUS is the classic full-disk linker symptom — `ld` mmaps its output and the mapping can't be extended.

## Cause

The hermetic test task's second command (`cargo test --no-run --workspace --all-features`) deliberately compile-checks every feature-gated e2e/integration test binary (the PR #201 lesson). Each of those ~37 binaries statically links the full kube/tokio dep tree; with `debug=2` that's >10 GB of `target/`, stacked on the restored rust-cache — right at the standard runner's disk limit. Yesterday's Rust 1.96.1→1.97.1 bump forced near-full rebuilds and tipped it over.

## Fix

- `CARGO_PROFILE_DEV_DEBUG: line-tables-only` for the Tests workflow: keeps file:line backtraces on test failures, drops the bulky variable/type debuginfo (typically 60–80 % of a debug binary). The compile-check property is untouched — it just writes far less.
- Bump both rust-cache `shared-key`s (`tests-v2`, `integration-v2`): the profile change invalidates every cached artifact's fingerprint, so without the bump the transition run would rebuild everything *on top of* the old full-debug cache — the exact overflow being fixed.

## Validation

Full `mise run test` (both commands) passes locally under the new env var: exit 0, 74 suites, 0 failures, all gated targets compiled.