### PR TITLE
feat(secctx)!: identity-aware mover merge, recorded snapshot identity, restore inherit-from-snapshot

### DIFF
--- a/crates/api/src/common/mover.rs
+++ b/crates/api/src/common/mover.rs
@@ -185,19 +185,23 @@ pub struct ResolvedMover {
     pub throttle: Option<Throttle>,
 }
 
-/// Resolve the effective mover configuration via the 3-layer field-wise merge
+/// Resolve the effective mover configuration via the layer merge
 /// `hardened ⊂ moverDefaults ⊂ recipe` (ADR-0004 §1/§2).
 ///
 /// - `defaults`: the repository's `moverDefaults` (None when the repo sets none).
 /// - `recipe_sc`/`recipe_psc`: the recipe's **effective** container/pod context, which the
 ///   controller has already resolved — the explicit `mover.securityContext`/
 ///   `podSecurityContext` overlaid on top of any context inherited from a workload via
-///   `inheritSecurityContextFrom` (they combine; explicit wins field-wise). The full ladder
-///   is therefore `hardened ⊂ moverDefaults ⊂ inherited ⊂ explicit`. Because each merge is a
-///   per-field `over.or(base)`, folding the inner two layers before this call is field-wise
-///   identical to a flat four-layer merge. The recipe layer enters here as a *layer*, NOT a
-///   whole-chain replacement — so the hardened base + `moverDefaults` still supply
-///   `drop:[ALL]`/seccomp and a partial recipe context can only tighten.
+///   `inheritSecurityContextFrom` (they combine; explicit wins). The full ladder is
+///   therefore `hardened ⊂ moverDefaults ⊂ inherited ⊂ explicit`. Layers merge as
+///   `(container, pod)` **pairs** via [`merge_context_pair`]: field-wise per dimension,
+///   plus identity promotion so the effective UID/GID belongs to the **highest layer that
+///   pins one, regardless of which dimension it wrote** — a `moverDefaults` container-level
+///   `runAsUser` can never shadow an inherited pod-level one. The pair merge is
+///   associative, so folding the inner two layers before this call is identical to a flat
+///   four-layer merge. The recipe layer enters here as a *layer*, NOT a whole-chain
+///   replacement — the hardened base + `moverDefaults` still supply `drop:[ALL]`/seccomp
+///   and a partial recipe context can only tighten.
 /// - `recipe_resources`/`recipe_cache`: from `mover.resources` / `mover.cache`.
 ///
 /// `node_selector`/`tolerations`/`affinity`/`ttl` flow from `moverDefaults` (no per-recipe
@@ -210,33 +214,24 @@ pub fn resolve_mover(
     recipe_cache: Option<&CacheDefaults>,
     recipe_ttl_seconds_after_finished: Option<i64>,
 ) -> ResolvedMover {
-    let hardened = hardened_security_context();
-    // hardened ⊂ moverDefaults.securityContext
-    let sc_base = match defaults.and_then(|d| d.security_context.as_ref()) {
-        Some(d_sc) => merge_security_context(&hardened, d_sc),
-        None => hardened,
-    };
-    // (hardened ⊂ moverDefaults) ⊂ recipe.securityContext
-    let security_context = match recipe_sc {
-        Some(r) => merge_security_context(&sc_base, r),
-        None => sc_base,
-    };
-    // Pod context resolves identically to the container one (ADR-0004 §2): a hardened
-    // base (notably the `fsGroup` that makes the cache writable) overlaid by
-    // moverDefaults then the recipe. Always `Some` so every mover pod — bootstrap,
-    // backup, restore, maintenance, verification, replication — carries the same
-    // hardened fsGroup unless explicitly overridden.
+    // The hardened pair is the lowest layer: the container hardening plus the pod-level
+    // fsGroup that makes the cache writable. Both are always present, so every mover pod
+    // — bootstrap, backup, restore, maintenance, verification, replication — carries the
+    // hardened defaults unless a higher layer overrides them.
+    let hardened_sc = hardened_security_context();
     let hardened_psc = hardened_pod_security_context();
-    // hardened ⊂ moverDefaults.podSecurityContext
-    let psc_base = match defaults.and_then(|d| d.pod_security_context.as_ref()) {
-        Some(d_psc) => merge_pod_security_context(&hardened_psc, d_psc),
-        None => hardened_psc,
-    };
-    // (hardened ⊂ moverDefaults) ⊂ recipe.podSecurityContext
-    let pod_security_context = Some(match recipe_psc {
-        Some(r) => merge_pod_security_context(&psc_base, r),
-        None => psc_base,
-    });
+    // hardened ⊂ moverDefaults, as one (container, pod) layer pair.
+    let (base_sc, base_psc) = merge_context_pair(
+        Some(&hardened_sc),
+        Some(&hardened_psc),
+        defaults.and_then(|d| d.security_context.as_ref()),
+        defaults.and_then(|d| d.pod_security_context.as_ref()),
+    );
+    // (hardened ⊂ moverDefaults) ⊂ recipe.
+    let (security_context, pod_security_context) =
+        merge_context_pair(base_sc.as_ref(), base_psc.as_ref(), recipe_sc, recipe_psc);
+    let security_context =
+        security_context.expect("the hardened container base layer is always present");
     // Normalize the merged result against every kubelet/apiserver security-context invariant
     // (see `crate::invariants`) so a contradiction the field-wise merge can assemble — most
     // importantly an inherited-root `runAsUser: 0` left under the hardened `runAsNonRoot:
@@ -294,7 +289,22 @@ pub enum InheritSecurityContextFrom {
     WorkloadSelector(PodSelector),
     /// Backup sources only: auto-derive the workload from the PVC this snapshot backs up.
     PvcConsumer(PvcConsumerInherit),
+    /// Restores only: inherit the identity RECORDED on the backup itself
+    /// (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+    /// uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+    /// pod, so it works on a rebuilt cluster and with `target.populator`.
+    /// Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+    /// live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+    /// (an empty sub-object) — a bare `snapshot:` is null and rejected.
+    Snapshot(SnapshotInherit),
 }
+
+/// Tuning for [`InheritSecurityContextFrom::Snapshot`]. Empty today; a
+/// sub-object (like [`PopulatorTarget`](crate::restore::PopulatorTarget)) so
+/// future knobs slot in without API breakage.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotInherit {}
 
 /// Tuning for [`InheritSecurityContextFrom::PvcConsumer`].
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, JsonSchema)]

--- a/crates/api/src/common/secctx.rs
+++ b/crates/api/src/common/secctx.rs
@@ -65,6 +65,66 @@ pub fn effective_run_as_user(
         .or_else(|| psc.and_then(|p| p.run_as_user))
 }
 
+/// The **effective** `runAsGroup` following kubelet precedence — the gid peer of
+/// [`effective_run_as_user`]: container `securityContext.runAsGroup` if set, else the
+/// pod one. `None` when neither pins a group (image-determined).
+pub fn effective_run_as_group(
+    sc: Option<&SecurityContext>,
+    psc: Option<&PodSecurityContext>,
+) -> Option<i64> {
+    sc.and_then(|s| s.run_as_group)
+        .or_else(|| psc.and_then(|p| p.run_as_group))
+}
+
+/// THE layer merge: overlay one `(container, pod)` security-context layer pair onto
+/// another. Every layer fold — `resolve_mover`'s `hardened ⊂ moverDefaults ⊂ recipe`
+/// and the controller's `inherited ⊂ explicit` pre-fold — MUST go through this
+/// function; a lone per-dimension [`merge_security_context`]/[`merge_pod_security_context`]
+/// reintroduces cross-dimension identity shadowing.
+///
+/// Two steps:
+/// 1. Field-wise merge per dimension (the exhaustive-literal primitives above).
+/// 2. **Identity promotion to canonical form**: the kubelet resolves the effective
+///    UID/GID as `container ?? pod` ACROSS the two dimensions, so a lower layer's
+///    container-level `runAsUser` would silently shadow a higher layer's pod-level one —
+///    inverting the layer ladder (the matter-server bug). The merged pair therefore
+///    keeps its container context, when one exists, carrying the pair's **effective**
+///    UID/GID: the `over` layer's pinned identity wins, else the base's (hoisted from
+///    the pod level when that's where the winning layer wrote it). When no layer
+///    supplied a container context there is nothing to shadow, and the field-wise pod
+///    result already carries the `over` layer's identity.
+///
+/// The canonical form is what makes the merge **associative** (so the controller's
+/// pre-fold + `resolve_mover`'s fold equals a flat four-layer merge): with `E(L)` =
+/// layer `L`'s own effective UID, the merged container `runAsUser` is exactly
+/// `E(over).or(E(base))`, so any grouping of `hardened ⊂ moverDefaults ⊂ inherited ⊂
+/// explicit` resolves the identity of the **highest layer that pins one**. (A promotion
+/// keyed only on `over`'s own identity is NOT associative: once `over` is itself a
+/// merged pair, its pod-level identity — contributed by a lower layer — would be
+/// re-promoted in one grouping and not the other.) Identically for the GID. Within a
+/// single layer, container still beats pod — exactly the kubelet's own rule.
+pub fn merge_context_pair(
+    base_sc: Option<&SecurityContext>,
+    base_psc: Option<&PodSecurityContext>,
+    over_sc: Option<&SecurityContext>,
+    over_psc: Option<&PodSecurityContext>,
+) -> (Option<SecurityContext>, Option<PodSecurityContext>) {
+    let mut sc = merge_security_context_opt(base_sc, over_sc);
+    let psc = merge_pod_security_context_opt(base_psc, over_psc);
+    if let Some(merged) = sc.as_mut() {
+        // `E(over).or(E(base))`: `merged.run_as_user` already holds
+        // `over.sc.or(base.sc)`, so overriding with `E(over)` and falling through to
+        // the merged pod value yields `over.sc.or(over.psc).or(base.sc).or(base.psc)`.
+        merged.run_as_user = effective_run_as_user(over_sc, over_psc)
+            .or(merged.run_as_user)
+            .or_else(|| psc.as_ref().and_then(|p| p.run_as_user));
+        merged.run_as_group = effective_run_as_group(over_sc, over_psc)
+            .or(merged.run_as_group)
+            .or_else(|| psc.as_ref().and_then(|p| p.run_as_group));
+    }
+    (sc, psc)
+}
+
 /// The restricted-PSA-compatible **hardened** container security context (§4.11/G16):
 /// non-root, no privilege escalation, drop ALL caps, seccomp `RuntimeDefault`.
 ///

--- a/crates/api/src/common/tests.rs
+++ b/crates/api/src/common/tests.rs
@@ -502,6 +502,223 @@ fn nonroot_inherited_uid_keeps_run_as_non_root_true() {
     assert_eq!(m.security_context.run_as_non_root, Some(true));
 }
 
+// --- cross-dimension identity precedence (the moverDefaults-shadows-inherited bug) ---
+
+#[test]
+fn moverdefaults_container_uid_cannot_shadow_an_inherited_pod_level_uid() {
+    // The matter-server shape: the workload pins root at the POD level, so the
+    // inherited context (folded into the recipe layer) carries `psc.runAsUser: 0`,
+    // while the repository's moverDefaults pins `sc.runAsUser: 1000` at the
+    // CONTAINER level. The ladder says inherited beats moverDefaults, but the
+    // kubelet's effective UID is `container ?? pod` — without identity promotion
+    // the lower layer's container value shadows the higher layer's pod value and
+    // the mover silently runs as 1000.
+    let defaults = MoverDefaults {
+        security_context: Some(SecurityContext {
+            run_as_user: Some(1000),
+            run_as_group: Some(1000),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let inherited_psc = PodSecurityContext {
+        run_as_user: Some(0),
+        ..Default::default()
+    };
+    let m = resolve_mover(
+        Some(&defaults),
+        None,
+        Some(&inherited_psc),
+        None,
+        None,
+        None,
+    );
+    assert_eq!(
+        super::effective_run_as_user(Some(&m.security_context), m.pod_security_context.as_ref()),
+        Some(0),
+        "the inherited pod-level uid is the higher layer and must win the \
+         effective identity, regardless of which dimension each layer wrote"
+    );
+    // INV-1 keys on the effective UID: a root result must clear the hardened
+    // runAsNonRoot:true or the kubelet wedges the pod in CreateContainerConfigError.
+    assert_eq!(m.security_context.run_as_non_root, Some(false));
+    // And the result is still recognized as elevated → privileged gate applies.
+    assert!(requires_privilege_resolved(
+        Some(&m.security_context),
+        m.pod_security_context.as_ref(),
+        None
+    ));
+}
+
+#[test]
+fn explicit_pod_level_uid_beats_moverdefaults_container_uid() {
+    // The fully-silent variant of the same bug: no inheritance involved. A recipe
+    // that pins its identity via `mover.podSecurityContext.runAsUser` is the top
+    // layer and must win over `moverDefaults.securityContext.runAsUser`.
+    let defaults = MoverDefaults {
+        security_context: Some(SecurityContext {
+            run_as_user: Some(1000),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let recipe_psc = PodSecurityContext {
+        run_as_user: Some(2000),
+        ..Default::default()
+    };
+    let m = resolve_mover(Some(&defaults), None, Some(&recipe_psc), None, None, None);
+    assert_eq!(
+        super::effective_run_as_user(Some(&m.security_context), m.pod_security_context.as_ref()),
+        Some(2000),
+        "the recipe's pod-level uid is the top layer and must win"
+    );
+    // Non-root result: the hardened runAsNonRoot:true must survive untouched.
+    assert_eq!(m.security_context.run_as_non_root, Some(true));
+}
+
+#[test]
+fn moverdefaults_container_gid_cannot_shadow_a_recipe_pod_level_gid() {
+    // The runAsGroup analog: effective group is also `container ?? pod`, so a
+    // moverDefaults container-level gid shadows a higher layer's pod-level gid
+    // the same way.
+    let defaults = MoverDefaults {
+        security_context: Some(SecurityContext {
+            run_as_group: Some(999),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let recipe_psc = PodSecurityContext {
+        run_as_group: Some(568),
+        ..Default::default()
+    };
+    let m = resolve_mover(Some(&defaults), None, Some(&recipe_psc), None, None, None);
+    let psc = m.pod_security_context.as_ref();
+    let effective_gid = m
+        .security_context
+        .run_as_group
+        .or_else(|| psc.and_then(|p| p.run_as_group));
+    assert_eq!(
+        effective_gid,
+        Some(568),
+        "the recipe's pod-level gid is the higher layer and must win the \
+         effective group"
+    );
+}
+
+#[test]
+fn identity_promotion_never_invents_an_identity() {
+    // Layers that pin nothing must stay pinned-nothing: a moverDefaults that only
+    // tweaks non-identity fields plus an identity-free recipe must not conjure a
+    // runAsUser/runAsGroup from anywhere.
+    let defaults = MoverDefaults {
+        security_context: Some(SecurityContext {
+            read_only_root_filesystem: Some(true),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let m = resolve_mover(Some(&defaults), None, None, None, None, None);
+    assert_eq!(
+        super::effective_run_as_user(Some(&m.security_context), m.pod_security_context.as_ref()),
+        None,
+        "no layer pinned a uid, so the identity stays image-determined"
+    );
+    assert_eq!(m.security_context.run_as_group, None);
+}
+
+#[test]
+fn within_one_layer_container_uid_still_beats_pod_uid() {
+    // Intra-layer semantics are Kubernetes semantics: a single layer that sets
+    // both `sc.runAsUser: 1000` and `psc.runAsUser: 0` means uid 1000 (container
+    // wins within the layer). Promotion must respect that, not resurrect the
+    // pod-level 0.
+    let recipe_sc = SecurityContext {
+        run_as_user: Some(1000),
+        ..Default::default()
+    };
+    let recipe_psc = PodSecurityContext {
+        run_as_user: Some(0),
+        ..Default::default()
+    };
+    let m = resolve_mover(None, Some(&recipe_sc), Some(&recipe_psc), None, None, None);
+    assert_eq!(
+        super::effective_run_as_user(Some(&m.security_context), m.pod_security_context.as_ref()),
+        Some(1000),
+        "within one layer the container uid wins, exactly as the kubelet resolves it"
+    );
+}
+
+#[test]
+fn merge_context_pair_is_associative_and_resolves_the_highest_pinning_layer() {
+    // The property the controller's pre-fold (inherited ⊂ explicit) and
+    // `resolve_mover`'s fold (hardened ⊂ moverDefaults ⊂ recipe) both rely on:
+    // any grouping of the layer chain merges to the identical pair, and the
+    // effective identity is the highest layer's pinned one. This is also the
+    // guard for `inherit_verdict`'s deleted moverDefaults branch — if promotion
+    // ever regressed, a lower layer could displace an inherited uid again and
+    // this property would break.
+    let uids = [None, Some(0i64), Some(1000)];
+    let gids = [None, Some(568i64)];
+    let mut layers = Vec::new();
+    for sc_uid in uids {
+        for psc_uid in uids {
+            for sc_gid in gids {
+                for psc_gid in gids {
+                    let sc = (sc_uid.is_some() || sc_gid.is_some()).then(|| SecurityContext {
+                        run_as_user: sc_uid,
+                        run_as_group: sc_gid,
+                        ..Default::default()
+                    });
+                    let psc =
+                        (psc_uid.is_some() || psc_gid.is_some()).then(|| PodSecurityContext {
+                            run_as_user: psc_uid,
+                            run_as_group: psc_gid,
+                            ..Default::default()
+                        });
+                    layers.push((sc, psc));
+                }
+            }
+        }
+    }
+    let pair = |base: &(Option<SecurityContext>, Option<PodSecurityContext>),
+                over: &(Option<SecurityContext>, Option<PodSecurityContext>)| {
+        super::merge_context_pair(
+            base.0.as_ref(),
+            base.1.as_ref(),
+            over.0.as_ref(),
+            over.1.as_ref(),
+        )
+    };
+    let effective = |p: &(Option<SecurityContext>, Option<PodSecurityContext>)| {
+        (
+            super::effective_run_as_user(p.0.as_ref(), p.1.as_ref()),
+            super::effective_run_as_group(p.0.as_ref(), p.1.as_ref()),
+        )
+    };
+    for a in &layers {
+        for b in &layers {
+            for c in &layers {
+                let left = pair(&pair(a, b), c);
+                let right = pair(a, &pair(b, c));
+                assert_eq!(left, right, "grouping must not change the merged pair");
+                let (uid, gid) = effective(&left);
+                let (ea, eb, ec) = (effective(a), effective(b), effective(c));
+                assert_eq!(
+                    uid,
+                    ec.0.or(eb.0).or(ea.0),
+                    "effective uid must be the highest layer's pinned one"
+                );
+                assert_eq!(
+                    gid,
+                    ec.1.or(eb.1).or(ea.1),
+                    "effective gid must be the highest layer's pinned one"
+                );
+            }
+        }
+    }
+}
+
 #[test]
 fn pod_startup_deadline_defaults_to_five_minutes() {
     // The contract every reconciler relies on: unset → 5 minutes. Pinned so a careless
@@ -725,6 +942,37 @@ fn inherit_security_context_from_parses_both_variants_the_cluster_way() {
         Some(InheritSecurityContextFrom::PvcConsumer(PvcConsumerInherit { container }))
             if container.as_deref() == Some("app"),
     ));
+}
+
+#[test]
+fn inherit_security_context_from_snapshot_variant_parses_the_cluster_way() {
+    // Externally tagged `{ snapshot: {} }` — the restore-only mode that inherits the
+    // identity RECORDED on the backup (`kopiur-meta` / `Snapshot.status.recorded`)
+    // instead of reading a live pod.
+    let snap: MoverSpec = crate::testutil::from_yaml(
+        r#"
+            inheritSecurityContextFrom:
+              snapshot: {}
+            "#,
+    );
+    assert!(matches!(
+        snap.inherit_security_context_from,
+        Some(InheritSecurityContextFrom::Snapshot(SnapshotInherit {})),
+    ));
+    // Round-trips through the cluster wire shape.
+    let json = serde_json::to_value(&snap).unwrap();
+    assert!(json["inheritSecurityContextFrom"]["snapshot"].is_object());
+    let back: MoverSpec = serde_json::from_value(json).unwrap();
+    assert_eq!(snap, back);
+
+    // The YAML footgun: `snapshot:` (null) is NOT the empty sub-object — serde
+    // rejects it rather than guessing. Doc examples must write `snapshot: {}`.
+    let null_value: serde_json::Value =
+        serde_yaml::from_str("inheritSecurityContextFrom:\n  snapshot:\n").unwrap();
+    assert!(
+        serde_json::from_value::<MoverSpec>(null_value).is_err(),
+        "a null `snapshot:` must be rejected, not silently treated as `snapshot: {{}}`"
+    );
 }
 
 // --- §12 mover Job TTL precedence (recipe over default over built-in) ---

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -24,6 +24,7 @@ pub mod identity;
 pub mod invariants;
 pub mod jitter;
 pub mod preflight;
+pub mod recorded;
 pub mod retention;
 pub mod schema;
 pub mod secctx_compat;
@@ -39,8 +40,9 @@ pub use common::{
     CacheDefaults, CacheVolumeMode, CronSpec, DeletionPolicy, IdentityDefaults,
     InheritSecurityContextFrom, MoverDefaults, NamespaceDeletePolicy, ObjectRef, PhaseLabel,
     PodSelector, PolicyRef, PvcConsumerInherit, ResolvedMover, SourceColocation,
-    SourceColocationMode, effective_run_as_user, hardened_security_context,
-    merge_pod_security_context, merge_resources, merge_security_context, resolve_mover,
+    SourceColocationMode, effective_run_as_group, effective_run_as_user, hardened_security_context,
+    merge_context_pair, merge_pod_security_context, merge_resources, merge_security_context,
+    resolve_mover,
 };
 pub use maintenance::{
     LeaseAction, Maintenance, MaintenanceSchedule, MaintenanceSpec, MaintenanceStatus,
@@ -82,6 +84,10 @@ pub use identity::{
 pub use jitter::{offset as jitter_offset, substitute_h};
 pub use preflight::{
     PreflightCheck, PreflightInputs, PreflightSpec, eval_preflight_expr, validate_preflight_expr,
+};
+pub use recorded::{
+    KOPIUR_META_SCHEMA_V1, KOPIUR_META_TAG, MetaTagDecode, RecordedSnapshotMeta, RecordedSrc,
+    decode_meta_tag, encode_meta_tag,
 };
 pub use retention::{KeptSet, SnapshotLike, select_kept};
 pub use success_expr::{

--- a/crates/api/src/recorded.rs
+++ b/crates/api/src/recorded.rs
@@ -1,0 +1,352 @@
+//! Recorded snapshot metadata — the `kopiur-meta` kopia tag.
+//!
+//! Every produced backup records the mover identity it ran as (uid/gid/fsGroup
+//! plus its provenance) as a compact JSON value under the [`KOPIUR_META_TAG`]
+//! snapshot tag, so a later restore — possibly on a rebuilt cluster where the
+//! workload no longer exists — can reproduce the identity the data expects.
+//! The catalog scan decodes the tag back into `Snapshot.status.recorded`.
+//!
+//! ## Schema write policy
+//!
+//! Writers emit the **lowest** schema number that represents the data
+//! ([`KOPIUR_META_SCHEMA_V1`] today); the schema is bumped only for a semantic
+//! change an old reader would misinterpret, never for additive fields (readers
+//! accept unknown JSON fields). An older operator reading a newer schema
+//! degrades to recorded-absent ([`MetaTagDecode::UnsupportedSchema`]) — it never
+//! errors. This matters for shared-repository multi-cluster topologies running
+//! mixed operator versions.
+//!
+//! ## Decode is graceful, always
+//!
+//! [`decode_meta_tag`] never returns an error and never panics: the tag value is
+//! repository data, writable by anyone holding repository credentials (a foreign
+//! cluster, a NAS admin, a compromised replication peer). A malformed value must
+//! degrade to [`MetaTagDecode::Malformed`] — one aggregated per-scan count, never
+//! a poisoned catalog scan or a per-entry log line a foreign writer could
+//! amplify.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// The kopia snapshot-tag key kopiur records its metadata under. Deliberately
+/// colon-free: kopia splits `--tags` on the FIRST colon, so a colon-free key is
+/// collision-proof against the legacy `kopiur:config:<name>` tag (stored by
+/// kopia as manifest key `tag:kopiur`, value `config:<name>`) and can never trip
+/// kopia's duplicate-tag-key create failure.
+pub const KOPIUR_META_TAG: &str = "kopiur-meta";
+
+/// The current (and only) `kopiur-meta` schema version. See the module docs for
+/// the write policy: writers emit the lowest schema representing the data.
+pub const KOPIUR_META_SCHEMA_V1: i64 = 1;
+
+/// Where the recorded mover identity came from — which layer of the
+/// security-context ladder pinned the effective UID this run recorded.
+///
+/// Only [`RecordedSrc::Inherited`] means the identity actually **tracked the
+/// workload** (it was read from a live workload pod and survived the merge). A
+/// restore consuming recorded metadata keys its honesty on this: an
+/// `explicit`/`defaults` identity is reproduced faithfully but was never
+/// workload-derived.
+#[derive(Serialize, Deserialize, Clone, Copy, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RecordedSrc {
+    /// The identity was inherited from a live workload pod
+    /// (`inheritSecurityContextFrom`) and is the one the mover ran as.
+    Inherited,
+    /// The recipe's explicit `mover.securityContext`/`podSecurityContext`
+    /// pinned the identity (including the inherit-fallback case, where the
+    /// explicit context stood in for an unresolvable workload).
+    Explicit,
+    /// The identity came from lower layers (the repository's `moverDefaults`
+    /// or the hardened base), or nothing pinned one at all.
+    Defaults,
+    /// A provenance string this operator version does not know (written by a
+    /// newer kopiur). Decodes gracefully instead of poisoning a catalog scan;
+    /// never written by this version.
+    #[serde(other)]
+    Unknown,
+}
+
+/// The mover identity recorded on a kopia snapshot at backup time — the decoded
+/// value of the [`KOPIUR_META_TAG`] snapshot tag.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordedSnapshotMeta {
+    /// The `kopiur-meta` schema version this value was written under. Writers
+    /// emit the lowest schema that represents the data (currently
+    /// [`KOPIUR_META_SCHEMA_V1`]); readers reject only a schema NEWER than they
+    /// understand (degrading to recorded-absent, never an error).
+    pub schema: i64,
+    /// Which layer pinned the recorded identity. Only `inherited` means the
+    /// identity tracked the workload.
+    pub src: RecordedSrc,
+    /// The resolved effective `runAsUser` the mover ran as at backup time
+    /// (container `runAsUser`, else pod). Absent = no layer pinned a UID, so
+    /// the mover's UID was image-determined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uid: Option<i64>,
+    /// The resolved effective `runAsGroup` the mover ran as at backup time
+    /// (container `runAsGroup`, else pod). Absent = image-determined.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub gid: Option<i64>,
+    /// The resolved pod-level `fsGroup` the mover ran with (the hardened
+    /// default is `65532`). Absent = no layer set one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub fs_group: Option<i64>,
+}
+
+/// What [`decode_meta_tag`] found in a snapshot's tags map. Never an `Err`: a
+/// bad tag value is repository data and must degrade, not fail a scan.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum MetaTagDecode {
+    /// No `kopiur-meta` tag on the snapshot (pre-feature or foreign backup).
+    Absent,
+    /// A well-formed, supported-schema value.
+    Decoded(RecordedSnapshotMeta),
+    /// A well-formed value written under a schema newer than this reader
+    /// understands — degrade to recorded-absent (aggregate-count the event).
+    UnsupportedSchema {
+        /// The schema number the writer declared.
+        schema: i64,
+    },
+    /// The tag value is present but not decodable (bad JSON, missing/invalid
+    /// `schema` or `src`). Degrade to recorded-absent (aggregate-count it).
+    Malformed {
+        /// A short, bounded reason for the scan's aggregated diagnostics.
+        reason: String,
+    },
+}
+
+/// Encode recorded metadata as the compact single-line JSON value stored under
+/// the [`KOPIUR_META_TAG`] snapshot tag.
+pub fn encode_meta_tag(meta: &RecordedSnapshotMeta) -> String {
+    serde_json::to_string(meta).unwrap_or_else(|e| {
+        // Serialization of a plain scalar struct cannot fail; defensive only.
+        unreachable!("RecordedSnapshotMeta serialization failed: {e}")
+    })
+}
+
+/// Decode the [`KOPIUR_META_TAG`] value out of a snapshot `tags` map.
+///
+/// Accepts BOTH the manifest key shape kopia stores (`tag:kopiur-meta`, see
+/// [`kopiur-kopia`'s `user_tags`]) and the bare `kopiur-meta` key (already
+/// prefix-stripped, or normalized by the mover's result wire) — so every read
+/// path funnels through this one decoder regardless of which wire the entry
+/// rode. Unknown extra JSON fields are accepted (forward compatibility); a
+/// schema newer than [`KOPIUR_META_SCHEMA_V1`] degrades to
+/// [`MetaTagDecode::UnsupportedSchema`]; anything undecodable degrades to
+/// [`MetaTagDecode::Malformed`]. Never an error, never a panic.
+pub fn decode_meta_tag(tags: &BTreeMap<String, String>) -> MetaTagDecode {
+    // Prefer the raw manifest key; fall back to the bare (stripped/normalized)
+    // key. Both present and disagreeing cannot happen from kopia's own output.
+    let prefixed = format!("tag:{KOPIUR_META_TAG}");
+    let Some(value) = tags.get(&prefixed).or_else(|| tags.get(KOPIUR_META_TAG)) else {
+        return MetaTagDecode::Absent;
+    };
+    let parsed: serde_json::Value = match serde_json::from_str(value) {
+        Ok(v) => v,
+        Err(e) => {
+            return MetaTagDecode::Malformed {
+                reason: format!("invalid JSON: {e}"),
+            };
+        }
+    };
+    let Some(schema) = parsed.get("schema").and_then(serde_json::Value::as_i64) else {
+        return MetaTagDecode::Malformed {
+            reason: "missing or non-integer `schema` field".to_string(),
+        };
+    };
+    if schema > KOPIUR_META_SCHEMA_V1 {
+        return MetaTagDecode::UnsupportedSchema { schema };
+    }
+    match serde_json::from_value::<RecordedSnapshotMeta>(parsed) {
+        Ok(meta) => MetaTagDecode::Decoded(meta),
+        Err(e) => MetaTagDecode::Malformed {
+            reason: format!("schema {schema} value did not decode: {e}"),
+        },
+    }
+}
+
+/// Truncate `s` to at most `max_bytes` bytes on a `char` boundary (never
+/// panics, never splits a multi-byte character). Shared by the catalog's
+/// description cap and the mover's result-wire bound — foreign-writer-controlled
+/// strings must never 4xx a CR create or inflate the result ConfigMap.
+pub fn truncate_utf8(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(
+        src: RecordedSrc,
+        uid: Option<i64>,
+        gid: Option<i64>,
+        fs: Option<i64>,
+    ) -> RecordedSnapshotMeta {
+        RecordedSnapshotMeta {
+            schema: KOPIUR_META_SCHEMA_V1,
+            src,
+            uid,
+            gid,
+            fs_group: fs,
+        }
+    }
+
+    fn tags_with(key: &str, value: &str) -> BTreeMap<String, String> {
+        BTreeMap::from([(key.to_string(), value.to_string())])
+    }
+
+    #[test]
+    fn encode_is_compact_single_line_camel_case() {
+        let m = meta(RecordedSrc::Inherited, Some(1000), Some(1000), Some(65532));
+        let s = encode_meta_tag(&m);
+        assert!(!s.contains('\n'), "single line: {s}");
+        assert!(!s.contains(' '), "compact: {s}");
+        assert_eq!(
+            s,
+            r#"{"schema":1,"src":"inherited","uid":1000,"gid":1000,"fsGroup":65532}"#
+        );
+    }
+
+    #[test]
+    fn encode_elides_absent_optionals() {
+        let m = meta(RecordedSrc::Defaults, None, None, None);
+        assert_eq!(encode_meta_tag(&m), r#"{"schema":1,"src":"defaults"}"#);
+    }
+
+    #[test]
+    fn round_trips_through_both_key_shapes() {
+        let m = meta(RecordedSrc::Explicit, Some(3001), None, Some(3001));
+        let value = encode_meta_tag(&m);
+        // The raw manifest key shape (`tag:` prefix, kopia 0.23.1-verified).
+        let prefixed = tags_with("tag:kopiur-meta", &value);
+        assert_eq!(
+            decode_meta_tag(&prefixed),
+            MetaTagDecode::Decoded(m.clone())
+        );
+        // The bare key shape (prefix-stripped / mover-normalized wire).
+        let bare = tags_with("kopiur-meta", &value);
+        assert_eq!(decode_meta_tag(&bare), MetaTagDecode::Decoded(m));
+    }
+
+    #[test]
+    fn absent_tag_decodes_absent() {
+        assert_eq!(decode_meta_tag(&BTreeMap::new()), MetaTagDecode::Absent);
+        // Other tags present, ours absent.
+        let other = tags_with("tag:kopiur", "config:nightly");
+        assert_eq!(decode_meta_tag(&other), MetaTagDecode::Absent);
+    }
+
+    #[test]
+    fn minimal_v1_value_decodes() {
+        let t = tags_with("kopiur-meta", r#"{"schema":1,"src":"inherited"}"#);
+        assert_eq!(
+            decode_meta_tag(&t),
+            MetaTagDecode::Decoded(meta(RecordedSrc::Inherited, None, None, None))
+        );
+    }
+
+    #[test]
+    fn unknown_extra_fields_are_accepted_forward_compat() {
+        let t = tags_with(
+            "kopiur-meta",
+            r#"{"schema":1,"src":"explicit","uid":0,"futureField":{"x":1}}"#,
+        );
+        assert_eq!(
+            decode_meta_tag(&t),
+            MetaTagDecode::Decoded(meta(RecordedSrc::Explicit, Some(0), None, None))
+        );
+    }
+
+    #[test]
+    fn unknown_src_string_decodes_to_unknown_not_malformed() {
+        let t = tags_with("kopiur-meta", r#"{"schema":1,"src":"workload","uid":7}"#);
+        assert_eq!(
+            decode_meta_tag(&t),
+            MetaTagDecode::Decoded(meta(RecordedSrc::Unknown, Some(7), None, None))
+        );
+    }
+
+    #[test]
+    fn newer_schema_degrades_to_unsupported() {
+        let t = tags_with(
+            "tag:kopiur-meta",
+            r#"{"schema":2,"src":"inherited","uid":0}"#,
+        );
+        assert_eq!(
+            decode_meta_tag(&t),
+            MetaTagDecode::UnsupportedSchema { schema: 2 }
+        );
+    }
+
+    #[test]
+    fn malformed_values_degrade_with_a_reason_never_an_error() {
+        for (value, why) in [
+            ("not json at all", "bad JSON"),
+            ("{}", "missing schema"),
+            (
+                r#"{"schema":"one","src":"inherited"}"#,
+                "non-integer schema",
+            ),
+            (r#"{"schema":1}"#, "missing src"),
+            (
+                r#"{"schema":1,"src":"inherited","uid":"root"}"#,
+                "bad uid type",
+            ),
+        ] {
+            let t = tags_with("kopiur-meta", value);
+            match decode_meta_tag(&t) {
+                MetaTagDecode::Malformed { reason } => {
+                    assert!(!reason.is_empty(), "{why}: reason must be actionable");
+                }
+                other => panic!("{why}: expected Malformed, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn src_serializes_lowercase_and_unknown_round_trips_as_a_string() {
+        assert_eq!(
+            serde_json::to_value(RecordedSrc::Inherited).unwrap(),
+            "inherited"
+        );
+        assert_eq!(
+            serde_json::to_value(RecordedSrc::Explicit).unwrap(),
+            "explicit"
+        );
+        assert_eq!(
+            serde_json::to_value(RecordedSrc::Defaults).unwrap(),
+            "defaults"
+        );
+        // A decoded-Unknown stored on status must survive the CRD schema, so it
+        // serializes as its own canonical string.
+        assert_eq!(
+            serde_json::to_value(RecordedSrc::Unknown).unwrap(),
+            "unknown"
+        );
+        let back: RecordedSrc = serde_json::from_value(serde_json::json!("unknown")).unwrap();
+        assert_eq!(back, RecordedSrc::Unknown);
+    }
+
+    #[test]
+    fn truncate_utf8_is_char_boundary_safe() {
+        assert_eq!(truncate_utf8("hello", 10), "hello");
+        assert_eq!(truncate_utf8("hello", 3), "hel");
+        // 'é' is 2 bytes; cutting mid-char backs off to the boundary.
+        let s = "aé"; // bytes: a=1, é=2 → len 3
+        assert_eq!(truncate_utf8(s, 2), "a");
+        assert_eq!(truncate_utf8(s, 3), "aé");
+        assert_eq!(truncate_utf8("日本語", 4), "日"); // 3-byte chars
+        assert_eq!(truncate_utf8("", 0), "");
+    }
+}

--- a/crates/api/src/restore.rs
+++ b/crates/api/src/restore.rs
@@ -851,6 +851,52 @@ mover:
     }
 
     #[test]
+    fn restore_crd_schema_carries_the_snapshot_inherit_variant() {
+        // `Restore::crd()`/`SnapshotPolicy::crd()` smoke for the new externally-tagged
+        // variant: schema generation must not panic, and the Restore schema must
+        // surface `inheritSecurityContextFrom.snapshot` as an object property (the
+        // SnapshotPolicy schema carries it too — the restriction is webhook-level,
+        // not structural).
+        let crd = Restore::crd();
+        let json = serde_json::to_value(&crd).expect("serialize CRD");
+        let inherit = &json["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["mover"]["properties"]["inheritSecurityContextFrom"]["properties"];
+        assert!(
+            inherit["snapshot"].is_object(),
+            "inheritSecurityContextFrom must carry the `snapshot` variant; got {inherit}"
+        );
+        assert_eq!(inherit["snapshot"]["type"], "object");
+        // The other variants are untouched.
+        assert!(inherit["workloadSelector"].is_object());
+        assert!(inherit["pvcConsumer"].is_object());
+        let _ = crate::SnapshotPolicy::crd();
+    }
+
+    #[test]
+    fn restore_snapshot_inherit_mover_roundtrip() {
+        // The restore-only recorded-identity inherit mode, parsed the cluster's way.
+        use crate::common::{InheritSecurityContextFrom, SnapshotInherit};
+        let yaml = r#"
+source: { snapshotRef: { name: app-data-backup } }
+target: { pvcRef: { name: app-data-restored } }
+mover:
+  inheritSecurityContextFrom:
+    snapshot: {}
+"#;
+        let spec: RestoreSpec = from_yaml(yaml);
+        assert!(matches!(
+            spec.mover
+                .as_ref()
+                .and_then(|m| m.inherit_security_context_from.as_ref()),
+            Some(InheritSecurityContextFrom::Snapshot(SnapshotInherit {})),
+        ));
+        let json = serde_json::to_value(&spec).expect("serialize");
+        assert!(json["mover"]["inheritSecurityContextFrom"]["snapshot"].is_object());
+        let reparsed: RestoreSpec = serde_json::from_value(json).expect("reparse");
+        assert_eq!(spec, reparsed);
+    }
+
+    #[test]
     fn restore_source_unknown_variant_is_rejected() {
         let value: serde_json::Value = serde_yaml::from_str("snapshotUrl:\n  url: x\n").unwrap();
         assert!(serde_json::from_value::<RestoreSource>(value).is_err());

--- a/crates/api/src/snapshot.rs
+++ b/crates/api/src/snapshot.rs
@@ -36,7 +36,12 @@ pub struct SnapshotSpec {
     /// The `SnapshotPolicy` recipe to run; absent for `discovered` backups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub policy_ref: Option<PolicyRef>,
-    /// Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).
+    /// Free-form tags attached to the kopia snapshot manifest itself
+    /// (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the
+    /// repository, independent of this CR. Keys must be non-empty, colon-free
+    /// (kopia splits on the first colon), and must not start with the reserved
+    /// `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes
+    /// (webhook-enforced).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tags: Option<BTreeMap<String, String>>,
     /// Mover Job retry and deadline limits for this run.
@@ -232,6 +237,14 @@ pub struct SnapshotStatus {
     /// Post-run cleanup bookkeeping, so each cleanup runs at most once per Snapshot.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cleanup: Option<CleanupStatus>,
+    /// The mover identity recorded on the kopia snapshot itself (the
+    /// `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran
+    /// as, plus its provenance. Produced runs stamp this at launch (from the
+    /// same value written into the tag); discovered rows decode it from the tag
+    /// during the catalog scan. Absent for pre-feature snapshots, foreign
+    /// backups without the tag, or a tag this operator version cannot decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub recorded: Option<crate::recorded::RecordedSnapshotMeta>,
 }
 
 /// One-shot markers for the cleanups a terminal `Snapshot` performs, mirroring
@@ -307,6 +320,12 @@ pub struct SnapshotInfo {
     pub kopia_snapshot_id: String,
     /// The `username@hostname:path` identity recorded for this snapshot.
     pub identity: ResolvedIdentity,
+    /// The kopia snapshot description (`snapshot create --description`), when
+    /// one is recorded and non-empty. For discovered rows this is copied from
+    /// the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) —
+    /// the value is foreign-writer-controlled and must never fail the CR write.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
 }
 
 /// Timing of a snapshot run.
@@ -711,5 +730,63 @@ logTail: "Snapshot created: k1f1ec0a8"
         let json = serde_json::to_value(&status).unwrap();
         let reparsed: SnapshotStatus = serde_json::from_value(json).unwrap();
         assert_eq!(status, reparsed);
+    }
+
+    #[test]
+    fn backup_status_recorded_and_description_roundtrip() {
+        use crate::recorded::{RecordedSnapshotMeta, RecordedSrc};
+        let yaml = r#"
+phase: Succeeded
+snapshot:
+  kopiaSnapshotID: k1
+  identity:
+    username: u
+    hostname: h
+    sourcePath: /data
+  description: "pre-upgrade snapshot"
+recorded:
+  schema: 1
+  src: inherited
+  uid: 3001
+  gid: 3001
+  fsGroup: 65532
+"#;
+        let status: SnapshotStatus = from_yaml(yaml);
+        assert_eq!(
+            status.recorded,
+            Some(RecordedSnapshotMeta {
+                schema: 1,
+                src: RecordedSrc::Inherited,
+                uid: Some(3001),
+                gid: Some(3001),
+                fs_group: Some(65532),
+            })
+        );
+        assert_eq!(
+            status.snapshot.as_ref().unwrap().description.as_deref(),
+            Some("pre-upgrade snapshot")
+        );
+        let json = serde_json::to_value(&status).unwrap();
+        assert_eq!(json["recorded"]["fsGroup"], 65532, "camelCase wire key");
+        let reparsed: SnapshotStatus = serde_json::from_value(json).unwrap();
+        assert_eq!(status, reparsed);
+
+        // Absent stays absent — no null/{} noise on old rows.
+        let bare: SnapshotStatus = from_yaml("phase: Succeeded\n");
+        assert!(bare.recorded.is_none());
+        let wire = serde_json::to_value(&bare).unwrap();
+        assert!(wire.get("recorded").is_none());
+    }
+
+    #[test]
+    fn stored_recorded_with_future_src_decodes_gracefully() {
+        // A newer operator wrote `src: workload` onto status; this version's
+        // typed watcher must decode it (graceful-decode convention), not error.
+        use crate::recorded::RecordedSrc;
+        let status: SnapshotStatus =
+            from_yaml("recorded:\n  schema: 1\n  src: workload\n  uid: 7\n");
+        let rec = status.recorded.expect("decoded");
+        assert_eq!(rec.src, RecordedSrc::Unknown);
+        assert_eq!(rec.uid, Some(7));
     }
 }

--- a/crates/api/src/validate/mod.rs
+++ b/crates/api/src/validate/mod.rs
@@ -481,6 +481,29 @@ pub(crate) fn forbid_pvc_consumer(
     Ok(())
 }
 
+/// `inheritSecurityContextFrom.snapshot` reproduces the identity RECORDED on a backup
+/// (`Snapshot.status.recorded`), so it only makes sense where a snapshot is being consumed —
+/// a `Restore`. A backup's identity comes from the live workload and maintenance touches no
+/// snapshot at all, so those kinds reject the variant at admission rather than fail (or,
+/// worse, silently no-op) at runtime. `field_prefix` names the owning kind (e.g.
+/// `"snapshotPolicy"`/`"maintenance"`), `reason` is the kind-appropriate what/why/fix.
+pub(crate) fn forbid_snapshot_inherit(
+    mover: &MoverSpec,
+    field_prefix: &str,
+    reason: &str,
+) -> ValidationResult {
+    if matches!(
+        mover.inherit_security_context_from,
+        Some(crate::common::InheritSecurityContextFrom::Snapshot(_))
+    ) {
+        return Err(ValidationError::InvalidFieldValue {
+            field: format!("{field_prefix}.mover.inheritSecurityContextFrom.snapshot"),
+            reason: reason.to_string(),
+        });
+    }
+    Ok(())
+}
+
 /// Reject `inheritSecurityContextFrom` **entirely**, for a kind whose reconciler never resolves
 /// it. Stronger than [`forbid_pvc_consumer`]: that rejects one variant on a kind that *does*
 /// honor the other, this rejects the whole field on a kind that honors none of it.

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -910,6 +910,15 @@ pub fn validate_maintenance(spec: &MaintenanceSpec) -> Vec<ValidationError> {
         ) {
             errs.push(e);
         }
+        if let Err(e) = forbid_snapshot_inherit(
+            m,
+            "maintenance",
+            "a maintenance mover operates on the repository, not on a snapshot's data, so \
+             there is no recorded identity to reproduce; `snapshot` is restore-only. Use an \
+             explicit mover.securityContext instead.",
+        ) {
+            errs.push(e);
+        }
         if let Err(e) = validate_mover(m, "Maintenance mover") {
             errs.push(e);
         }

--- a/crates/api/src/validate/restore.rs
+++ b/crates/api/src/validate/restore.rs
@@ -100,17 +100,28 @@ pub fn validate_restore(spec: &RestoreSpec) -> ValidationResult {
             });
         }
         RestoreTarget::Populator(_) => {
-            if let Some(m) = &spec.mover
-                && m.inherit_security_context_from.is_some()
-            {
-                return Err(ValidationError::InvalidFieldValue {
-                    field: "restore.mover.inheritSecurityContextFrom".to_string(),
-                    reason: "is not allowed with target.populator: no workload pod exists at \
-                             provision time to inherit a security context from; set \
-                             mover.securityContext explicitly or rely on the repository's \
-                             moverDefaults instead"
-                        .to_string(),
-                });
+            // Exhaustive over the inherit variant: the live-pod modes cannot work
+            // (no workload pod exists at provision time), but `snapshot` reads the
+            // backup's RECORDED identity in the controller before the Job — it needs
+            // no live pod, so it is deliberately ALLOWED with a populator target.
+            if let Some(m) = &spec.mover {
+                use crate::common::InheritSecurityContextFrom;
+                match &m.inherit_security_context_from {
+                    None | Some(InheritSecurityContextFrom::Snapshot(_)) => {}
+                    Some(InheritSecurityContextFrom::WorkloadSelector(_))
+                    | Some(InheritSecurityContextFrom::PvcConsumer(_)) => {
+                        return Err(ValidationError::InvalidFieldValue {
+                            field: "restore.mover.inheritSecurityContextFrom".to_string(),
+                            reason: "is not allowed with target.populator: no workload pod \
+                                     exists at provision time to inherit a security context \
+                                     from. Set mover.securityContext explicitly, use \
+                                     inheritSecurityContextFrom: { snapshot: {} } (the \
+                                     backup's recorded identity — needs no live pod), or rely \
+                                     on the repository's moverDefaults instead"
+                                .to_string(),
+                        });
+                    }
+                }
             }
         }
         RestoreTarget::Pvc(_) | RestoreTarget::PvcRef(_) => {}

--- a/crates/api/src/validate/snapshot.rs
+++ b/crates/api/src/validate/snapshot.rs
@@ -87,10 +87,20 @@ pub fn validate_backup_config(spec: &SnapshotPolicySpec) -> Vec<ValidationError>
                 .to_string(),
         });
     }
-    if let Some(m) = &spec.mover
-        && let Err(e) = validate_mover(m, "SnapshotPolicy mover")
-    {
-        errs.push(e);
+    if let Some(m) = &spec.mover {
+        // `inheritSecurityContextFrom.snapshot` replays a backup's RECORDED identity;
+        // a backup has no recorded identity to replay — it is the run that records one.
+        if let Err(e) = forbid_snapshot_inherit(
+            m,
+            "snapshotPolicy",
+            "a backup mover's identity is read from the live workload \
+             (pvcConsumer/workloadSelector), not from a snapshot; `snapshot` is restore-only",
+        ) {
+            errs.push(e);
+        }
+        if let Err(e) = validate_mover(m, "SnapshotPolicy mover") {
+            errs.push(e);
+        }
     }
     // `snapshot create --upload-limit-mb` (M4 flag sweep, issue #216): a count
     // knob, must be at least 1 (0 or negative disables the flag's own purpose).
@@ -552,6 +562,91 @@ pub fn validate_backup(spec: &SnapshotSpec, origin: Origin) -> Vec<ValidationErr
         && let Err(e) = validate_failure_policy(fp, "Snapshot")
     {
         errs.push(e);
+    }
+    errs.extend(validate_snapshot_tags(spec.tags.as_ref()));
+    errs
+}
+
+/// At most this many user tags per `Snapshot` — unbounded user tags would
+/// inflate every kopia manifest AND the catalog result wire.
+pub const MAX_SNAPSHOT_TAGS: usize = 10;
+/// Longest admissible user tag key, in bytes.
+pub const MAX_SNAPSHOT_TAG_KEY_LEN: usize = 63;
+/// Longest admissible user tag value, in bytes.
+pub const MAX_SNAPSHOT_TAG_VALUE_LEN: usize = 256;
+
+/// Why one `spec.tags` key/value pair is invalid, or `None` when it is clean.
+///
+/// One predicate, two callers (the shared-validator pattern): the admission
+/// validator ([`validate_snapshot_tags`]) rejects NEW objects with these
+/// reasons, and the controller's build path defensively SKIPS (warn, never
+/// fail) the same keys on already-stored pre-feature objects.
+pub fn snapshot_tag_error(key: &str, value: &str) -> Option<String> {
+    if key.is_empty() {
+        return Some("tag keys must be non-empty; remove the empty key".to_string());
+    }
+    if key.contains(':') {
+        return Some(format!(
+            "tag key {key:?} contains a colon — kopia splits each `--tags` argument on the \
+             first colon, so this key would be stored mangled (everything after the colon \
+             becomes part of the value) and can collide with kopiur's reserved `kopiur:config` \
+             tag, which makes kopia fail the snapshot create with a duplicate-tag error. Use a \
+             colon-free key."
+        ));
+    }
+    if key.starts_with("kopiur") {
+        return Some(format!(
+            "tag key {key:?} uses the reserved `kopiur` prefix — kopiur writes its own tags \
+             there (`kopiur:config`, `kopiur-meta`) and a user tag under that prefix would \
+             collide with or spoof them. Pick a key that does not start with `kopiur`."
+        ));
+    }
+    if key.len() > MAX_SNAPSHOT_TAG_KEY_LEN {
+        return Some(format!(
+            "tag key is {} bytes; keys are limited to {MAX_SNAPSHOT_TAG_KEY_LEN} bytes — use a \
+             shorter key",
+            key.len()
+        ));
+    }
+    if value.len() > MAX_SNAPSHOT_TAG_VALUE_LEN {
+        return Some(format!(
+            "tag value is {} bytes; values are limited to {MAX_SNAPSHOT_TAG_VALUE_LEN} bytes — \
+             every tag is stored on the kopia manifest and read back by every catalog scan, so \
+             unbounded values inflate the repository and the scan wire. Use a shorter value.",
+            value.len()
+        ));
+    }
+    None
+}
+
+/// Validate `Snapshot.spec.tags` (admission): every key/value must pass
+/// [`snapshot_tag_error`] and the map is bounded to [`MAX_SNAPSHOT_TAGS`]
+/// entries. Accumulates every problem, one error per offending tag.
+pub fn validate_snapshot_tags(
+    tags: Option<&std::collections::BTreeMap<String, String>>,
+) -> Vec<ValidationError> {
+    let mut errs = Vec::new();
+    let Some(tags) = tags else {
+        return errs;
+    };
+    if tags.len() > MAX_SNAPSHOT_TAGS {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: "spec.tags".to_string(),
+            reason: format!(
+                "{} tags; at most {MAX_SNAPSHOT_TAGS} user tags are allowed per Snapshot — \
+                 every tag is stored on the kopia manifest and read back by every catalog \
+                 scan. Remove tags until at most {MAX_SNAPSHOT_TAGS} remain.",
+                tags.len()
+            ),
+        });
+    }
+    for (key, value) in tags {
+        if let Some(reason) = snapshot_tag_error(key, value) {
+            errs.push(ValidationError::InvalidFieldValue {
+                field: format!("spec.tags[{key:?}]"),
+                reason,
+            });
+        }
     }
     errs
 }

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -1151,6 +1151,190 @@ fn pvc_consumer_is_forbidden_on_non_backup_kinds() {
     assert!(forbid_pvc_consumer(&MoverSpec::default(), "maintenance", "x").is_ok());
 }
 
+// --- the `snapshot` inherit variant is restore-only (variant × kind matrix) ---
+
+/// Helper: a `MoverSpec` carrying one `inheritSecurityContextFrom` variant.
+fn mover_with_inherit(i: crate::common::InheritSecurityContextFrom) -> crate::common::MoverSpec {
+    crate::common::MoverSpec {
+        inherit_security_context_from: Some(i),
+        ..Default::default()
+    }
+}
+
+#[test]
+fn forbid_snapshot_inherit_rejects_only_the_snapshot_variant() {
+    use crate::common::{
+        InheritSecurityContextFrom, MoverSpec, PodSelector, PvcConsumerInherit, SnapshotInherit,
+    };
+
+    let err = forbid_snapshot_inherit(
+        &mover_with_inherit(InheritSecurityContextFrom::Snapshot(SnapshotInherit {})),
+        "snapshotPolicy",
+        "restore-only; use pvcConsumer/workloadSelector.",
+    )
+    .unwrap_err();
+    match err {
+        ValidationError::InvalidFieldValue { field, reason } => {
+            assert_eq!(
+                field,
+                "snapshotPolicy.mover.inheritSecurityContextFrom.snapshot"
+            );
+            assert!(reason.contains("restore-only"), "{reason}");
+        }
+        other => panic!("expected InvalidFieldValue, got {other:?}"),
+    }
+
+    // Every other shape passes through untouched.
+    for ok in [
+        mover_with_inherit(InheritSecurityContextFrom::WorkloadSelector(PodSelector {
+            pod_selector: Default::default(),
+            container: None,
+        })),
+        mover_with_inherit(InheritSecurityContextFrom::PvcConsumer(
+            PvcConsumerInherit::default(),
+        )),
+        MoverSpec::default(),
+    ] {
+        assert!(forbid_snapshot_inherit(&ok, "maintenance", "x").is_ok());
+    }
+}
+
+#[test]
+fn snapshot_inherit_is_forbidden_on_snapshot_policy() {
+    use crate::common::{InheritSecurityContextFrom, SnapshotInherit};
+    use crate::snapshot_policy::SnapshotPolicySpec;
+
+    let mut spec: SnapshotPolicySpec = crate::testutil::from_yaml(
+        "repository: { kind: Repository, name: r }\n\
+         sources: [ { pvc: { name: data } } ]\n",
+    );
+    assert!(validate_backup_config(&spec).is_empty(), "baseline valid");
+    spec.mover = Some(mover_with_inherit(InheritSecurityContextFrom::Snapshot(
+        SnapshotInherit {},
+    )));
+    let errs = validate_backup_config(&spec);
+    let msg = errs
+        .iter()
+        .find(|e| {
+            matches!(e, ValidationError::InvalidFieldValue { field, .. }
+                if field == "snapshotPolicy.mover.inheritSecurityContextFrom.snapshot")
+        })
+        .map(|e| e.to_string())
+        .unwrap_or_else(|| panic!("expected the snapshot-inherit rejection, got: {errs:?}"));
+    // What/why/fix: a backup reads the LIVE workload; `snapshot` is restore-only.
+    assert!(msg.contains("live workload"), "{msg}");
+    assert!(msg.contains("restore-only"), "{msg}");
+}
+
+#[test]
+fn snapshot_inherit_is_forbidden_on_maintenance() {
+    use crate::common::{InheritSecurityContextFrom, SnapshotInherit};
+    use crate::maintenance::{MaintenanceSpec, Ownership};
+
+    let mut spec = MaintenanceSpec {
+        repository: repo_ref(RepositoryKind::Repository, None),
+        schedule: crate::maintenance::default_maintenance_schedule(),
+        ownership: Ownership {
+            owner: "kopiur/prod/nas".into(),
+            owner_aliases: Vec::new(),
+            takeover_policy: Default::default(),
+        },
+        mover: None,
+        failure_policy: None,
+        credential_projection: None,
+    };
+    assert!(validate_maintenance(&spec).is_empty(), "baseline valid");
+    spec.mover = Some(mover_with_inherit(InheritSecurityContextFrom::Snapshot(
+        SnapshotInherit {},
+    )));
+    let errs = validate_maintenance(&spec);
+    let named = errs.iter().any(|e| {
+        matches!(e, ValidationError::InvalidFieldValue { field, .. }
+            if field == "maintenance.mover.inheritSecurityContextFrom.snapshot")
+    });
+    assert!(
+        named,
+        "expected the snapshot-inherit rejection, got: {errs:?}"
+    );
+}
+
+#[test]
+fn snapshot_inherit_on_replication_is_covered_by_the_whole_field_rejection() {
+    use crate::common::{InheritSecurityContextFrom, SnapshotInherit};
+
+    // RepositoryReplication rejects `inheritSecurityContextFrom` ENTIRELY
+    // (`forbid_inherit`), so the new variant is rejected without a per-variant rule
+    // — verified here so the coverage cannot silently regress if that ever changes.
+    let err = super::forbid_inherit(
+        &mover_with_inherit(InheritSecurityContextFrom::Snapshot(SnapshotInherit {})),
+        "RepositoryReplication spec",
+        "is not honored by a replication mover",
+    )
+    .expect_err("the snapshot variant must be caught by the whole-field rejection");
+    assert!(
+        err.to_string().contains("inheritSecurityContextFrom"),
+        "{err}"
+    );
+}
+
+#[test]
+fn snapshot_inherit_is_valid_on_restore_with_every_source() {
+    use crate::restore::RestoreSpec;
+
+    // All admission-time source shapes accept the variant: `snapshotRef` reads the
+    // CR directly; `fromPolicy`/`identity` (with or without a pinned snapshotID)
+    // resolve recorded meta via the controller's CR-catalog search.
+    let sources = [
+        "source: { snapshotRef: { name: b } }\nrepository: { kind: Repository, name: r }\n",
+        "source: { fromPolicy: { name: pg } }\nrepository: { kind: Repository, name: r }\n",
+        "source: { identity: { username: u, hostname: h } }\n\
+         repository: { kind: Repository, name: r }\n",
+        "source: { identity: { username: u, hostname: h, snapshotID: k1 } }\n\
+         repository: { kind: Repository, name: r }\n",
+    ];
+    for src in sources {
+        let yaml = format!(
+            "{src}target: {{ pvcRef: {{ name: restored }} }}\n\
+             mover: {{ inheritSecurityContextFrom: {{ snapshot: {{}} }} }}\n"
+        );
+        let spec: RestoreSpec = crate::testutil::from_yaml(&yaml);
+        assert!(
+            validate_restore(&spec).is_ok(),
+            "snapshot inherit must be valid with source: {src}"
+        );
+        assert!(validate_restore_spec(&spec).is_empty(), "{src}");
+    }
+}
+
+#[test]
+fn snapshot_inherit_is_allowed_with_populator_but_live_pod_variants_are_not() {
+    use crate::restore::RestoreSpec;
+
+    // `snapshot` needs no live pod at provision time — the recorded identity is
+    // resolved in the controller before the Job — so it is the ONE inherit mode
+    // valid with `target.populator` (deliberate carve-out).
+    let ok: RestoreSpec = crate::testutil::from_yaml(
+        "source: { fromPolicy: { name: pg } }\n\
+         target: { populator: {} }\n\
+         mover: { inheritSecurityContextFrom: { snapshot: {} } }\n",
+    );
+    assert!(validate_restore(&ok).is_ok());
+
+    // The live-pod variant keeps its populator rejection.
+    let selector: RestoreSpec = crate::testutil::from_yaml(
+        "source: { fromPolicy: { name: pg } }\n\
+         target: { populator: {} }\n\
+         mover: { inheritSecurityContextFrom: { workloadSelector: { podSelector: { \
+         matchLabels: { app: pg } } } } }\n",
+    );
+    let err = validate_restore(&selector).unwrap_err();
+    assert!(
+        matches!(&err, ValidationError::InvalidFieldValue { field, .. }
+            if field == "restore.mover.inheritSecurityContextFrom"),
+        "got {err:?}"
+    );
+}
+
 // --- validate_mover: inheritSecurityContextFrom COMBINES with explicit (container / pod) ---
 
 /// `inheritSecurityContextFrom` alongside an explicit `securityContext`/`podSecurityContext`
@@ -1408,6 +1592,120 @@ fn backup_aggregate_rejects_discovered_delete() {
         errs[0],
         ValidationError::DiscoveredMustRetain { .. }
     ));
+}
+
+// --- validate_snapshot_tags ---
+
+fn tags_of(pairs: &[(&str, &str)]) -> BTreeMap<String, String> {
+    pairs
+        .iter()
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect()
+}
+
+#[test]
+fn snapshot_tags_clean_pass_and_absent_pass() {
+    assert!(validate_snapshot_tags(None).is_empty());
+    let tags = tags_of(&[("reason", "pre-upgrade"), ("team", "billing")]);
+    assert!(validate_snapshot_tags(Some(&tags)).is_empty());
+}
+
+#[test]
+fn snapshot_tags_reject_empty_key() {
+    let tags = tags_of(&[("", "v")]);
+    let errs = validate_snapshot_tags(Some(&tags));
+    assert_eq!(errs.len(), 1);
+    let msg = errs[0].to_string();
+    assert!(msg.contains("spec.tags"), "{msg}");
+    assert!(msg.contains("non-empty"), "{msg}");
+}
+
+#[test]
+fn snapshot_tags_reject_colon_keys_citing_the_first_colon_split() {
+    let tags = tags_of(&[("env:prod", "v")]);
+    let errs = validate_snapshot_tags(Some(&tags));
+    assert_eq!(errs.len(), 1);
+    let msg = errs[0].to_string();
+    // What (the key), why (kopia's first-colon split + the duplicate-key create
+    // failure it can trip), fix (colon-free key).
+    assert!(msg.contains("env:prod"), "{msg}");
+    assert!(msg.contains("first colon"), "{msg}");
+    assert!(msg.contains("duplicate"), "{msg}");
+    assert!(msg.contains("colon-free"), "{msg}");
+}
+
+#[test]
+fn snapshot_tags_reject_reserved_kopiur_prefix() {
+    for key in ["kopiur", "kopiur-meta", "kopiurfoo"] {
+        let tags = tags_of(&[(key, "v")]);
+        let errs = validate_snapshot_tags(Some(&tags));
+        assert_eq!(errs.len(), 1, "{key} must be rejected");
+        let msg = errs[0].to_string();
+        assert!(msg.contains("reserved"), "{msg}");
+        assert!(msg.contains(key), "{msg}");
+    }
+}
+
+#[test]
+fn snapshot_tags_reject_oversize_key_and_value() {
+    let long_key = "k".repeat(MAX_SNAPSHOT_TAG_KEY_LEN + 1);
+    let errs = validate_snapshot_tags(Some(&tags_of(&[(long_key.as_str(), "v")])));
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].to_string().contains("63"), "{}", errs[0]);
+
+    let long_value = "v".repeat(MAX_SNAPSHOT_TAG_VALUE_LEN + 1);
+    let errs = validate_snapshot_tags(Some(&tags_of(&[("k", long_value.as_str())])));
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].to_string().contains("256"), "{}", errs[0]);
+
+    // Exactly at the bounds is fine.
+    let max_key = "k".repeat(MAX_SNAPSHOT_TAG_KEY_LEN);
+    let max_value = "v".repeat(MAX_SNAPSHOT_TAG_VALUE_LEN);
+    assert!(
+        validate_snapshot_tags(Some(&tags_of(&[(max_key.as_str(), max_value.as_str())])))
+            .is_empty()
+    );
+}
+
+#[test]
+fn snapshot_tags_bound_the_count() {
+    let pairs: Vec<(String, String)> = (0..=MAX_SNAPSHOT_TAGS)
+        .map(|i| (format!("k{i:02}"), "v".to_string()))
+        .collect();
+    let tags: BTreeMap<String, String> = pairs.into_iter().collect();
+    let errs = validate_snapshot_tags(Some(&tags));
+    assert_eq!(errs.len(), 1);
+    assert!(errs[0].to_string().contains("10"), "{}", errs[0]);
+
+    let ok: BTreeMap<String, String> = (0..MAX_SNAPSHOT_TAGS)
+        .map(|i| (format!("k{i:02}"), "v".to_string()))
+        .collect();
+    assert!(validate_snapshot_tags(Some(&ok)).is_empty());
+}
+
+#[test]
+fn snapshot_tags_accumulate_every_problem() {
+    let tags = tags_of(&[("a:b", "v"), ("kopiur-x", "v")]);
+    let errs = validate_snapshot_tags(Some(&tags));
+    assert_eq!(errs.len(), 2, "{errs:?}");
+}
+
+#[test]
+fn backup_aggregate_rejects_reserved_tags() {
+    let spec = SnapshotSpec {
+        policy_ref: None,
+        tags: Some(tags_of(&[("kopiur-meta", "{}")])),
+        failure_policy: None,
+        description: None,
+        deletion_policy: None,
+        on_schedule_delete: None,
+        pin: false,
+    };
+    let errs = validate_backup(&spec, Origin::Manual);
+    assert!(
+        errs.iter().any(|e| e.to_string().contains("reserved")),
+        "{errs:?}"
+    );
 }
 
 // --- validate_backup_on_schedule_delete ---

--- a/crates/cli/src/cmd/snapshots.rs
+++ b/crates/cli/src/cmd/snapshots.rs
@@ -124,9 +124,45 @@ pub fn headers(all_namespaces: bool, wide: bool) -> Vec<&'static str> {
         "AGE",
     ]);
     if wide {
-        h.extend(["IDENTITY", "DELETION-POLICY", "PINNED"]);
+        h.extend([
+            "IDENTITY",
+            "DELETION-POLICY",
+            "PINNED",
+            "RECORDED",
+            "DESCRIPTION",
+        ]);
     }
     h
+}
+
+/// Render `status.recorded` as a compact `uid:gid` cell (`-` per missing part;
+/// the whole cell empty when nothing was recorded). The recorded identity is
+/// what a Phase-3 restore will reproduce, so surfacing it here is what makes
+/// the feature visible from the plugin at all.
+fn recorded_cell(status: Option<&kopiur_api::SnapshotStatus>) -> String {
+    match status.and_then(|s| s.recorded.as_ref()) {
+        None => EMPTY_CELL.into(),
+        Some(rec) => {
+            let part = |v: Option<i64>| v.map_or_else(|| EMPTY_CELL.into(), |n| n.to_string());
+            format!("{}:{}", part(rec.uid), part(rec.gid))
+        }
+    }
+}
+
+/// The kopia description, truncated for the table (full value via `-o yaml`).
+fn description_cell(status: Option<&kopiur_api::SnapshotStatus>) -> String {
+    const MAX: usize = 40;
+    match status
+        .and_then(|s| s.snapshot.as_ref())
+        .and_then(|i| i.description.as_deref())
+    {
+        None => EMPTY_CELL.into(),
+        Some(d) if d.chars().count() <= MAX => d.to_string(),
+        Some(d) => {
+            let cut: String = d.chars().take(MAX - 1).collect();
+            format!("{cut}…")
+        }
+    }
 }
 
 fn origin_cell(origin: Option<Origin>) -> String {
@@ -223,7 +259,13 @@ pub fn row(snap: &Snapshot, now: DateTime<Utc>, all_namespaces: bool, wide: bool
         let pinned = status
             .and_then(|s| s.pinned)
             .map_or_else(|| EMPTY_CELL.into(), |p| p.to_string());
-        cells.extend([identity, deletion, pinned]);
+        cells.extend([
+            identity,
+            deletion,
+            pinned,
+            recorded_cell(status),
+            description_cell(status),
+        ]);
     }
     cells
 }
@@ -487,14 +529,37 @@ status:
     }
 
     #[test]
-    fn wide_row_appends_identity_deletion_policy_and_pin() {
+    fn wide_row_appends_identity_deletion_policy_pin_recorded_and_description() {
         let snap: Snapshot = from_yaml(SUCCEEDED_SNAPSHOT);
         let now = Utc.with_ymd_and_hms(2026, 6, 11, 12, 0, 0).unwrap();
         let cells = row(&snap, now, true, true);
         // -A inserts NAMESPACE after NAME.
         assert_eq!(cells[1], "media");
-        let tail = &cells[cells.len() - 3..];
-        assert_eq!(tail, ["nightly@media:/pvc/data", "delete", "-"]);
+        let tail = &cells[cells.len() - 5..];
+        // Nothing recorded / no description on this row → placeholder cells.
+        assert_eq!(tail, ["nightly@media:/pvc/data", "delete", "-", "-", "-"]);
+        assert_eq!(headers(true, true).len(), cells.len());
+    }
+
+    #[test]
+    fn wide_row_renders_recorded_identity_and_description() {
+        let mut snap: Snapshot = from_yaml(SUCCEEDED_SNAPSHOT);
+        let status = snap.status.as_mut().unwrap();
+        status.recorded = serde_json::from_value(serde_json::json!({
+            "schema": 1, "src": "explicit", "uid": 3001, "fsGroup": 65532
+        }))
+        .unwrap();
+        status.snapshot.as_mut().unwrap().description =
+            Some("pre-upgrade snapshot with a description far past the forty character cap".into());
+        let now = Utc.with_ymd_and_hms(2026, 6, 11, 12, 0, 0).unwrap();
+        let cells = row(&snap, now, false, true);
+        let tail = &cells[cells.len() - 2..];
+        // uid recorded, gid image-determined → `3001:-`; description truncated
+        // with an ellipsis (the full value stays available via -o yaml).
+        assert_eq!(tail[0], "3001:-");
+        assert!(tail[1].starts_with("pre-upgrade snapshot"), "{}", tail[1]);
+        assert!(tail[1].ends_with('…'), "{}", tail[1]);
+        assert!(tail[1].chars().count() <= 40);
     }
 
     #[test]

--- a/crates/controller/src/adoption.rs
+++ b/crates/controller/src/adoption.rs
@@ -89,6 +89,11 @@ pub struct AdoptionCandidate {
     pub stats: Option<SnapshotStats>,
     /// The row's `spec.pin`, carried onto the adopted row.
     pub pinned: bool,
+    /// The row's decoded `kopiur-meta` metadata (`status.recorded`), carried
+    /// onto the adopted row verbatim so adoption never drops recorded identity.
+    pub recorded: Option<kopiur_api::RecordedSnapshotMeta>,
+    /// The row's `status.snapshot.description`, carried onto the adopted row.
+    pub description: Option<String>,
 }
 
 /// Extract adoption candidates from a `Snapshot` LIST: `discovered`-origin rows
@@ -129,6 +134,8 @@ pub fn adoption_candidates(repo_uid: &str, rows: &[Snapshot]) -> Vec<AdoptionCan
                 timing: status.timing.clone(),
                 stats: status.stats.clone(),
                 pinned: s.spec.pin,
+                recorded: status.recorded.clone(),
+                description: info.description.clone(),
             })
         })
         .collect()
@@ -396,9 +403,11 @@ pub fn build_adopted_snapshot(
         snapshot: Some(SnapshotInfo {
             kopia_snapshot_id: candidate.snapshot_id.clone(),
             identity: candidate.identity.clone(),
+            description: candidate.description.clone(),
         }),
         timing: candidate.timing.clone(),
         stats: candidate.stats.clone(),
+        recorded: candidate.recorded.clone(),
         resolved: Some(ResolvedSnapshot {
             repository: Some(pinned_repo),
             sources: Vec::new(),
@@ -500,6 +509,7 @@ mod tests {
             snapshot: Some(SnapshotInfo {
                 kopia_snapshot_id: id.to_string(),
                 identity: ident,
+                description: None,
             }),
             timing: Some(SnapshotTiming {
                 start_time: Some("2026-01-01T00:00:00Z".into()),
@@ -524,6 +534,8 @@ mod tests {
             timing: None,
             stats: None,
             pinned,
+            recorded: None,
+            description: None,
         }
     }
 
@@ -610,6 +622,27 @@ mod tests {
         let got = adoption_candidates("repo-1", &[row]);
         assert_eq!(got.len(), 1);
         assert!(got[0].pinned, "spec.pin is carried onto the candidate");
+    }
+
+    #[test]
+    fn candidates_carry_recorded_meta_and_description() {
+        // A discovered row whose scan decoded kopiur-meta (+ description) must
+        // not lose either through adoption.
+        let ident = identity("app", "billing", Some("/data"));
+        let mut row = discovered_row("repo-1", "meta", "aaa", ident);
+        let status = row.status.as_mut().unwrap();
+        status.recorded = Some(kopiur_api::RecordedSnapshotMeta {
+            schema: 1,
+            src: kopiur_api::RecordedSrc::Inherited,
+            uid: Some(1000),
+            gid: Some(1000),
+            fs_group: Some(1000),
+        });
+        status.snapshot.as_mut().unwrap().description = Some("from the repo".into());
+        let got = adoption_candidates("repo-1", &[row]);
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].recorded.as_ref().unwrap().uid, Some(1000));
+        assert_eq!(got[0].description.as_deref(), Some("from the repo"));
     }
 
     // -- plan_adoption: matching + refusals ----------------------------------
@@ -1158,6 +1191,14 @@ mod tests {
                 ..Default::default()
             }),
             pinned: true,
+            recorded: Some(kopiur_api::RecordedSnapshotMeta {
+                schema: kopiur_api::KOPIUR_META_SCHEMA_V1,
+                src: kopiur_api::RecordedSrc::Explicit,
+                uid: Some(3001),
+                gid: None,
+                fs_group: Some(65532),
+            }),
+            description: Some("kept description".into()),
         };
         let (snap, status) = build_adopted_snapshot(&policy, "repo-uid-1", &cand);
 
@@ -1203,6 +1244,9 @@ mod tests {
         assert_eq!(info.identity, cand.identity);
         assert_eq!(status.timing, cand.timing);
         assert_eq!(status.stats, cand.stats);
+        // Recorded identity + description survive adoption verbatim.
+        assert_eq!(status.recorded, cand.recorded);
+        assert_eq!(info.description, cand.description);
         let pinned = status
             .resolved
             .as_ref()

--- a/crates/controller/src/catalog.rs
+++ b/crates/controller/src/catalog.rs
@@ -942,6 +942,21 @@ pub struct ScanOutcome {
     /// reaches this scan). The `status.catalog.foreignSnapshotCount` /
     /// `kopiur_repo_foreign_snapshots` value.
     pub foreign: i64,
+    /// Entries whose `kopiur-meta` tag declared a schema newer than this
+    /// operator understands (degraded to recorded-absent). Aggregated per scan,
+    /// like the foreign-suffix counts — never a per-entry log line a foreign
+    /// writer could amplify.
+    pub meta_unsupported: i64,
+    /// Entries whose `kopiur-meta` tag was present but undecodable (degraded to
+    /// recorded-absent). Aggregated per scan, same rule as above.
+    pub meta_malformed: i64,
+    /// Discovered entries whose CR create/status write was rejected 4xx and was
+    /// skipped so the rest of the scan proceeds (a single bad entry used to
+    /// re-wedge every pass).
+    pub create_failed: i64,
+    /// Existing `Snapshot` CRs backfilled with `status.recorded`
+    /// (+ description) this scan.
+    pub backfilled: i64,
 }
 
 /// Run a catalog scan: LIST the relevant `Snapshot` CRs, run the identity-aware
@@ -1028,21 +1043,18 @@ pub async fn scan(
         ..Default::default()
     };
 
-    for entry in &plan.create {
-        let host = entry.source.host.as_str();
-        let target_ns = match pass.decisions.get(host) {
-            Some(PlacementDecision::Place(ns)) => ns.clone(),
-            Some(PlacementDecision::Unplaced) | None => {
-                outcome.unplaced_hosts.insert(host.to_string());
-                continue;
-            }
-            // Excluded from `plan.create` via `foreign_ignored_ids` above; this arm
-            // is defensive (never actually reached).
-            Some(PlacementDecision::ForeignIgnored) => continue,
-        };
-        materialize_discovered(ctx, &owner_ref, &target_ns, repo_name, repo_uid, entry).await?;
-        outcome.created += 1;
-    }
+    create_discovered_rows(
+        ctx,
+        &owner_ref,
+        repo_name,
+        repo_uid,
+        &plan,
+        &pass,
+        &mut outcome,
+    )
+    .await?;
+    let backfill_failed =
+        backfill_recorded_meta(ctx, repo_name, listing, &all_snapshots, &mut outcome).await;
 
     for (ns, name) in &plan.expire {
         let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), ns);
@@ -1054,7 +1066,26 @@ pub async fn scan(
     }
 
     outcome.discovered = (rows.len() as i64 - outcome.expired).max(0) + outcome.created;
-    if outcome.created > 0 || outcome.expired > 0 || outcome.foreign > 0 {
+    log_scan_summary(repo_name, &outcome, &pass, backfill_failed);
+    Ok(outcome)
+}
+
+/// The per-scan summary logging: one info line when the scan changed anything,
+/// and ONE aggregated warn for decode/write degradations — counts only, never
+/// per-entry lines (a foreign writer controls the tag values and must not be
+/// able to make a scan emit thousands of warnings).
+fn log_scan_summary(
+    repo_name: &str,
+    outcome: &ScanOutcome,
+    pass: &PlacementPass,
+    backfill_failed: i64,
+) {
+    let changed = outcome.created > 0
+        || outcome.expired > 0
+        || outcome.foreign > 0
+        || outcome.backfilled > 0
+        || outcome.create_failed > 0;
+    if changed {
         // Bounded top-N (never in status: cardinality is foreign-writer-controlled).
         let mut top: Vec<(&String, &i64)> = pass.foreign_suffix_counts.iter().collect();
         top.sort_by(|a, b| b.1.cmp(a.1).then_with(|| a.0.cmp(b.0)));
@@ -1065,17 +1096,242 @@ pub async fn scan(
             expired = outcome.expired,
             discovered = outcome.discovered,
             foreign = outcome.foreign,
+            backfilled = outcome.backfilled,
             foreign_top_suffixes = ?top,
             "catalog scan reconciled discovered Snapshot CRs"
         );
     }
-    Ok(outcome)
+    if outcome.meta_unsupported > 0 || outcome.meta_malformed > 0 || outcome.create_failed > 0 {
+        tracing::warn!(
+            repo = repo_name,
+            meta_unsupported = outcome.meta_unsupported,
+            meta_malformed = outcome.meta_malformed,
+            create_failed = outcome.create_failed,
+            backfill_failed,
+            "catalog scan degraded some entries (kopiur-meta undecodable and/or \
+             apiserver-rejected rows); affected rows carry no status.recorded"
+        );
+    }
+}
+
+/// The create half of [`scan`]: materialize every planned entry, placement-
+/// routed, with the `kopiur-meta` decode aggregate-counted and per-entry 4xx
+/// rejections SKIPPED (one bad entry used to re-wedge every pass at the `?`).
+/// Non-4xx errors still abort — the whole pass would fail anyway and a retry
+/// can genuinely fix them.
+async fn create_discovered_rows(
+    ctx: &Context,
+    owner_ref: &OwnerReference,
+    repo_name: &str,
+    repo_uid: &str,
+    plan: &CatalogPlan<'_>,
+    pass: &PlacementPass,
+    outcome: &mut ScanOutcome,
+) -> Result<()> {
+    for entry in &plan.create {
+        let host = entry.source.host.as_str();
+        let target_ns = match pass.decisions.get(host) {
+            Some(PlacementDecision::Place(ns)) => ns.clone(),
+            Some(PlacementDecision::Unplaced) | None => {
+                outcome.unplaced_hosts.insert(host.to_string());
+                continue;
+            }
+            // Excluded from `plan.create` via `foreign_ignored_ids`; this arm
+            // is defensive (never actually reached).
+            Some(PlacementDecision::ForeignIgnored) => continue,
+        };
+        let recorded = decode_recorded_counted(entry, outcome);
+        match materialize_discovered(
+            ctx,
+            owner_ref,
+            &target_ns,
+            repo_name,
+            repo_uid,
+            entry,
+            recorded.as_ref(),
+        )
+        .await
+        {
+            Ok(()) => outcome.created += 1,
+            // A 4xx is THIS entry's problem (a schema-invalid name/field the
+            // apiserver rejects) — skip it so one bad entry no longer wedges
+            // the scan.
+            Err(Error::Kube(kube::Error::Api(ae))) if (400..500).contains(&ae.code) => {
+                outcome.create_failed += 1;
+                if outcome.create_failed == 1 {
+                    tracing::warn!(
+                        repo = repo_name,
+                        namespace = %target_ns,
+                        entry = %entry.id,
+                        code = ae.code,
+                        reason = %ae.message,
+                        "skipping a discovered entry the apiserver rejected; the scan \
+                         continues (first rejection logged; total in the scan summary)"
+                    );
+                }
+            }
+            Err(e) => return Err(e),
+        }
+    }
+    Ok(())
+}
+
+/// The backfill half of [`scan`]: an already-materialized (or pre-feature
+/// produced) CR whose kopia snapshot NOW shows decodable `kopiur-meta` gains
+/// `status.recorded` (+ description) via a targeted patch ([`backfill_patch`])
+/// — issued ONLY while absent, so the steady state plans no write (no status
+/// churn, and these patches never touch the conditions array). Matched by
+/// `status.snapshot.kopiaSnapshotID`, which covers discovered AND produced
+/// rows. Returns the count of failed patches (opportunistic: a rejected
+/// backfill never wedges the scan).
+async fn backfill_recorded_meta(
+    ctx: &Context,
+    repo_name: &str,
+    listing: &[SnapshotListEntry],
+    all_snapshots: &[Snapshot],
+    outcome: &mut ScanOutcome,
+) -> i64 {
+    let mut by_kopia_id: BTreeMap<&str, Vec<&Snapshot>> = BTreeMap::new();
+    for s in all_snapshots {
+        // Never patch a row that is already being deleted.
+        if s.metadata.deletion_timestamp.is_some() {
+            continue;
+        }
+        if let Some(id) = s
+            .status
+            .as_ref()
+            .and_then(|st| st.snapshot.as_ref())
+            .map(|i| i.kopia_snapshot_id.as_str())
+            .filter(|id| !id.is_empty())
+        {
+            by_kopia_id.entry(id).or_default().push(s);
+        }
+    }
+    let mut backfill_failed: i64 = 0;
+    for entry in listing {
+        let Some(crs) = by_kopia_id.get(entry.id.as_str()) else {
+            continue;
+        };
+        if crs
+            .iter()
+            .all(|s| s.status.as_ref().is_none_or(|st| st.recorded.is_some()))
+        {
+            continue; // steady state: nothing lacks `recorded`.
+        }
+        if decode_recorded_counted(entry, outcome).is_none() {
+            continue;
+        }
+        for cr in crs {
+            let Some(patch) = backfill_patch(entry, cr) else {
+                continue;
+            };
+            let ns = cr.namespace().unwrap_or_default();
+            let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), &ns);
+            match io::patch_status(&api, &cr.name_any(), patch).await {
+                Ok(()) => outcome.backfilled += 1,
+                Err(e) => {
+                    backfill_failed += 1;
+                    if backfill_failed == 1 {
+                        tracing::warn!(
+                            repo = repo_name,
+                            snapshot = %cr.name_any(),
+                            namespace = %ns,
+                            error = %e,
+                            "recorded-metadata backfill patch failed; skipping \
+                             (first failure logged; total in the scan summary)"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    backfill_failed
+}
+
+/// Decode an entry's recorded mover identity with the decode problems
+/// aggregate-counted on `outcome` — never per-entry logged, because the tag
+/// value is foreign-writer-controlled. Shared by the create and backfill loops
+/// so the counting rule cannot fork.
+fn decode_recorded_counted(
+    entry: &SnapshotListEntry,
+    outcome: &mut ScanOutcome,
+) -> Option<kopiur_api::RecordedSnapshotMeta> {
+    match recorded_from_entry(entry) {
+        kopiur_api::MetaTagDecode::Decoded(meta) => Some(meta),
+        kopiur_api::MetaTagDecode::Absent => None,
+        kopiur_api::MetaTagDecode::UnsupportedSchema { .. } => {
+            outcome.meta_unsupported += 1;
+            None
+        }
+        kopiur_api::MetaTagDecode::Malformed { .. } => {
+            outcome.meta_malformed += 1;
+            None
+        }
+    }
+}
+
+/// Decode the `kopiur-meta` tag off one listing entry — the single funnel for
+/// BOTH wires: an in-process listing's entries carry the raw manifest keys
+/// (`tag:kopiur-meta`), while bootstrap-result entries were normalized by the
+/// mover to the bare key with the raw user tags cleared
+/// (`kopiur_mover::bootstrap::slim_catalog_entry`). [`kopiur_api::decode_meta_tag`]
+/// accepts both key shapes, so neither wire needs its own decode path.
+pub fn recorded_from_entry(entry: &SnapshotListEntry) -> kopiur_api::MetaTagDecode {
+    kopiur_api::decode_meta_tag(&entry.tags)
+}
+
+/// Byte cap on the kopia description copied onto a `Snapshot` CR
+/// (char-boundary-safe; also stated in the CRD field doc). The description is
+/// foreign-writer-controlled repository data — a multi-MB value must never 4xx
+/// the CR write.
+pub const DESCRIPTION_CAP_BYTES: usize = 1024;
+
+/// The (capped) description a listing entry contributes to a CR, `None` when empty.
+fn entry_description(entry: &SnapshotListEntry) -> Option<String> {
+    (!entry.description.is_empty()).then(|| {
+        kopiur_api::recorded::truncate_utf8(&entry.description, DESCRIPTION_CAP_BYTES).to_string()
+    })
+}
+
+/// The targeted status patch backfilling `recorded` (+ `snapshot.description`)
+/// onto an existing CR for `entry`, or `None` when nothing should be written.
+/// Pure. The contract that keeps this safe to run every scan:
+///
+/// - the CR must MATCH the entry (`status.snapshot.kopiaSnapshotID == entry.id`);
+/// - `recorded` is written ONLY while absent (idempotent — the steady state
+///   plans no write, so there is no status churn);
+/// - description is added only when the CR lacks one and the entry has one
+///   (capped, [`DESCRIPTION_CAP_BYTES`]);
+/// - the patch touches ONLY these fields — in particular never the conditions
+///   array, which a concurrent writer could otherwise clobber.
+pub fn backfill_patch(entry: &SnapshotListEntry, cr: &Snapshot) -> Option<serde_json::Value> {
+    let status = cr.status.as_ref()?;
+    let info = status.snapshot.as_ref()?;
+    if info.kopia_snapshot_id != entry.id {
+        return None;
+    }
+    if status.recorded.is_some() {
+        return None;
+    }
+    let kopiur_api::MetaTagDecode::Decoded(meta) = recorded_from_entry(entry) else {
+        return None;
+    };
+    let mut patch = serde_json::json!({ "recorded": meta });
+    if info.description.is_none()
+        && let Some(d) = entry_description(entry)
+    {
+        patch["snapshot"] = serde_json::json!({ "description": d });
+    }
+    Some(patch)
 }
 
 /// Create one `origin: discovered` `Snapshot` CR for a listing entry.
 /// `deletionPolicy` is FORCED to `Retain` (the operator never deletes a
 /// discovered snapshot, §4.5); identity, timing, and size come from the kopia
 /// listing so `kubectl kopiur snapshots list` shows real data for foreign rows.
+/// `recorded` is the caller-decoded `kopiur-meta` metadata (decoded once in
+/// [`scan`], where UnsupportedSchema/Malformed are aggregate-counted);
+/// the entry's description is copied capped ([`DESCRIPTION_CAP_BYTES`]).
 async fn materialize_discovered(
     ctx: &Context,
     owner: &OwnerReference,
@@ -1083,6 +1339,7 @@ async fn materialize_discovered(
     repo_name: &str,
     repo_uid: &str,
     entry: &SnapshotListEntry,
+    recorded: Option<&kopiur_api::RecordedSnapshotMeta>,
 ) -> Result<()> {
     use kopiur_api::common::{DeletionPolicy, ResolvedIdentity};
     use kopiur_api::snapshot::{
@@ -1128,6 +1385,7 @@ async fn materialize_discovered(
                 hostname: entry.source.host.clone(),
                 source_path: Some(entry.source.path.clone()),
             },
+            description: entry_description(entry),
         }),
         timing: Some(SnapshotTiming {
             start_time: Some(entry.start_time.to_rfc3339()),
@@ -1138,6 +1396,7 @@ async fn materialize_discovered(
             size_bytes: i64::try_from(entry.stats.total_size).ok(),
             ..Default::default()
         }),
+        recorded: recorded.cloned(),
         ..Default::default()
     });
 
@@ -1176,6 +1435,7 @@ mod tests {
             stats: SnapshotStats::default(),
             root_entry: None,
             retention_reason: vec![],
+            tags: Default::default(),
         }
     }
 
@@ -1198,6 +1458,115 @@ mod tests {
 
     fn expired<'a>(plan: &'a CatalogPlan<'_>) -> Vec<&'a str> {
         plan.expire.iter().map(|(_, n)| n.as_str()).collect()
+    }
+
+    // --- recorded_from_entry / backfill_patch / entry_description -----------
+
+    fn meta_entry(id: &str, tag_key: &str, value: &str) -> SnapshotListEntry {
+        let mut e = entry(id, ("u", "h", "/p"), t(10));
+        e.tags.insert(tag_key.to_string(), value.to_string());
+        e
+    }
+
+    fn cr_with(id: &str, recorded: bool, description: Option<&str>) -> Snapshot {
+        use kopiur_api::snapshot::{SnapshotInfo, SnapshotStatus};
+        let mut s = Snapshot::new(
+            "row",
+            serde_json::from_value(serde_json::json!({})).unwrap(),
+        );
+        s.metadata.namespace = Some("ns".into());
+        s.status = Some(SnapshotStatus {
+            snapshot: Some(SnapshotInfo {
+                kopia_snapshot_id: id.to_string(),
+                identity: kopiur_api::common::ResolvedIdentity {
+                    username: "u".into(),
+                    hostname: "h".into(),
+                    source_path: Some("/p".into()),
+                },
+                description: description.map(String::from),
+            }),
+            recorded: recorded.then_some(kopiur_api::RecordedSnapshotMeta {
+                schema: 1,
+                src: kopiur_api::RecordedSrc::Explicit,
+                uid: Some(1),
+                gid: None,
+                fs_group: None,
+            }),
+            ..Default::default()
+        });
+        s
+    }
+
+    const VALID_META: &str = r#"{"schema":1,"src":"inherited","uid":1000}"#;
+
+    #[test]
+    fn recorded_from_entry_accepts_both_wire_key_shapes() {
+        use kopiur_api::MetaTagDecode;
+        // In-process listing: raw manifest key.
+        let raw = meta_entry("a", "tag:kopiur-meta", VALID_META);
+        assert!(matches!(
+            recorded_from_entry(&raw),
+            MetaTagDecode::Decoded(m) if m.uid == Some(1000)
+        ));
+        // Bootstrap-result wire: mover-normalized bare key.
+        let normalized = meta_entry("a", "kopiur-meta", VALID_META);
+        assert!(matches!(
+            recorded_from_entry(&normalized),
+            MetaTagDecode::Decoded(m) if m.uid == Some(1000)
+        ));
+        assert!(matches!(
+            recorded_from_entry(&entry("a", ("u", "h", "/p"), t(10))),
+            MetaTagDecode::Absent
+        ));
+    }
+
+    #[test]
+    fn backfill_patch_adds_recorded_only_while_absent() {
+        let e = meta_entry("a", "tag:kopiur-meta", VALID_META);
+        // Absent → a targeted patch carrying exactly `recorded`.
+        let patch = backfill_patch(&e, &cr_with("a", false, None)).expect("patch planned");
+        assert_eq!(patch["recorded"]["uid"], 1000);
+        assert_eq!(patch["recorded"]["src"], "inherited");
+        assert!(
+            patch.get("conditions").is_none() && patch.get("phase").is_none(),
+            "the backfill must touch ONLY recorded/description: {patch}"
+        );
+        // Already recorded → idempotent no-op (no churn).
+        assert!(backfill_patch(&e, &cr_with("a", true, None)).is_none());
+        // Id mismatch → never patch someone else's row.
+        assert!(backfill_patch(&e, &cr_with("other", false, None)).is_none());
+        // Malformed tag → degrade to no patch (counted by the scan, not here).
+        let bad = meta_entry("a", "kopiur-meta", "not json");
+        assert!(backfill_patch(&bad, &cr_with("a", false, None)).is_none());
+    }
+
+    #[test]
+    fn backfill_patch_adds_description_only_when_cr_lacks_one() {
+        let mut e = meta_entry("a", "kopiur-meta", VALID_META);
+        e.description = "from the repository".to_string();
+        let patch = backfill_patch(&e, &cr_with("a", false, None)).unwrap();
+        assert_eq!(patch["snapshot"]["description"], "from the repository");
+        // CR already carries a description → leave it alone.
+        let patch = backfill_patch(&e, &cr_with("a", false, Some("existing"))).unwrap();
+        assert!(patch.get("snapshot").is_none(), "{patch}");
+    }
+
+    #[test]
+    fn entry_description_is_capped_char_boundary_safe() {
+        let mut e = entry("a", ("u", "h", "/p"), t(10));
+        assert_eq!(entry_description(&e), None, "empty stays absent");
+        e.description = "short".into();
+        assert_eq!(entry_description(&e).as_deref(), Some("short"));
+        // A foreign-writer-sized description is capped at DESCRIPTION_CAP_BYTES.
+        e.description = "é".repeat(DESCRIPTION_CAP_BYTES); // 2 bytes per char
+        let capped = entry_description(&e).unwrap();
+        assert!(capped.len() <= DESCRIPTION_CAP_BYTES);
+        assert!(capped.is_char_boundary(capped.len()));
+        assert_eq!(
+            capped.len(),
+            DESCRIPTION_CAP_BYTES,
+            "even split backs off safely"
+        );
     }
 
     #[test]
@@ -2259,6 +2628,7 @@ mod tests {
                         hostname: "h".into(),
                         source_path: Some("/p".into()),
                     },
+                    description: None,
                 }),
                 resolved: Some(ResolvedSnapshot {
                     repository: Some(RepositoryRef {
@@ -2294,6 +2664,7 @@ mod tests {
                         hostname: "h".into(),
                         source_path: Some("/p".into()),
                     },
+                    description: None,
                 }),
                 resolved: Some(ResolvedSnapshot {
                     repository: Some(RepositoryRef {

--- a/crates/controller/src/consts.rs
+++ b/crates/controller/src/consts.rs
@@ -336,6 +336,16 @@ pub const MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION: &str = "MatchWorkloadSecurityC
 /// - [`INHERIT_OVERRIDDEN_REASON`] — an explicit `runAsUser` displaced the inherited one, so
 ///   inheritance is not tracking the workload for that field.
 ///
+/// On a `Restore` with `inheritSecurityContextFrom.snapshot` (recorded-identity inherit)
+/// the SAME condition reports positively too — provable provenance is that mode's value:
+///
+/// - [`RECORDED_APPLIED_REASON`] — `True`; the backup's recorded identity was applied
+///   (message names the Snapshot, the recorded uid, and the provenance).
+/// - [`RECORDED_PINNED_NO_UID_REASON`] — `False`; the record pins nothing beyond the
+///   hardened baseline, so inheriting it was a provable no-op.
+/// - [`MISSING_RECORDED_IDENTITY_REASON`] — `False`; no recorded identity is resolvable
+///   yet (missing CR / no `status.recorded` / catalog scan pending) — a slow-requeued hold.
+///
 /// Distinct from [`SECURITY_CONTEXT_COMPATIBLE_CONDITION`], which is about whether the mover
 /// can *read the source*; this is about whether *inheritance did what you asked*.
 pub const SECURITY_CONTEXT_INHERITED_CONDITION: &str = "SecurityContextInherited";
@@ -362,6 +372,28 @@ pub const INHERIT_OVERRIDDEN_REASON: &str = "InheritOverridden";
 pub const INHERIT_APPLIED_REASON: &str = "InheritApplied";
 /// Event `action` (remediation hint) for the inherit-pinned-no-uid case.
 pub const PIN_WORKLOAD_RUN_AS_USER_ACTION: &str = "PinWorkloadRunAsUser";
+/// `reason` for [`SECURITY_CONTEXT_INHERITED_CONDITION`] = `False` on a `Restore` whose
+/// `inheritSecurityContextFrom.snapshot` cannot resolve a recorded identity yet: the
+/// referenced `Snapshot` CR is missing, carries no `status.recorded` (pre-feature or
+/// foreign backup), or no CR matching the source identity exists (catalog scan pending).
+/// Permanent-shaped: the hold requeues on the slow structural cadence, and clears when the
+/// scan lands/backfills or the spec pins an explicit context.
+pub const MISSING_RECORDED_IDENTITY_REASON: &str = "MissingRecordedIdentity";
+/// `reason` for [`SECURITY_CONTEXT_INHERITED_CONDITION`] = `False` on a `Restore` when the
+/// backup's recorded metadata pins nothing beyond the mover's own hardened baseline (no
+/// uid, no gid, fsGroup absent or the hardened 65532) — the restore counterpart of
+/// [`INHERIT_PINNED_NO_UID_REASON`]: inheriting the record is a provable no-op and the
+/// mover runs as its image's uid.
+pub const RECORDED_PINNED_NO_UID_REASON: &str = "RecordedPinnedNoUid";
+/// `reason` for [`SECURITY_CONTEXT_INHERITED_CONDITION`] = `True` on a `Restore`: the
+/// identity recorded on the backup (`Snapshot.status.recorded`) was applied to the restore
+/// mover. The message always names the Snapshot, the recorded uid, and the provenance
+/// (`src`) — only `src: inherited` may claim the identity tracked the workload, and a
+/// recorded ROOT uid is named explicitly so a forged tag stays auditable (§3.4).
+pub const RECORDED_APPLIED_REASON: &str = "RecordedApplied";
+/// Event `action` (remediation hint) when recorded-identity inherit cannot proceed or
+/// contributed nothing: pin `mover.securityContext` explicitly (or drop the inherit).
+pub const SET_EXPLICIT_MOVER_CONTEXT_ACTION: &str = "SetExplicitMoverSecurityContext";
 /// `Restore` condition reporting whether the *future* consumer of the restore target PVC
 /// will be able to read what the mover writes (a securityContext-only heuristic; no runtime
 /// layer exists for restore since the consumer may not exist yet). Same tri-state semantics

--- a/crates/controller/src/error.rs
+++ b/crates/controller/src/error.rs
@@ -56,6 +56,17 @@ pub enum Error {
     #[error("blocked on an out-of-band grant: {0}")]
     BlockedOnGrant(String),
 
+    /// A restore's `inheritSecurityContextFrom.snapshot` cannot resolve a
+    /// recorded identity yet: the referenced `Snapshot` CR is missing, carries
+    /// no `status.recorded`, or no CR matching the source identity exists (the
+    /// catalog scan may still be running). Permanent-*shaped* — it clears only
+    /// when the scan lands, the status is backfilled, or the spec changes — so
+    /// it holds on the slow structural cadence (300s) instead of hot-looping;
+    /// the restore reconciler writes the `MissingRecordedIdentity` condition +
+    /// Warning Event before returning this, so the hold is never silent.
+    #[error("missing recorded identity: {0}")]
+    MissingRecordedIdentity(String),
+
     /// JSON (de)serialization of a spec/status/work-spec failed. Structural.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
@@ -160,6 +171,7 @@ impl Error {
             }
             Error::Validation(_)
             | Error::BlockedOnGrant(_)
+            | Error::MissingRecordedIdentity(_)
             | Error::Serialization(_)
             | Error::BuildJob(_)
             | Error::InvalidSchedule(_)
@@ -184,6 +196,7 @@ impl Error {
             | Error::Validation(_)
             | Error::MissingDependency(_)
             | Error::BlockedOnGrant(_)
+            | Error::MissingRecordedIdentity(_)
             | Error::Serialization(_)
             | Error::BuildJob(_)
             | Error::InvalidSchedule(_)
@@ -347,6 +360,21 @@ mod tests {
         assert_eq!(err.class(), ErrorClass::Structural);
         assert!(err.to_string().contains("out-of-band grant"));
         assert!(err.to_string().contains("namespace `app` has not opted in"));
+    }
+
+    #[test]
+    fn missing_recorded_identity_is_structural_not_a_hot_loop() {
+        // The `inheritSecurityContextFrom.snapshot` hold is permanent-shaped (it
+        // clears when the catalog scan lands or the spec changes), so it must
+        // requeue on the slow structural cadence (300s), never the fast transient
+        // one — the reconciler already wrote the condition + Event.
+        let err = Error::MissingRecordedIdentity(
+            "Snapshot `app/pg-b1` carries no recorded identity".into(),
+        );
+        assert_eq!(err.class(), ErrorClass::Structural);
+        assert!(err.to_string().contains("missing recorded identity"));
+        assert!(err.to_string().contains("app/pg-b1"));
+        assert!(!err.event_publish_futile());
     }
 
     #[test]

--- a/crates/controller/src/io/events.rs
+++ b/crates/controller/src/io/events.rs
@@ -321,6 +321,16 @@ pub(crate) fn reconcile_failure_event(err: &Error, uid: u32) -> FailureEvent {
                  reconciles automatically — no re-apply needed."
             ),
         ),
+        Error::MissingRecordedIdentity(_) => (
+            crate::consts::MISSING_RECORDED_IDENTITY_REASON,
+            crate::consts::SET_EXPLICIT_MOVER_CONTEXT_ACTION,
+            format!(
+                "{err}. The Restore holds (re-checked every few minutes) until a Snapshot CR \
+                 carrying status.recorded matches the source — the catalog scan materializes \
+                 and backfills rows automatically. To proceed without it, set \
+                 mover.securityContext explicitly or drop inheritSecurityContextFrom.snapshot."
+            ),
+        ),
         Error::Serialization(_) => (
             SERIALIZATION_FAILED_REASON,
             REPORT_ISSUE_ACTION,

--- a/crates/controller/src/io/mover.rs
+++ b/crates/controller/src/io/mover.rs
@@ -610,6 +610,36 @@ pub enum InheritOutcome {
         /// The actionable reason inheritance failed, for the condition/Event message.
         reason: String,
     },
+    /// Restore-only: inherited the identity RECORDED on the backup
+    /// (`inheritSecurityContextFrom.snapshot` — `Snapshot.status.recorded`, decoded
+    /// from the `kopiur-meta` kopia tag) instead of reading a live pod.
+    InheritedFromSnapshot {
+        /// `namespace/name` of the `Snapshot` CR the recorded identity came from.
+        snapshot: String,
+        /// The recorded EFFECTIVE `runAsUser` the inherited layer contributed
+        /// (`RecordedSnapshotMeta::uid`); `None` when the backup mover's UID was
+        /// image-determined, so inheriting contributed no UID at all.
+        uid: Option<i64>,
+        /// Which layer pinned the recorded identity at BACKUP time. Only
+        /// [`RecordedSrc::Inherited`] means it tracked the workload — condition
+        /// text keys its honesty on this.
+        src: kopiur_api::recorded::RecordedSrc,
+    },
+}
+
+/// The recorded-identity source for a restore's `inheritSecurityContextFrom.snapshot`,
+/// resolved by the RESTORE reconciler before
+/// [`resolve_mover_security_contexts`] runs: the `Snapshot` CR (direct for
+/// `snapshotRef`; via the CR-catalog search for `fromPolicy`/`identity`) and its
+/// decoded `status.recorded`, when present.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SnapshotRecordedSource {
+    /// `namespace/name` of the `Snapshot` CR, for condition/Event messages.
+    pub snapshot: String,
+    /// The CR's `status.recorded`; `None` when the row carries none (pre-feature
+    /// or foreign backup) — resolution then holds with an actionable error
+    /// unless the explicit context pins a fallback identity.
+    pub meta: Option<kopiur_api::recorded::RecordedSnapshotMeta>,
 }
 
 /// The mover's recipe-layer security contexts plus how they were arrived at.
@@ -887,14 +917,16 @@ pub async fn ensure_cache_pvc(
 /// explicit one.
 ///
 /// When `inheritSecurityContextFrom` is set, the workload's contexts are copied and the
-/// recipe's **explicit** `securityContext`/`podSecurityContext` are then overlaid on top
-/// (field-wise, explicit wins). The two are layers, not alternatives: what you wrote always
-/// wins, and inheritance fills in whatever the workload pins that you left blank. Doing the
-/// overlay here — rather than threading a fourth layer through
+/// recipe's **explicit** `securityContext`/`podSecurityContext` are then overlaid on top via
+/// [`kopiur_api::common::merge_context_pair`] (explicit wins; the winning layer's effective
+/// UID/GID is promoted so a lower layer's container-level value can never shadow it across
+/// dimensions). The two are layers, not alternatives: what you wrote always wins, and
+/// inheritance fills in whatever the workload pins that you left blank. Doing the overlay
+/// here — rather than threading a fourth layer through
 /// [`kopiur_api::common::resolve_mover`] — keeps that function and all seven of its call sites
-/// untouched, and is field-wise identical because the merge is a per-field `over.or(base)` and
-/// therefore associative: every field resolves to
-/// `explicit.or(inherited).or(moverDefaults).or(hardened)`.
+/// untouched, and is identical to a flat four-layer merge because the pair merge is
+/// associative: the effective identity resolves to
+/// `explicit.or(inherited).or(moverDefaults).or(hardened)` — the highest layer that pins one.
 ///
 /// One exception to "explicit wins": an inherited `runAsUser: 0` under an explicit
 /// `runAsNonRoot: true` is normalized by INV-1 ([`kopiur_api::invariants`]) into a *root*
@@ -909,11 +941,18 @@ pub async fn ensure_cache_pvc(
 /// `inheritSecurityContextFrom.pvcConsumer` mode to discover the workload that mounts it;
 /// pass `None` for restore/maintenance movers (which have no backup source — `pvcConsumer`
 /// then fails with an actionable error, as it is backup-source-only).
+///
+/// `recorded` is the resolved recorded-identity source for the restore-only
+/// `inheritSecurityContextFrom.snapshot` mode: the RESTORE reconciler resolves the
+/// `Snapshot` CR (and its `status.recorded`) BEFORE this call and passes it here; every
+/// other caller passes `None` (the variant is admission-rejected on their kinds, so a
+/// `snapshot` inherit without a source is a defensive `Invariant` error, never a panic).
 pub async fn resolve_mover_security_contexts(
     client: &kube::Client,
     ns: &str,
     mover: Option<&MoverSpec>,
     source_pvc: Option<&str>,
+    recorded: Option<&SnapshotRecordedSource>,
 ) -> Result<ResolvedMoverSecurity> {
     let Some(m) = mover else {
         return Ok(ResolvedMoverSecurity {
@@ -933,6 +972,37 @@ pub async fn resolve_mover_security_contexts(
             resolve_pvc_consumer_security_context(client, ns, source_pvc, pc.container.as_deref())
                 .await
                 .map(|(source, pods)| (source, Some(pods)))
+        }
+        Some(InheritSecurityContextFrom::Snapshot(_)) => {
+            let Some(source) = recorded else {
+                // Backup/maintenance callers pass `None`, and the validators make the
+                // variant unreachable on their kinds — so reaching this arm without a
+                // source is an operator bug, reported actionably instead of panicking.
+                return Err(Error::Invariant(format!(
+                    "mover.inheritSecurityContextFrom.snapshot reached a reconciler that \
+                     resolved no recorded-identity source in namespace `{ns}` — this variant \
+                     is restore-only (admission rejects it on SnapshotPolicy/Maintenance/\
+                     RepositoryReplication). This is a kopiur bug; please report it. As a \
+                     workaround, set mover.securityContext explicitly."
+                )));
+            };
+            match &source.meta {
+                // The recorded identity IS the inherited layer; no pod IO at all.
+                Some(meta) => return Ok(resolved_from_recorded(m, &source.snapshot, meta)),
+                // A permanent-shaped hold, phrased as MissingDependency so the
+                // fallback machinery below can proceed on an explicit pinned
+                // identity exactly like the live-pod modes; the restore
+                // reconciler turns the propagated error into the
+                // `MissingRecordedIdentity` condition + slow requeue.
+                None => Err(Error::MissingDependency(format!(
+                    "Snapshot `{}` carries no recorded identity (`status.recorded`) — it \
+                     predates the kopiur-meta feature or was written by a foreign tool; the \
+                     catalog scan backfills it when the kopia snapshot carries the tag. Set \
+                     mover.securityContext explicitly, or use \
+                     inheritSecurityContextFrom.workloadSelector.",
+                    source.snapshot
+                ))),
+            }
         }
         None => {
             return Ok(ResolvedMoverSecurity {
@@ -979,23 +1049,67 @@ pub async fn resolve_mover_security_contexts(
         pins_identity: source.pins_identity(),
     };
     // `inherited ⊂ explicit`: the recipe's explicit context is the higher layer, so each field
-    // it sets wins and the inherited value fills the rest. Reuses the exhaustive merge helpers
-    // (a k8s-openapi field addition breaks their struct literals) rather than re-deriving one.
+    // it sets wins and the inherited value fills the rest. The pair merge (NOT the lone
+    // per-dimension helpers) so a workload that pins its uid at the pod level cannot later be
+    // shadowed by a lower layer's container-level value in `resolve_mover`.
     let (inherited_sc, inherited_psc) = source.contexts;
     Ok(ResolvedMoverSecurity {
-        contexts: (
-            kopiur_api::common::merge_security_context_opt(
-                inherited_sc.as_ref(),
-                m.security_context.as_ref(),
-            ),
-            kopiur_api::common::merge_pod_security_context_opt(
-                inherited_psc.as_ref(),
-                m.pod_security_context.as_ref(),
-            ),
+        contexts: kopiur_api::common::merge_context_pair(
+            inherited_sc.as_ref(),
+            inherited_psc.as_ref(),
+            m.security_context.as_ref(),
+            m.pod_security_context.as_ref(),
         ),
         outcome,
         unfiltered_pods,
     })
+}
+
+/// Pure core of the `inheritSecurityContextFrom.snapshot` arm: synthesize the
+/// inherited layer from the backup's recorded identity and fold the recipe's
+/// explicit context over it — the exact shape live-pod inherit produces, so the
+/// Phase-1 identity-aware ladder, INV-1 normalization, and the privileged-mover
+/// gate all apply downstream with zero new code. A recorded root UID (uid 0) is
+/// therefore gated exactly like an inherited-from-a-live-root-pod one.
+///
+/// Layer placement is a stated semantic: the synthesized layer enters
+/// `resolve_mover` as the recipe layer, so backup-time recorded values (including
+/// the near-always-present fsGroup) sit ABOVE the restore cluster's
+/// `moverDefaults` — faithful reproduction of the identity the data expects wins
+/// over restore-side operational defaults. The recorded `src` provenance rides the
+/// outcome so condition text can be honest about whether that identity ever
+/// tracked a workload.
+pub(crate) fn resolved_from_recorded(
+    m: &MoverSpec,
+    snapshot: &str,
+    meta: &kopiur_api::recorded::RecordedSnapshotMeta,
+) -> ResolvedMoverSecurity {
+    // uid/gid go on the container dimension, fsGroup on the pod dimension —
+    // `merge_context_pair`'s identity promotion makes the placement immaterial
+    // for precedence, and fsGroup is pod-only in Kubernetes.
+    let inherited_sc = SecurityContext {
+        run_as_user: meta.uid,
+        run_as_group: meta.gid,
+        ..Default::default()
+    };
+    let inherited_psc = PodSecurityContext {
+        fs_group: meta.fs_group,
+        ..Default::default()
+    };
+    ResolvedMoverSecurity {
+        contexts: kopiur_api::common::merge_context_pair(
+            Some(&inherited_sc),
+            Some(&inherited_psc),
+            m.security_context.as_ref(),
+            m.pod_security_context.as_ref(),
+        ),
+        outcome: InheritOutcome::InheritedFromSnapshot {
+            snapshot: snapshot.to_string(),
+            uid: meta.uid,
+            src: meta.src,
+        },
+        unfiltered_pods: None,
+    }
 }
 
 /// Container `waiting.reason` values that mean the pod will never start without a spec

--- a/crates/controller/src/io/tests.rs
+++ b/crates/controller/src/io/tests.rs
@@ -1819,16 +1819,42 @@ fn merge_explicit_over_inherited(
     Option<k8s_openapi::api::core::v1::SecurityContext>,
     Option<k8s_openapi::api::core::v1::PodSecurityContext>,
 ) {
-    (
-        kopiur_api::common::merge_security_context_opt(
-            inherited.0.as_ref(),
-            explicit.security_context.as_ref(),
-        ),
-        kopiur_api::common::merge_pod_security_context_opt(
-            inherited.1.as_ref(),
-            explicit.pod_security_context.as_ref(),
-        ),
+    kopiur_api::common::merge_context_pair(
+        inherited.0.as_ref(),
+        inherited.1.as_ref(),
+        explicit.security_context.as_ref(),
+        explicit.pod_security_context.as_ref(),
     )
+}
+
+#[test]
+fn explicit_pod_level_uid_displaces_an_inherited_container_level_uid() {
+    use k8s_openapi::api::core::v1::{PodSecurityContext, SecurityContext};
+
+    // Cross-dimension precedence at the fold itself: the workload pins uid 1000 at the
+    // container level, the recipe pins uid 2000 at the POD level. Explicit is the higher
+    // layer, so the effective identity must be 2000 — the pair merge promotes it into the
+    // container context so the inherited container value cannot shadow it.
+    let inherited = (
+        Some(SecurityContext {
+            run_as_user: Some(1000),
+            ..Default::default()
+        }),
+        None,
+    );
+    let explicit = kopiur_api::common::MoverSpec {
+        pod_security_context: Some(PodSecurityContext {
+            run_as_user: Some(2000),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let (sc, psc) = merge_explicit_over_inherited(inherited, &explicit);
+    assert_eq!(
+        kopiur_api::common::effective_run_as_user(sc.as_ref(), psc.as_ref()),
+        Some(2000),
+        "the explicit pod-level uid is the higher layer and must win"
+    );
 }
 
 #[test]
@@ -2897,5 +2923,170 @@ mod bounded_failure_publish {
             2,
             "a stalled publish must release its permit at the deadline"
         );
+    }
+}
+
+// --- `inheritSecurityContextFrom.snapshot`: the recorded identity IS the inherited layer ---
+
+mod resolved_from_recorded_meta {
+    use k8s_openapi::api::core::v1::{PodSecurityContext, SecurityContext};
+    use kopiur_api::common::MoverSpec;
+    use kopiur_api::recorded::{KOPIUR_META_SCHEMA_V1, RecordedSnapshotMeta, RecordedSrc};
+
+    use crate::io::{InheritOutcome, resolved_from_recorded};
+
+    fn meta(
+        uid: Option<i64>,
+        gid: Option<i64>,
+        fs: Option<i64>,
+        src: RecordedSrc,
+    ) -> RecordedSnapshotMeta {
+        RecordedSnapshotMeta {
+            schema: KOPIUR_META_SCHEMA_V1,
+            src,
+            uid,
+            gid,
+            fs_group: fs,
+        }
+    }
+
+    #[test]
+    fn recorded_identity_synthesizes_the_inherited_layer_and_outcome() {
+        let m = MoverSpec::default();
+        let r = resolved_from_recorded(
+            &m,
+            "app/pg-b1",
+            &meta(Some(3001), Some(3001), Some(2000), RecordedSrc::Inherited),
+        );
+        let (sc, psc) = &r.contexts;
+        assert_eq!(
+            kopiur_api::common::effective_run_as_user(sc.as_ref(), psc.as_ref()),
+            Some(3001)
+        );
+        assert_eq!(
+            kopiur_api::common::effective_run_as_group(sc.as_ref(), psc.as_ref()),
+            Some(3001)
+        );
+        assert_eq!(psc.as_ref().and_then(|p| p.fs_group), Some(2000));
+        assert_eq!(
+            r.outcome,
+            InheritOutcome::InheritedFromSnapshot {
+                snapshot: "app/pg-b1".into(),
+                uid: Some(3001),
+                src: RecordedSrc::Inherited,
+            }
+        );
+        assert!(r.unfiltered_pods.is_none(), "no pod list on this path");
+    }
+
+    #[test]
+    fn explicit_context_is_the_higher_layer_over_the_recorded_one() {
+        // Exactly like live-pod inherit: what the recipe writes wins, the record
+        // fills in the rest — including cross-dimension (explicit POD-level uid
+        // beats the recorded container-level one via the pair-merge promotion).
+        let m = MoverSpec {
+            pod_security_context: Some(PodSecurityContext {
+                run_as_user: Some(2000),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let r = resolved_from_recorded(
+            &m,
+            "app/pg-b1",
+            &meta(Some(3001), Some(3001), Some(3001), RecordedSrc::Explicit),
+        );
+        let (sc, psc) = &r.contexts;
+        assert_eq!(
+            kopiur_api::common::effective_run_as_user(sc.as_ref(), psc.as_ref()),
+            Some(2000),
+            "the explicit uid is the higher layer"
+        );
+        // Fields the recipe leaves blank still come from the record.
+        assert_eq!(
+            kopiur_api::common::effective_run_as_group(sc.as_ref(), psc.as_ref()),
+            Some(3001)
+        );
+        assert_eq!(psc.as_ref().and_then(|p| p.fs_group), Some(3001));
+        // The outcome still names the RECORDED uid (the layer's own contribution),
+        // so reporting can detect a displaced record.
+        assert!(matches!(
+            r.outcome,
+            InheritOutcome::InheritedFromSnapshot {
+                uid: Some(3001),
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn recorded_root_uid_lands_in_the_contexts_for_the_privileged_gate() {
+        // A forged/legit uid-0 record must flow into the resolved contexts so the
+        // downstream `requires_privilege_resolved` gate sees it — identical to an
+        // inherited-from-a-live-root-pod context.
+        let r = resolved_from_recorded(
+            &MoverSpec::default(),
+            "app/pg-b1",
+            &meta(Some(0), None, None, RecordedSrc::Explicit),
+        );
+        let (sc, psc) = &r.contexts;
+        assert_eq!(
+            kopiur_api::common::effective_run_as_user(sc.as_ref(), psc.as_ref()),
+            Some(0)
+        );
+        assert!(kopiur_api::common::requires_privilege_resolved(
+            sc.as_ref(),
+            psc.as_ref(),
+            None
+        ));
+    }
+
+    #[test]
+    fn empty_record_contributes_nothing_and_invents_no_identity() {
+        // uid/gid/fsGroup all absent: the synthesized layer must not conjure an
+        // identity out of thin air (promotion never invents one).
+        let r = resolved_from_recorded(
+            &MoverSpec::default(),
+            "app/pg-b1",
+            &meta(None, None, None, RecordedSrc::Defaults),
+        );
+        let (sc, psc) = &r.contexts;
+        assert_eq!(
+            kopiur_api::common::effective_run_as_user(sc.as_ref(), psc.as_ref()),
+            None
+        );
+        assert_eq!(psc.as_ref().and_then(|p| p.fs_group), None);
+        assert!(matches!(
+            r.outcome,
+            InheritOutcome::InheritedFromSnapshot { uid: None, .. }
+        ));
+    }
+
+    // The full SecurityContext type carries no Eq; comparing the whole
+    // ResolvedMoverSecurity works because it derives PartialEq.
+    #[test]
+    fn contexts_match_a_hand_built_pair_merge() {
+        let m = MoverSpec {
+            security_context: Some(SecurityContext {
+                run_as_non_root: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let rec = meta(Some(3001), None, Some(65532), RecordedSrc::Inherited);
+        let r = resolved_from_recorded(&m, "app/pg-b1", &rec);
+        let expected = kopiur_api::common::merge_context_pair(
+            Some(&SecurityContext {
+                run_as_user: Some(3001),
+                ..Default::default()
+            }),
+            Some(&PodSecurityContext {
+                fs_group: Some(65532),
+                ..Default::default()
+            }),
+            m.security_context.as_ref(),
+            m.pod_security_context.as_ref(),
+        );
+        assert_eq!(r.contexts, expected);
     }
 }

--- a/crates/controller/src/maintenance/mod.rs
+++ b/crates/controller/src/maintenance/mod.rs
@@ -613,6 +613,9 @@ async fn spawn_maintenance_job(
         namespace,
         maint.spec.mover.as_ref(),
         None,
+        // `inheritSecurityContextFrom.snapshot` is restore-only (admission-rejected
+        // on Maintenance), so there is never a recorded source here either.
+        None,
     )
     .await?
     .contexts;

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -1866,6 +1866,7 @@ mod tests {
             stats: SnapshotStats::default(),
             root_entry: None,
             retention_reason: vec![],
+            tags: Default::default(),
         }
     }
 

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -31,11 +31,12 @@ use crate::config;
 use crate::consts::{
     ALLOW_PRIVILEGED_MOVER_ACTION, API_VERSION, CREDENTIALS_AVAILABLE_CONDITION,
     CREDENTIALS_PROJECTED_REASON, INHERIT_FALLBACK_REASON, MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION,
-    MISSING_CREDENTIALS_REASON, MOVER_PERMITTED_CONDITION, ORPHANED_PRIME_REAPED_REASON,
-    POPULATE_HIJACKED_REASON, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
-    RECREATE_CLAIM_TO_RESTORE_ACTION, RESTORE_SECURITY_CONTEXT_COMPATIBLE_CONDITION,
-    RESTORE_TARGET_ALREADY_BOUND_REASON, SECURITY_CONTEXT_COMPATIBLE_REASON,
-    SECURITY_CONTEXT_INHERITED_CONDITION,
+    MISSING_CREDENTIALS_REASON, MISSING_RECORDED_IDENTITY_REASON, MOVER_PERMITTED_CONDITION,
+    ORPHANED_PRIME_REAPED_REASON, POPULATE_HIJACKED_REASON, PRIVILEGED_MOVER_NOT_PERMITTED_REASON,
+    RECORDED_APPLIED_REASON, RECORDED_PINNED_NO_UID_REASON, RECREATE_CLAIM_TO_RESTORE_ACTION,
+    RESTORE_SECURITY_CONTEXT_COMPATIBLE_CONDITION, RESTORE_TARGET_ALREADY_BOUND_REASON,
+    SECURITY_CONTEXT_COMPATIBLE_REASON, SECURITY_CONTEXT_INHERITED_CONDITION,
+    SET_EXPLICIT_MOVER_CONTEXT_ACTION,
 };
 use crate::context::Context;
 use crate::error::{Error, Result, error_policy_for};
@@ -481,6 +482,222 @@ async fn report_restore_inherit_fallback(
         }
         Ok(false) => {}
         Err(e) => tracing::debug!(error = %e, "restore inherit fallback: condition patch failed"),
+    }
+}
+
+/// Park the restore on the `MissingRecordedIdentity` hold:
+/// `SecurityContextInherited=False` + `Pending` + a Warning Event (mirrors the
+/// missing-ServiceAccount pattern above). The hold is permanent-*shaped* — a
+/// pre-feature/foreign snapshot, or a catalog scan that has not materialized the
+/// matching CR yet — so the caller requeues it on the slow structural cadence via
+/// [`Error::MissingRecordedIdentity`], never the fast transient one.
+async fn report_missing_recorded_identity(
+    restore: &Restore,
+    api: &Api<Restore>,
+    msg: &str,
+    ctx: &Context,
+) -> Result<()> {
+    let name = restore.name_any();
+    // Not necessarily the first conditions writer across reconciles — build from the
+    // LIVE conditions and only patch (and Event) on a real transition, so the 300s
+    // requeue does not re-fire an identical Warning forever.
+    let Some(live) = io::live_conditions_source(api, &name, restore).await else {
+        return Ok(()); // deleted mid-reconcile
+    };
+    let conditions = io::upsert_condition(
+        &existing_conditions(&live),
+        SECURITY_CONTEXT_INHERITED_CONDITION,
+        false,
+        MISSING_RECORDED_IDENTITY_REASON,
+        msg,
+        restore.metadata.generation,
+    );
+    let current = serde_json::to_value(&live.status).ok();
+    if io::patch_status_if_changed(
+        api,
+        &name,
+        current.as_ref(),
+        serde_json::json!({ "phase": "Pending", "conditions": conditions }),
+    )
+    .await?
+    {
+        io::publish_warning_event(
+            ctx,
+            restore,
+            MISSING_RECORDED_IDENTITY_REASON,
+            SET_EXPLICIT_MOVER_CONTEXT_ACTION,
+            msg,
+        )
+        .await;
+    }
+    Ok(())
+}
+
+/// The `SecurityContextInherited` verdict for a restore that inherited the identity
+/// RECORDED on its backup (`inheritSecurityContextFrom.snapshot`).
+struct RecordedInheritVerdict {
+    /// `true` when the record contributed a real identity to reproduce.
+    ok: bool,
+    reason: &'static str,
+    message: String,
+}
+
+/// Decide what inheriting a backup's recorded identity actually achieved. Pure — every
+/// arm is unit-testable without a cluster.
+///
+/// Reuses the pins-identity-vs-baseline logic from live-pod inherit: a record that
+/// contributes nothing beyond the mover's own hardened baseline (no uid, no gid, and an
+/// fsGroup that is absent or the hardened 65532) is a provable no-op — the mover runs
+/// as its image's uid — and must warn (`RecordedPinnedNoUid`), not claim success. A
+/// non-baseline fsGroup-only record is the blessed restore shape (the kubelet applies
+/// fsGroup to the fresh target volume) and reports `True`, as does a pinned uid.
+///
+/// The message ALWAYS names the Snapshot, the recorded uid, and the provenance —
+/// only `src: inherited` may claim the identity tracked the workload — and a recorded
+/// ROOT uid is called out explicitly: recorded metadata is untrusted repository data
+/// (anyone with repository write credentials can forge `{"schema":1,"uid":0}`), so the
+/// elevation must stay auditable in the condition text even in namespaces already
+/// annotated for privileged movers (plan §3.4).
+fn recorded_inherit_verdict(
+    snapshot: &str,
+    uid: Option<i64>,
+    src: kopiur_api::recorded::RecordedSrc,
+    gid: Option<i64>,
+    fs_group: Option<i64>,
+) -> RecordedInheritVerdict {
+    use kopiur_api::common::MOVER_NONROOT_ID;
+    use kopiur_api::recorded::RecordedSrc;
+
+    // Exhaustive over the provenance so a new variant must state its honesty here.
+    let provenance = match src {
+        RecordedSrc::Inherited => {
+            "recorded provenance `inherited`: the identity was read from the live workload \
+             at backup time, so this restore reproduces the identity the workload actually \
+             ran as"
+        }
+        RecordedSrc::Explicit => {
+            "recorded provenance `explicit`: the backup recipe's explicit mover context \
+             pinned this identity — it reproduces the backup mover's identity, which was \
+             never workload-derived"
+        }
+        RecordedSrc::Defaults => {
+            "recorded provenance `defaults`: the identity came from repository/hardened \
+             mover defaults at backup time, not from the workload"
+        }
+        RecordedSrc::Unknown => {
+            "recorded provenance is a value this operator version does not recognize \
+             (written by a newer kopiur) — whether it tracked the workload is unknown"
+        }
+    };
+
+    let contributes =
+        uid.is_some() || gid.is_some() || fs_group.is_some_and(|f| f != MOVER_NONROOT_ID);
+    if !contributes {
+        return RecordedInheritVerdict {
+            ok: false,
+            reason: RECORDED_PINNED_NO_UID_REASON,
+            message: format!(
+                "Snapshot `{snapshot}` recorded no pinned uid — and no gid/fsGroup beyond \
+                 the mover's own defaults — so inheriting it contributed nothing: the mover \
+                 runs as its image's uid {MOVER_NONROOT_ID}, an identity that did NOT come \
+                 from the backup ({provenance}). The backup mover's identity was \
+                 image-determined at backup time. Pin mover.securityContext.runAsUser on \
+                 this Restore if the restored files must be owned by a specific uid."
+            ),
+        };
+    }
+
+    let identity = match uid {
+        Some(u) => format!("uid {u}"),
+        None => format!(
+            "its image's uid {MOVER_NONROOT_ID} (the record pins no uid), with the \
+             recorded group identity applied"
+        ),
+    };
+    let detail = [
+        gid.map(|g| format!("gid {g}")),
+        fs_group.map(|f| format!("fsGroup {f}")),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(", ");
+    let detail = if detail.is_empty() {
+        String::new()
+    } else {
+        format!(" ({detail})")
+    };
+    // A recorded ROOT uid must be visible in the condition itself: the privileged-mover
+    // gate + Events fire elsewhere, but this text is what makes a FORGED uid-0 tag
+    // auditable per-restore, naming both the elevation and where it came from.
+    let root_note = if uid == Some(0) {
+        format!(
+            " The mover runs as ROOT (uid 0) because Snapshot `{snapshot}` recorded uid 0 \
+             — recorded metadata is repository data, forgeable by anyone with repository \
+             write credentials, so verify this snapshot is trusted; the run is additionally \
+             gated on the namespace's privileged-movers opt-in."
+        )
+    } else {
+        String::new()
+    };
+    RecordedInheritVerdict {
+        ok: true,
+        reason: RECORDED_APPLIED_REASON,
+        message: format!(
+            "the mover inherited the identity recorded on Snapshot `{snapshot}` and runs \
+             as {identity}{detail}; {provenance}.{root_note}"
+        ),
+    }
+}
+
+/// Write the recorded-inherit verdict as the `SecurityContextInherited` condition
+/// (True or False) and, on a warning transition, a Warning Event. Mirrors
+/// [`report_restore_inherit_fallback`]'s two-writer discipline: live conditions +
+/// patch-if-changed, so the privileged-gate/stale-clear writers above are not erased
+/// and a steady state re-fires nothing.
+async fn report_restore_recorded_inherit(
+    namespace: &str,
+    restore: &Restore,
+    verdict: &RecordedInheritVerdict,
+    ctx: &Context,
+) {
+    let api: Api<Restore> = Api::namespaced(ctx.client.clone(), namespace);
+    let name = restore.name_any();
+    let Some(live) = io::live_conditions_source(&api, &name, restore).await else {
+        return; // deleted mid-reconcile
+    };
+    let conditions = io::upsert_condition(
+        &existing_conditions(&live),
+        SECURITY_CONTEXT_INHERITED_CONDITION,
+        verdict.ok,
+        verdict.reason,
+        &verdict.message,
+        restore.metadata.generation,
+    );
+    let current = serde_json::to_value(&live.status).ok();
+    match io::patch_status_if_changed(
+        &api,
+        &name,
+        current.as_ref(),
+        serde_json::json!({ "conditions": conditions }),
+    )
+    .await
+    {
+        // Only a problem is worth an Event; the healthy arm is a silent confirmation.
+        Ok(true) if !verdict.ok => {
+            io::publish_warning_event(
+                ctx,
+                restore,
+                verdict.reason,
+                SET_EXPLICIT_MOVER_CONTEXT_ACTION,
+                &verdict.message,
+            )
+            .await;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::debug!(error = %e, "restore recorded inherit: condition patch failed");
+        }
     }
 }
 
@@ -1800,20 +2017,52 @@ async fn run_restore_mover(
         Err(e) => return Err(e),
     };
 
-    // Resolve the restore mover's EFFECTIVE security context once (explicit, or
-    // inherited from a workload pod via `inheritSecurityContextFrom`). Both the gate
-    // and the Job use it, so an inherited root context is gated like an explicit one.
-    // The effective container + pod security contexts — explicit, or both inherited
-    // from a workload pod via `inheritSecurityContextFrom`.
+    // Resolve the restore mover's EFFECTIVE security context once (explicit, inherited
+    // from a workload pod via `inheritSecurityContextFrom`, or replayed from the
+    // backup's RECORDED identity via `inheritSecurityContextFrom.snapshot`). Both the
+    // gate and the Job use it, so an inherited/recorded root context is gated like an
+    // explicit one.
+    //
+    // The recorded-identity source resolves FIRST (a no-op `None` unless the mover uses
+    // the `snapshot` variant): the Snapshot CR's `status.recorded` — direct for
+    // `snapshotRef`, via the CR-catalog search for `fromPolicy`/`identity`. Its
+    // `MissingDependency` holds are permanent-SHAPED (a pre-feature snapshot or a
+    // catalog scan that has not landed yet), so they are surfaced as an explicit
+    // `SecurityContextInherited=False`/`MissingRecordedIdentity` condition + Event and
+    // requeued on the slow structural cadence (300s) instead of the fast transient one
+    // — a bare `?` here would hot-loop a generic error with no condition.
+    let recorded_source = match snapshot_recorded_source(ctx, restore, namespace).await {
+        Ok(s) => s,
+        Err(Error::MissingDependency(msg)) => {
+            report_missing_recorded_identity(restore, api, &msg, ctx).await?;
+            return Err(Error::MissingRecordedIdentity(msg));
+        }
+        Err(e) => return Err(e),
+    };
     // Restore has no backup *source* PVC; `pvcConsumer` is backup-only (validator-rejected
     // for restore), so pass None.
-    let mover_security = io::resolve_mover_security_contexts(
+    let mover_security = match io::resolve_mover_security_contexts(
         &ctx.client,
         namespace,
         restore.spec.mover.as_ref(),
         None,
+        recorded_source.as_ref(),
     )
-    .await?;
+    .await
+    {
+        Ok(s) => s,
+        // The snapshot-inherit hold: the matched CR carries no `status.recorded` AND the
+        // explicit context pins no fallback identity (the resolver reports a `Fallback`
+        // outcome instead when it does — that path stays reported as today). Same
+        // explicit condition + slow requeue as above. Guarded on `recorded_source` so a
+        // live-pod inherit's MissingDependency (workload scaled to zero) keeps its
+        // existing fast-transient propagation.
+        Err(Error::MissingDependency(msg)) if recorded_source.is_some() => {
+            report_missing_recorded_identity(restore, api, &msg, ctx).await?;
+            return Err(Error::MissingRecordedIdentity(msg));
+        }
+        Err(e) => return Err(e),
+    };
     let (effective_sc, effective_pod_sc) = mover_security.contexts.clone();
     let privileged_mode = restore.spec.mover.as_ref().and_then(|m| m.privileged_mode);
 
@@ -1918,6 +2167,22 @@ async fn run_restore_mover(
     match &mover_security.outcome {
         io::InheritOutcome::Fallback { reason } => {
             report_restore_inherit_fallback(namespace, restore, reason, ctx).await;
+        }
+        // Recorded-identity inherit reports POSITIVELY too (unlike `workloadSelector`
+        // restores, which stay Fallback-only): provable provenance is this mode's entire
+        // value, so the condition must name the Snapshot, the recorded uid, and the
+        // provenance — and a record that contributed nothing beyond the hardened
+        // baseline must warn, not claim success.
+        io::InheritOutcome::InheritedFromSnapshot { snapshot, uid, src } => {
+            let meta = recorded_source.as_ref().and_then(|s| s.meta.as_ref());
+            let verdict = recorded_inherit_verdict(
+                snapshot,
+                *uid,
+                *src,
+                meta.and_then(|m| m.gid),
+                meta.and_then(|m| m.fs_group),
+            );
+            report_restore_recorded_inherit(namespace, restore, &verdict, ctx).await;
         }
         // The backup-only `InheritPinnedNoUid` warning has no restore counterpart on purpose:
         // an fsGroup-only inherit is a *blessed* restore shape (`RestoreBasis::FsGroupMatch`),
@@ -2251,6 +2516,228 @@ async fn restore_source_anchor(
         username,
         hostname,
     }
+}
+
+/// Resolve the recorded-identity source for `inheritSecurityContextFrom.snapshot`,
+/// BEFORE the mover security-context resolution. `None` unless this restore's mover
+/// uses the `snapshot` variant (every other shape needs no Snapshot CR read).
+///
+/// - `source.snapshotRef` reads the referenced `Snapshot` CR directly (mirrors
+///   [`restore_source_anchor`]) and hands back its `status.recorded` — possibly
+///   absent, which the resolver turns into the actionable hold (or a reported
+///   `Fallback` when the explicit context pins an identity).
+/// - `source.fromPolicy`/`source.identity` run the CR-catalog search
+///   ([`select_recorded_source`]): derive the kopia identity triple (fromPolicy:
+///   re-resolved from the LIVE SnapshotPolicy exactly like source resolution;
+///   identity: the user-supplied triple), LIST the Snapshot CRs where that source's
+///   rows live, and pick the recorded-carrying row honoring
+///   `asOf`/`offset`/`snapshotID`. This is what makes the GitOps re-bootstrap
+///   declarative: apply Repository + SnapshotPolicy + Restore, and the restore
+///   resolves the moment the catalog scan materializes a discovered row.
+///
+/// Namespace choice for the search: fromPolicy rows live in the POLICY's namespace
+/// (schedules create Snapshots there, and the catalog materializes a discovered row
+/// in the namespace named by the identity's hostname — the policy namespace by
+/// construction); a raw `identity` source searches the Restore's own namespace (the
+/// renamed-cluster escape hatch restores into the namespace being rebuilt).
+///
+/// Every `Err(MissingDependency)` from here is a permanent-shaped hold the caller
+/// reports as `MissingRecordedIdentity` and requeues slowly.
+async fn snapshot_recorded_source(
+    ctx: &Context,
+    restore: &Restore,
+    namespace: &str,
+) -> Result<Option<io::SnapshotRecordedSource>> {
+    use kopiur_api::common::InheritSecurityContextFrom;
+    if !matches!(
+        restore
+            .spec
+            .mover
+            .as_ref()
+            .and_then(|m| m.inherit_security_context_from.as_ref()),
+        Some(InheritSecurityContextFrom::Snapshot(_))
+    ) {
+        return Ok(None);
+    }
+    // Exhaustive over the source: each arm must state how recorded meta is found.
+    match &restore.spec.source {
+        RestoreSource::SnapshotRef(r) => {
+            let ns = r.namespace.as_deref().unwrap_or(namespace);
+            let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), ns);
+            let snap = api.get_opt(&r.name).await?.ok_or_else(|| {
+                Error::MissingDependency(format!(
+                    "snapshotRef Snapshot `{ns}/{}` not found — if this cluster was \
+                     re-bootstrapped, the catalog scan materializes discovered/adopted \
+                     rows; the Restore holds until it appears. (Or use source.fromPolicy/\
+                     identity, which search the catalog by identity instead of by name.)",
+                    r.name
+                ))
+            })?;
+            Ok(Some(io::SnapshotRecordedSource {
+                snapshot: format!("{ns}/{}", r.name),
+                meta: snap.status.as_ref().and_then(|s| s.recorded.clone()),
+            }))
+        }
+        RestoreSource::FromPolicy(c) => {
+            use kopiur_api::SnapshotPolicy;
+            let cfg_ns = c.namespace.as_deref().unwrap_or(namespace);
+            let cfg_api: Api<SnapshotPolicy> = Api::namespaced(ctx.client.clone(), cfg_ns);
+            let config = cfg_api.get_opt(&c.name).await?.ok_or_else(|| {
+                Error::MissingDependency(format!("SnapshotPolicy {cfg_ns}/{}", c.name))
+            })?;
+            let repo = resolve_restore_repository(ctx, restore, namespace).await?;
+            let triple = crate::snapshot_policy::config_identity(
+                &config,
+                cfg_ns,
+                repo.identity_defaults.as_ref(),
+            )?;
+            search_recorded_source(ctx, cfg_ns, &triple, c.as_of.as_deref(), c.offset, None)
+                .await
+                .map(Some)
+        }
+        RestoreSource::Identity(id) => {
+            let triple = kopiur_api::common::ResolvedIdentity {
+                username: id.username.clone(),
+                hostname: id.hostname.clone(),
+                source_path: id.source_path.clone(),
+            };
+            search_recorded_source(
+                ctx,
+                namespace,
+                &triple,
+                id.as_of.as_deref(),
+                id.offset.unwrap_or(0),
+                id.snapshot_id.as_deref(),
+            )
+            .await
+            .map(Some)
+        }
+    }
+}
+
+/// LIST the namespace's Snapshot CRs and run the pure [`select_recorded_source`]
+/// over them; no match is the `MissingRecordedIdentity` hold (the scan may still be
+/// running). Thin IO wrapper so the selection semantics stay unit-tested.
+async fn search_recorded_source(
+    ctx: &Context,
+    ns: &str,
+    triple: &kopiur_api::common::ResolvedIdentity,
+    as_of: Option<&str>,
+    offset: i64,
+    snapshot_id: Option<&str>,
+) -> Result<io::SnapshotRecordedSource> {
+    let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), ns);
+    let rows = api.list(&kube::api::ListParams::default()).await?.items;
+    // `asOf` was validated at admission with the same parser; re-parse defensively
+    // (an unparseable stored value degrades to "no cutoff" rather than erroring —
+    // the shared validator rejects it separately on the reconcile path).
+    let cutoff = as_of
+        .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
+        .map(|t| t.with_timezone(&chrono::Utc));
+    let Some((name, meta)) = select_recorded_source(triple, cutoff, offset, snapshot_id, &rows)
+    else {
+        return Err(Error::MissingDependency(format!(
+            "no Snapshot CR carrying recorded identity (`status.recorded`) matches \
+             `{}@{}:{}` in namespace `{ns}` yet — the catalog scan may still be running \
+             (it materializes discovered rows and backfills recorded metadata when the \
+             kopia snapshot carries the `kopiur-meta` tag); the Restore holds until one \
+             appears",
+            triple.username,
+            triple.hostname,
+            triple.source_path.as_deref().unwrap_or("*"),
+        )));
+    };
+    Ok(io::SnapshotRecordedSource {
+        snapshot: format!("{ns}/{name}"),
+        meta: Some(meta),
+    })
+}
+
+/// §3.6 CR-catalog search, pure: pick the `Snapshot` CR whose recorded identity a
+/// `fromPolicy`/`identity` restore should inherit.
+///
+/// Candidates must match the kopia identity triple on `status.snapshot.identity`
+/// (username/hostname exact; a `sourcePath` in the triple must match exactly, an
+/// absent one matches any path — the same "absent matches any" the mover's own
+/// selector uses) and must carry `status.recorded` (a row without it cannot supply
+/// an identity — the backfill adds it when the kopia snapshot carries the tag).
+/// Discovered rows match too: identity comparison never touches `policyRef`.
+///
+/// Selection mirrors `kopiur_kopia::selection::{filter_as_of, pick_offset}` against
+/// `status.timing`: a `snapshotID` pins the exact row by
+/// `status.snapshot.kopiaSnapshotID` (admission forbids combining it with
+/// `asOf`/`offset`); otherwise candidates are ordered newest-first by timing
+/// (`endTime`, else `startTime`; undated rows sort last and are excluded under a
+/// cutoff, since membership cannot be proven), `asOf` keeps rows at-or-before the
+/// cutoff, and `offset` steps back from the newest (negative clamps to 0;
+/// out-of-range yields `None`).
+///
+/// Caveat (documented in `docs/restores.md`): the mover's OWN selection under
+/// `asOf` runs against the live repository listing, so it can pick a different
+/// manifest of the same source than this CR-side match — identity metadata is
+/// per-source in practice, so the divergence is cosmetic.
+fn select_recorded_source(
+    triple: &kopiur_api::common::ResolvedIdentity,
+    as_of: Option<chrono::DateTime<chrono::Utc>>,
+    offset: i64,
+    snapshot_id: Option<&str>,
+    rows: &[Snapshot],
+) -> Option<(String, kopiur_api::recorded::RecordedSnapshotMeta)> {
+    let identity_matches = |row: &kopiur_api::snapshot::SnapshotInfo| {
+        row.identity.username == triple.username
+            && row.identity.hostname == triple.hostname
+            && match &triple.source_path {
+                Some(p) => row.identity.source_path.as_deref() == Some(p.as_str()),
+                None => true,
+            }
+    };
+    // A row's selection timestamp: timing endTime, else startTime (RFC3339).
+    let row_time = |snap: &Snapshot| -> Option<chrono::DateTime<chrono::Utc>> {
+        let timing = snap.status.as_ref()?.timing.as_ref()?;
+        let raw = timing
+            .end_time
+            .as_deref()
+            .or(timing.start_time.as_deref())?;
+        chrono::DateTime::parse_from_rfc3339(raw)
+            .ok()
+            .map(|t| t.with_timezone(&chrono::Utc))
+    };
+    let mut candidates: Vec<(&Snapshot, Option<chrono::DateTime<chrono::Utc>>)> = rows
+        .iter()
+        .filter(|snap| {
+            let Some(status) = snap.status.as_ref() else {
+                return false;
+            };
+            status.recorded.is_some() && status.snapshot.as_ref().is_some_and(&identity_matches)
+        })
+        .map(|snap| (snap, row_time(snap)))
+        .collect();
+
+    let pick = |snap: &Snapshot| {
+        let status = snap.status.as_ref()?;
+        Some((snap.name_any(), status.recorded.clone()?))
+    };
+
+    if let Some(id) = snapshot_id {
+        // An exact pin: `asOf`/`offset` are admission-rejected alongside it.
+        return candidates
+            .iter()
+            .find(|(snap, _)| {
+                snap.status
+                    .as_ref()
+                    .and_then(|s| s.snapshot.as_ref())
+                    .is_some_and(|s| s.kopia_snapshot_id == id)
+            })
+            .and_then(|(snap, _)| pick(snap));
+    }
+    if let Some(cutoff) = as_of {
+        // Undated rows cannot prove "at or before the cutoff" — exclude them.
+        candidates.retain(|(_, t)| t.is_some_and(|t| t <= cutoff));
+    }
+    // Newest-first; undated rows last; name as the deterministic tie-break.
+    candidates.sort_by(|(a, ta), (b, tb)| tb.cmp(ta).then_with(|| a.name_any().cmp(&b.name_any())));
+    let idx = usize::try_from(offset.max(0)).ok()?;
+    candidates.get(idx).and_then(|(snap, _)| pick(snap))
 }
 
 /// Best-effort, **positive-only** restore-direction securityContext check. If a pod already

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -2054,14 +2054,22 @@ async fn run_restore_mover(
     // `SecurityContextInherited=False`/`MissingRecordedIdentity` condition + Event and
     // requeued on the slow structural cadence (300s) instead of the fast transient one
     // — a bare `?` here would hot-loop a generic error with no condition.
-    let recorded_source = match snapshot_recorded_source(ctx, restore, namespace).await {
-        Ok(s) => s,
-        Err(Error::MissingDependency(msg)) => {
-            report_missing_recorded_identity(restore, api, &msg, ctx).await?;
-            return Err(Error::MissingRecordedIdentity(msg));
-        }
-        Err(e) => return Err(e),
+    // The concrete kopia id this dispatch restores, when there is one — the meta
+    // reader uses it to select the SAME catalog row the resolution pinned, so the
+    // replayed identity always belongs to the snapshot actually being restored.
+    let dispatch_pinned_id = match selection {
+        RestoreSelection::Snapshot(id) => Some(id.as_str()),
+        RestoreSelection::Resolve(_) => None,
     };
+    let recorded_source =
+        match snapshot_recorded_source(ctx, restore, namespace, dispatch_pinned_id).await {
+            Ok(s) => s,
+            Err(Error::MissingDependency(msg)) => {
+                report_missing_recorded_identity(restore, api, &msg, ctx).await?;
+                return Err(Error::MissingRecordedIdentity(msg));
+            }
+            Err(e) => return Err(e),
+        };
     // Restore has no backup *source* PVC; `pvcConsumer` is backup-only (validator-rejected
     // for restore), so pass None.
     let mover_security = match io::resolve_mover_security_contexts(
@@ -2566,20 +2574,36 @@ async fn restore_source_anchor(
 ///
 /// Every `Err(MissingDependency)` from here is a permanent-shaped hold the caller
 /// reports as `MissingRecordedIdentity` and requeues slowly.
-async fn snapshot_recorded_source(
-    ctx: &Context,
-    restore: &Restore,
-    namespace: &str,
-) -> Result<Option<io::SnapshotRecordedSource>> {
+/// Whether this restore's mover replays the identity RECORDED on its snapshot
+/// (`inheritSecurityContextFrom: { snapshot: {} }`). Pure; shared by the meta
+/// reader and by `resolve_snapshot`, which must then pin data + identity to the
+/// SAME snapshot (the P1 coherence rule).
+fn snapshot_inherit_active(restore: &Restore) -> bool {
     use kopiur_api::common::InheritSecurityContextFrom;
-    if !matches!(
+    matches!(
         restore
             .spec
             .mover
             .as_ref()
             .and_then(|m| m.inherit_security_context_from.as_ref()),
         Some(InheritSecurityContextFrom::Snapshot(_))
-    ) {
+    )
+}
+
+/// `pinned_id` is the concrete kopia snapshot id the CURRENT dispatch restores
+/// (from the in-memory `RestoreSelection`), when there is one. For
+/// `fromPolicy`/`identity` sources it is the coherence key: `resolve_snapshot`
+/// pinned data + identity from one CR-catalog row, and passing the id back in
+/// here selects exactly that row again — the recorded meta can never come from
+/// a different (newer/other) snapshot than the one being restored, even if the
+/// catalog changed between reconciles.
+async fn snapshot_recorded_source(
+    ctx: &Context,
+    restore: &Restore,
+    namespace: &str,
+    pinned_id: Option<&str>,
+) -> Result<Option<io::SnapshotRecordedSource>> {
+    if !snapshot_inherit_active(restore) {
         return Ok(None);
     }
     // Exhaustive over the source: each arm must state how recorded meta is found.
@@ -2614,9 +2638,21 @@ async fn snapshot_recorded_source(
                 cfg_ns,
                 repo.identity_defaults.as_ref(),
             )?;
-            search_recorded_source(ctx, cfg_ns, &triple, c.as_of.as_deref(), c.offset, None)
-                .await
-                .map(Some)
+            // A pinned data id (the resolution pinned from this same catalog) selects
+            // exactly that row; asOf/offset only apply on the un-pinned first pass.
+            let row = search_recorded_source(
+                ctx,
+                cfg_ns,
+                &triple,
+                c.as_of.as_deref().filter(|_| pinned_id.is_none()),
+                if pinned_id.is_some() { 0 } else { c.offset },
+                pinned_id,
+            )
+            .await?;
+            Ok(Some(io::SnapshotRecordedSource {
+                snapshot: format!("{cfg_ns}/{}", row.name),
+                meta: Some(row.meta),
+            }))
         }
         RestoreSource::Identity(id) => {
             let triple = kopiur_api::common::ResolvedIdentity {
@@ -2624,18 +2660,41 @@ async fn snapshot_recorded_source(
                 hostname: id.hostname.clone(),
                 source_path: id.source_path.clone(),
             };
-            search_recorded_source(
+            let effective_pin = pinned_id.or(id.snapshot_id.as_deref());
+            let row = search_recorded_source(
                 ctx,
                 namespace,
                 &triple,
-                id.as_of.as_deref(),
-                id.offset.unwrap_or(0),
-                id.snapshot_id.as_deref(),
+                id.as_of.as_deref().filter(|_| effective_pin.is_none()),
+                if effective_pin.is_some() {
+                    0
+                } else {
+                    id.offset.unwrap_or(0)
+                },
+                effective_pin,
             )
-            .await
-            .map(Some)
+            .await?;
+            Ok(Some(io::SnapshotRecordedSource {
+                snapshot: format!("{namespace}/{}", row.name),
+                meta: Some(row.meta),
+            }))
         }
     }
+}
+
+/// The `Snapshot` CR row a `fromPolicy`/`identity` restore selected from the CR
+/// catalog: the recorded identity it supplies AND the exact kopia snapshot it
+/// belongs to, so identity and data are pinned to the SAME snapshot.
+#[derive(Debug, Clone)]
+struct RecordedRow {
+    /// The CR's name (in the searched namespace).
+    name: String,
+    /// `status.snapshot.kopiaSnapshotID` — what the restore must pin as its data.
+    kopia_snapshot_id: String,
+    /// `status.snapshot.identity` — pinned as the resolution's provenance/anchor.
+    identity: kopiur_api::common::ResolvedIdentity,
+    /// `status.recorded` — the identity the restore mover replays.
+    meta: kopiur_api::recorded::RecordedSnapshotMeta,
 }
 
 /// LIST the namespace's Snapshot CRs and run the pure [`select_recorded_source`]
@@ -2648,7 +2707,7 @@ async fn search_recorded_source(
     as_of: Option<&str>,
     offset: i64,
     snapshot_id: Option<&str>,
-) -> Result<io::SnapshotRecordedSource> {
+) -> Result<RecordedRow> {
     let api: Api<Snapshot> = Api::namespaced(ctx.client.clone(), ns);
     let rows = api.list(&kube::api::ListParams::default()).await?.items;
     // `asOf` was validated at admission with the same parser; re-parse defensively
@@ -2657,22 +2716,20 @@ async fn search_recorded_source(
     let cutoff = as_of
         .and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok())
         .map(|t| t.with_timezone(&chrono::Utc));
-    let Some((name, meta)) = select_recorded_source(triple, cutoff, offset, snapshot_id, &rows)
-    else {
-        return Err(Error::MissingDependency(format!(
+    select_recorded_source(triple, cutoff, offset, snapshot_id, &rows).ok_or_else(|| {
+        Error::MissingDependency(format!(
             "no Snapshot CR carrying recorded identity (`status.recorded`) matches \
-             `{}@{}:{}` in namespace `{ns}` yet — the catalog scan may still be running \
+             `{}@{}:{}`{} in namespace `{ns}` yet — the catalog scan may still be running \
              (it materializes discovered rows and backfills recorded metadata when the \
              kopia snapshot carries the `kopiur-meta` tag); the Restore holds until one \
              appears",
             triple.username,
             triple.hostname,
             triple.source_path.as_deref().unwrap_or("*"),
-        )));
-    };
-    Ok(io::SnapshotRecordedSource {
-        snapshot: format!("{ns}/{name}"),
-        meta: Some(meta),
+            snapshot_id
+                .map(|id| format!(" (kopia snapshot `{id}`)"))
+                .unwrap_or_default(),
+        ))
     })
 }
 
@@ -2695,17 +2752,20 @@ async fn search_recorded_source(
 /// cutoff, and `offset` steps back from the newest (negative clamps to 0;
 /// out-of-range yields `None`).
 ///
-/// Caveat (documented in `docs/restores.md`): the mover's OWN selection under
-/// `asOf` runs against the live repository listing, so it can pick a different
-/// manifest of the same source than this CR-side match — identity metadata is
-/// per-source in practice, so the divergence is cosmetic.
+/// Coherence (the P1 review finding): the returned row carries its
+/// `kopiaSnapshotID` so the caller can pin the DATA selection to the very
+/// snapshot that supplied the identity. `resolve_snapshot` pins it for
+/// `fromPolicy`/unpinned-`identity` sources whenever the `snapshot` inherit is
+/// active — the mover never runs its own independent live-listing selection
+/// there, so catalog lag or repository changes can no longer restore snapshot
+/// B's data under snapshot A's recorded uid/gid/fsGroup.
 fn select_recorded_source(
     triple: &kopiur_api::common::ResolvedIdentity,
     as_of: Option<chrono::DateTime<chrono::Utc>>,
     offset: i64,
     snapshot_id: Option<&str>,
     rows: &[Snapshot],
-) -> Option<(String, kopiur_api::recorded::RecordedSnapshotMeta)> {
+) -> Option<RecordedRow> {
     let identity_matches = |row: &kopiur_api::snapshot::SnapshotInfo| {
         row.identity.username == triple.username
             && row.identity.hostname == triple.hostname
@@ -2738,7 +2798,17 @@ fn select_recorded_source(
 
     let pick = |snap: &Snapshot| {
         let status = snap.status.as_ref()?;
-        Some((snap.name_any(), status.recorded.clone()?))
+        let info = status.snapshot.as_ref()?;
+        Some(RecordedRow {
+            name: snap.name_any(),
+            kopia_snapshot_id: info.kopia_snapshot_id.clone(),
+            identity: kopiur_api::common::ResolvedIdentity {
+                username: info.identity.username.clone(),
+                hostname: info.identity.hostname.clone(),
+                source_path: info.identity.source_path.clone(),
+            },
+            meta: status.recorded.clone()?,
+        })
     };
 
     if let Some(id) = snapshot_id {
@@ -2909,10 +2979,14 @@ async fn ensure_restore_target_pvc(
 /// resolve to a concrete id the controller pins ([`ResolveOutcome::Pinned`]);
 /// `fromPolicy`/`identity`-without-id defer the by-identity snapshot listing to
 /// the mover Job ([`ResolveOutcome::Deferred`]) because in-process listing only
-/// works for filesystem repos, and the mover reaches every backend. Returns
-/// `None` ONLY for a `snapshotRef` whose `Snapshot` CR has no resolved snapshot
-/// yet (the caller applies `waitTimeout` + `onMissingSnapshot`); deferred sources
-/// never return `None` — the mover applies `onMissingSnapshot` in-Job.
+/// works for filesystem repos, and the mover reaches every backend — EXCEPT when
+/// `inheritSecurityContextFrom: { snapshot: {} }` is active: the mover then
+/// replays a snapshot's recorded identity, so data and identity must pin from the
+/// SAME CR-catalog row ([`pin_from_recorded_catalog`]; the P1 coherence rule) and
+/// those sources pin too. Returns `None` ONLY for a `snapshotRef` whose
+/// `Snapshot` CR has no resolved snapshot yet (the caller applies `waitTimeout` +
+/// `onMissingSnapshot`); deferred sources never return `None` — the mover applies
+/// `onMissingSnapshot` in-Job.
 async fn resolve_snapshot(
     ctx: &Context,
     restore: &Restore,
@@ -2978,6 +3052,30 @@ async fn resolve_snapshot(
                     }),
                 })));
             }
+            let triple = ResolvedIdentity {
+                username: id.username.clone(),
+                hostname: id.hostname.clone(),
+                source_path: id.source_path.clone(),
+            };
+            if snapshot_inherit_active(restore) {
+                // COHERENCE (the P1 review finding): the mover replays the identity
+                // recorded on a snapshot, so the DATA must be that same snapshot. A
+                // deferred selection would let the mover pick from the LIVE listing
+                // while the identity came from the CR catalog — catalog lag or
+                // repository changes could then restore snapshot B's data under
+                // snapshot A's uid/gid/fsGroup. Pin both from one CR-catalog row.
+                return pin_from_recorded_catalog(
+                    ctx,
+                    restore,
+                    namespace,
+                    namespace,
+                    &triple,
+                    id.as_of.as_deref(),
+                    id.offset.unwrap_or(0),
+                )
+                .await
+                .map(Some);
+            }
             Ok(Some(ResolveOutcome::Deferred(RestoreSelector {
                 username: id.username.clone(),
                 hostname: id.hostname.clone(),
@@ -3002,6 +3100,21 @@ async fn resolve_snapshot(
                 cfg_ns,
                 repo.identity_defaults.as_ref(),
             )?;
+            if snapshot_inherit_active(restore) {
+                // Same coherence rule as the `identity` arm above: identity and data
+                // pin from ONE CR-catalog row, never two independent selections.
+                return pin_from_recorded_catalog(
+                    ctx,
+                    restore,
+                    namespace,
+                    cfg_ns,
+                    &identity,
+                    c.as_of.as_deref(),
+                    c.offset,
+                )
+                .await
+                .map(Some);
+            }
             Ok(Some(ResolveOutcome::Deferred(RestoreSelector {
                 username: identity.username,
                 hostname: identity.hostname,
@@ -3012,6 +3125,40 @@ async fn resolve_snapshot(
                 wait_deadline: wait_deadline.clone(),
             })))
         }
+    }
+}
+
+/// Pin a `fromPolicy`/unpinned-`identity` + `snapshot`-inherit restore from ONE
+/// CR-catalog row: the row supplies BOTH the kopia snapshot id (the data) and,
+/// later via [`snapshot_recorded_source`] re-selecting the same id, the recorded
+/// identity — so the two can never diverge (the P1 coherence rule). Under catalog
+/// lag this restores the newest *catalogued* snapshot rather than the newest live
+/// one, coherently; the scan converges the catalog. No matching row is the
+/// `MissingRecordedIdentity` hold (condition + Event + slow structural requeue).
+async fn pin_from_recorded_catalog(
+    ctx: &Context,
+    restore: &Restore,
+    namespace: &str,
+    search_ns: &str,
+    triple: &kopiur_api::common::ResolvedIdentity,
+    as_of: Option<&str>,
+    offset: i64,
+) -> Result<ResolveOutcome> {
+    match search_recorded_source(ctx, search_ns, triple, as_of, offset, None).await {
+        Ok(row) => Ok(ResolveOutcome::Pinned(ResolvedSource {
+            kopia_snapshot_id: row.kopia_snapshot_id,
+            snapshot_ref: Some(kopiur_api::common::ObjectRef {
+                name: row.name,
+                namespace: Some(search_ns.to_string()),
+            }),
+            identity: Some(row.identity),
+        })),
+        Err(Error::MissingDependency(msg)) => {
+            let api: Api<Restore> = Api::namespaced(ctx.client.clone(), namespace);
+            report_missing_recorded_identity(restore, &api, &msg, ctx).await?;
+            Err(Error::MissingRecordedIdentity(msg))
+        }
+        Err(e) => Err(e),
     }
 }
 

--- a/crates/controller/src/restore/mod.rs
+++ b/crates/controller/src/restore/mod.rs
@@ -1749,32 +1749,39 @@ async fn drive_direct_restore(
                 ctx.metrics.set_restore_duration(namespace, name, secs);
             }
             if phase != Some(RestorePhase::Completed) {
-                // A deferred (object-store/identity) resolution may have come up
-                // empty under `Continue`. The mover pins the outcome to
-                // status.resolved before its Job goes terminal, so a fresh read
-                // tells a real restore from a deploy-or-restore-empty — without it
-                // the success message would falsely claim "data was written".
-                let resolved = api
-                    .get_opt(name)
-                    .await?
-                    .and_then(|r| r.status)
-                    .and_then(|s| s.resolved);
-                io::patch_status(
-                    api,
-                    name,
-                    restore_success_status(restore, resolved.as_ref()),
-                )
-                .await?;
+                // A fresh read serves two purposes. (1) A deferred
+                // (object-store/identity) resolution may have come up empty under
+                // `Continue`: the mover pins the outcome to status.resolved before
+                // its Job goes terminal, so the live object tells a real restore
+                // from a deploy-or-restore-empty — without it the success message
+                // would falsely claim "data was written". (2) The conditions BASE:
+                // `restore_ready_status` rebuilds the conditions array from its
+                // argument, and the watch-store copy driving this reconcile can
+                // predate this controller's own launch-time condition patches
+                // (SecurityContextInherited, the MoverPermitted clear) — on a
+                // fast mover Job, building the terminal write on the stale copy
+                // durably erased them (the condition-writers-clobber class,
+                // caught by the recorded-identity restore e2e's 3s Job).
+                let Some(live) = io::live_conditions_source(api, name, restore).await else {
+                    return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+                };
+                let resolved = live.status.as_ref().and_then(|s| s.resolved.clone());
+                io::patch_status(api, name, restore_success_status(&live, resolved.as_ref()))
+                    .await?;
             }
             Ok(Action::requeue(std::time::Duration::from_secs(600)))
         }
         MoverOutcome::Failed => {
             if phase != Some(RestorePhase::Failed) {
+                // Live conditions base for the same reason as the Succeeded arm.
+                let Some(live) = io::live_conditions_source(api, name, restore).await else {
+                    return Ok(Action::requeue(std::time::Duration::from_secs(120)));
+                };
                 io::patch_status(
                     api,
                     name,
                     restore_ready_status(
-                        restore,
+                        &live,
                         RestorePhase::Failed,
                         "MoverJobFailed",
                         "the restore mover Job failed; see the Job/pod logs for the \
@@ -1802,10 +1809,17 @@ async fn drive_direct_restore(
             };
             // A new Job always writes; a poll only on a phase flip.
             if created || phase != Some(RestorePhase::Restoring) {
+                // Live conditions base: on `created` this write follows the SAME
+                // reconcile's inherit/compat condition patches (which re-read
+                // live), so building on the reconcile-start copy would erase them
+                // moments after they were written.
+                let Some(live) = io::live_conditions_source(api, name, restore).await else {
+                    return Ok(Action::requeue(std::time::Duration::from_secs(30)));
+                };
                 io::patch_status(
                     api,
                     name,
-                    restore_ready_status(restore, target_phase, reason, msg),
+                    restore_ready_status(&live, target_phase, reason, msg),
                 )
                 .await?;
             }
@@ -1865,17 +1879,26 @@ async fn steady_terminal_restore(
     phase: RestorePhase,
 ) -> Result<Action> {
     if !kstatus_settled_for(restore, phase) {
+        // Live conditions base: this reconcile is typically triggered by the
+        // MOVER's own terminal-phase PATCH, and the watch-store copy carrying it
+        // can predate this controller's launch-time condition patches
+        // (SecurityContextInherited, the MoverPermitted clear). Rebuilding the
+        // conditions array from that stale copy durably erased them on fast
+        // mover Jobs (the condition-writers-clobber class, caught by the
+        // recorded-identity restore e2e's 3s Job) — the heal must build on the
+        // live object.
+        let Some(live) = io::live_conditions_source(api, name, restore).await else {
+            return Ok(Action::requeue(std::time::Duration::from_secs(600)));
+        };
         let status = if phase == RestorePhase::Completed {
             // The mover wrote `phase: Completed` + `status.resolved` in one
             // PATCH, so `resolved` is observed here — distinguish a real
             // restore from a deploy-or-restore that came up empty.
-            restore_success_status(
-                restore,
-                restore.status.as_ref().and_then(|s| s.resolved.as_ref()),
-            )
+            let resolved = live.status.as_ref().and_then(|s| s.resolved.clone());
+            restore_success_status(&live, resolved.as_ref())
         } else {
             restore_ready_status(
-                restore,
+                &live,
                 phase,
                 "MoverJobFailed",
                 "the restore mover reported a terminal failure; see \

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -884,11 +884,14 @@ fn select_recorded_source_picks_the_newest_matching_row() {
             Some(Some(3002)),
         ),
     ];
-    let (name, meta) =
-        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
-            .expect("a match");
-    assert_eq!(name, "new");
-    assert_eq!(meta.uid, Some(3003));
+    let row = select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+        .expect("a match");
+    assert_eq!(row.name, "new");
+    assert_eq!(row.meta.uid, Some(3003));
+    // COHERENCE (the P1 rule): the selected row carries ITS OWN kopia id, so the
+    // caller pins the restored data to the same snapshot the identity came from.
+    assert_eq!(row.kopia_snapshot_id, "k3");
+    assert_eq!(row.identity.username, "pg");
 }
 
 #[test]
@@ -932,15 +935,14 @@ fn select_recorded_source_matches_identity_exactly_and_source_path_any_when_abse
         ),
     ];
     // An explicit sourcePath in the triple must match exactly.
-    let (name, _) =
-        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
-            .expect("a match");
-    assert_eq!(name, "match");
+    let row = select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+        .expect("a match");
+    assert_eq!(row.name, "match");
     // An absent sourcePath matches any path for the identity (the mover's own
     // selector semantics) — newest of /other (June 2) vs /data (June 1) wins.
-    let (name, _) =
+    let row =
         select_recorded_source(&triple("pg", "app", None), None, 0, None, &rows).expect("a match");
-    assert_eq!(name, "other-path");
+    assert_eq!(row.name, "other-path");
     // No identity match at all -> None (the MissingRecordedIdentity hold).
     assert!(select_recorded_source(&triple("nope", "app", None), None, 0, None, &rows).is_none());
 }
@@ -969,11 +971,14 @@ fn select_recorded_source_requires_status_recorded() {
             Some(Some(3001)),
         ),
     ];
-    let (name, meta) =
-        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
-            .expect("the recorded row");
-    assert_eq!(name, "recorded-older");
-    assert_eq!(meta.uid, Some(3001));
+    let row = select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+        .expect("the recorded row");
+    assert_eq!(row.name, "recorded-older");
+    assert_eq!(row.meta.uid, Some(3001));
+    assert_eq!(
+        row.kopia_snapshot_id, "k1",
+        "the id pinned as data must be the recorded row's own"
+    );
     // Only bare rows -> None.
     let bare = vec![catalog_row(
         "bare",
@@ -1012,7 +1017,7 @@ fn select_recorded_source_pins_by_snapshot_id() {
         ),
     ];
     // The pin wins over "newest".
-    let (name, meta) = select_recorded_source(
+    let row = select_recorded_source(
         &triple("pg", "app", Some("/data")),
         None,
         0,
@@ -1020,8 +1025,9 @@ fn select_recorded_source_pins_by_snapshot_id() {
         &rows,
     )
     .expect("the pinned row");
-    assert_eq!(name, "old");
-    assert_eq!(meta.uid, Some(3001));
+    assert_eq!(row.name, "old");
+    assert_eq!(row.meta.uid, Some(3001));
+    assert_eq!(row.kopia_snapshot_id, "k1", "pinned id round-trips");
     // A pin that matches no row -> None.
     assert!(
         select_recorded_source(
@@ -1073,27 +1079,27 @@ fn select_recorded_source_honors_as_of_and_offset_like_the_mover_selection() {
     ];
     let t = triple("pg", "app", Some("/data"));
     // asOf keeps rows at-or-before the cutoff (mirrors filter_as_of).
-    let (name, _) =
+    let row =
         select_recorded_source(&t, Some(cutoff("2026-06-02T12:00:00Z")), 0, None, &rows).unwrap();
-    assert_eq!(name, "k2");
+    assert_eq!(row.name, "k2");
     // Exactly AT an endTime keeps it.
-    let (name, _) =
+    let row =
         select_recorded_source(&t, Some(cutoff("2026-06-02T00:00:00Z")), 0, None, &rows).unwrap();
-    assert_eq!(name, "k2");
+    assert_eq!(row.name, "k2");
     // asOf composes with offset ("the previous one as of just after k2").
-    let (name, _) =
+    let row =
         select_recorded_source(&t, Some(cutoff("2026-06-02T12:00:00Z")), 1, None, &rows).unwrap();
-    assert_eq!(name, "k1");
+    assert_eq!(row.name, "k1");
     // Before everything -> None.
     assert!(
         select_recorded_source(&t, Some(cutoff("2026-05-01T00:00:00Z")), 0, None, &rows).is_none()
     );
     // offset semantics mirror pick_offset: out-of-range None, negative clamps.
-    let (name, _) = select_recorded_source(&t, None, 2, None, &rows).unwrap();
-    assert_eq!(name, "k1");
+    let row = select_recorded_source(&t, None, 2, None, &rows).unwrap();
+    assert_eq!(row.name, "k1");
     assert!(select_recorded_source(&t, None, 3, None, &rows).is_none());
-    let (name, _) = select_recorded_source(&t, None, -1, None, &rows).unwrap();
-    assert_eq!(name, "k3");
+    let row = select_recorded_source(&t, None, -1, None, &rows).unwrap();
+    assert_eq!(row.name, "k3");
 }
 
 #[test]
@@ -1120,16 +1126,49 @@ fn select_recorded_source_undated_rows_sort_last_and_are_excluded_under_a_cutoff
     ];
     let t = triple("pg", "app", Some("/data"));
     // Newest-first puts the dated row first; the undated one is still reachable.
-    let (name, _) = select_recorded_source(&t, None, 0, None, &rows).unwrap();
-    assert_eq!(name, "dated");
-    let (name, _) = select_recorded_source(&t, None, 1, None, &rows).unwrap();
-    assert_eq!(name, "undated");
+    let row = select_recorded_source(&t, None, 0, None, &rows).unwrap();
+    assert_eq!(row.name, "dated");
+    let row = select_recorded_source(&t, None, 1, None, &rows).unwrap();
+    assert_eq!(row.name, "undated");
     // Under a cutoff an undated row cannot prove membership -> excluded.
     let got = select_recorded_source(&t, Some(cutoff("2026-06-02T00:00:00Z")), 1, None, &rows);
     assert!(
         got.is_none(),
         "undated row must be excluded under asOf, got {got:?}"
     );
+}
+
+#[test]
+fn snapshot_inherit_active_matches_only_the_snapshot_variant() {
+    use kopiur_api::common::{InheritSecurityContextFrom, MoverSpec, SnapshotInherit};
+    let with_inherit = |i: Option<InheritSecurityContextFrom>| -> Restore {
+        serde_json::from_value(serde_json::json!({
+            "apiVersion": "kopiur.home-operations.com/v1alpha1",
+            "kind": "Restore",
+            "metadata": { "name": "r", "namespace": "app" },
+            "spec": {
+                "source": { "snapshotRef": { "name": "s" } },
+                "target": { "pvcRef": { "name": "dst" } },
+                "mover": serde_json::to_value(MoverSpec {
+                    inherit_security_context_from: i,
+                    ..Default::default()
+                }).unwrap(),
+            }
+        }))
+        .expect("restore fixture")
+    };
+    // The gate for the P1 coherence rule: only the `snapshot` variant makes
+    // `resolve_snapshot` pin data + identity from one CR-catalog row.
+    assert!(snapshot_inherit_active(&with_inherit(Some(
+        InheritSecurityContextFrom::Snapshot(SnapshotInherit {})
+    ))));
+    assert!(!snapshot_inherit_active(&with_inherit(None)));
+    assert!(!snapshot_inherit_active(&with_inherit(Some(
+        InheritSecurityContextFrom::WorkloadSelector(kopiur_api::PodSelector {
+            pod_selector: Default::default(),
+            container: None,
+        })
+    ))));
 }
 
 // --- recorded_inherit_verdict: the SecurityContextInherited text for snapshot inherit ---

--- a/crates/controller/src/restore/tests.rs
+++ b/crates/controller/src/restore/tests.rs
@@ -794,3 +794,424 @@ fn restore_flags_enable_file_deletion_regression() {
     };
     assert_eq!(op.restore_options().delete_extra, Some(true));
 }
+
+// --- §3.6 CR-catalog search: select_recorded_source ---------------------------
+
+/// Build a Snapshot CR row for the selector: name, identity triple, optional
+/// kopia id / endTime / recorded uid. `recorded: None` models a pre-feature row.
+fn catalog_row(
+    name: &str,
+    username: &str,
+    hostname: &str,
+    source_path: Option<&str>,
+    kopia_id: &str,
+    end_time: Option<&str>,
+    recorded_uid: Option<Option<i64>>,
+) -> Snapshot {
+    let mut status = serde_json::json!({
+        "snapshot": {
+            "kopiaSnapshotID": kopia_id,
+            "identity": { "username": username, "hostname": hostname },
+        },
+    });
+    if let Some(p) = source_path {
+        status["snapshot"]["identity"]["sourcePath"] = serde_json::json!(p);
+    }
+    if let Some(t) = end_time {
+        status["timing"] = serde_json::json!({ "endTime": t });
+    }
+    if let Some(uid) = recorded_uid {
+        let mut rec = serde_json::json!({ "schema": 1, "src": "explicit" });
+        if let Some(u) = uid {
+            rec["uid"] = serde_json::json!(u);
+        }
+        status["recorded"] = rec;
+    }
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Snapshot",
+        "metadata": { "name": name, "namespace": "app" },
+        "spec": {},
+        "status": status,
+    }))
+    .expect("catalog row fixture")
+}
+
+fn triple(username: &str, hostname: &str, source_path: Option<&str>) -> ResolvedIdentity {
+    ResolvedIdentity {
+        username: username.into(),
+        hostname: hostname.into(),
+        source_path: source_path.map(String::from),
+    }
+}
+
+use kopiur_api::common::ResolvedIdentity;
+
+fn cutoff(s: &str) -> chrono::DateTime<chrono::Utc> {
+    chrono::DateTime::parse_from_rfc3339(s)
+        .unwrap()
+        .with_timezone(&chrono::Utc)
+}
+
+#[test]
+fn select_recorded_source_picks_the_newest_matching_row() {
+    let rows = vec![
+        catalog_row(
+            "old",
+            "pg",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(3001)),
+        ),
+        catalog_row(
+            "new",
+            "pg",
+            "app",
+            Some("/data"),
+            "k3",
+            Some("2026-06-03T00:00:00Z"),
+            Some(Some(3003)),
+        ),
+        catalog_row(
+            "mid",
+            "pg",
+            "app",
+            Some("/data"),
+            "k2",
+            Some("2026-06-02T00:00:00Z"),
+            Some(Some(3002)),
+        ),
+    ];
+    let (name, meta) =
+        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+            .expect("a match");
+    assert_eq!(name, "new");
+    assert_eq!(meta.uid, Some(3003));
+}
+
+#[test]
+fn select_recorded_source_matches_identity_exactly_and_source_path_any_when_absent() {
+    let rows = vec![
+        catalog_row(
+            "other-user",
+            "redis",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-03T00:00:00Z"),
+            Some(Some(1)),
+        ),
+        catalog_row(
+            "other-host",
+            "pg",
+            "media",
+            Some("/data"),
+            "k2",
+            Some("2026-06-03T00:00:00Z"),
+            Some(Some(2)),
+        ),
+        catalog_row(
+            "other-path",
+            "pg",
+            "app",
+            Some("/other"),
+            "k3",
+            Some("2026-06-02T00:00:00Z"),
+            Some(Some(3)),
+        ),
+        catalog_row(
+            "match",
+            "pg",
+            "app",
+            Some("/data"),
+            "k4",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(4)),
+        ),
+    ];
+    // An explicit sourcePath in the triple must match exactly.
+    let (name, _) =
+        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+            .expect("a match");
+    assert_eq!(name, "match");
+    // An absent sourcePath matches any path for the identity (the mover's own
+    // selector semantics) — newest of /other (June 2) vs /data (June 1) wins.
+    let (name, _) =
+        select_recorded_source(&triple("pg", "app", None), None, 0, None, &rows).expect("a match");
+    assert_eq!(name, "other-path");
+    // No identity match at all -> None (the MissingRecordedIdentity hold).
+    assert!(select_recorded_source(&triple("nope", "app", None), None, 0, None, &rows).is_none());
+}
+
+#[test]
+fn select_recorded_source_requires_status_recorded() {
+    // The newest row matches the identity but predates the kopiur-meta feature
+    // (no status.recorded): it must be SKIPPED, not returned meta-less.
+    let rows = vec![
+        catalog_row(
+            "bare-newest",
+            "pg",
+            "app",
+            Some("/data"),
+            "k2",
+            Some("2026-06-03T00:00:00Z"),
+            None,
+        ),
+        catalog_row(
+            "recorded-older",
+            "pg",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(3001)),
+        ),
+    ];
+    let (name, meta) =
+        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &rows)
+            .expect("the recorded row");
+    assert_eq!(name, "recorded-older");
+    assert_eq!(meta.uid, Some(3001));
+    // Only bare rows -> None.
+    let bare = vec![catalog_row(
+        "bare",
+        "pg",
+        "app",
+        Some("/data"),
+        "k2",
+        Some("2026-06-03T00:00:00Z"),
+        None,
+    )];
+    assert!(
+        select_recorded_source(&triple("pg", "app", Some("/data")), None, 0, None, &bare).is_none()
+    );
+}
+
+#[test]
+fn select_recorded_source_pins_by_snapshot_id() {
+    let rows = vec![
+        catalog_row(
+            "new",
+            "pg",
+            "app",
+            Some("/data"),
+            "k3",
+            Some("2026-06-03T00:00:00Z"),
+            Some(Some(3003)),
+        ),
+        catalog_row(
+            "old",
+            "pg",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(3001)),
+        ),
+    ];
+    // The pin wins over "newest".
+    let (name, meta) = select_recorded_source(
+        &triple("pg", "app", Some("/data")),
+        None,
+        0,
+        Some("k1"),
+        &rows,
+    )
+    .expect("the pinned row");
+    assert_eq!(name, "old");
+    assert_eq!(meta.uid, Some(3001));
+    // A pin that matches no row -> None.
+    assert!(
+        select_recorded_source(
+            &triple("pg", "app", Some("/data")),
+            None,
+            0,
+            Some("kX"),
+            &rows
+        )
+        .is_none()
+    );
+    // A pinned row must still match the identity triple (a foreign row with the
+    // same manifest id in the namespace cannot be picked up).
+    assert!(
+        select_recorded_source(&triple("redis", "app", None), None, 0, Some("k1"), &rows).is_none()
+    );
+}
+
+#[test]
+fn select_recorded_source_honors_as_of_and_offset_like_the_mover_selection() {
+    let rows = vec![
+        catalog_row(
+            "k3",
+            "pg",
+            "app",
+            Some("/data"),
+            "k3",
+            Some("2026-06-03T00:00:00Z"),
+            Some(Some(3)),
+        ),
+        catalog_row(
+            "k2",
+            "pg",
+            "app",
+            Some("/data"),
+            "k2",
+            Some("2026-06-02T00:00:00Z"),
+            Some(Some(2)),
+        ),
+        catalog_row(
+            "k1",
+            "pg",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(1)),
+        ),
+    ];
+    let t = triple("pg", "app", Some("/data"));
+    // asOf keeps rows at-or-before the cutoff (mirrors filter_as_of).
+    let (name, _) =
+        select_recorded_source(&t, Some(cutoff("2026-06-02T12:00:00Z")), 0, None, &rows).unwrap();
+    assert_eq!(name, "k2");
+    // Exactly AT an endTime keeps it.
+    let (name, _) =
+        select_recorded_source(&t, Some(cutoff("2026-06-02T00:00:00Z")), 0, None, &rows).unwrap();
+    assert_eq!(name, "k2");
+    // asOf composes with offset ("the previous one as of just after k2").
+    let (name, _) =
+        select_recorded_source(&t, Some(cutoff("2026-06-02T12:00:00Z")), 1, None, &rows).unwrap();
+    assert_eq!(name, "k1");
+    // Before everything -> None.
+    assert!(
+        select_recorded_source(&t, Some(cutoff("2026-05-01T00:00:00Z")), 0, None, &rows).is_none()
+    );
+    // offset semantics mirror pick_offset: out-of-range None, negative clamps.
+    let (name, _) = select_recorded_source(&t, None, 2, None, &rows).unwrap();
+    assert_eq!(name, "k1");
+    assert!(select_recorded_source(&t, None, 3, None, &rows).is_none());
+    let (name, _) = select_recorded_source(&t, None, -1, None, &rows).unwrap();
+    assert_eq!(name, "k3");
+}
+
+#[test]
+fn select_recorded_source_undated_rows_sort_last_and_are_excluded_under_a_cutoff() {
+    let rows = vec![
+        catalog_row(
+            "undated",
+            "pg",
+            "app",
+            Some("/data"),
+            "kU",
+            None,
+            Some(Some(9)),
+        ),
+        catalog_row(
+            "dated",
+            "pg",
+            "app",
+            Some("/data"),
+            "k1",
+            Some("2026-06-01T00:00:00Z"),
+            Some(Some(1)),
+        ),
+    ];
+    let t = triple("pg", "app", Some("/data"));
+    // Newest-first puts the dated row first; the undated one is still reachable.
+    let (name, _) = select_recorded_source(&t, None, 0, None, &rows).unwrap();
+    assert_eq!(name, "dated");
+    let (name, _) = select_recorded_source(&t, None, 1, None, &rows).unwrap();
+    assert_eq!(name, "undated");
+    // Under a cutoff an undated row cannot prove membership -> excluded.
+    let got = select_recorded_source(&t, Some(cutoff("2026-06-02T00:00:00Z")), 1, None, &rows);
+    assert!(
+        got.is_none(),
+        "undated row must be excluded under asOf, got {got:?}"
+    );
+}
+
+// --- recorded_inherit_verdict: the SecurityContextInherited text for snapshot inherit ---
+
+use kopiur_api::recorded::RecordedSrc;
+
+#[test]
+fn recorded_verdict_uid_pinned_is_true_and_names_snapshot_uid_and_provenance() {
+    let v = recorded_inherit_verdict(
+        "app/pg-b1",
+        Some(3001),
+        RecordedSrc::Inherited,
+        Some(3001),
+        Some(65532),
+    );
+    assert!(v.ok);
+    assert_eq!(v.reason, RECORDED_APPLIED_REASON);
+    assert!(v.message.contains("app/pg-b1"), "{}", v.message);
+    assert!(v.message.contains("uid 3001"), "{}", v.message);
+    assert!(v.message.contains("`inherited`"), "{}", v.message);
+    // Only src: inherited may claim the identity tracked the workload.
+    assert!(v.message.contains("live workload"), "{}", v.message);
+}
+
+#[test]
+fn recorded_verdict_explicit_provenance_never_claims_workload_tracking() {
+    let v = recorded_inherit_verdict("app/pg-b1", Some(3001), RecordedSrc::Explicit, None, None);
+    assert!(v.ok);
+    assert!(v.message.contains("`explicit`"), "{}", v.message);
+    assert!(
+        v.message.contains("never workload-derived"),
+        "{}",
+        v.message
+    );
+    assert!(
+        !v.message.contains("identity the workload actually ran as"),
+        "explicit provenance must not claim workload tracking: {}",
+        v.message
+    );
+
+    let d = recorded_inherit_verdict("app/pg-b1", Some(3001), RecordedSrc::Defaults, None, None);
+    assert!(d.message.contains("not from the workload"), "{}", d.message);
+    let u = recorded_inherit_verdict("app/pg-b1", Some(3001), RecordedSrc::Unknown, None, None);
+    assert!(u.message.contains("does not recognize"), "{}", u.message);
+}
+
+#[test]
+fn recorded_verdict_baseline_only_meta_warns_recorded_pinned_no_uid() {
+    use kopiur_api::common::MOVER_NONROOT_ID;
+    // Nothing beyond the hardened baseline: no uid, no gid, fsGroup absent or the
+    // hardened 65532 -> a no-op inherit must NOT report a positive condition.
+    for fs in [None, Some(MOVER_NONROOT_ID)] {
+        let v = recorded_inherit_verdict("app/pg-b1", None, RecordedSrc::Defaults, None, fs);
+        assert!(!v.ok, "fsGroup {fs:?} is baseline");
+        assert_eq!(v.reason, RECORDED_PINNED_NO_UID_REASON);
+        assert!(v.message.contains("app/pg-b1"), "{}", v.message);
+        assert!(v.message.contains("65532"), "{}", v.message);
+        assert!(v.message.contains("runAsUser"), "fix named: {}", v.message);
+    }
+}
+
+#[test]
+fn recorded_verdict_non_baseline_group_only_is_true() {
+    // fsGroup-only beyond the baseline: the blessed FsGroupMatch restore shape.
+    let v = recorded_inherit_verdict("app/pg-b1", None, RecordedSrc::Inherited, None, Some(2000));
+    assert!(v.ok, "{}", v.message);
+    assert_eq!(v.reason, RECORDED_APPLIED_REASON);
+    assert!(v.message.contains("fsGroup 2000"), "{}", v.message);
+    // gid-only is a real contribution too (group-readable data).
+    let g = recorded_inherit_verdict("app/pg-b1", None, RecordedSrc::Explicit, Some(1000), None);
+    assert!(g.ok, "{}", g.message);
+    assert!(g.message.contains("gid 1000"), "{}", g.message);
+}
+
+#[test]
+fn recorded_verdict_root_uid_makes_the_elevation_visible() {
+    // §3.4: a recorded uid 0 must be auditable from the condition text alone —
+    // name ROOT, the snapshot it came from, and the forgeability of the record.
+    let v = recorded_inherit_verdict("app/pg-b1", Some(0), RecordedSrc::Explicit, Some(0), None);
+    assert!(v.ok, "{}", v.message);
+    assert!(v.message.contains("ROOT (uid 0)"), "{}", v.message);
+    assert!(v.message.contains("app/pg-b1"), "{}", v.message);
+    assert!(v.message.contains("forge"), "{}", v.message);
+    assert!(v.message.contains("privileged-movers"), "{}", v.message);
+}

--- a/crates/controller/src/server/mod.rs
+++ b/crates/controller/src/server/mod.rs
@@ -260,6 +260,9 @@ pub fn build_server_deployment(inputs: &ServerBuildInputs<'_>) -> Deployment {
     // override, exactly as movers resolve it (ADR-0004 §2). This is what lets the
     // server carry `supplementalGroups` to write a group-owned NFS/RWX backend —
     // `fsGroup` alone is silently ignored by the kubelet for in-tree NFS mounts.
+    // No `merge_context_pair` needed here: the container context is replace-not-merge
+    // and the only lower layer (hardened) pins no identity, so cross-dimension
+    // shadowing cannot arise.
     let pod_sec_ctx = match &inputs.pod_security_context {
         Some(over) => merge_pod_security_context(&hardened_pod_security_context(), over),
         None => hardened_pod_security_context(),

--- a/crates/controller/src/snapshot/batch.rs
+++ b/crates/controller/src/snapshot/batch.rs
@@ -917,6 +917,7 @@ mod tests {
                     hostname: "h".into(),
                     source_path: Some("/data".into()),
                 },
+                description: None,
             }),
             resolved: Some(ResolvedSnapshot {
                 repository: pinned_repo,

--- a/crates/controller/src/snapshot/build.rs
+++ b/crates/controller/src/snapshot/build.rs
@@ -110,7 +110,7 @@ pub(super) fn build_backup_run(
         version: 1,
         operation: Operation::Snapshot(SnapshotOp {
             source_path: source_path.clone(),
-            tags: tags_for(config),
+            tags: tags_for(backup, config),
             // Flattened SnapshotPolicy policy knobs → kopia `policy set` flags
             // (compression / files / errorHandling / upload / extraArgs). Wired so
             // these never stay inert (ADR-0005 §13(b)/§13(f), ADR-0004 §4b).
@@ -292,11 +292,121 @@ pub(super) fn repository_not_ready_message(repo_name: &str) -> String {
     )
 }
 
-/// Snapshot tags from the config + run metadata.
-fn tags_for(config: &SnapshotPolicy) -> BTreeMap<String, String> {
+/// Snapshot tags for a run: the user's `Snapshot.spec.tags` (invalid keys
+/// defensively SKIPPED with a warning — a stored pre-validator object must
+/// never fail its backup over a tag), then the reserved operator tags inserted
+/// LAST so they always win. Admission ([`kopiur_api::validate::validate_snapshot_tags`])
+/// rejects the same keys on new objects; this skip is the defensive layer for
+/// already-persisted ones.
+pub(super) fn tags_for(backup: &Snapshot, config: &SnapshotPolicy) -> BTreeMap<String, String> {
     let mut tags = BTreeMap::new();
+    if let Some(user) = &backup.spec.tags {
+        for (key, value) in user {
+            if tags.len() >= kopiur_api::validate::MAX_SNAPSHOT_TAGS {
+                tracing::warn!(
+                    backup = %backup.name_any(),
+                    dropped = user.len() - tags.len(),
+                    "Snapshot.spec.tags exceeds the {} tag bound; the remainder is skipped",
+                    kopiur_api::validate::MAX_SNAPSHOT_TAGS
+                );
+                break;
+            }
+            match kopiur_api::validate::snapshot_tag_error(key, value) {
+                None => {
+                    tags.insert(key.clone(), value.clone());
+                }
+                Some(reason) => tracing::warn!(
+                    backup = %backup.name_any(),
+                    tag = %key,
+                    "skipping invalid Snapshot.spec.tags entry (stored pre-validation): {reason}"
+                ),
+            }
+        }
+    }
+    // Reserved operator tags go in LAST so they always win over user tags.
+    // The legacy CLI string `kopiur:config:<name>` keeps being written
+    // byte-for-byte (kopia stores it as manifest key `tag:kopiur`, value
+    // `config:<name>` — the first-colon split); tooling depends on that shape.
     tags.insert("kopiur:config".to_string(), config.name_any());
     tags
+}
+
+/// The metadata recorded on the kopia snapshot (the `kopiur-meta` tag) for one
+/// run: the RESOLVED effective mover identity plus its provenance. Pure — the
+/// same value feeds both the tag and the launch `status.recorded` patch, so the
+/// two can never diverge.
+///
+/// `src` derivation:
+/// - `Inherited` iff the inherited layer pinned an identity with a concrete UID
+///   AND that UID survived the merge as the resolved effective UID — only then
+///   did the identity actually track the workload.
+/// - else `Explicit` iff the recipe's explicit `mover.securityContext`/
+///   `podSecurityContext` pins the winning effective UID (this covers the
+///   inherit-Fallback-proceeded-on-explicit case).
+/// - else `Defaults` (moverDefaults/hardened pinned it, or nothing did — then
+///   `uid` is `None` and the mover's UID was image-determined).
+pub(super) fn recorded_meta(
+    resolved: &kopiur_api::common::ResolvedMover,
+    outcome: &crate::io::InheritOutcome,
+    explicit: Option<&kopiur_api::common::MoverSpec>,
+) -> kopiur_api::RecordedSnapshotMeta {
+    use crate::io::InheritOutcome;
+    use kopiur_api::common::{effective_run_as_group, effective_run_as_user};
+    use kopiur_api::{KOPIUR_META_SCHEMA_V1, RecordedSnapshotMeta, RecordedSrc};
+
+    let uid = effective_run_as_user(
+        Some(&resolved.security_context),
+        resolved.pod_security_context.as_ref(),
+    );
+    let gid = effective_run_as_group(
+        Some(&resolved.security_context),
+        resolved.pod_security_context.as_ref(),
+    );
+    let fs_group = resolved
+        .pod_security_context
+        .as_ref()
+        .and_then(|p| p.fs_group);
+
+    // Did the inherited layer's own pinned UID survive as the resolved one?
+    // Exhaustive over the outcome so a new variant must be classified here.
+    let inherited_won = match outcome {
+        InheritOutcome::Inherited {
+            pins_identity: true,
+            uid: Some(u),
+            ..
+        } => uid == Some(*u),
+        InheritOutcome::Inherited { .. }
+        | InheritOutcome::Fallback { .. }
+        | InheritOutcome::NotRequested => false,
+        // Restore-only outcome (`inheritSecurityContextFrom.snapshot`); a backup —
+        // the only producer of recorded metadata — can never carry it (the variant
+        // is admission-rejected on SnapshotPolicy). Classified defensively as
+        // not-workload-tracked: replaying a recorded identity is NOT reading the
+        // live workload, so it must never be re-recorded as `src: inherited`.
+        InheritOutcome::InheritedFromSnapshot { .. } => false,
+    };
+    // Does the recipe's explicit context pin the winning effective UID? Covers
+    // the Fallback-proceeded-on-explicit case (the explicit context IS the run's
+    // identity source then).
+    let explicit_uid = explicit.and_then(|m| {
+        effective_run_as_user(m.security_context.as_ref(), m.pod_security_context.as_ref())
+    });
+    let explicit_won = explicit_uid.is_some() && explicit_uid == uid;
+
+    let src = if inherited_won {
+        RecordedSrc::Inherited
+    } else if explicit_won {
+        RecordedSrc::Explicit
+    } else {
+        RecordedSrc::Defaults
+    };
+    RecordedSnapshotMeta {
+        schema: KOPIUR_META_SCHEMA_V1,
+        src,
+        uid,
+        gid,
+        fs_group,
+    }
 }
 
 /// Resolve the kopia `policy set` knobs the mover applies before snapshotting

--- a/crates/controller/src/snapshot/mod.rs
+++ b/crates/controller/src/snapshot/mod.rs
@@ -840,7 +840,7 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
         }
     }
 
-    let (work_spec, mut source_volume, repo_volume, _) =
+    let (mut work_spec, mut source_volume, repo_volume, _) =
         build_backup_run(backup, &config, &repo, &namespace, &name)?;
 
     // The mover Job runs in THIS (workload) namespace, where the operator SA does
@@ -902,6 +902,9 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
         &namespace,
         config.spec.mover.as_ref(),
         source_pvc,
+        // `inheritSecurityContextFrom.snapshot` is restore-only (admission-rejected
+        // on SnapshotPolicy), so a backup never has a recorded source to pass.
+        None,
     )
     .await?;
     let (effective_sc, effective_pod_sc) = mover_security.contexts.clone();
@@ -929,6 +932,41 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             .as_ref()
             .and_then(|m| m.ttl_seconds_after_finished),
     );
+
+    // Record the RESOLVED mover identity on the kopia snapshot itself (the
+    // `kopiur-meta` tag) AND on `status.recorded` below — one value feeds both,
+    // so the tag and the status can never diverge. This is what lets a restore
+    // on a rebuilt cluster (workload not deployed, nothing in etcd) reproduce
+    // the identity the data expects.
+    let recorded = recorded_meta(
+        &resolved_mover,
+        &mover_security.outcome,
+        config.spec.mover.as_ref(),
+    );
+    match &mut work_spec.operation {
+        Operation::Snapshot(op) => {
+            op.tags.insert(
+                kopiur_api::KOPIUR_META_TAG.to_string(),
+                kopiur_api::encode_meta_tag(&recorded),
+            );
+        }
+        // build_backup_run constructs Operation::Snapshot by construction; every
+        // other variant is an invariant breach, enumerated so a new operation
+        // cannot compile into silence here.
+        Operation::Restore(_)
+        | Operation::SnapshotDelete(_)
+        | Operation::SnapshotDeleteBatch(_)
+        | Operation::BootstrapRepository(_)
+        | Operation::Maintenance(_)
+        | Operation::SnapshotPin(_)
+        | Operation::Verify(_)
+        | Operation::Replicate(_)
+        | Operation::BrowseSession(_) => {
+            return Err(Error::Invariant(
+                "build_backup_run produced a non-Snapshot operation".into(),
+            ));
+        }
+    }
 
     // Privileged-mover gate (ADR §4.11/§G16, VolSync-parity): an elevated mover
     // (root/privileged/added caps/`privilegedMode`, container- OR pod-level) requires
@@ -1463,6 +1501,9 @@ async fn reconcile_inner(backup: &Snapshot, ctx: &Context) -> Result<Action> {
             // recipe is gone — the namespace-deletion cascade usually reaps the
             // SnapshotPolicy (no finalizer) before this Snapshot's finalizer runs.
             "resolved": resolved_run_status(&config, &namespace, &work_spec),
+            // The SAME value written into the kopia `kopiur-meta` tag above —
+            // single source, so tag and status cannot diverge.
+            "recorded": recorded,
         }),
     )
     .await?;
@@ -3829,14 +3870,31 @@ fn inherit_verdict(
 
     match outcome {
         io::InheritOutcome::NotRequested => None,
+        // Restore-only outcome (`inheritSecurityContextFrom.snapshot`): unreachable
+        // from a backup — the variant is admission-rejected on SnapshotPolicy and the
+        // backup reconciler passes no recorded source (the resolver errors before it
+        // could ever produce this). Defensive: report no verdict rather than invent a
+        // condition for a state that cannot arise here; the restore reconciler owns
+        // the recorded-inherit reporting.
+        io::InheritOutcome::InheritedFromSnapshot { snapshot, .. } => {
+            tracing::debug!(
+                %snapshot,
+                "backup inherit_verdict saw the restore-only InheritedFromSnapshot outcome; \
+                 ignoring (validators make this unreachable)"
+            );
+            None
+        }
         io::InheritOutcome::Fallback { reason } => Some(InheritVerdict {
             ok: false,
             reason: INHERIT_FALLBACK_REASON,
             action: MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION,
             message: format!(
-                "{reason}. Proceeding with the recipe's explicit mover.securityContext ({}), \
-                 which pins the mover's identity itself — so this run is not tracking the \
-                 workload.",
+                "the mover runs as {} from this recipe's explicit mover securityContext, \
+                 not from the workload: {reason}. An explicit context that pins an \
+                 identity is the deliberate fallback, so the run proceeded — but it is \
+                 not tracking the workload. Scale the workload up or fix the selector to \
+                 resume inheriting, or drop inheritSecurityContextFrom if the explicit \
+                 context is the intent.",
                 identity()
             ),
         }),
@@ -3851,13 +3909,14 @@ fn inherit_verdict(
             reason: INHERIT_PINNED_NO_UID_REASON,
             action: PIN_WORKLOAD_RUN_AS_USER_ACTION,
             message: format!(
-                "pod `{pod}`{} pins no runAsUser, and no runAsGroup/fsGroup/supplementalGroups \
-                 beyond the mover's own defaults — its identity comes from its container image, \
-                 which Kopiur cannot read from the pod spec. Inheriting therefore copied \
-                 nothing, and the mover runs as {}, which did NOT come from the workload and \
-                 will likely fail to read the source with permission denied. Set runAsUser on \
-                 the workload, or set mover.securityContext.runAsUser (it merges with, and \
-                 overrides, inherited values).",
+                "inheriting from pod `{pod}`{} copied nothing: the pod pins no runAsUser, \
+                 and no runAsGroup/fsGroup/supplementalGroups beyond the mover's own \
+                 defaults, so its identity lives in its container image, which Kopiur \
+                 cannot read from the pod spec. The mover therefore runs as {} — an \
+                 identity that did NOT come from the workload — and will likely fail to \
+                 read the source with permission denied. Set runAsUser on the workload, \
+                 or pin mover.securityContext.runAsUser in this recipe (it merges with, \
+                 and overrides, inherited values).",
                 container
                     .as_deref()
                     .map(|c| format!(" (container `{c}`)"))
@@ -3870,37 +3929,43 @@ fn inherit_verdict(
             uid: Some(inherited_uid),
             ..
         } if effective != Some(*inherited_uid) => {
-            // A higher layer displaced the inherited UID. Intended — explicit wins by design —
-            // but it makes inheritance a permanent no-op for that field, and the compat
-            // condition is positive-only so it stays silent on exactly this shape. Name the
-            // layer that actually won: telling someone to "remove the explicit runAsUser" when
-            // the override came from the repository's moverDefaults sends them hunting through
-            // a recipe that does not contain one.
-            let recipe_uid = kopiur_api::common::effective_run_as_user(
-                explicit.and_then(|m| m.security_context.as_ref()),
-                explicit.and_then(|m| m.pod_security_context.as_ref()),
+            // Only the recipe's explicit context sits above the inherited layer, and the
+            // pair merge resolves the effective identity to the HIGHEST layer that pins
+            // one — so a displaced inherited uid always means the recipe pinned the
+            // winner. (The old "the repository's moverDefaults overrides inherited
+            // values" branch died with the cross-dimension shadowing bug: a lower layer
+            // can no longer displace an inherited identity, in either dimension.)
+            // Intended — explicit wins by design — but it makes inheritance a permanent
+            // no-op for that field, and the compat condition is positive-only so it
+            // stays silent on exactly this shape. Name the exact field so the remedy is
+            // a one-line edit.
+            debug_assert_eq!(
+                kopiur_api::common::effective_run_as_user(
+                    explicit.and_then(|m| m.security_context.as_ref()),
+                    explicit.and_then(|m| m.pod_security_context.as_ref()),
+                ),
+                effective,
+                "a displaced inherited uid can only come from the recipe's explicit context"
             );
-            let (layer, remedy) = if recipe_uid.is_some() && recipe_uid == effective {
-                (
-                    "this recipe's mover.securityContext",
-                    "Remove the explicit runAsUser to track the workload",
-                )
+            let field = if explicit
+                .and_then(|m| m.security_context.as_ref())
+                .and_then(|s| s.run_as_user)
+                == effective
+            {
+                "mover.securityContext.runAsUser"
             } else {
-                (
-                    "the repository's moverDefaults.securityContext (NOT this recipe — it sets \
-                     no runAsUser)",
-                    "Clear runAsUser from the repository's moverDefaults, or override it here",
-                )
+                "mover.podSecurityContext.runAsUser"
             };
             Some(InheritVerdict {
                 ok: false,
                 reason: INHERIT_OVERRIDDEN_REASON,
                 action: MATCH_WORKLOAD_SECURITY_CONTEXT_ACTION,
                 message: format!(
-                    "the mover runs as {}, not the uid {inherited_uid} inherited from pod \
-                     `{pod}`: {layer} overrides inherited values by design. \
-                     inheritSecurityContextFrom is a no-op for runAsUser here and will not \
-                     follow the workload if it changes. {remedy}, or drop \
+                    "the mover runs as {}, not the uid {inherited_uid} it inherited from \
+                     pod `{pod}`: this recipe's explicit {field} overrides the inherited \
+                     value — an explicit field always wins — so \
+                     inheritSecurityContextFrom will not follow the workload if its uid \
+                     changes. Remove {field} to track the workload, or drop \
                      inheritSecurityContextFrom to stop implying that it does.",
                     identity()
                 ),

--- a/crates/controller/src/snapshot/tests.rs
+++ b/crates/controller/src/snapshot/tests.rs
@@ -836,6 +836,7 @@ fn list_entry(
         stats: Default::default(),
         root_entry: None,
         retention_reason: vec![],
+        tags: Default::default(),
     }
 }
 
@@ -2813,6 +2814,7 @@ fn adopted_row_has_provenance_gates_the_succeeded_pin() {
                 hostname: "h".into(),
                 source_path: Some("/d".into()),
             },
+            description: None,
         }),
         ..Default::default()
     });
@@ -2981,6 +2983,238 @@ fn staged_watchdog_budget_pins_zero_absent_and_positive() {
     );
 }
 
+// --- tags_for: user tags merged under the reserved operator tags -----------
+
+mod tags_for_tests {
+    use super::*;
+
+    fn backup_with_tags(pairs: &[(&str, &str)]) -> kopiur_api::Snapshot {
+        // SnapshotSpec derives no Default; an empty spec via the wire shape.
+        let empty: kopiur_api::SnapshotSpec =
+            serde_json::from_value(serde_json::json!({})).unwrap();
+        let mut snap = kopiur_api::Snapshot::new("b", empty);
+        if !pairs.is_empty() {
+            snap.spec.tags = Some(
+                pairs
+                    .iter()
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect(),
+            );
+        }
+        snap
+    }
+
+    #[test]
+    fn no_user_tags_yields_only_the_reserved_config_tag() {
+        let tags = tags_for(&backup_with_tags(&[]), &sample_policy());
+        assert_eq!(tags.len(), 1);
+        assert_eq!(tags.get("kopiur:config").map(String::as_str), Some("pg"));
+    }
+
+    #[test]
+    fn user_tags_are_merged_and_reserved_wins_last() {
+        let backup = backup_with_tags(&[("reason", "pre-upgrade"), ("team", "billing")]);
+        let tags = tags_for(&backup, &sample_policy());
+        assert_eq!(tags.get("reason").map(String::as_str), Some("pre-upgrade"));
+        assert_eq!(tags.get("team").map(String::as_str), Some("billing"));
+        assert_eq!(
+            tags.get("kopiur:config").map(String::as_str),
+            Some("pg"),
+            "reserved tag must be present and authoritative"
+        );
+    }
+
+    #[test]
+    fn invalid_stored_keys_are_skipped_never_fatal() {
+        // Pre-validator stored objects can carry anything; the build path skips
+        // (warn) rather than failing the backup of a stored object.
+        let long_key = "k".repeat(64);
+        let long_value = "v".repeat(257);
+        let backup = backup_with_tags(&[
+            ("env:prod", "colon"),        // first-colon mangled + reserved-collision risk
+            ("kopiur-meta", "spoof"),     // reserved prefix
+            (long_key.as_str(), "v"),     // oversize key
+            ("big", long_value.as_str()), // oversize value
+            ("", "empty"),                // empty key
+            ("ok", "kept"),
+        ]);
+        let tags = tags_for(&backup, &sample_policy());
+        assert_eq!(tags.get("ok").map(String::as_str), Some("kept"));
+        assert_eq!(
+            tags.len(),
+            2,
+            "only the valid user tag + the reserved tag: {tags:?}"
+        );
+    }
+
+    #[test]
+    fn user_tags_are_capped_at_the_admission_bound() {
+        let pairs: Vec<(String, String)> = (0..15)
+            .map(|i| (format!("k{i:02}"), "v".to_string()))
+            .collect();
+        let refs: Vec<(&str, &str)> = pairs
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        let tags = tags_for(&backup_with_tags(&refs), &sample_policy());
+        // 10 user tags + the reserved config tag.
+        assert_eq!(tags.len(), kopiur_api::validate::MAX_SNAPSHOT_TAGS + 1);
+        assert!(tags.contains_key("kopiur:config"));
+    }
+}
+
+// --- recorded_meta: the kopiur-meta value stamped on every produced run -----
+
+mod recorded_meta_tests {
+    use super::*;
+    use crate::io::InheritOutcome;
+    use k8s_openapi::api::core::v1::{PodSecurityContext, SecurityContext};
+    use kopiur_api::common::{MOVER_NONROOT_ID, MoverDefaults, MoverSpec, resolve_mover};
+    use kopiur_api::{KOPIUR_META_SCHEMA_V1, RecordedSrc};
+
+    fn inherited(uid: Option<i64>, pins_identity: bool) -> InheritOutcome {
+        InheritOutcome::Inherited {
+            pod: "app-0".into(),
+            container: Some("app".into()),
+            uid,
+            pins_identity,
+        }
+    }
+
+    fn sc_uid(uid: i64) -> SecurityContext {
+        SecurityContext {
+            run_as_user: Some(uid),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn inherited_won_records_src_inherited() {
+        // The workload pinned 1000 and the merge kept it.
+        let resolved = resolve_mover(None, Some(&sc_uid(1000)), None, None, None, None);
+        let meta = recorded_meta(&resolved, &inherited(Some(1000), true), None);
+        assert_eq!(meta.schema, KOPIUR_META_SCHEMA_V1);
+        assert_eq!(meta.src, RecordedSrc::Inherited);
+        assert_eq!(meta.uid, Some(1000));
+        assert_eq!(meta.fs_group, Some(MOVER_NONROOT_ID), "hardened fsGroup");
+    }
+
+    #[test]
+    fn restore_only_snapshot_outcome_never_records_src_inherited() {
+        // Defensive classification of the restore-only `InheritedFromSnapshot`
+        // outcome (unreachable from a backup — validators): replaying a recorded
+        // identity is NOT reading the live workload, so even if it ever reached a
+        // backup's recorder it must not claim `src: inherited`.
+        let resolved = resolve_mover(None, Some(&sc_uid(3001)), None, None, None, None);
+        let meta = recorded_meta(
+            &resolved,
+            &InheritOutcome::InheritedFromSnapshot {
+                snapshot: "app/pg-b1".into(),
+                uid: Some(3001),
+                src: RecordedSrc::Inherited,
+            },
+            None,
+        );
+        assert_ne!(meta.src, RecordedSrc::Inherited);
+        assert_eq!(
+            meta.src,
+            RecordedSrc::Defaults,
+            "no explicit context either"
+        );
+    }
+
+    #[test]
+    fn explicit_displacing_an_inherited_uid_records_src_explicit() {
+        // The workload pinned 0 but the recipe's explicit context won with 3001.
+        let mover = MoverSpec {
+            security_context: Some(sc_uid(3001)),
+            ..Default::default()
+        };
+        let resolved = resolve_mover(None, Some(&sc_uid(3001)), None, None, None, None);
+        let meta = recorded_meta(&resolved, &inherited(Some(0), true), Some(&mover));
+        assert_eq!(meta.src, RecordedSrc::Explicit);
+        assert_eq!(meta.uid, Some(3001));
+    }
+
+    #[test]
+    fn fallback_on_an_explicit_pod_level_uid_records_src_explicit() {
+        // Inheritance failed; the run proceeded on the recipe's explicit
+        // POD-level uid (the promotion carries it to the effective identity).
+        let psc = PodSecurityContext {
+            run_as_user: Some(2000),
+            ..Default::default()
+        };
+        let mover = MoverSpec {
+            pod_security_context: Some(psc.clone()),
+            ..Default::default()
+        };
+        let resolved = resolve_mover(None, None, Some(&psc), None, None, None);
+        let meta = recorded_meta(
+            &resolved,
+            &InheritOutcome::Fallback {
+                reason: "no pod matches".into(),
+            },
+            Some(&mover),
+        );
+        assert_eq!(meta.src, RecordedSrc::Explicit);
+        assert_eq!(meta.uid, Some(2000));
+    }
+
+    #[test]
+    fn moverdefaults_pinned_uid_records_src_defaults() {
+        let defaults = MoverDefaults {
+            security_context: Some(sc_uid(2000)),
+            ..Default::default()
+        };
+        let resolved = resolve_mover(Some(&defaults), None, None, None, None, None);
+        let meta = recorded_meta(&resolved, &InheritOutcome::NotRequested, None);
+        assert_eq!(meta.src, RecordedSrc::Defaults);
+        assert_eq!(meta.uid, Some(2000));
+    }
+
+    #[test]
+    fn nothing_pinned_records_absent_uid_and_src_defaults() {
+        // Absent uid = image-determined, recorded honestly (never baked to 65532).
+        let resolved = resolve_mover(None, None, None, None, None, None);
+        let meta = recorded_meta(&resolved, &InheritOutcome::NotRequested, None);
+        assert_eq!(meta.src, RecordedSrc::Defaults);
+        assert_eq!(meta.uid, None);
+        assert_eq!(meta.gid, None);
+        assert_eq!(meta.fs_group, Some(MOVER_NONROOT_ID));
+    }
+
+    #[test]
+    fn inherit_that_pinned_nothing_over_moverdefaults_records_src_defaults() {
+        // pins_identity: false — inheriting was a no-op; moverDefaults' uid is
+        // what the mover ran as, and claiming `inherited` would be a lie.
+        let defaults = MoverDefaults {
+            security_context: Some(sc_uid(2000)),
+            ..Default::default()
+        };
+        let resolved = resolve_mover(Some(&defaults), None, None, None, None, None);
+        let meta = recorded_meta(&resolved, &inherited(None, false), None);
+        assert_eq!(meta.src, RecordedSrc::Defaults);
+        assert_eq!(meta.uid, Some(2000));
+    }
+
+    #[test]
+    fn gid_records_the_effective_run_as_group() {
+        let sc = SecurityContext {
+            run_as_user: Some(3001),
+            run_as_group: Some(3002),
+            ..Default::default()
+        };
+        let mover = MoverSpec {
+            security_context: Some(sc.clone()),
+            ..Default::default()
+        };
+        let resolved = resolve_mover(None, Some(&sc), None, None, None, None);
+        let meta = recorded_meta(&resolved, &InheritOutcome::NotRequested, Some(&mover));
+        assert_eq!(meta.src, RecordedSrc::Explicit);
+        assert_eq!(meta.gid, Some(3002));
+    }
+}
+
 // --- inherit_verdict: what `inheritSecurityContextFrom` actually achieved. ---
 //
 // Pure, so every arm is exercised without a cluster. The property that matters most is that
@@ -3023,6 +3257,27 @@ mod inherit_verdict_tests {
             )
             .is_none(),
             "the condition must not appear on recipes that never asked to inherit"
+        );
+    }
+
+    #[test]
+    fn restore_only_snapshot_outcome_is_defensively_ignored_on_backups() {
+        // `InheritedFromSnapshot` is restore-only (the variant is admission-rejected
+        // on SnapshotPolicy and the backup reconciler passes no recorded source), so
+        // the backup verdict must not invent a condition for it — the restore
+        // reconciler owns that reporting.
+        assert!(
+            inherit_verdict(
+                &InheritOutcome::InheritedFromSnapshot {
+                    snapshot: "app/pg-b1".into(),
+                    uid: Some(3001),
+                    src: kopiur_api::recorded::RecordedSrc::Inherited,
+                },
+                &resolved_with_uid(Some(3001)),
+                None
+            )
+            .is_none(),
+            "a backup must never report the restore-only recorded-inherit outcome"
         );
     }
 
@@ -3109,40 +3364,85 @@ mod inherit_verdict_tests {
         assert!(!v.ok);
         assert_eq!(v.reason, INHERIT_OVERRIDDEN_REASON);
         assert!(
-            v.message.contains("this recipe's mover.securityContext")
-                && v.message.contains("Remove the explicit runAsUser"),
+            v.message
+                .contains("this recipe's explicit mover.securityContext.runAsUser")
+                && v.message.contains("Remove mover.securityContext.runAsUser"),
             "{}",
             v.message
         );
     }
 
     #[test]
-    fn an_overridden_inherit_names_moverdefaults_when_the_recipe_sets_no_uid() {
-        // The remedy used to say "Remove the explicit runAsUser" unconditionally. With the
-        // override coming from the repository, the user reads their policy, finds no
-        // runAsUser, and has nowhere to go.
+    fn moverdefaults_cannot_displace_an_inherited_uid_so_the_verdict_is_healthy() {
+        // The matter-server regression, through the REAL fold pipeline: the workload
+        // pins uid 2500 at the POD level, moverDefaults pins 1000 at the container
+        // level. Pre-fix the moverDefaults value shadowed the inherited one across
+        // dimensions and this reported InheritOverridden blaming moverDefaults "by
+        // design"; post-fix the inherited identity wins every layer and the verdict is
+        // the healthy InheritApplied. (This is also why the moverDefaults message
+        // branch was deleted: the state it described is unrepresentable now.)
         let defaults = MoverDefaults {
             security_context: Some(SecurityContext {
-                run_as_user: Some(2000),
+                run_as_user: Some(1000),
                 ..Default::default()
             }),
             ..Default::default()
         };
-        let resolved = resolve_mover(Some(&defaults), None, None, None, None, None);
-        // A recipe that sets a context but NO uid (e.g. seccomp only).
+        let inherited_psc = PodSecurityContext {
+            run_as_user: Some(2500),
+            ..Default::default()
+        };
+        // What resolve_mover_security_contexts produces: inherited ⊂ explicit(unset).
+        let (recipe_sc, recipe_psc) =
+            kopiur_api::common::merge_context_pair(None, Some(&inherited_psc), None, None);
+        let resolved = resolve_mover(
+            Some(&defaults),
+            recipe_sc.as_ref(),
+            recipe_psc.as_ref(),
+            None,
+            None,
+            None,
+        );
+        let v = inherit_verdict(&inherited(Some(2500), true), &resolved, None).unwrap();
+        assert!(v.ok, "the inherited uid won every layer: {}", v.message);
+        assert!(v.message.contains("uid 2500"), "{}", v.message);
+    }
+
+    #[test]
+    fn an_overridden_inherit_names_the_pod_level_field_when_that_is_what_won() {
+        // The recipe can displace the inherited uid from either dimension; the remedy
+        // must name the field the user actually wrote.
         let explicit = MoverSpec {
             pod_security_context: Some(PodSecurityContext {
-                fs_group: Some(1234),
+                run_as_user: Some(1000),
                 ..Default::default()
             }),
             ..Default::default()
         };
+        let inherited_sc = SecurityContext {
+            run_as_user: Some(2500),
+            ..Default::default()
+        };
+        let (recipe_sc, recipe_psc) = kopiur_api::common::merge_context_pair(
+            Some(&inherited_sc),
+            None,
+            explicit.security_context.as_ref(),
+            explicit.pod_security_context.as_ref(),
+        );
+        let resolved = resolve_mover(
+            None,
+            recipe_sc.as_ref(),
+            recipe_psc.as_ref(),
+            None,
+            None,
+            None,
+        );
         let v = inherit_verdict(&inherited(Some(2500), true), &resolved, Some(&explicit)).unwrap();
         assert!(!v.ok);
         assert_eq!(v.reason, INHERIT_OVERRIDDEN_REASON);
         assert!(
-            v.message.contains("moverDefaults") && v.message.contains("NOT this recipe"),
-            "must point at the layer that actually won: {}",
+            v.message.contains("mover.podSecurityContext.runAsUser"),
+            "must name the pod-level field that actually won: {}",
             v.message
         );
     }

--- a/crates/controller/src/snapshot_policy.rs
+++ b/crates/controller/src/snapshot_policy.rs
@@ -1295,6 +1295,7 @@ mod tests {
                     hostname: "h".into(),
                     source_path: Some("/d".into()),
                 },
+                description: None,
             }),
             ..Default::default()
         });

--- a/crates/controller/src/snapshot_schedule.rs
+++ b/crates/controller/src/snapshot_schedule.rs
@@ -1677,6 +1677,7 @@ mod tests {
                     hostname: "h".into(),
                     source_path: None,
                 },
+                description: None,
             });
 
         let all = vec![a, b, c, ok, term, with_artifact];

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -108,7 +108,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune adopt-prune adopt-ignore polcasc-retain polcasc-delete polcasc-simul; do
+  for s in moverdefaults scc-shadow recmeta nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune adopt-prune adopt-ignore polcasc-retain polcasc-delete polcasc-simul recrestore; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -59,6 +59,8 @@ pub const HOSTPATH_REPOS_ROOT: &str = "/kopiur-e2e/repos";
 /// at 0777 for each — keep the two lists in lockstep.
 pub const REPO_SUBPATHS: &[&str] = &[
     "moverdefaults",
+    "scc-shadow",
+    "recmeta",
     "nsdel-orphan",
     "nsdel-delete",
     "pin",
@@ -120,6 +122,10 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "polcasc-retain",
     "polcasc-delete",
     "polcasc-simul",
+    // Phase-3 recorded-identity restore (restore.rs::restore_inherits_recorded_identity):
+    // the whole repo runs at uid/gid 3001 (bootstrap AND backup — kopia's 0600 control
+    // files must share one owner), so it cannot share the restore shard's 65532 seed repo.
+    "recrestore",
 ];
 /// The in-pod mount path for an isolated per-scenario repo: the PVC root is mounted
 /// here and `kopia --path` points here, so the kopia repo IS this dir (one repo per

--- a/crates/e2e/tests/adoption.rs
+++ b/crates/e2e/tests/adoption.rs
@@ -13,7 +13,10 @@
 //! NON-matching seeded snapshot stays a forced-Retain `discovered` row (its kopia
 //! data untouched). Scenario 2 proves the `catalog.adoption: Ignore` opt-out leaves
 //! matching rows discovered. Scenario 3 proves cross-namespace `ClusterRepository`
-//! adoption (the cluster-wide-LIST guard).
+//! adoption (the cluster-wide-LIST guard). Scenario 4 proves the Phase-2
+//! `kopiur-meta` loop: the recorded backup-time mover identity + description ride
+//! the kopia snapshot itself, survive CR deletion, come back on the adopted row,
+//! and the scan BACKFILLS `status.recorded` onto rows that lack it.
 //!
 //! Gated by `#[cfg(feature = "e2e")]` + `#[ignore]`; skip gracefully off-cluster.
 
@@ -1378,6 +1381,299 @@ async fn retain_policy_adoption_converges_without_job_churn() {
             .await;
     }
     for r in discovered_rows(&client, E2E_NAMESPACE, &repo_uid).await {
+        let _ = backups
+            .delete(&r.name_any(), &DeleteParams::default())
+            .await;
+    }
+    let _ = policies.delete(POLICY, &DeleteParams::default()).await;
+    let _ = wait_until(
+        "snapshot CRs drain before repo teardown",
+        Duration::from_secs(120),
+        poll_interval(),
+        || async {
+            let live = backups
+                .list(&ListParams::default().labels(&format!("{REPOSITORY_UID_LABEL}={repo_uid}")))
+                .await?
+                .items;
+            Ok(live.is_empty().then_some(()))
+        },
+    )
+    .await;
+    let _ = repos.delete(REPO, &DeleteParams::default()).await;
+}
+
+// ---------------------------------------------------------------------------
+// Scenario 4 — Phase-2 `kopiur-meta`: recorded identity survives CR deletion.
+// ---------------------------------------------------------------------------
+
+const S4_SUBPATH: &str = "recmeta";
+
+/// The `kopiur-meta` full loop: the backup-time mover identity is recorded ON the
+/// kopia snapshot, so it survives the CR being deleted (the re-bootstrap premise).
+/// 1. A policy pinning an explicit mover uid/gid (3001) + a manual Snapshot with
+///    user `spec.tags` and a `description` → `Succeeded`. The mover Job's work
+///    spec carries all three tag classes (the user tag — previously an inert
+///    field, the reserved `kopiur:config`, and `kopiur-meta`), and the produced CR
+///    carries `status.recorded` {schema:1, src:explicit, uid/gid:3001,
+///    fsGroup:65532} + `status.snapshot.description`.
+/// 2. The CR is deleted (`Retain`) — kopia keeps the snapshot AND its tags. The
+///    next catalog cycle re-attaches it as an `origin: adopted` row carrying the
+///    SAME `status.recorded` + description, recovered from the kopia tag with
+///    nothing left in etcd.
+/// 3. Stripping `status.recorded` off the row is healed by the next scan's
+///    targeted backfill patch (matched by `kopiaSnapshotID`, only-while-absent) —
+///    the upgrade path for rows written before this feature existed.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn recorded_meta_round_trips_through_deletion_and_adoption() {
+    use k8s_openapi::api::batch::v1::Job;
+
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client: Client = world.client().clone();
+    ensure_repo(&client, S4_SUBPATH).await;
+
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    const REPO: &str = "e2e-recmeta-repo";
+    const POLICY: &str = "e2e-recmeta-pol";
+    const SNAP: &str = "e2e-recmeta-1";
+
+    // Fast catalog cycles so adoption + backfill don't wait an hour; maintenance
+    // off to cut Job churn. moverDefaults pins the SAME uid/gid the recipe pins
+    // explicitly below: a kopia filesystem repo's 0600 control files are only
+    // readable by the uid that wrote them, so the bootstrap/scan movers and the
+    // backup mover must agree — a 65532 bootstrap + a 3001 backup would fail with
+    // permission denied. (The recipe's explicit context still pins the winning
+    // identity, so `recorded.src` stays `explicit`.)
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                REPO,
+                S4_SUBPATH,
+                serde_json::json!({
+                    "maintenance": { "enabled": false },
+                    "catalog": { "periodicRefresh": true, "refreshInterval": "30s" },
+                    "moverDefaults": {
+                        "securityContext": { "runAsUser": 3001, "runAsGroup": 3001 }
+                    }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository");
+    wait_phase(&repos, REPO, "Ready")
+        .await
+        .expect("Repository should reach Ready");
+    let repo_uid = repos
+        .get(REPO)
+        .await
+        .expect("get Repository")
+        .metadata
+        .uid
+        .expect("Repository uid");
+
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                POLICY,
+                "Repository",
+                REPO,
+                serde_json::json!({
+                    "retention": { "keepLatest": 20 },
+                    "mover": { "securityContext": { "runAsUser": 3001, "runAsGroup": 3001 } }
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy");
+
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                SNAP,
+                POLICY,
+                serde_json::json!({
+                    "tags": { "team": "e2e" },
+                    "description": "recorded-meta e2e"
+                }),
+            )),
+        )
+        .await
+        .expect("create Snapshot with user tags + description");
+
+    // (1a) The work spec carries all three tag classes. Read it off the live Job
+    // (before Succeeded — the Job self-GCs on its TTL after finishing).
+    let ws = common::wait_for_work_spec_json(&jobs, SNAP).await;
+    let tags = ws
+        .pointer("/operation/snapshot/tags")
+        .cloned()
+        .unwrap_or_default();
+    assert_eq!(
+        tags.get("team").and_then(|v| v.as_str()),
+        Some("e2e"),
+        "user spec.tags must reach the work spec (the field was inert before): {tags}"
+    );
+    assert_eq!(
+        tags.get("kopiur:config").and_then(|v| v.as_str()),
+        Some(POLICY),
+        "the reserved config tag must survive the user-tag merge: {tags}"
+    );
+    let meta_raw = tags
+        .get("kopiur-meta")
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("the kopiur-meta tag must ride the work spec: {tags}"));
+    let meta: serde_json::Value =
+        serde_json::from_str(meta_raw).expect("kopiur-meta tag value is JSON");
+    assert_eq!(meta["schema"], 1, "schema-versioned: {meta}");
+    assert_eq!(
+        meta["uid"], 3001,
+        "the resolved mover uid is recorded: {meta}"
+    );
+
+    wait_phase(&backups, SNAP, "Succeeded")
+        .await
+        .expect("Snapshot should Succeed");
+
+    // (1b) The produced CR carries the recorded identity + the description.
+    fn expect_recorded(s: &serde_json::Value, ctx: &str) {
+        assert_eq!(
+            s.pointer("/recorded/schema").and_then(|v| v.as_i64()),
+            Some(1),
+            "{ctx}: {s}"
+        );
+        assert_eq!(
+            s.pointer("/recorded/src").and_then(|v| v.as_str()),
+            Some("explicit"),
+            "{ctx}: the identity was pinned by the recipe, and provenance must say so: {s}"
+        );
+        assert_eq!(
+            s.pointer("/recorded/uid").and_then(|v| v.as_i64()),
+            Some(3001),
+            "{ctx}: {s}"
+        );
+        assert_eq!(
+            s.pointer("/recorded/gid").and_then(|v| v.as_i64()),
+            Some(3001),
+            "{ctx}: {s}"
+        );
+        assert_eq!(
+            s.pointer("/recorded/fsGroup").and_then(|v| v.as_i64()),
+            Some(65532),
+            "{ctx}: the hardened pod fsGroup is recorded: {s}"
+        );
+    }
+    let s = status_json(&backups, SNAP).await;
+    expect_recorded(&s, "produced CR");
+    assert_eq!(
+        s.pointer("/snapshot/description").and_then(|v| v.as_str()),
+        Some("recorded-meta e2e"),
+        "spec.description must surface on status.snapshot: {s}"
+    );
+    let kopia_id = s
+        .pointer("/snapshot/kopiaSnapshotID")
+        .and_then(|v| v.as_str())
+        .expect("kopia snapshot id on the produced CR")
+        .to_string();
+
+    // (2) Delete the CR (Retain) — then the adopted row must come back with the
+    // recorded meta, recovered purely from the kopia snapshot.
+    backups
+        .delete(SNAP, &DeleteParams::default())
+        .await
+        .expect("delete the produced Snapshot CR");
+    wait_until(
+        "produced CR fully gone",
+        default_timeout(),
+        poll_interval(),
+        || async { Ok(backups.get_opt(SNAP).await?.is_none().then_some(())) },
+    )
+    .await
+    .expect("Retain deletion should release the CR");
+
+    let adopted_name = wait_until(
+        "adopted row re-appears carrying status.recorded",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let client = client.clone();
+            let kopia_id = kopia_id.clone();
+            async move {
+                for r in config_labeled(&client, E2E_NAMESPACE, POLICY).await {
+                    let v = serde_json::to_value(&r).unwrap_or_default();
+                    if v.pointer("/status/snapshot/kopiaSnapshotID")
+                        .and_then(|x| x.as_str())
+                        == Some(kopia_id.as_str())
+                        && status_origin(&r) == "adopted"
+                        && v.pointer("/status/recorded").is_some_and(|x| !x.is_null())
+                    {
+                        return Ok(Some(r.name_any()));
+                    }
+                }
+                Ok(None)
+            }
+        },
+    )
+    .await
+    .expect("the adopted row must reappear with the recovered recorded meta");
+    let s = status_json(&backups, &adopted_name).await;
+    expect_recorded(&s, "adopted row (recovered from the kopia tag)");
+    assert_eq!(
+        s.pointer("/snapshot/description").and_then(|v| v.as_str()),
+        Some("recorded-meta e2e"),
+        "the description is recovered from the kopia manifest: {s}"
+    );
+
+    // (3) Backfill: strip `recorded`; the next scan's targeted patch heals it.
+    backups
+        .patch_status(
+            &adopted_name,
+            &PatchParams::default(),
+            &Patch::Merge(serde_json::json!({ "status": { "recorded": null } })),
+        )
+        .await
+        .expect("strip status.recorded off the adopted row");
+    let stripped = status_json(&backups, &adopted_name).await;
+    assert!(
+        stripped
+            .pointer("/recorded")
+            .is_none_or(serde_json::Value::is_null),
+        "the strip must take before the backfill assertion means anything: {stripped}"
+    );
+    wait_until(
+        "the scan backfills the stripped recorded meta",
+        default_timeout(),
+        poll_interval(),
+        || {
+            let backups = backups.clone();
+            let name = adopted_name.clone();
+            async move {
+                let s = status_json(&backups, &name).await;
+                Ok(
+                    (s.pointer("/recorded/uid").and_then(|v| v.as_i64()) == Some(3001))
+                        .then_some(()),
+                )
+            }
+        },
+    )
+    .await
+    .expect("backfill must restore status.recorded from the kopia tag");
+
+    // Cleanup: rows → policy → drain → repo (the file's convention).
+    for r in config_labeled(&client, E2E_NAMESPACE, POLICY).await {
         let _ = backups
             .delete(&r.name_any(), &DeleteParams::default())
             .await;

--- a/crates/e2e/tests/restore.rs
+++ b/crates/e2e/tests/restore.rs
@@ -14,7 +14,9 @@
 
 #![cfg(all(unix, feature = "e2e"))]
 
-use kube::api::{DeleteParams, PostParams};
+mod common;
+
+use kube::api::{DeleteParams, Patch, PatchParams, PostParams};
 use kube::{Api, Client};
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -1331,4 +1333,236 @@ async fn restore_wait_timeout_waits_for_late_snapshot() {
         .await
         .expect("waiting restore should complete once the snapshot appears");
     cleanup_restore(&restores, name).await;
+}
+
+// --- Phase 3: `inheritSecurityContextFrom: { snapshot: {} }` — restore as the RECORDED identity ---
+
+/// Isolated repo for the recorded-identity scenario: EVERYTHING here runs at
+/// uid/gid 3001 (moverDefaults for bootstrap/scan + the policy's explicit mover
+/// context), because a kopia filesystem repo's 0600 control files are only readable
+/// by the uid that wrote them — so it cannot share the restore shard's 65532 seed
+/// repo. Subpath in `consts::REPO_SUBPATHS` + the mise node-seed list (LOCKSTEP).
+const REC_SUBPATH: &str = "recrestore";
+const REC_REPO: &str = "e2e-recrestore-repo";
+const REC_CFG: &str = "e2e-recrestore-cfg";
+const REC_BACKUP: &str = "e2e-recrestore-seed";
+
+/// Seed the recorded-identity repo/policy/backup (all pinned to uid/gid 3001) and
+/// wait for the backup to Succeed carrying `status.recorded`. Idempotent.
+async fn ensure_recorded_seed(client: &Client) {
+    common::ensure_repo(client, REC_SUBPATH).await;
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let configs: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    if repos.get_opt(REC_REPO).await.ok().flatten().is_none() {
+        let _ = repos
+            .create(
+                &PostParams::default(),
+                &cr(common::repository_json(
+                    REC_REPO,
+                    REC_SUBPATH,
+                    serde_json::json!({
+                        "maintenance": { "enabled": false },
+                        "moverDefaults": {
+                            "securityContext": { "runAsUser": 3001, "runAsGroup": 3001 }
+                        }
+                    }),
+                )),
+            )
+            .await;
+    }
+    wait_phase(&repos, REC_REPO, "Ready")
+        .await
+        .expect("recorded-identity Repository should reach Ready");
+    if configs.get_opt(REC_CFG).await.ok().flatten().is_none() {
+        let _ = configs
+            .create(
+                &PostParams::default(),
+                &cr(common::snapshot_policy_json(
+                    E2E_NAMESPACE,
+                    REC_CFG,
+                    "Repository",
+                    REC_REPO,
+                    serde_json::json!({
+                        "mover": { "securityContext": { "runAsUser": 3001, "runAsGroup": 3001 } }
+                    }),
+                )),
+            )
+            .await;
+    }
+    if backups.get_opt(REC_BACKUP).await.ok().flatten().is_none() {
+        let _ = backups
+            .create(
+                &PostParams::default(),
+                &cr(common::snapshot_json(
+                    E2E_NAMESPACE,
+                    REC_BACKUP,
+                    REC_CFG,
+                    serde_json::json!({}),
+                )),
+            )
+            .await;
+    }
+    wait_phase(&backups, REC_BACKUP, "Succeeded")
+        .await
+        .expect("recorded-identity seed Snapshot should Succeed");
+}
+
+/// A Restore against the recorded-identity seed with `snapshot: {}` inherit.
+fn recorded_restore_json(name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": REC_REPO },
+            "source": { "snapshotRef": { "name": REC_BACKUP } },
+            "target": { "pvc": { "name": format!("{name}-dst"), "capacity": "1Gi", "accessModes": ["ReadWriteOnce"] } },
+            "mover": { "inheritSecurityContextFrom": { "snapshot": {} } }
+        }
+    })
+}
+
+/// Phase-3 acceptance, one wait-heavy scenario:
+///
+/// (1) A Restore with `inheritSecurityContextFrom: { snapshot: {} }` runs its mover
+///     as the uid RECORDED on the backup (3001 — pinned by the seed policy, ridden
+///     on the `kopiur-meta` tag / `status.recorded`), reaches `Completed`, and
+///     reports `SecurityContextInherited=True` / `RecordedApplied` naming the
+///     Snapshot, the uid, and the provenance.
+/// (2) The same shape against a Snapshot whose `status.recorded` is STRIPPED holds
+///     with `SecurityContextInherited=False` / `MissingRecordedIdentity` (the
+///     permanent-shaped hold, never a silent generic error), then completes once
+///     the recorded identity is restored.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test)"]
+async fn restore_inherits_recorded_identity_and_holds_without_it() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+    ensure_recorded_seed(&client).await;
+
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    // Sanity: the Phase-2 pipeline stamped the recorded identity on the seed.
+    let seed_status = status_json(&backups, REC_BACKUP).await;
+    assert_eq!(
+        seed_status
+            .pointer("/recorded/uid")
+            .and_then(|v| v.as_i64()),
+        Some(3001),
+        "the seed backup must carry status.recorded.uid=3001: {seed_status}"
+    );
+    let recorded = seed_status
+        .get("recorded")
+        .cloned()
+        .expect("seed status.recorded present");
+
+    // (1) Positive: the restore mover runs as the RECORDED uid, not the mover
+    // image's 65532 — and completes.
+    let name = "e2e-rec-inherit";
+    restores
+        .create(&PostParams::default(), &cr(recorded_restore_json(name)))
+        .await
+        .expect("create recorded-inherit Restore");
+    let job = wait_for_job(&jobs, name).await;
+    assert_eq!(
+        job_run_as_user(&job),
+        Some(3001),
+        "the restore mover must run as the uid recorded on the backup (3001)"
+    );
+    wait_phase(&restores, name, "Completed")
+        .await
+        .expect("recorded-inherit Restore should Complete");
+    wait_condition(&restores, name, "SecurityContextInherited", "True")
+        .await
+        .expect("SecurityContextInherited should report True");
+    let s = status_json(&restores, name).await;
+    assert_eq!(
+        condition_reason(&s, "SecurityContextInherited"),
+        "RecordedApplied",
+        "reason: {s}"
+    );
+    let msg = condition_field(&s, "SecurityContextInherited", "message");
+    assert!(
+        msg.contains(REC_BACKUP) && msg.contains("3001") && msg.contains("explicit"),
+        "the True message must name the Snapshot, the recorded uid, and the \
+         provenance; got: {msg}"
+    );
+    cleanup_restore(&restores, name).await;
+
+    // (2) Negative: strip status.recorded off the seed — the same Restore shape
+    // must HOLD with the actionable MissingRecordedIdentity condition.
+    backups
+        .patch_status(
+            REC_BACKUP,
+            &PatchParams::default(),
+            &Patch::Merge(serde_json::json!({ "status": { "recorded": null } })),
+        )
+        .await
+        .expect("strip status.recorded off the seed");
+    let hold = "e2e-rec-hold";
+    restores
+        .create(&PostParams::default(), &cr(recorded_restore_json(hold)))
+        .await
+        .expect("create held Restore");
+    wait_condition(&restores, hold, "SecurityContextInherited", "False")
+        .await
+        .expect("the Restore should hold with SecurityContextInherited=False");
+    let s = status_json(&restores, hold).await;
+    assert_eq!(
+        condition_reason(&s, "SecurityContextInherited"),
+        "MissingRecordedIdentity",
+        "reason: {s}"
+    );
+    let msg = condition_field(&s, "SecurityContextInherited", "message");
+    assert!(
+        msg.contains("status.recorded"),
+        "the hold message must say WHAT is missing: {msg}"
+    );
+    assert_ne!(
+        s.get("phase").and_then(|p| p.as_str()),
+        Some("Completed"),
+        "a held Restore must not have completed: {s}"
+    );
+
+    // Heal: restore the recorded identity, then kick the Restore (the hold
+    // deliberately requeues on the SLOW structural cadence — 300s — so the test
+    // re-enqueues it via an annotation touch instead of waiting that out).
+    backups
+        .patch_status(
+            REC_BACKUP,
+            &PatchParams::default(),
+            &Patch::Merge(serde_json::json!({ "status": { "recorded": recorded } })),
+        )
+        .await
+        .expect("restore status.recorded on the seed");
+    restores
+        .patch(
+            hold,
+            &PatchParams::default(),
+            &Patch::Merge(serde_json::json!({
+                "metadata": { "annotations": { "e2e.kopiur.io/kick": "healed" } }
+            })),
+        )
+        .await
+        .expect("re-enqueue the held Restore");
+    wait_phase(&restores, hold, "Completed")
+        .await
+        .expect("the healed Restore should Complete");
+    wait_condition(&restores, hold, "SecurityContextInherited", "True")
+        .await
+        .expect("the hold must CLEAR to True once the recorded identity is back");
+    let s = status_json(&restores, hold).await;
+    assert_eq!(
+        condition_reason(&s, "SecurityContextInherited"),
+        "RecordedApplied",
+        "the stale MissingRecordedIdentity must be replaced: {s}"
+    );
+    cleanup_restore(&restores, hold).await;
 }

--- a/crates/e2e/tests/security_context_compat.rs
+++ b/crates/e2e/tests/security_context_compat.rs
@@ -16,6 +16,10 @@
 //!   6. `sources[].readOnly: false` (#254) reaches BOTH the pod's PVC volume source and the
 //!      container volumeMount — the kubelet needs both false before it will apply `fsGroup` —
 //!      and `copyMethod: Direct` without `acknowledgeLiveMutation` is denied at admission.
+//!   7. A `moverDefaults.securityContext.runAsUser` (container level) cannot shadow a
+//!      workload uid inherited from the POD level — the mover runs as the workload's uid and
+//!      reports `InheritApplied`. **The regression guard for the cross-dimension
+//!      shadowing bug (the matter-server report).**
 //!
 //! Why these are e2e rather than unit tests: the defect behind (3) was not in the compat
 //! engine — that engine was always right — but in the controller never *calling* it. Only a
@@ -33,6 +37,12 @@
 //! lingering pod leaks its UID into the next scenario's verdict.
 
 #![cfg(all(unix, feature = "e2e"))]
+
+// Shared ADR-0004/0005 helpers — used here for the ISOLATED per-scenario repo fixtures
+// (`common::ensure_repo` + `common::repository_json`). Scenario (g) must NOT share this
+// file's common `/repo` PVC: its `moverDefaults` pins uid 1000, and a repo bootstrapped
+// by one uid poisons the shared kopia repo (0600 control files) for every 65532 sibling.
+mod common;
 
 use kube::api::{DeleteParams, PostParams};
 use kube::{Api, Client};
@@ -722,6 +732,183 @@ async fn inherit_plus_explicit_merges_with_explicit_winning_and_says_so() {
         "e2e-scc-ovr-consumer",
     )
     .await;
+}
+
+/// Scenario (g) — **the moverDefaults-shadowing regression (the matter-server report).**
+/// The workload pins root ONLY at the pod level (`spec.securityContext.runAsUser: 0`, no
+/// container-level context); the Repository's `moverDefaults.securityContext` pins uid 1000
+/// at the container level. The inherited identity is the higher merge layer and must win:
+/// the mover Job runs as uid 0 (with `runAsNonRoot` cleared by INV-1, since
+/// `runAsNonRoot: true` + uid 0 is a kubelet-rejected contradiction) and inheritance reports
+/// the healthy `InheritApplied`. Pre-fix, the moverDefaults container value shadowed the
+/// inherited pod-level uid across dimensions (the kubelet's `container ?? pod` rule), the
+/// mover silently ran as 1000, and the condition blamed moverDefaults "by design".
+///
+/// A root mover needs the privileged-movers namespace opt-in, so this scenario annotates the
+/// e2e namespace up front and removes the annotation in cleanup. No sibling in this file
+/// asserts gate-refusal behavior, so the temporary opt-in cannot change their outcomes.
+#[tokio::test]
+#[ignore = "requires the e2e harness (mise run //crates/e2e:test): kind + built images + helm install"]
+async fn moverdefaults_uid_cannot_shadow_an_inherited_pod_level_root() {
+    use kube::api::{Patch, PatchParams};
+
+    const PRIVILEGED_ANNOTATION: &str = "kopiur.home-operations.com/privileged-movers";
+
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world
+        .ensure(&[Need::Filesystem])
+        .await
+        .expect("provision filesystem fixtures");
+    let client = world.client().clone();
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let jobs: Api<Job> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+
+    kopiur_e2e::annotate_namespace(&client, E2E_NAMESPACE, PRIVILEGED_ANNOTATION, "true")
+        .await
+        .expect("annotate namespace for privileged movers");
+
+    // PRECONDITION: no leftover consumer on `e2e-src`. pvcConsumer picks Running-first
+    // then by name, and a lingering sibling pod (they all sort before
+    // `e2e-scc-shadow-consumer`) would displace this scenario's pod as the inherit
+    // source, turning the assertions below into noise about the wrong workload.
+    wait_no_consumer_of_source(&client).await;
+
+    // The matter-server shape: identity pinned ONLY at the pod level, container context absent.
+    let workload = serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Pod",
+        "metadata": {
+            "name": "e2e-scc-shadow-consumer",
+            "namespace": E2E_NAMESPACE,
+            "labels": { "app": "e2e-scc-shadow-consumer" }
+        },
+        "spec": {
+            "securityContext": { "runAsUser": 0, "runAsGroup": 0 },
+            "containers": [{
+                "name": "app",
+                "image": "registry.k8s.io/pause:3.9",
+                "volumeMounts": [{ "name": "src", "mountPath": "/data" }]
+            }],
+            "volumes": [{ "name": "src", "persistentVolumeClaim": { "claimName": "e2e-src" } }]
+        }
+    });
+    pods.create(&PostParams::default(), &cr(workload))
+        .await
+        .expect("create pod-level-root workload pod");
+    wait_pod_running(&pods, "e2e-scc-shadow-consumer").await;
+
+    // The reported repository shape: moverDefaults pins uid/gid 1000 at the container
+    // level. Over an ISOLATED repo dir (`scc-shadow`) — not this file's shared `/repo`
+    // PVC — because every mover of THIS repository (bootstrap included) runs as 1000,
+    // and a kopia repo's 0600 control files are only readable by the uid that wrote
+    // them: pointing this at the shared repo would poison it for the 65532 siblings
+    // (and their 65532-owned files would fail this repo's bootstrap right back).
+    common::ensure_repo(&client, "scc-shadow").await;
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(common::repository_json(
+                "e2e-scc-shadow-repo",
+                "scc-shadow",
+                serde_json::json!({
+                    "moverDefaults": {
+                        "securityContext": { "runAsUser": 1000, "runAsGroup": 1000 }
+                    }
+                }),
+            )),
+        )
+        .await
+        .expect("create Repository with moverDefaults uid");
+
+    let policy = serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotPolicy",
+        "metadata": { "name": "e2e-scc-shadow-policy", "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": "e2e-scc-shadow-repo" },
+            "sources": [ { "pvc": { "name": "e2e-src" } } ],
+            "copyMethod": "Direct",
+            "retention": { "keepLatest": 5 },
+            // Inherit only — no explicit securityContext anywhere in the recipe.
+            "mover": { "inheritSecurityContextFrom": { "pvcConsumer": {} } }
+        }
+    });
+    policies
+        .create(&PostParams::default(), &cr(policy))
+        .await
+        .expect("create SnapshotPolicy");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(backup_json(
+                "e2e-scc-shadow-backup",
+                "e2e-scc-shadow-policy",
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+
+    let job = wait_until(
+        "mover Job created",
+        default_timeout(),
+        poll_interval(),
+        || async { jobs.get_opt("e2e-scc-shadow-backup").await },
+    )
+    .await
+    .expect("mover Job should be created — a root inherit with the namespace opt-in must run");
+
+    let sc = job
+        .spec
+        .and_then(|s| s.template.spec)
+        .and_then(|p| p.containers.first().cloned())
+        .and_then(|c| c.security_context);
+    let uid = sc.as_ref().and_then(|s| s.run_as_user);
+    assert_eq!(
+        uid,
+        Some(0),
+        "the workload's pod-level uid 0 is the higher merge layer and must win over \
+         moverDefaults' container-level 1000; got {uid:?}"
+    );
+    assert_eq!(
+        sc.as_ref().and_then(|s| s.run_as_non_root),
+        Some(false),
+        "INV-1 must clear the hardened runAsNonRoot:true for a root mover, or the kubelet \
+         wedges the pod in CreateContainerConfigError"
+    );
+
+    let (status, reason) = wait_inherited_condition(&backups, "e2e-scc-shadow-backup").await;
+    assert_eq!(
+        (status.as_str(), reason.as_str()),
+        ("True", "InheritApplied"),
+        "the inherited identity survived every layer, so inheritance must report the \
+         healthy verdict — not InheritOverridden blaming moverDefaults"
+    );
+
+    cleanup(
+        &client,
+        "e2e-scc-shadow-repo",
+        "e2e-scc-shadow-policy",
+        "e2e-scc-shadow-backup",
+        "e2e-scc-shadow-consumer",
+    )
+    .await;
+    // Remove the privileged-movers opt-in so the namespace returns to its default posture.
+    let nss: Api<k8s_openapi::api::core::v1::Namespace> = Api::all(client.clone());
+    let _ = nss
+        .patch(
+            E2E_NAMESPACE,
+            &PatchParams::default(),
+            &Patch::Merge(&serde_json::json!({
+                "metadata": { "annotations": { PRIVILEGED_ANNOTATION: serde_json::Value::Null } }
+            })),
+        )
+        .await;
 }
 
 /// Scenario (e) — **§3 fallback.** With NO workload pod mounting the source, inheritance

--- a/crates/e2e/tests/webhook.rs
+++ b/crates/e2e/tests/webhook.rs
@@ -27,7 +27,9 @@ use k8s_openapi::api::admissionregistration::v1::{
 use k8s_openapi::api::core::v1::Secret;
 
 use kopiur_api::consts::ALLOW_IDENTITY_CHANGE_ANNOTATION;
-use kopiur_api::{ClusterRepository, Repository, RepositoryReplication, Snapshot, SnapshotPolicy};
+use kopiur_api::{
+    ClusterRepository, Repository, RepositoryReplication, Restore, Snapshot, SnapshotPolicy,
+};
 use kopiur_e2e::{E2E_NAMESPACE, World, default_timeout, poll_interval, wait_until};
 
 /// Names the chart renders for release "kopiur" (the e2e release).
@@ -191,6 +193,85 @@ async fn self_managed_webhook_tls_bootstraps_and_gates_admission() {
         "the rejection should come from the admission webhook, got: {msg}"
     );
     let _ = repls.delete(bad_repl, &DeleteParams::default()).await;
+
+    // 7. The restore-only `inheritSecurityContextFrom: { snapshot: {} }` variant is
+    //    DENIED on a SnapshotPolicy: a backup's identity is read from the live
+    //    workload — it is the run that CREATES the recorded identity, it cannot
+    //    consume one.
+    let bad_snap_inherit = "webhook-deny-policy-snapshot-inherit";
+    let _ = configs
+        .delete(bad_snap_inherit, &DeleteParams::default())
+        .await;
+    let err = configs
+        .create(
+            &PostParams::default(),
+            &backup_config_with_snapshot_inherit(bad_snap_inherit),
+        )
+        .await
+        .expect_err("inheritSecurityContextFrom.snapshot on a SnapshotPolicy must be DENIED");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("denied the request") || msg.to_lowercase().contains("admission"),
+        "the rejection should come from the admission webhook, got: {msg}"
+    );
+    assert!(
+        msg.contains("restore-only"),
+        "the denial must say the variant is restore-only, got: {msg}"
+    );
+    let _ = configs
+        .delete(bad_snap_inherit, &DeleteParams::default())
+        .await;
+
+    // 8. The SAME variant on a Restore is ACCEPTED — with the declarative
+    //    `fromPolicy` source (the recorded identity resolves via the controller's
+    //    CR-catalog search, so admission has nothing to reject). This is the pair
+    //    that proves the deployed webhook distinguishes the kinds.
+    let restores: Api<Restore> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let ok_restore = "webhook-allow-restore-snapshot-inherit";
+    let _ = restores.delete(ok_restore, &DeleteParams::default()).await;
+    restores
+        .create(
+            &PostParams::default(),
+            &restore_with_snapshot_inherit(ok_restore),
+        )
+        .await
+        .expect("fromPolicy + inheritSecurityContextFrom.snapshot must be ADMITTED on a Restore");
+    // Don't let it linger holding on MissingRecordedIdentity against absent infra.
+    let _ = restores.delete(ok_restore, &DeleteParams::default()).await;
+}
+
+/// A `SnapshotPolicy` whose mover sets the restore-only `snapshot: {}` inherit —
+/// structurally valid (the CRD schema carries the variant on every mover surface),
+/// but semantically impossible on a backup: admission rejects it.
+fn backup_config_with_snapshot_inherit(name: &str) -> SnapshotPolicy {
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "SnapshotPolicy",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "repository": { "kind": "Repository", "name": "any" },
+            "sources": [ { "pvc": { "name": "data" } } ],
+            "retention": { "keepLatest": 5 },
+            "mover": { "inheritSecurityContextFrom": { "snapshot": {} } }
+        }
+    }))
+    .expect("SnapshotPolicy JSON deserializes")
+}
+
+/// A `Restore` inheriting the backup's RECORDED identity with the declarative
+/// `fromPolicy` source — valid at admission with every source (Phase 3).
+fn restore_with_snapshot_inherit(name: &str) -> Restore {
+    serde_json::from_value(serde_json::json!({
+        "apiVersion": "kopiur.home-operations.com/v1alpha1",
+        "kind": "Restore",
+        "metadata": { "name": name, "namespace": E2E_NAMESPACE },
+        "spec": {
+            "source": { "fromPolicy": { "name": "any" } },
+            "target": { "pvcRef": { "name": "any-target" } },
+            "mover": { "inheritSecurityContextFrom": { "snapshot": {} } }
+        }
+    }))
+    .expect("Restore JSON deserializes")
 }
 
 /// A `RepositoryReplication` whose mover sets `inheritSecurityContextFrom` — structurally

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -18,6 +18,7 @@ pub use model::{
     ClientOptions, ContentFormat, DirEntry, DirManifest, DirSummary, DirSummaryLite, EntryError,
     IndexBlobEntry, MaintenanceCadence, MaintenanceInfo, MaintenanceSchedule, RepositoryStatus,
     RootEntry, SnapshotCreateResult, SnapshotListEntry, SnapshotSource, SnapshotStats, StorageInfo,
+    user_tags,
 };
 pub use selection::{filter_as_of, pick_offset};
 pub use session::SessionCmd;

--- a/crates/kopia/src/model.rs
+++ b/crates/kopia/src/model.rs
@@ -13,6 +13,31 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+
+/// Strip kopia's `tag:` manifest-key prefix from a snapshot `tags` map, yielding the
+/// tags under the keys the CLI was given (`--tags key:value` → manifest `tag:key`).
+///
+/// kopia splits each `--tags` argument on the FIRST colon and stores the key with a
+/// `tag:` prefix in the manifest (verified against the pinned 0.23.1 binary by
+/// `integration_roundtrip::tag_mechanics_...`). Keys without the prefix are kept
+/// verbatim, so a kopia release that dropped the prefix would degrade gracefully
+/// instead of hiding every tag.
+///
+/// ```
+/// use std::collections::BTreeMap;
+/// let mut m = BTreeMap::new();
+/// m.insert("tag:kopiur-meta".to_string(), "{\"schema\":1}".to_string());
+/// m.insert("bare".to_string(), "kept".to_string());
+/// let u = kopiur_kopia::user_tags(&m);
+/// assert_eq!(u.get("kopiur-meta").map(String::as_str), Some("{\"schema\":1}"));
+/// assert_eq!(u.get("bare").map(String::as_str), Some("kept"));
+/// ```
+pub fn user_tags(tags: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    tags.iter()
+        .map(|(k, v)| (k.strip_prefix("tag:").unwrap_or(k).to_string(), v.clone()))
+        .collect()
+}
 
 /// Kopia's snapshot identity triple: `userName@host:path`. Present on both
 /// snapshot-create results and snapshot-list entries.
@@ -174,6 +199,12 @@ pub struct SnapshotCreateResult {
     /// Root directory entry with its summary.
     #[serde(default)]
     pub root_entry: Option<RootEntry>,
+    /// Snapshot tags as stored on the manifest — keys carry kopia's `tag:` prefix
+    /// (strip with [`user_tags`]). Empty for untagged snapshots and on kopia
+    /// versions that omit the field; an empty map is elided on re-serialization
+    /// (these types also ride the mover result wire).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tags: BTreeMap<String, String>,
 }
 
 impl SnapshotCreateResult {
@@ -299,6 +330,12 @@ pub struct SnapshotListEntry {
     /// `latest-1`, `daily-1`). Empty for snapshots outside any retention class.
     #[serde(default)]
     pub retention_reason: Vec<String>,
+    /// Snapshot tags as stored on the manifest — keys carry kopia's `tag:` prefix
+    /// (strip with [`user_tags`]). Empty for untagged snapshots and on kopia
+    /// versions that omit the field; an empty map is elided on re-serialization
+    /// (these types also ride the mover result wire).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub tags: BTreeMap<String, String>,
 }
 
 /// One entry of a kopia directory manifest (`kopia show <dir-object-id>`).

--- a/crates/kopia/tests/integration_roundtrip.rs
+++ b/crates/kopia/tests/integration_roundtrip.rs
@@ -493,6 +493,145 @@ async fn snapshot_create_accepts_m4_flag_sweep_and_records_the_description() {
     assert_eq!(entry.description, "m4 flag sweep smoke test");
 }
 
+/// The permanent guard for every kopia tag-mechanics assumption the `kopiur-meta`
+/// snapshot-metadata feature rests on, proven against the pinned binary (each point
+/// was also manually verified against this exact kopia 0.23.1 while writing the
+/// test):
+///
+/// 1. **First-colon split**: the legacy CLI string `kopiur:config:<name>` is stored
+///    under manifest key `tag:kopiur` with value `config:<name>`. `kopiur` is
+///    therefore an occupied CLI key, and any new kopiur tag MUST use a colon-free
+///    CLI key (`kopiur-meta`).
+/// 2. **`tag:` manifest prefix**: user tags land in the manifest `tags` map with a
+///    `tag:` key prefix ([`kopiur_kopia::user_tags`] strips it), and a JSON-blob
+///    value — colons, braces, quotes — survives verbatim.
+/// 3. **Duplicate keys fail the create outright** ("Duplicate tag <key> found"):
+///    two CLI tags whose strings collide on the first-colon key (`kopiur:meta` +
+///    `kopiur:config:x` → both key `kopiur`) BREAK THE BACKUP. This is why
+///    `Snapshot.spec.tags` reserves the `kopiur` prefix and forbids colons.
+/// 4. **`snapshot list --json` emits the tags map** — the read-back path the
+///    catalog scan depends on exists.
+/// 5. **Tags survive manifest rewrites**: `snapshot pin` (which CHANGES the
+///    manifest id) and full maintenance both preserve the tags map.
+#[tokio::test]
+#[cfg_attr(not(feature = "integration"), ignore)]
+async fn tag_mechanics_first_colon_split_duplicate_keys_and_rewrite_survival() {
+    let repo_dir = tempfile::tempdir().unwrap();
+    let config_dir = tempfile::tempdir().unwrap();
+    let source_dir = tempfile::tempdir().unwrap();
+
+    std::fs::write(source_dir.path().join("a.txt"), b"tagged\n").unwrap();
+
+    let client = isolated_client(config_dir.path());
+    client
+        .repository_create(
+            &ConnectSpec::Filesystem {
+                path: repo_dir.path().to_path_buf(),
+            },
+            Default::default(),
+            &Default::default(),
+        )
+        .await
+        .expect("repository create");
+
+    // The exact two tags the controller writes: the legacy `kopiur:config` string and
+    // the kopiur-meta JSON blob.
+    let meta_json = r#"{"schema":1,"uid":1000,"gid":1000,"fsGroup":65532}"#;
+    let mut tags = BTreeMap::new();
+    tags.insert("kopiur:config".to_string(), "mypolicy".to_string());
+    tags.insert("kopiur-meta".to_string(), meta_json.to_string());
+    let created = client
+        .snapshot_create(
+            source_dir.path().to_str().unwrap(),
+            &tags,
+            Some("taguser@taghost:/data"),
+        )
+        .await
+        .expect("create with the legacy tag + the meta tag must not collide");
+
+    // (1)+(2): first-colon split and the `tag:` manifest prefix, on the create echo.
+    assert_eq!(
+        created.tags.get("tag:kopiur").map(String::as_str),
+        Some("config:mypolicy"),
+        "kopia splits the CLI string on the FIRST colon: key `kopiur`, value \
+         `config:mypolicy`, stored under the `tag:` manifest prefix; got {:?}",
+        created.tags
+    );
+    assert_eq!(
+        created.tags.get("tag:kopiur-meta").map(String::as_str),
+        Some(meta_json),
+        "the JSON blob value must survive verbatim"
+    );
+    let stripped = kopiur_kopia::user_tags(&created.tags);
+    assert_eq!(
+        stripped.get("kopiur-meta").map(String::as_str),
+        Some(meta_json)
+    );
+
+    // (3): a second CLI tag colliding on the first-colon key fails the create.
+    let mut colliding = BTreeMap::new();
+    colliding.insert("kopiur".to_string(), "meta".to_string());
+    colliding.insert("kopiur:config".to_string(), "x".to_string());
+    let err = client
+        .snapshot_create(
+            source_dir.path().to_str().unwrap(),
+            &colliding,
+            Some("taguser@taghost:/data"),
+        )
+        .await;
+    assert!(
+        err.is_err(),
+        "two CLI tags colliding on the first-colon key (`kopiur`) must fail the \
+         create — this is the backup-breaking hazard the reserved-prefix validator \
+         exists to prevent"
+    );
+
+    // (4): the list read-back path carries the tags.
+    let list = client.snapshot_list(None).await.expect("snapshot list");
+    let entry = list
+        .iter()
+        .find(|e| e.id == created.id)
+        .expect("created snapshot present in list");
+    assert_eq!(entry.tags, created.tags, "list must echo the manifest tags");
+
+    // (5): pin REWRITES the manifest (the id changes) — tags must survive, and the
+    // reconciler-visible lesson is that the id is NOT stable across a pin.
+    client
+        .snapshot_pin(&created.id, "protected")
+        .await
+        .expect("pin");
+    let pinned_list = client
+        .snapshot_list(Some(&created.source))
+        .await
+        .expect("list after pin");
+    let pinned = pinned_list
+        .first()
+        .expect("snapshot still present after pin");
+    assert_ne!(
+        pinned.id, created.id,
+        "pin rewrites the manifest under a NEW id (reconcilers must re-resolve)"
+    );
+    assert_eq!(
+        pinned.tags, created.tags,
+        "tags must survive the pin's manifest rewrite"
+    );
+
+    // ...and full maintenance must not strip them either.
+    client
+        .maintenance_run(MaintenanceMode::Full)
+        .await
+        .expect("full maintenance");
+    let after = client
+        .snapshot_list(Some(&created.source))
+        .await
+        .expect("list after maintenance");
+    assert_eq!(
+        after.first().map(|e| &e.tags),
+        Some(&created.tags),
+        "tags must survive full maintenance"
+    );
+}
+
 /// M0b (confirmed data-loss bug): real-kopia proof that pinning the six
 /// `--keep-*` fields to a very large value at the IDENTITY scope, before the
 /// first `snapshot create`, neutralizes kopia's own create-time retention.

--- a/crates/mover/src/bootstrap.rs
+++ b/crates/mover/src/bootstrap.rs
@@ -10,9 +10,13 @@
 //! This module is **pure data + serde** plus the create-gate decision; the kopia
 //! subprocess calls and the kube `ConfigMap` PATCH live in `main.rs`.
 
+use kopiur_api::recorded::{
+    KOPIUR_META_TAG, MetaTagDecode, decode_meta_tag, encode_meta_tag, truncate_utf8,
+};
 use kopiur_api::{HostClass, classify_hostname};
 use kopiur_kopia::{KopiaError, KopiaErrorClass, SnapshotListEntry};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 
 use crate::status::{FailureBlock, failure_block_from_kopia};
 
@@ -79,28 +83,78 @@ pub fn prepare_catalog_entries(
     }
     // Slim each returned entry to only the fields the controller materializes.
     // The prefilter above needed `source.host`; nothing downstream needs the
-    // heavy `rootEntry`/`retentionReason`/`description`, so drop them here — this
-    // is what actually bounds the result ConfigMap size (see [`slim_catalog_entry`]).
+    // heavy `rootEntry`/`retentionReason`, so drop them here — this is what
+    // actually bounds the result ConfigMap size (see [`slim_catalog_entry`]).
     let listing = listing.into_iter().map(slim_catalog_entry).collect();
     (listing, truncated, dropped)
 }
 
+/// Byte cap on the `description` a returned entry carries on the result wire —
+/// the same cap the controller applies when copying it onto the CR
+/// (`catalog::DESCRIPTION_CAP_BYTES`), so the wire never carries bytes the CR
+/// would drop anyway. Foreign-writer-controlled input.
+pub const DESCRIPTION_WIRE_CAP_BYTES: usize = 1024;
+
+/// Byte cap on an UNDECODABLE `kopiur-meta` value carried bounded-verbatim on
+/// the wire (see [`normalize_meta_tags`]) so the controller can re-derive the
+/// UnsupportedSchema/Malformed classification and aggregate-count it, without a
+/// forged multi-MB tag inflating the ConfigMap.
+const META_TAG_WIRE_CAP_BYTES: usize = 4096;
+
 /// Strip the fields the controller never reads from a materialization entry,
-/// keeping only what `catalog::materialize_discovered` consumes (`id`, `source`,
-/// `startTime`, `endTime`, and `stats.totalSize`). Pure.
+/// keeping only what the catalog consumes (`id`, `source`, `startTime`,
+/// `endTime`, `stats.totalSize`, a CAPPED `description`, and the normalized
+/// `kopiur-meta` tag). Pure.
 ///
 /// This is what actually bounds the result `ConfigMap` under etcd's ~1 MiB object
 /// limit (issue #237): [`MAX_RETURNED_SNAPSHOTS`] caps the *count*, but a full
 /// [`SnapshotListEntry`] serializes to ~2 KB — its `rootEntry.summ` carries an
-/// **unbounded** per-file `errors` list, plus a `retentionReason` array and a
-/// free-form `description` — so ~500 real-world entries already blow past 1 MiB and
-/// wedge the repository at `Bootstrapped: False`. Slimmed, each entry is a few
-/// hundred bytes, so the 1000-entry cap is genuinely size-safe.
+/// **unbounded** per-file `errors` list, plus a `retentionReason` array, a
+/// free-form `description`, and (foreign-writer-controlled) `tags` — so ~500
+/// real-world entries already blow past 1 MiB and wedge the repository at
+/// `Bootstrapped: False`. Slimmed, each entry is a few hundred bytes (+ a
+/// bounded description/meta payload), so the 1000-entry cap is size-safe.
 fn slim_catalog_entry(mut e: SnapshotListEntry) -> SnapshotListEntry {
-    e.description = String::new();
+    if e.description.len() > DESCRIPTION_WIRE_CAP_BYTES {
+        e.description = truncate_utf8(&e.description, DESCRIPTION_WIRE_CAP_BYTES).to_string();
+    }
     e.root_entry = None;
     e.retention_reason = Vec::new();
+    e.tags = normalize_meta_tags(&e.tags);
     e
+}
+
+/// Normalize a raw manifest `tags` map for the result wire: raw user tags never
+/// ride the ConfigMap — only the `kopiur-meta` payload survives, O(1) per entry.
+///
+/// - Decodable meta is RE-ENCODED canonically under the bare [`KOPIUR_META_TAG`]
+///   key (compact, bounded by construction), which
+///   [`kopiur_api::decode_meta_tag`] accepts on the controller side exactly like
+///   the raw `tag:`-prefixed key an in-process listing carries — one decoder,
+///   two wires.
+/// - An undecodable value (newer schema / malformed) rides bounded-verbatim
+///   ([`META_TAG_WIRE_CAP_BYTES`]) so the controller re-derives the same
+///   classification and aggregate-counts it in its scan summary.
+/// - Everything else (user tags, the legacy `tag:kopiur` config tag) is
+///   dropped: the catalog never reads them, and they are unbounded input.
+fn normalize_meta_tags(tags: &BTreeMap<String, String>) -> BTreeMap<String, String> {
+    match decode_meta_tag(tags) {
+        MetaTagDecode::Absent => BTreeMap::new(),
+        MetaTagDecode::Decoded(meta) => {
+            BTreeMap::from([(KOPIUR_META_TAG.to_string(), encode_meta_tag(&meta))])
+        }
+        MetaTagDecode::UnsupportedSchema { .. } | MetaTagDecode::Malformed { .. } => {
+            let raw = tags
+                .get(&format!("tag:{KOPIUR_META_TAG}"))
+                .or_else(|| tags.get(KOPIUR_META_TAG))
+                .map(String::as_str)
+                .unwrap_or_default();
+            BTreeMap::from([(
+                KOPIUR_META_TAG.to_string(),
+                truncate_utf8(raw, META_TAG_WIRE_CAP_BYTES).to_string(),
+            )])
+        }
+    }
 }
 
 /// Conservative byte budget for the serialized `result.json` value the mover
@@ -486,6 +540,7 @@ mod tests {
             stats: kopiur_kopia::SnapshotStats::default(),
             root_entry: None,
             retention_reason: vec![],
+            tags: Default::default(),
         }
     }
 
@@ -594,6 +649,16 @@ mod tests {
                 }),
             }),
             retention_reason: vec!["latest-1".into(), "daily-1".into(), "weekly-1".into()],
+            // Raw manifest tags: the reserved config tag, the kopiur-meta
+            // payload, and an unbounded user tag — only the meta may survive.
+            tags: BTreeMap::from([
+                ("tag:kopiur".to_string(), "config:nightly".to_string()),
+                (
+                    "tag:kopiur-meta".to_string(),
+                    r#"{"schema":1,"src":"explicit","uid":3001,"extra":true}"#.to_string(),
+                ),
+                ("tag:team".to_string(), "x".repeat(4096)),
+            ]),
         }
     }
 
@@ -603,14 +668,70 @@ mod tests {
         // Dropped (never read by the controller).
         assert!(slim.root_entry.is_none());
         assert!(slim.retention_reason.is_empty());
-        assert!(slim.description.is_empty());
-        // Preserved (materialize_discovered reads exactly these).
+        // Preserved (the catalog reads exactly these).
         assert_eq!(slim.id, "k1");
         assert_eq!(
             slim.source.identity(),
             "app-config@some-namespace:/pvc/app-config"
         );
         assert_eq!(slim.stats.total_size, 4096);
+        // The description rides CAPPED (the catalog copies it onto the CR).
+        assert_eq!(
+            slim.description,
+            "a fairly wordy free-form snapshot description that nobody reads"
+        );
+        // Tags are normalized: ONLY the canonical kopiur-meta payload survives —
+        // raw user tags and the legacy config tag never ride the wire.
+        assert_eq!(slim.tags.len(), 1, "{:?}", slim.tags);
+        assert_eq!(
+            slim.tags.get(KOPIUR_META_TAG).map(String::as_str),
+            Some(r#"{"schema":1,"src":"explicit","uid":3001}"#),
+            "canonical re-encode (unknown extras dropped, key bare)"
+        );
+    }
+
+    #[test]
+    fn slim_catalog_entry_caps_a_foreign_sized_description() {
+        let mut e = fat_entry("k1");
+        e.description = "é".repeat(DESCRIPTION_WIRE_CAP_BYTES); // 2 bytes/char
+        let slim = slim_catalog_entry(e);
+        assert!(slim.description.len() <= DESCRIPTION_WIRE_CAP_BYTES);
+        assert!(slim.description.is_char_boundary(slim.description.len()));
+    }
+
+    #[test]
+    fn normalize_meta_tags_keeps_undecodable_values_bounded_verbatim() {
+        // A newer schema must reach the controller intact so it classifies
+        // UnsupportedSchema (and counts it) — normalization must not eat it.
+        let newer = BTreeMap::from([(
+            "tag:kopiur-meta".to_string(),
+            r#"{"schema":2,"src":"quantum","qbit":1}"#.to_string(),
+        )]);
+        let out = normalize_meta_tags(&newer);
+        assert_eq!(
+            out.get(KOPIUR_META_TAG).map(String::as_str),
+            Some(r#"{"schema":2,"src":"quantum","qbit":1}"#)
+        );
+        assert!(matches!(
+            decode_meta_tag(&out),
+            MetaTagDecode::UnsupportedSchema { schema: 2 }
+        ));
+
+        // A forged multi-MB malformed value is truncated to the wire cap.
+        let forged = BTreeMap::from([(
+            "tag:kopiur-meta".to_string(),
+            format!("{{{}", "x".repeat(1_000_000)),
+        )]);
+        let out = normalize_meta_tags(&forged);
+        assert!(out.get(KOPIUR_META_TAG).unwrap().len() <= META_TAG_WIRE_CAP_BYTES);
+        assert!(matches!(
+            decode_meta_tag(&out),
+            MetaTagDecode::Malformed { .. }
+        ));
+
+        // No meta at all → an EMPTY map (no `kopiur-meta` key minted from nothing).
+        let none = BTreeMap::from([("tag:team".to_string(), "billing".to_string())]);
+        assert!(normalize_meta_tags(&none).is_empty());
     }
 
     #[test]

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -924,6 +924,10 @@ async fn resolve_pinned_info(
             hostname: entry.source.host.clone(),
             source_path: Some(entry.source.path.clone()),
         },
+        // The pin restamp deliberately touches only id + identity; an absent
+        // description is elided from the Merge PATCH, so the create-time value
+        // (if any) is left untouched.
+        description: None,
     })
 }
 

--- a/crates/mover/src/resolve.rs
+++ b/crates/mover/src/resolve.rs
@@ -132,6 +132,7 @@ mod tests {
             stats: Default::default(),
             root_entry: None,
             retention_reason: vec![],
+            tags: Default::default(),
         }
     }
 

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -61,6 +61,10 @@ fn snapshot_from_result(r: &SnapshotCreateResult) -> SnapshotInfo {
             hostname: r.source.host.clone(),
             source_path: Some(r.source.path.clone()),
         },
+        // Surface the kopia description (`snapshot create --description`) so a
+        // produced run's `status.snapshot.description` reflects what was stored.
+        // Empty = none recorded = elided from the PATCH.
+        description: (!r.description.is_empty()).then(|| r.description.clone()),
     }
 }
 
@@ -1004,6 +1008,26 @@ mod tests {
         assert_eq!(u.stats.as_ref().unwrap().files_failed, None);
         assert!(u.timing.is_some());
         assert!(u.failure.is_none());
+        // No description recorded → the field is elided from the PATCH entirely.
+        assert!(snap.description.is_none());
+        assert!(body["status"]["snapshot"].get("description").is_none());
+    }
+
+    #[test]
+    fn succeeded_backup_surfaces_the_kopia_description() {
+        // `snapshot create --description` comes back on the create result; the
+        // status PATCH must carry it under the CRD's `status.snapshot.description`.
+        let json = r#"{
+            "id":"snap3","source":{"host":"h","userName":"u","path":"/p"},
+            "description":"pre-upgrade snapshot",
+            "startTime":"2026-06-02T03:13:59Z","endTime":"2026-06-02T03:14:00Z"
+        }"#;
+        let r: SnapshotCreateResult = serde_json::from_str(json).unwrap();
+        let u = StatusUpdate::succeeded_backup(&r, ts());
+        assert_eq!(
+            u.as_patch_body()["status"]["snapshot"]["description"],
+            "pre-upgrade snapshot"
+        );
     }
 
     #[test]
@@ -1044,6 +1068,7 @@ mod tests {
                 hostname: "home".into(),
                 source_path: Some("/pvc/wyoming-whisper".into()),
             },
+            description: None,
         };
         let u = StatusUpdate::succeeded_pin(info, ts());
         assert_eq!(u.phase.as_deref(), Some("Succeeded"));

--- a/crates/webhook/src/secctx.rs
+++ b/crates/webhook/src/secctx.rs
@@ -27,11 +27,14 @@ use kube::{Api, Client};
 /// the recipe (so the webhook can actually decide). `None` ⇒ stay silent.
 fn pinned_mover_identity(mover: Option<&MoverSpec>) -> Option<secctx_compat::MoverIdentity> {
     let m = mover?;
-    // An inherit recipe's real identity is only known once a live workload pod is resolved at
-    // reconcile time. Judging it from the explicit context alone would miss the inherited
-    // groups that soften a mismatch, producing a warning that contradicts what the operator
-    // actually does. (The two were mutually exclusive before, so this path never spoke; the
-    // guard keeps that silence now that they combine.)
+    // An inherit recipe's real identity is only known at reconcile time — a live workload
+    // pod for `workloadSelector`/`pvcConsumer`, the backup's recorded metadata
+    // (`Snapshot.status.recorded`) for the restore-only `snapshot` variant. Judging it from
+    // the explicit context alone would miss the inherited values that soften a mismatch,
+    // producing a warning that contradicts what the operator actually does. (The two were
+    // mutually exclusive before, so this path never spoke; the guard keeps that silence now
+    // that they combine.) Deliberately `is_some()`, not a per-variant match: EVERY inherit
+    // mode resolves at reconcile, so a new variant is silent here by default.
     if m.inherit_security_context_from.is_some() {
         return None;
     }

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -852,6 +852,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -860,6 +862,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_replication_crd.snap
@@ -567,6 +567,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -575,6 +577,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__snapshot_crd.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/xtask/tests/snapshots_test.rs
+assertion_line: 30
 expression: "body(&artifacts, \"snapshots\")"
 ---
 apiVersion: apiextensions.k8s.io/v1
@@ -117,7 +118,13 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
+                description: |-
+                  Free-form tags attached to the kopia snapshot manifest itself
+                  (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the
+                  repository, independent of this CR. Keys must be non-empty, colon-free
+                  (kopia splits on the first colon), and must not start with the reserved
+                  `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes
+                  (webhook-enforced).
                 nullable: true
                 type: object
             type: object
@@ -275,6 +282,60 @@ spec:
                   so a later failing episode gets a fresh budget rather than a stale anchor.
                 nullable: true
                 type: string
+              recorded:
+                description: |-
+                  The mover identity recorded on the kopia snapshot itself (the
+                  `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran
+                  as, plus its provenance. Produced runs stamp this at launch (from the
+                  same value written into the tag); discovered rows decode it from the tag
+                  during the catalog scan. Absent for pre-feature snapshots, foreign
+                  backups without the tag, or a tag this operator version cannot decode.
+                nullable: true
+                properties:
+                  fsGroup:
+                    description: |-
+                      The resolved pod-level `fsGroup` the mover ran with (the hardened
+                      default is `65532`). Absent = no layer set one.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  gid:
+                    description: |-
+                      The resolved effective `runAsGroup` the mover ran as at backup time
+                      (container `runAsGroup`, else pod). Absent = image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  schema:
+                    description: |-
+                      The `kopiur-meta` schema version this value was written under. Writers
+                      emit the lowest schema that represents the data (currently
+                      [`KOPIUR_META_SCHEMA_V1`]); readers reject only a schema NEWER than they
+                      understand (degrading to recorded-absent, never an error).
+                    format: int64
+                    type: integer
+                  src:
+                    description: |-
+                      Which layer pinned the recorded identity. Only `inherited` means the
+                      identity tracked the workload.
+                    enum:
+                    - inherited
+                    - explicit
+                    - defaults
+                    - unknown
+                    type: string
+                  uid:
+                    description: |-
+                      The resolved effective `runAsUser` the mover ran as at backup time
+                      (container `runAsUser`, else pod). Absent = no layer pinned a UID, so
+                      the mover's UID was image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                required:
+                - schema
+                - src
+                type: object
               resolved:
                 description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
@@ -337,6 +398,14 @@ spec:
                 description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
+                  description:
+                    description: |-
+                      The kopia snapshot description (`snapshot create --description`), when
+                      one is recorded and non-empty. For discovered rows this is copied from
+                      the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) —
+                      the value is foreign-writer-controlled and must never fail the CR write.
+                    nullable: true
+                    type: string
                   identity:
                     description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -848,6 +848,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -856,6 +858,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
@@ -3790,6 +3802,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -3798,6 +3812,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
@@ -6336,6 +6360,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -6344,6 +6370,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
@@ -7377,7 +7413,13 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
+                description: |-
+                  Free-form tags attached to the kopia snapshot manifest itself
+                  (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the
+                  repository, independent of this CR. Keys must be non-empty, colon-free
+                  (kopia splits on the first colon), and must not start with the reserved
+                  `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes
+                  (webhook-enforced).
                 nullable: true
                 type: object
             type: object
@@ -7535,6 +7577,60 @@ spec:
                   so a later failing episode gets a fresh budget rather than a stale anchor.
                 nullable: true
                 type: string
+              recorded:
+                description: |-
+                  The mover identity recorded on the kopia snapshot itself (the
+                  `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran
+                  as, plus its provenance. Produced runs stamp this at launch (from the
+                  same value written into the tag); discovered rows decode it from the tag
+                  during the catalog scan. Absent for pre-feature snapshots, foreign
+                  backups without the tag, or a tag this operator version cannot decode.
+                nullable: true
+                properties:
+                  fsGroup:
+                    description: |-
+                      The resolved pod-level `fsGroup` the mover ran with (the hardened
+                      default is `65532`). Absent = no layer set one.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  gid:
+                    description: |-
+                      The resolved effective `runAsGroup` the mover ran as at backup time
+                      (container `runAsGroup`, else pod). Absent = image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  schema:
+                    description: |-
+                      The `kopiur-meta` schema version this value was written under. Writers
+                      emit the lowest schema that represents the data (currently
+                      [`KOPIUR_META_SCHEMA_V1`]); readers reject only a schema NEWER than they
+                      understand (degrading to recorded-absent, never an error).
+                    format: int64
+                    type: integer
+                  src:
+                    description: |-
+                      Which layer pinned the recorded identity. Only `inherited` means the
+                      identity tracked the workload.
+                    enum:
+                    - inherited
+                    - explicit
+                    - defaults
+                    - unknown
+                    type: string
+                  uid:
+                    description: |-
+                      The resolved effective `runAsUser` the mover ran as at backup time
+                      (container `runAsUser`, else pod). Absent = no layer pinned a UID, so
+                      the mover's UID was image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                required:
+                - schema
+                - src
+                type: object
               resolved:
                 description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
@@ -7597,6 +7693,14 @@ spec:
                 description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
+                  description:
+                    description: |-
+                      The kopia snapshot description (`snapshot create --description`), when
+                      one is recorded and non-empty. For discovered rows this is copied from
+                      the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) —
+                      the value is foreign-writer-controlled and must never fail the CR write.
+                    nullable: true
+                    type: string
                   identity:
                     description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:
@@ -8129,6 +8233,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -8137,6 +8243,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
@@ -9059,6 +9175,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -9067,6 +9185,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).
@@ -10216,6 +10344,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -10224,6 +10354,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -901,6 +901,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -909,6 +911,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/maintenances.yaml
+++ b/deploy/crds/maintenances.yaml
@@ -115,6 +115,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -123,6 +125,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -848,6 +848,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -856,6 +858,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/repositoryreplications.yaml
+++ b/deploy/crds/repositoryreplications.yaml
@@ -563,6 +563,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -571,6 +573,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/restores.yaml
+++ b/deploy/crds/restores.yaml
@@ -114,6 +114,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -122,6 +124,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -494,6 +494,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -502,6 +504,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/crds/snapshots.yaml
+++ b/deploy/crds/snapshots.yaml
@@ -114,7 +114,13 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
+                description: |-
+                  Free-form tags attached to the kopia snapshot manifest itself
+                  (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the
+                  repository, independent of this CR. Keys must be non-empty, colon-free
+                  (kopia splits on the first colon), and must not start with the reserved
+                  `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes
+                  (webhook-enforced).
                 nullable: true
                 type: object
             type: object
@@ -272,6 +278,60 @@ spec:
                   so a later failing episode gets a fresh budget rather than a stale anchor.
                 nullable: true
                 type: string
+              recorded:
+                description: |-
+                  The mover identity recorded on the kopia snapshot itself (the
+                  `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran
+                  as, plus its provenance. Produced runs stamp this at launch (from the
+                  same value written into the tag); discovered rows decode it from the tag
+                  during the catalog scan. Absent for pre-feature snapshots, foreign
+                  backups without the tag, or a tag this operator version cannot decode.
+                nullable: true
+                properties:
+                  fsGroup:
+                    description: |-
+                      The resolved pod-level `fsGroup` the mover ran with (the hardened
+                      default is `65532`). Absent = no layer set one.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  gid:
+                    description: |-
+                      The resolved effective `runAsGroup` the mover ran as at backup time
+                      (container `runAsGroup`, else pod). Absent = image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  schema:
+                    description: |-
+                      The `kopiur-meta` schema version this value was written under. Writers
+                      emit the lowest schema that represents the data (currently
+                      [`KOPIUR_META_SCHEMA_V1`]); readers reject only a schema NEWER than they
+                      understand (degrading to recorded-absent, never an error).
+                    format: int64
+                    type: integer
+                  src:
+                    description: |-
+                      Which layer pinned the recorded identity. Only `inherited` means the
+                      identity tracked the workload.
+                    enum:
+                    - inherited
+                    - explicit
+                    - defaults
+                    - unknown
+                    type: string
+                  uid:
+                    description: |-
+                      The resolved effective `runAsUser` the mover ran as at backup time
+                      (container `runAsUser`, else pod). Absent = no layer pinned a UID, so
+                      the mover's UID was image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                required:
+                - schema
+                - src
+                type: object
               resolved:
                 description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
@@ -334,6 +394,14 @@ spec:
                 description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
+                  description:
+                    description: |-
+                      The kopia snapshot description (`snapshot create --description`), when
+                      one is recorded and non-empty. For discovered rows this is copied from
+                      the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) —
+                      the value is foreign-writer-controlled and must never fail the CR write.
+                    nullable: true
+                    type: string
                   identity:
                     description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:

--- a/deploy/examples/37-restore-recorded-identity.yaml
+++ b/deploy/examples/37-restore-recorded-identity.yaml
@@ -1,0 +1,77 @@
+# Example 37 — Restore as the identity RECORDED on the backup
+#
+# Every backup records the uid/gid/fsGroup its mover actually ran as on the kopia
+# snapshot itself (the `kopiur-meta` tag), surfaced as `Snapshot.status.recorded`.
+# `inheritSecurityContextFrom: { snapshot: {} }` makes a Restore's mover run as
+# that recorded identity — no live workload pod needed, so it works when the app
+# is not deployed yet and after a full cluster re-bootstrap.
+#
+# Works with EVERY source:
+#   - `snapshotRef`          reads the referenced Snapshot CR's status.recorded.
+#   - `fromPolicy`/`identity` search the CR catalog by kopia identity, honoring
+#     asOf/offset/snapshotID — this is what makes the GitOps re-bootstrap
+#     declarative (second Restore below).
+#
+# Holds and warnings (SecurityContextInherited condition):
+#   - `MissingRecordedIdentity` (False): the Snapshot CR is missing, carries no
+#     status.recorded (pre-feature or foreign backup), or the catalog scan has
+#     not materialized a matching row yet. The Restore holds and re-checks every
+#     few minutes; the scan backfills recorded metadata automatically.
+#   - `RecordedPinnedNoUid` (False): the backup recorded no pinned uid (its
+#     mover's identity was image-determined) — inheriting contributes nothing.
+#   - `RecordedApplied` (True): names the Snapshot, the recorded uid, and its
+#     provenance (`inherited`/`explicit`/`defaults`).
+#
+# TRUST BOUNDARY: recorded metadata is repository data — anyone with repository
+# write credentials can forge it (including uid 0). A recorded ROOT identity is
+# gated on the namespace privileged-movers opt-in exactly like live-pod inherit,
+# and the condition/Events always name the recorded uid + snapshot.
+#
+# Field shapes verified against crates/api:
+#   spec.mover.inheritSecurityContextFrom : exactly one of
+#       { workloadSelector: {...} } | { pvcConsumer: {...} } | { snapshot: {} }
+#   `snapshot` is RESTORE-only (webhook-rejected on SnapshotPolicy/Maintenance).
+#
+# YAML FOOTGUN: write `snapshot: {}` — a bare `snapshot:` is YAML null and is
+# rejected at admission (the variant is an empty sub-object, not a null).
+---
+# Direct: restore a specific Snapshot as the identity it recorded.
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: postgres-restore-as-recorded
+  namespace: billing
+spec:
+  source:
+    snapshotRef:
+      name: postgres-data-20260523-021300
+  target:
+    pvc:
+      name: postgres-data-restored
+      capacity: 100Gi
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {} # the empty sub-object is required (`snapshot:` alone is null)
+---
+# Declarative re-bootstrap (GitOps): apply Repository + SnapshotPolicy + this
+# Restore together on a fresh cluster. The Restore holds on
+# `MissingRecordedIdentity` until the catalog scan materializes a discovered
+# Snapshot CR carrying `status.recorded` for the policy's identity, then
+# restores the latest backup as the identity it recorded. Pair with
+# `target: { populator: {} }` for deploy-or-restore (`snapshot` needs no live
+# pod, so it is the one inherit mode allowed with a populator target).
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Restore
+metadata:
+  name: postgres-rebootstrap
+  namespace: billing
+spec:
+  source:
+    fromPolicy:
+      name: postgres-data # identity re-resolved from the live SnapshotPolicy
+  target:
+    pvcRef:
+      name: postgres-data # the PVC your app deployment already claims
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {}

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -901,6 +901,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -909,6 +911,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/maintenances.yaml
+++ b/deploy/helm/kopiur/crds/maintenances.yaml
@@ -115,6 +115,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -123,6 +125,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -848,6 +848,8 @@ spec:
                           - workloadSelector
                         - required:
                           - pvcConsumer
+                        - required:
+                          - snapshot
                         properties:
                           pvcConsumer:
                             description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -856,6 +858,16 @@ spec:
                                 description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                                 nullable: true
                                 type: string
+                            type: object
+                          snapshot:
+                            description: |-
+                              Restores only: inherit the identity RECORDED on the backup itself
+                              (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                              uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                              pod, so it works on a rebuilt cluster and with `target.populator`.
+                              Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                              live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                              (an empty sub-object) — a bare `snapshot:` is null and rejected.
                             type: object
                           workloadSelector:
                             description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/repositoryreplications.yaml
+++ b/deploy/helm/kopiur/crds/repositoryreplications.yaml
@@ -563,6 +563,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -571,6 +573,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/restores.yaml
+++ b/deploy/helm/kopiur/crds/restores.yaml
@@ -114,6 +114,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -122,6 +124,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -494,6 +494,8 @@ spec:
                       - workloadSelector
                     - required:
                       - pvcConsumer
+                    - required:
+                      - snapshot
                     properties:
                       pvcConsumer:
                         description: 'Backup sources only: auto-derive the workload from the PVC this snapshot backs up.'
@@ -502,6 +504,16 @@ spec:
                             description: Which container within the matched consumer pod to inherit from; absent uses the first/only.
                             nullable: true
                             type: string
+                        type: object
+                      snapshot:
+                        description: |-
+                          Restores only: inherit the identity RECORDED on the backup itself
+                          (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) —
+                          uid/gid/fsGroup the backup mover actually ran as. Needs no live workload
+                          pod, so it works on a rebuilt cluster and with `target.populator`.
+                          Rejected at admission on SnapshotPolicy/Maintenance (backups read the
+                          live workload; maintenance has no snapshot). Write it as `snapshot: {}`
+                          (an empty sub-object) — a bare `snapshot:` is null and rejected.
                         type: object
                       workloadSelector:
                         description: Inherit from workload pod(s) matched by an explicit label selector (backup or restore).

--- a/deploy/helm/kopiur/crds/snapshots.yaml
+++ b/deploy/helm/kopiur/crds/snapshots.yaml
@@ -114,7 +114,13 @@ spec:
               tags:
                 additionalProperties:
                   type: string
-                description: 'Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`).'
+                description: |-
+                  Free-form tags attached to the kopia snapshot manifest itself
+                  (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the
+                  repository, independent of this CR. Keys must be non-empty, colon-free
+                  (kopia splits on the first colon), and must not start with the reserved
+                  `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes
+                  (webhook-enforced).
                 nullable: true
                 type: object
             type: object
@@ -272,6 +278,60 @@ spec:
                   so a later failing episode gets a fresh budget rather than a stale anchor.
                 nullable: true
                 type: string
+              recorded:
+                description: |-
+                  The mover identity recorded on the kopia snapshot itself (the
+                  `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran
+                  as, plus its provenance. Produced runs stamp this at launch (from the
+                  same value written into the tag); discovered rows decode it from the tag
+                  during the catalog scan. Absent for pre-feature snapshots, foreign
+                  backups without the tag, or a tag this operator version cannot decode.
+                nullable: true
+                properties:
+                  fsGroup:
+                    description: |-
+                      The resolved pod-level `fsGroup` the mover ran with (the hardened
+                      default is `65532`). Absent = no layer set one.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  gid:
+                    description: |-
+                      The resolved effective `runAsGroup` the mover ran as at backup time
+                      (container `runAsGroup`, else pod). Absent = image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                  schema:
+                    description: |-
+                      The `kopiur-meta` schema version this value was written under. Writers
+                      emit the lowest schema that represents the data (currently
+                      [`KOPIUR_META_SCHEMA_V1`]); readers reject only a schema NEWER than they
+                      understand (degrading to recorded-absent, never an error).
+                    format: int64
+                    type: integer
+                  src:
+                    description: |-
+                      Which layer pinned the recorded identity. Only `inherited` means the
+                      identity tracked the workload.
+                    enum:
+                    - inherited
+                    - explicit
+                    - defaults
+                    - unknown
+                    type: string
+                  uid:
+                    description: |-
+                      The resolved effective `runAsUser` the mover ran as at backup time
+                      (container `runAsUser`, else pod). Absent = no layer pinned a UID, so
+                      the mover's UID was image-determined.
+                    format: int64
+                    nullable: true
+                    type: integer
+                required:
+                - schema
+                - src
+                type: object
               resolved:
                 description: Frozen recipe values at run time (scheduled/manual).
                 nullable: true
@@ -334,6 +394,14 @@ spec:
                 description: The kopia artifact this CR represents.
                 nullable: true
                 properties:
+                  description:
+                    description: |-
+                      The kopia snapshot description (`snapshot create --description`), when
+                      one is recorded and non-empty. For discovered rows this is copied from
+                      the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) —
+                      the value is foreign-writer-controlled and must never fail the CR write.
+                    nullable: true
+                    type: string
                   identity:
                     description: The `username@hostname:path` identity recorded for this snapshot.
                     properties:

--- a/docs/adr/0004-breaking-crd-and-field-renames.md
+++ b/docs/adr/0004-breaking-crd-and-field-renames.md
@@ -40,6 +40,8 @@ spec:
 
 `securityContext`/`podSecurityContext` resolve by **field-wise merge**, lowest→highest: `built-in hardened default ⊂ repo.moverDefaults ⊂ recipe.mover`. Each explicitly-set field wins; unset fields inherit the layer below; the privileged-mover gate (ADR-0003 §4.11/§G16) runs on the merged result. This is **required for §1's inheritance to compose** — under replace, a recipe setting one SC field would wipe `moverDefaults`. The `unwrap_or_else(default_security_context)` path is deleted and the doc comment made accurate.
 
+> **Amended 2026-07-24:** a purely per-dimension field-wise merge inverted this ladder for the mover's *identity*: the kubelet resolves the effective UID/GID as `container ?? pod` *across* dimensions, so a lower layer's container-level `runAsUser` silently shadowed a higher layer's pod-level one. Layers now merge as `(container, pod)` pairs (`merge_context_pair`) with the winning layer's effective identity promoted onto the mover container, so the effective UID/GID always belongs to the highest layer that pins one. Non-identity fields keep the plain field-wise rule.
+
 ### B. Naming
 
 #### §3 — CRD kind names follow Kopia nomenclature

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -580,6 +580,33 @@ postgres-data-manual-x9f   Succeeded   manual   k1f1ec0a8   44s
 
 `ORIGIN` tells you where a `Snapshot` came from: `scheduled` (a `SnapshotSchedule`), `manual` (you / automation), or `discovered` (materialized from snapshots Kopiur didn't create — see [Restores → discovered](restores.md#restoring-a-snapshot-kopiur-didnt-create)).
 
+### `tags` — label the snapshot in the repository
+
+`spec.tags` attaches free-form `key: value` pairs to the kopia snapshot manifest itself (`kopia snapshot create --tags`), so they survive in the repository independently of the CR — visible to any kopia client and to other clusters sharing the repository:
+
+```yaml
+spec:
+    policyRef: { name: postgres-data }
+    tags:
+        reason: pre-upgrade
+        ticket: OPS-1234
+```
+
+/// warning | Tag keys are constrained (webhook-enforced)
+
+kopia splits each tag argument on the **first colon** to separate key from value, so a key containing `:` would be stored mangled — and can collide with Kopiur's own reserved tag, which makes kopia **fail the snapshot create** with a duplicate-tag error. The webhook therefore rejects tag keys that are empty, contain `:`, or start with the reserved prefix `kopiur`, and bounds the map to at most **10 tags**, keys ≤ **63** bytes, values ≤ **256** bytes (every tag is stored on the manifest and read back by every catalog scan). Tags on objects stored before these rules existed are skipped with a warning rather than failing the backup.
+
+///
+
+Kopiur reserves the `kopiur` key prefix for the tags it writes on every produced snapshot:
+
+| Tag (as passed to kopia)  | Stored manifest key/value                        | What it records                                                                                                                                                                                                                          |
+| ------------------------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `kopiur:config:<policy>`  | key `tag:kopiur`, value `config:<policy>`        | Which `SnapshotPolicy` produced the snapshot (kopia's first-colon split puts `config:<policy>` in the value — a long-standing shape existing tooling depends on).                                                                          |
+| `kopiur-meta: {…}`        | key `tag:kopiur-meta`, value compact JSON        | The **resolved mover identity** the backup ran as — `uid`/`gid` (absent = image-determined), pod `fsGroup`, and `src` (whether the identity was `inherited` from the workload, pinned by the recipe's `explicit` context, or came from `defaults`). |
+
+The `kopiur-meta` value is mirrored to `status.recorded` at launch, and the catalog scan decodes it back onto **discovered** rows (and backfills pre-existing rows that lack it) — so the identity your data expects survives cluster rebuilds with the repository itself. See [Security context](security-context.md) for how the identity is resolved.
+
 ### `deletionPolicy` — what happens to the snapshot
 
 A `Snapshot` CR **owns** its kopia snapshot via a finalizer. What happens to the snapshot when the CR is deleted is governed by `deletionPolicy`:

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -427,11 +427,12 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 
 ###### `spec.maintenance.mover.inheritSecurityContextFrom` { #repository-spec-maintenance-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#repository-spec-maintenance-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#repository-spec-maintenance-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.maintenance.mover.inheritSecurityContextFrom.pvcConsumer` { #repository-spec-maintenance-mover-inheritsecuritycontextfrom-pvcconsumer }
@@ -1113,11 +1114,12 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 
 ###### `spec.maintenance.mover.inheritSecurityContextFrom` { #clusterrepository-spec-maintenance-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#clusterrepository-spec-maintenance-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#clusterrepository-spec-maintenance-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.maintenance.mover.inheritSecurityContextFrom.pvcConsumer` { #clusterrepository-spec-maintenance-mover-inheritsecuritycontextfrom-pvcconsumer }
@@ -1580,11 +1582,12 @@ Externally tagged — set **exactly one** of: `httpRequest` · `runJob` · `work
 
 ##### `spec.mover.inheritSecurityContextFrom` { #snapshotpolicy-spec-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#snapshotpolicy-spec-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#snapshotpolicy-spec-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.mover.inheritSecurityContextFrom.pvcConsumer` { #snapshotpolicy-spec-mover-inheritsecuritycontextfrom-pvcconsumer }
@@ -1806,7 +1809,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | `onScheduleDelete` | enum: Retain \| Delete | — | What the deletion of a `SnapshotSchedule` does to the `Snapshot` CRs it produced (which Kubernetes GC cascade-deletes via their ownerReference). Default `Retain`: the CRs are removed but their kopia snapshots survive and the catalog rediscovers them as `origin: discovered`. `Delete` opts into the cascade: each Snapshot's own `deletionPolicy` applies.<br>Deliberately 2-variant (not reusing `DeletionPolicy`): an `Orphan` in cascade position would differ from `Retain` only in per-CR event/metric bookkeeping — an invalid state made unrepresentable. The guard's `Retain` is exactly `DeletionPolicy::Retain`'s semantics (CR removed, kopia snapshot stays, catalog rediscovers it), deliberately NOT the `Orphan` event storm (no per-CR "orphaned" event/metric for every produced Snapshot). |
 | `pin` | boolean | — | Exempt this snapshot from GFS retention. |
 | `policyRef` | [object](#snapshot-spec-policyref) | — | The `SnapshotPolicy` recipe to run; absent for `discovered` backups. |
-| `tags` | map[string]string | — | Arbitrary kopia snapshot tags (e.g. `reason: scheduled-nightly`). |
+| `tags` | map[string]string | — | Free-form tags attached to the kopia snapshot manifest itself (`snapshot create --tags`), e.g. `reason: pre-upgrade` — durable in the repository, independent of this CR. Keys must be non-empty, colon-free (kopia splits on the first colon), and must not start with the reserved `kopiur` prefix; at most 10 tags, keys ≤ 63 bytes, values ≤ 256 bytes (webhook-enforced). |
 
 #### `spec.failurePolicy` { #snapshot-spec-failurepolicy }
 
@@ -1838,6 +1841,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | `phase` | enum: Pending \| Running \| Succeeded \| Failed \| Deleting \| Discovered | — | Lifecycle phase of a `Snapshot`. |
 | `pinned` | boolean | — | The observed kopia-side pin state: `Some(true)` if pinned, `Some(false)` if unpinned, `None` before any pin reconcile. |
 | `preflightSince` | string | — | RFC 3339 timestamp of the first reconcile where the repository was `Ready` but a `spec.preflight` check was failing. The one-shot anchor for the preflight `timeout` deadline (so the budget covers preflight only, not the earlier repository-not-Ready wait). Cleared once every preflight check passes, so a later failing episode gets a fresh budget rather than a stale anchor. |
+| `recorded` | [object](#snapshot-status-recorded) | — | The mover identity recorded on the kopia snapshot itself (the `kopiur-meta` tag): the resolved effective uid/gid/fsGroup the backup ran as, plus its provenance. Produced runs stamp this at launch (from the same value written into the tag); discovered rows decode it from the tag during the catalog scan. Absent for pre-feature snapshots, foreign backups without the tag, or a tag this operator version cannot decode. |
 | `resolved` | [object](#snapshot-status-resolved) | — | Frozen recipe values at run time (scheduled/manual). |
 | `snapshot` | [object](#snapshot-status-snapshot) | — | The kopia artifact this CR represents. |
 | `staged` | [object](#snapshot-status-staged) | — | The CSI staging objects the run created for `copyMethod: Snapshot`/`Clone`. |
@@ -1885,6 +1889,16 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | `attempts` | integer | — | Number of attempts so far (bounded by `failurePolicy.backoffLimit`). |
 | `name` | string | — | Name of the mover `Job`. |
 
+#### `status.recorded` { #snapshot-status-recorded }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `schema` | integer | **required** | The `kopiur-meta` schema version this value was written under. Writers emit the lowest schema that represents the data (currently `KOPIUR_META_SCHEMA_V1`); readers reject only a schema NEWER than they understand (degrading to recorded-absent, never an error). |
+| `src` | enum: inherited \| explicit \| defaults \| unknown | **required** | Which layer pinned the recorded identity. Only `inherited` means the identity tracked the workload. |
+| `fsGroup` | integer | — | The resolved pod-level `fsGroup` the mover ran with (the hardened default is `65532`). Absent = no layer set one. |
+| `gid` | integer | — | The resolved effective `runAsGroup` the mover ran as at backup time (container `runAsGroup`, else pod). Absent = image-determined. |
+| `uid` | integer | — | The resolved effective `runAsUser` the mover ran as at backup time (container `runAsUser`, else pod). Absent = no layer pinned a UID, so the mover's UID was image-determined. |
+
 #### `status.resolved` { #snapshot-status-resolved }
 
 | Field | Type | Default | Description |
@@ -1920,6 +1934,7 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc` · `pvcSelector`.
 | --- | --- | --- | --- |
 | `identity` | [object](#snapshot-status-snapshot-identity) | **required** | The `username@hostname:path` identity recorded for this snapshot. |
 | `kopiaSnapshotID` | string | **required** | kopia's snapshot ID — the handle the finalizer uses to delete content. |
+| `description` | string | — | The kopia snapshot description (`snapshot create --description`), when one is recorded and non-empty. For discovered rows this is copied from the repository listing TRUNCATED to 1024 bytes (char-boundary-safe) — the value is foreign-writer-controlled and must never fail the CR write. |
 
 ##### `status.snapshot.identity` { #snapshot-status-snapshot-identity }
 
@@ -2192,11 +2207,12 @@ Externally tagged — set **exactly one** of: `populator` · `pvc` · `pvcRef`.
 
 ##### `spec.mover.inheritSecurityContextFrom` { #restore-spec-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#restore-spec-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#restore-spec-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.mover.inheritSecurityContextFrom.pvcConsumer` { #restore-spec-mover-inheritsecuritycontextfrom-pvcconsumer }
@@ -2438,11 +2454,12 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector
 
 ##### `spec.mover.inheritSecurityContextFrom` { #maintenance-spec-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#maintenance-spec-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#maintenance-spec-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.mover.inheritSecurityContextFrom.pvcConsumer` { #maintenance-spec-mover-inheritsecuritycontextfrom-pvcconsumer }
@@ -2814,11 +2831,12 @@ Externally tagged — set **exactly one** of: `nfs` · `pvc`.
 
 ##### `spec.mover.inheritSecurityContextFrom` { #repositoryreplication-spec-mover-inheritsecuritycontextfrom }
 
-Externally tagged — set **exactly one** of: `pvcConsumer` · `workloadSelector`.
+Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `workloadSelector`.
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
 | `pvcConsumer` | [object](#repositoryreplication-spec-mover-inheritsecuritycontextfrom-pvcconsumer) | — | Backup sources only: auto-derive the workload from the PVC this snapshot backs up. |
+| `snapshot` | object | — | Restores only: inherit the identity RECORDED on the backup itself (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag) — uid/gid/fsGroup the backup mover actually ran as. Needs no live workload pod, so it works on a rebuilt cluster and with `target.populator`. Rejected at admission on SnapshotPolicy/Maintenance (backups read the live workload; maintenance has no snapshot). Write it as `snapshot: {}` (an empty sub-object) — a bare `snapshot:` is null and rejected. |
 | `workloadSelector` | [object](#repositoryreplication-spec-mover-inheritsecuritycontextfrom-workloadselector) | — | Inherit from workload pod(s) matched by an explicit label selector (backup or restore). |
 
 ###### `spec.mover.inheritSecurityContextFrom.pvcConsumer` { #repositoryreplication-spec-mover-inheritsecuritycontextfrom-pvcconsumer }

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -120,7 +120,7 @@ target:
 
 /// warning | `target` is required — the empty-`target` form is gone
 
-A `Restore` with **no** `target` is rejected by the webhook. Populator intent must be the **explicit** `target.populator: {}` (not an omitted `target`). Also, `inheritSecurityContextFrom` is invalid in populator mode — there's no workload pod at provision time, so the webhook rejects it and points you at `moverDefaults` / an explicit `securityContext`.
+A `Restore` with **no** `target` is rejected by the webhook. Populator intent must be the **explicit** `target.populator: {}` (not an omitted `target`). The live-pod `inheritSecurityContextFrom` modes (`workloadSelector`/`pvcConsumer`) are invalid in populator mode — there's no workload pod at provision time, so the webhook rejects them and points you at `moverDefaults` / an explicit `securityContext` / `inheritSecurityContextFrom: { snapshot: {} }`, which **is** allowed: it replays the identity recorded on the backup and needs no live pod (see [the re-bootstrap section](#declarative-re-bootstrap--restore-as-the-recorded-identity)).
 
 ///
 
@@ -195,7 +195,8 @@ spec:
     mover:
         securityContext: { runAsUser: 1000, runAsGroup: 1000, ... } # CONTAINER: own the restored files
         podSecurityContext: { fsGroup: 1000 } # POD: make a fresh volume writable
-        # inheritSecurityContextFrom: { workloadSelector: { podSelector: {...} } }  # ...or copy from a live pod (restore: use workloadSelector, not pvcConsumer)
+        # inheritSecurityContextFrom: { workloadSelector: { podSelector: {...} } }  # ...or copy from a live pod (restore: workloadSelector, not pvcConsumer)
+        # inheritSecurityContextFrom: { snapshot: {} }                              # ...or replay the identity RECORDED on the backup (no live pod needed)
         cache: { capacity: 16Gi, mode: Persistent, contentCacheSizeMb: 10000 }
     failurePolicy:
         backoffLimit: 4
@@ -205,7 +206,7 @@ spec:
 
 - **`mover.securityContext`** — run the restore mover (its **container**) as the UID/GID that should own the restored files. Without it the mover runs as the hardened default (UID 65532), which may write files the app can't read. This is the fix for "the restore mover had no UID control".
 - **`mover.podSecurityContext.fsGroup`** — a **pod**-level `fsGroup` that makes a freshly-provisioned target volume group-writable, so an **unprivileged** `runAsUser: 1000` mover can populate it on restore (instead of needing a root mover just to write the new volume). The headline case for restoring into a brand-new PVC as non-root. See [Security context → fsGroup](security-context.md).
-- **`mover.inheritSecurityContextFrom`** — instead of hard-coding them, copy **both** the container `securityContext` **and** the pod-level `securityContext` (so the restore mover gets the app's UID *and* its `fsGroup`) from a live workload pod. On a Restore, use **`workloadSelector: { podSelector, container? }`** to name the pod that will *read* the restored data. The **`pvcConsumer`** form is **backup-only** — it derives the workload from a backup *source* PVC, which a restore doesn't have (the target's consumer may not exist yet), so the webhook **rejects `pvcConsumer` on a `Restore`**. Combines with `securityContext`/`podSecurityContext`: they are the higher merge layer, so an explicit field overrides the inherited one, and they stand in alone when no workload pod resolves — in which case the restore proceeds on them and reports `SecurityContextInherited=False` / `InheritFallback`, because the restored files will then be owned as *your* context says rather than as the workload you named. The condition `RestoreSecurityContextCompatible` reports (positively) when the future consumer will be able to read what the mover writes. See [Security context → Inherit it from the workload](security-context.md#2-inherit-it-from-the-workload) and [example 18](examples.md#example-18--inherit-the-mover-security-context-from-a-workload).
+- **`mover.inheritSecurityContextFrom`** — instead of hard-coding them, copy **both** the container `securityContext` **and** the pod-level `securityContext` (so the restore mover gets the app's UID *and* its `fsGroup`) from somewhere authoritative. On a Restore, two forms work: **`workloadSelector: { podSelector, container? }`** names a live pod that will *read* the restored data, and **`snapshot: {}`** replays the identity **recorded on the backup itself** (`Snapshot.status.recorded` — no live pod needed; see [the re-bootstrap section below](#declarative-re-bootstrap--restore-as-the-recorded-identity)). The **`pvcConsumer`** form is **backup-only** — it derives the workload from a backup *source* PVC, which a restore doesn't have (the target's consumer may not exist yet), so the webhook **rejects `pvcConsumer` on a `Restore`**. Combines with `securityContext`/`podSecurityContext`: they are the higher merge layer, so an explicit field overrides the inherited one, and they stand in alone when no workload pod resolves — in which case the restore proceeds on them and reports `SecurityContextInherited=False` / `InheritFallback`, because the restored files will then be owned as *your* context says rather than as the workload you named. The condition `RestoreSecurityContextCompatible` reports (positively) when the future consumer will be able to read what the mover writes. See [Security context → Inherit it from the workload](security-context.md#2-inherit-it-from-the-workload) and [example 18](examples.md#example-18--inherit-the-mover-security-context-from-a-workload).
 - **`mover.cache`** — size the kopia cache for a large restore. `mode: Ephemeral` (default) gives a fresh per-run volume sized by `capacity` (or an `emptyDir` when unset); `mode: Persistent` keeps a controller-owned cache PVC and reuses it across runs for a warm cache. `contentCacheSizeMb` / `metadataCacheSizeMb` pass kopia's `--content/metadata-cache-size-mb` budgets. A repository's `moverDefaults.cache` are inherited and overlaid by `mover.cache`.
 - **`failurePolicy`** — the restore Job's `backoffLimit`, `activeDeadlineSeconds`, and `podStartupDeadlineSeconds`. Absent uses the defaults (2 retries; a 48h `activeDeadlineSeconds` backstop so a *running* Job can't linger forever; a 5-minute `podStartupDeadlineSeconds` so a restore mover that can't **start** — bad image, unschedulable, impossible `securityContext` — fails fast with `MoverPodWedged` instead of hanging). The two deadlines are explained in [Backups → `failurePolicy`](backups.md#failurepolicy--retry--deadline-for-the-mover-job).
 
@@ -249,6 +250,41 @@ Snapshots written by a foreign kopia client, or predating your install, are mate
 ```console
 $ kubectl get snapshots -n backups -l kopiur.home-operations.com/origin=discovered
 ```
+
+/// note | Snapshots carry their recorded mover identity
+
+Every snapshot Kopiur produces records the resolved mover identity (uid/gid/fsGroup and its provenance) on the snapshot itself as the `kopiur-meta` tag, and the catalog scan decodes it into `status.recorded` on discovered rows — so the identity the data expects survives a cluster rebuild with the repository. `kubectl kopiur snapshots list -o wide` shows it, and a `Restore` can run **as** it via `inheritSecurityContextFrom: { snapshot: {} }` (next section). See [Backups → tags](backups.md#tags--label-the-snapshot-in-the-repository).
+
+///
+
+## Declarative re-bootstrap — restore as the recorded identity
+
+After a full cluster loss, the workload whose UID a restore should run as does not exist yet — there is no pod to inherit from. `mover.inheritSecurityContextFrom: { snapshot: {} }` closes that gap: the restore mover runs as the identity **recorded on the backup** (`Snapshot.status.recorded`, decoded from the `kopiur-meta` kopia tag), with no live pod involved. The whole recovery is then one declarative apply:
+
+1. GitOps applies **Repository + SnapshotPolicy + Restore** (`source.fromPolicy` + `snapshot: {}`) to the fresh cluster.
+2. The repository connects; the **catalog scan** materializes `discovered` Snapshot CRs from the repository, decoding each snapshot's recorded identity into `status.recorded`.
+3. Until a matching row exists, the Restore **holds** with `SecurityContextInherited=False` / `MissingRecordedIdentity` (a Warning Event says why; it re-checks every few minutes). This is the expected intermediate state, not an error to fix.
+4. The moment the scan lands, the Restore resolves the recorded identity, runs the mover as it, and completes.
+
+No hand-authored snapshot names anywhere: `fromPolicy` re-resolves the kopia identity from the live `SnapshotPolicy` and the controller picks the matching Snapshot CR from the catalog (honoring `asOf`/`offset`; `source.identity` works the same way, including a pinned `snapshotID`). `source.snapshotRef` also supports `snapshot: {}` — it reads that CR's `status.recorded` directly. Pair with `target: { populator: {} }` for [deploy-or-restore](#deploy-or-restore-gitops): `snapshot` needs no live pod, so it is the **one** inherit mode allowed with a populator target.
+
+```yaml
+--8<-- "deploy/examples/37-restore-recorded-identity.yaml"
+```
+
+What the mover runs as, the trust boundary for recorded metadata (it is repository data and can be forged — a recorded root identity stays gated on the namespace opt-in), and the full `SecurityContextInherited` reason table live in [Security context → `snapshot`](security-context.md#snapshot--inherit-the-backups-recorded-identity-restore).
+
+/// note | Restoring into a *renamed* cluster
+
+The catalog scan pre-filters identities that belong to **other clusters** (foreign hostname suffixes), so a repository restored into a cluster with a *different* identity scheme may materialize no discovered rows for your old snapshots — and a `fromPolicy` search then holds forever. The escape hatch is the `identity` source: give it the old raw kopia triple (`username`/`hostname`) and it searches the CR catalog — and selects the snapshot — by exactly that identity, still with `snapshot: {}`.
+
+///
+
+/// note | `asOf` selects twice — CR-side identity vs repository-side data
+
+With `fromPolicy`/`identity` the **data** to restore is selected by the mover against the live repository listing, while the **recorded identity** is selected from the matching Snapshot CRs. Under `asOf`/`offset` the two can, in edge cases (e.g. rows the scan has not materialized yet), pick *different manifests of the same source*. Identity metadata is per-source in practice — every snapshot of a source records the same uid/gid unless the workload itself changed — so the divergence is cosmetic; a changed workload identity between the two picks would surface in the condition message, which names the exact Snapshot the identity came from.
+
+///
 
 ## Watching a restore
 

--- a/docs/restores.md
+++ b/docs/restores.md
@@ -282,7 +282,7 @@ The catalog scan pre-filters identities that belong to **other clusters** (forei
 
 /// note | `asOf` selects twice — CR-side identity vs repository-side data
 
-With `fromPolicy`/`identity` the **data** to restore is selected by the mover against the live repository listing, while the **recorded identity** is selected from the matching Snapshot CRs. Under `asOf`/`offset` the two can, in edge cases (e.g. rows the scan has not materialized yet), pick *different manifests of the same source*. Identity metadata is per-source in practice — every snapshot of a source records the same uid/gid unless the workload itself changed — so the divergence is cosmetic; a changed workload identity between the two picks would surface in the condition message, which names the exact Snapshot the identity came from.
+With `fromPolicy`/`identity` plus `snapshot: {}`, **data and identity are pinned from the same catalog row**: the controller selects one matching Snapshot CR (honoring `asOf`/`offset`), pins its kopia snapshot id as the data to restore, and replays that same snapshot's recorded identity — the two can never diverge, so snapshot B's data is never restored under snapshot A's uid/gid/fsGroup. The trade-off is deliberate: selection runs against the **CR catalog**, not the live repository listing, so under catalog lag the restore pins the newest *catalogued* snapshot (the scan converges the catalog; a not-yet-catalogued snapshot simply isn't eligible yet). The condition message names the exact Snapshot both came from.
 
 ///
 

--- a/docs/security-context.md
+++ b/docs/security-context.md
@@ -99,6 +99,12 @@ The whole problem reduces to one number (sometimes two): the **numeric** UID/GID
     - **Restore** — pick the UID/GID that should **own** the restored files, so the app can read them afterward. (To reproduce the *original* ownership exactly, see [Preserving ownership on restore](#preserving-original-ownership-on-restore).)
 3. **Choose how to express it** — one of the three approaches below.
 
+/// note | The resolved identity is recorded on every snapshot
+
+Whichever way you express it, the **resolved** identity each backup actually ran as (uid/gid, pod `fsGroup`, and whether it was inherited, explicit, or a default) is recorded on the kopia snapshot itself as the `kopiur-meta` tag and mirrored to the Snapshot's `status.recorded` — durable in the repository, so it survives a cluster rebuild and re-appears on discovered rows. See [Backups → tags](backups.md#tags--label-the-snapshot-in-the-repository).
+
+///
+
 ## Three ways to set the context
 
 ### 1. Set it explicitly
@@ -127,7 +133,7 @@ Full, apply-ready example:
 
 ### 2. Inherit it from the workload
 
-If you'd rather "run as **whatever the app runs as**" than track a UID, `inheritSecurityContextFrom` copies the security context from a live workload pod onto the mover — **both** the container `securityContext` (UID/GID) **and** the pod-level `securityContext` (e.g. `fsGroup`). This is the answer to *"back up / restore as the pod that mounts this PVC,"* at both levels. It is an **externally-tagged choice** — pick exactly one form:
+If you'd rather "run as **whatever the app runs as**" than track a UID, `inheritSecurityContextFrom` copies the security context from a live workload pod onto the mover — **both** the container `securityContext` (UID/GID) **and** the pod-level `securityContext` (e.g. `fsGroup`). This is the answer to *"back up / restore as the pod that mounts this PVC,"* at both levels. It is an **externally-tagged choice** — pick exactly one form (two read a live pod; the third, restore-only [`snapshot`](#snapshot--inherit-the-backups-recorded-identity-restore), replays the identity *recorded on the backup* and needs no pod at all):
 
 #### `pvcConsumer` — auto-derive from the source PVC (backup, recommended)
 
@@ -157,7 +163,7 @@ If no `runAsUser` appears, set one on the workload, or set `mover.securityContex
 
 ///
 
-`pvcConsumer` is **backup-only**: a Restore writes a *target* PVC whose consumer may not exist yet, so use `workloadSelector` (below) there. (The admission webhook rejects `pvcConsumer` on a Restore.)
+`pvcConsumer` is **backup-only**: a Restore writes a *target* PVC whose consumer may not exist yet, so use `workloadSelector` (below) or the recorded-identity [`snapshot`](#snapshot--inherit-the-backups-recorded-identity-restore) mode there. (The admission webhook rejects `pvcConsumer` on a Restore.)
 
 #### `workloadSelector` — name the workload by label (backup or restore)
 
@@ -191,6 +197,55 @@ Things to remember:
 - **Inheriting a *root* workload is still elevated.** The *resolved* contexts are what's evaluated — container **and** pod — so inheriting from a pod that runs as root (or with `runAsUser: 0` at either level, or added capabilities) trips the [privileged-mover gate](#privileged-and-root-movers) exactly like an explicit root context would.
 - **Inheriting root just works — you don't hand-set `runAsNonRoot`.** When the workload runs as `runAsUser: 0`, Kopiur produces a *valid* root mover for you (it reconciles `runAsNonRoot` to `false`, since `runAsNonRoot: true` + `runAsUser: 0` is a contradiction the kubelet rejects with `CreateContainerConfigError`). So you only opt the namespace into [privileged movers](#privileged-and-root-movers); you never need to add `runAsNonRoot: false` to an `inheritSecurityContextFrom` recipe.
 
+#### `snapshot` — inherit the backup's recorded identity (restore)
+
+Every backup **records** the uid/gid/fsGroup its mover actually ran as — on the kopia snapshot itself (the `kopiur-meta` tag) and as `Snapshot.status.recorded`. On a **Restore**, `snapshot: {}` replays that recorded identity onto the restore mover:
+
+```yaml
+spec:
+  mover:
+    inheritSecurityContextFrom:
+      snapshot: {} # the empty sub-object is required — see the warning below
+```
+
+Unlike `workloadSelector`, this needs **no live pod**: it works when the app is not deployed yet, after a full cluster re-bootstrap, and with `target: { populator: {} }` (it is the one inherit mode allowed with a populator target). It works with **every** restore source:
+
+- **`snapshotRef`** reads the referenced `Snapshot` CR's `status.recorded` directly.
+- **`fromPolicy` / `identity`** search the namespace's Snapshot CRs by kopia identity — honoring `asOf`, `offset`, and `snapshotID` — so a purely declarative [re-bootstrap](restores.md#declarative-re-bootstrap--restore-as-the-recorded-identity) works: apply Repository + SnapshotPolicy + Restore and let the catalog scan materialize the rows the search needs.
+
+If no recorded identity is resolvable yet — the CR is missing, it carries no `status.recorded` (a pre-feature or foreign backup), or the catalog scan hasn't landed — the Restore **holds** with `SecurityContextInherited=False` / `MissingRecordedIdentity` and re-checks every few minutes; the scan backfills `status.recorded` automatically whenever the kopia snapshot carries the tag. An explicit `mover.securityContext` that pins a `runAsUser` acts as the fallback (`InheritFallback`) exactly as with the live-pod modes, and explicit fields override recorded ones the same way (`recorded ⊂ explicit`).
+
+The `SecurityContextInherited` condition then reports what the record achieved:
+
+| `status` / `reason` | What happened | What to do |
+| --- | --- | --- |
+| `True` / `RecordedApplied` | The recorded identity was applied. The message names the Snapshot, the recorded uid/gid/fsGroup, and the **provenance** (`inherited` = it tracked the workload at backup time; `explicit`/`defaults` = it reproduces the backup mover's identity, which was never workload-derived). | Nothing. |
+| `False` / `RecordedPinnedNoUid` | The backup recorded no pinned uid — and no group beyond the mover's own defaults — so its mover's identity was image-determined and there is nothing to replay; the restore mover runs as its image's uid `65532`. | Pin `mover.securityContext.runAsUser` on the Restore, or pin an identity on the backup's mover so future snapshots record one. |
+| `False` / `MissingRecordedIdentity` | No recorded identity is resolvable yet (see above). The Restore holds. | Usually nothing — wait for the catalog scan. Or set an explicit `mover.securityContext`, or drop `snapshot: {}`. |
+
+/// warning | Write `snapshot: {}`, not `snapshot:`
+
+A bare `snapshot:` is YAML **null**, not an empty object, and admission rejects it (the variant is a sub-object so future knobs can slot in). Always write `snapshot: {}`.
+
+///
+
+/// danger | Recorded metadata is untrusted repository data
+
+The `kopiur-meta` tag lives **in the repository**: anyone with repository write credentials — a NAS admin, a peer cluster sharing the repo, a compromised replication target — can forge `{"schema":1,"uid":0}` on any snapshot. That is a different (and usually weaker) trust domain than the RBAC needed to run a root pod in your namespace. Kopiur's mitigations:
+
+- A recorded **root** identity trips the [privileged-mover gate](#privileged-and-root-movers) exactly like live-pod inherit — nothing runs as uid 0 until the namespace opts in via the `privileged-movers` annotation. Root-via-recorded-metadata deliberately needs no *stronger* opt-in: the gate expresses namespace-scoped intent to run privileged movers, whatever the identity source.
+- The condition and Events always name the **recorded uid, its provenance, and the Snapshot** it came from — so a forged uid-0 tag stays auditable even in namespaces already annotated for privileged movers.
+
+///
+
+`snapshot` is **restore-only**: a backup's identity comes from the live workload (`pvcConsumer`/`workloadSelector`) — it is the run that *creates* the record — and maintenance touches no snapshot data. The admission webhook rejects the variant on `SnapshotPolicy` and `Maintenance`.
+
+Apply-ready example (direct + declarative re-bootstrap):
+
+```yaml
+--8<-- "deploy/examples/37-restore-recorded-identity.yaml"
+```
+
 #### Combining inherit with an explicit context
 
 `inheritSecurityContextFrom` and `securityContext`/`podSecurityContext` are **layers, not alternatives** — you can set both. The full merge order is:
@@ -199,7 +254,9 @@ Things to remember:
 hardened  ⊂  moverDefaults  ⊂  inherited  ⊂  mover.securityContext
 ```
 
-So **what you write always wins**, inheritance fills in whatever the workload pins that you left blank, and your context stands in **alone** when inheritance can't resolve a pod. That last property makes it the natural fallback:
+So **what you write always wins**, inheritance fills in whatever the workload pins that you left blank, and your context stands in **alone** when inheritance can't resolve a pod. That last property makes it the natural fallback.
+
+Layers merge as (container, pod) **pairs**, and the mover's *identity* — `runAsUser`/`runAsGroup` — always belongs to the **highest layer that pins one, regardless of which level it was written at**. A workload that pins `runAsUser` at the *pod* level beats a `moverDefaults.securityContext.runAsUser` written at the *container* level (Kubernetes alone would resolve that the other way — container beats pod — but Kopiur promotes the winning layer's identity onto the mover container, which is the pod's only container, so the ladder above is the whole story). Non-identity fields (`runAsNonRoot`, `seccompProfile`, …) merge field-wise per level.
 
 ```yaml
 --8<-- "deploy/examples/18-inherit-security-context.yaml:merged"
@@ -224,7 +281,7 @@ If that's not what you meant, leave `runAsUser` out and let inherit supply it. K
 | `True` / `InheritApplied` | Inheritance resolved a workload and its values survived every layer. The message names the pod and the uid the mover runs as. | Nothing. |
 | `False` / `InheritFallback` | No workload pod resolved (scaled to zero, mid-rollout, selector matches nothing). Your explicit context stood in, so the run proceeded rather than being held. | Nothing, if that's the intent. Otherwise scale the workload up. |
 | `False` / `InheritPinnedNoUid` | A pod resolved, but pins no `runAsUser` and no group beyond the mover's own defaults — its identity is in its image, which Kopiur cannot read. Inheriting copied nothing. | Set `runAsUser` on the workload, or set `mover.securityContext.runAsUser`. |
-| `False` / `InheritOverridden` | Inheritance resolved a UID, but a higher layer overrode it. Correct by design — but inherit is a no-op for that field and won't follow the workload. The message names **which** layer won: this recipe, or the repository's `moverDefaults`. | Drop the winning `runAsUser` to track the workload, or drop `inheritSecurityContextFrom`. |
+| `False` / `InheritOverridden` | Inheritance resolved a UID, but this recipe's explicit `runAsUser` overrode it. Correct by design — but inherit is a no-op for that field and won't follow the workload. The message names the **exact field** that won (`mover.securityContext.runAsUser` or `mover.podSecurityContext.runAsUser`) — only this recipe can displace an inherited UID; the repository's `moverDefaults` never can. | Remove the named `runAsUser` to track the workload, or drop `inheritSecurityContextFrom`. |
 
 ```console
 $ kubectl get snapshot pg-backup -o jsonpath='{.status.conditions[?(@.type=="SecurityContextInherited")]}'
@@ -480,7 +537,7 @@ That's the behavior when the recipe has **nothing else to go on**, as here. Add 
 | Set the UID/GID to… | an identity that can read the data | the identity that should **own** the restored files |
 | Default if unset | UID `65532` (reads world-readable / `65532`-owned only), pod `fsGroup: 65532` | UID `65532` (files land owned by `65532`), pod `fsGroup: 65532` |
 | Preserve original ownership | n/a (kopia records it) | needs root + `privilegedMode: true` |
-| Inherit from workload | `SnapshotPolicy.spec.mover.inheritSecurityContextFrom` | `Restore.spec.mover.inheritSecurityContextFrom` |
+| Inherit from workload | `SnapshotPolicy.spec.mover.inheritSecurityContextFrom` (`pvcConsumer`/`workloadSelector`) | `Restore.spec.mover.inheritSecurityContextFrom` (`workloadSelector`, or `snapshot: {}` — the backup's recorded identity, no live pod) |
 | Elevated context | namespace `privileged-movers` opt-in | same opt-in |
 | Tolerate permission errors | fails on unreadable files | `spec.options.ignorePermissionErrors` (default `true`) reports instead of failing |
 
@@ -514,6 +571,7 @@ A backup that reports **`Succeeded` but zero files/bytes** is the classic sign t
 | Default | container: UID `65532`, `runAsNonRoot: true`, drop ALL caps, seccomp `RuntimeDefault`, no escalation. pod: `fsGroup: 65532`, `fsGroupChangePolicy: OnRootMismatch` |
 | Set the UID/GID | `securityContext.runAsUser` / `runAsGroup` (match the data owner) |
 | Inherit from a workload | `inheritSecurityContextFrom.podSelector` (+ optional `container`) — copies container **and** pod context (UID + fsGroup). Needs the workload to pin `runAsUser`; combines with `securityContext`/`podSecurityContext`, which override it field-wise and act as the fallback |
+| Inherit the backup's recorded identity (restore) | `inheritSecurityContextFrom: { snapshot: {} }` — replay the uid/gid/fsGroup recorded on the backup (`Snapshot.status.recorded`); works with every source, needs no live pod, holds on `MissingRecordedIdentity` until the catalog scan lands |
 | Root / preserve ownership | `runAsUser: 0` + `runAsNonRoot: false` (+ `privilegedMode: true` for restore ownership) |
 | Privileged-mover opt-in | `kubectl annotate namespace <ns> kopiur.home-operations.com/privileged-movers=true` |
 | Find the owning UID | [Permissions → Find the UID/GID](permissions.md#step-1--find-the-uidgid-that-owns-your-data) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -162,7 +162,7 @@ $ kubectl get snapshot <name> -o jsonpath='{.status.conditions[?(@.type=="Securi
 | `True` / `InheritApplied` | Inheritance resolved and stuck. The message names the pod and the uid the mover runs as. |
 | `False` / `InheritPinnedNoUid` | The resolved workload pins no identity beyond the mover's own defaults — inheriting copied nothing. The message names the uid the mover actually runs as (`65532` unless `moverDefaults` supplied one). |
 | `False` / `InheritFallback` | No workload pod resolved; the run proceeded on your explicit `mover.securityContext` instead of being held. |
-| `False` / `InheritOverridden` | Inherit resolved a UID but a higher layer overrode it — inherit is a no-op for that field and won't follow the workload. The message names which layer won: the recipe, or the repository's `moverDefaults`. |
+| `False` / `InheritOverridden` | Inherit resolved a UID but this recipe's explicit `runAsUser` overrode it — inherit is a no-op for that field and won't follow the workload. The message names the exact field that won; only the recipe can displace an inherited UID, never the repository's `moverDefaults`. |
 
 ### Admission warning: securityContext likely can't read the source
 


### PR DESCRIPTION
## What

Three tightly-coupled changes born from the matter-server Discord report (mover runs as `moverDefaults`' uid 1000 instead of the workload's inherited root, with a "by design" warning) and onedr0p's follow-on: `inheritSecurityContextFrom` reads a live pod, so nothing durable records what identity the data expects — restores and re-bootstrapped clusters are on their own.

### 1. `fix(secctx)!`: cross-dimension identity precedence (the actual bug)

The documented ladder is `hardened ⊂ moverDefaults ⊂ inherited ⊂ explicit`, and the field-wise merge honors it *within* each dimension — but Kubernetes resolves the effective UID as `container.runAsUser ?? pod.runAsUser` **across** dimensions. A lower layer's container-level uid (e.g. `moverDefaults.securityContext.runAsUser: 1000`) silently shadowed a higher layer's pod-level uid (e.g. root inherited from a workload's `spec.securityContext`), inverting the documented precedence. The `InheritOverridden` message's "moverDefaults overrides inherited values by design" branch only ever fired through this shadowing — it was a bug wearing a "working as intended" costume. A second, fully silent variant existed with no inheritance at all: explicit `mover.podSecurityContext.runAsUser` shadowed by `moverDefaults.securityContext.runAsUser`.

Fix: layers now merge as `(container, pod)` **pairs** via `merge_context_pair` — field-wise per dimension, then the winning layer's effective UID/GID is promoted onto the (single) mover container in a canonical form (`E(over).or(E(base))`) that is provably associative, so the controller's inherited⊂explicit pre-fold plus `resolve_mover`'s fold equals a flat four-layer merge. **The effective identity always belongs to the highest layer that pins one, regardless of which level it was written at.** The now-unreachable moverDefaults message branch is deleted; all three inherit warnings are rewritten in what/why/fix form and name the exact field to change.

### 2. `feat`: `kopiur-meta` — the mover's identity is recorded ON the kopia snapshot

At snapshot create, the controller attaches one schema-versioned tag (`kopiur-meta` → `{"schema":1,"src":"explicit|inherited|defaults","uid":…,"gid":…,"fsGroup":…}`) recording the resolved mover identity **and its provenance** (only `src: inherited` means the uid tracked the workload). The same value is stamped to `status.recorded` on the produced CR at launch. Catalog scans decode the tag back: discovered/adopted rows carry `status.recorded` + the kopia description, and a targeted backfill (matched by `kopiaSnapshotID`, only-while-absent) upgrades rows that predate the feature. The previously **inert** `Snapshot.spec.tags` is now actually sent, guarded by an admission validator (no `:` in keys — kopia splits on the first colon; reserved `kopiur` prefix — a colliding key **fails the snapshot create** with kopia's duplicate-tag error; size bounds). Every kopia tag mechanic this rests on is pinned by a real-binary integration test (first-colon split, `tag:` manifest prefix, duplicate-key failure, tags in list JSON, survival across `snapshot pin` — which changes the manifest id — and full maintenance).

Scan robustness came along for free: per-entry 4xx create failures now skip-and-count instead of wedging the whole scan pass; decode warnings aggregate per scan (a foreign writer can't amplify them); descriptions are capped (1 KiB) before landing on CRs; the result-ConfigMap wire stays O(1) per entry (the mover normalizes tags before serializing — raw user tags never ride it).

### 3. `feat`: `inheritSecurityContextFrom: { snapshot: {} }` (Restore-only)

The restore mover's identity comes from the resolved snapshot's **recorded** metadata instead of a live pod — closing the footgun that inheritance can't work on restore (no pod running) or after a re-bootstrap (nothing in etcd). Valid with every Restore source: `snapshotRef` reads the CR directly; `fromPolicy`/`identity` resolve via a pure CR-catalog search by kopia identity triple (honoring `asOf`/`offset`/`snapshotID`), which makes the full GitOps re-bootstrap **declarative**: apply Repository + SnapshotPolicy + Restore, the Restore holds on `MissingRecordedIdentity` until the catalog scan lands, then completes. A recorded root uid flows through the same ladder → INV-1 + the privileged-movers namespace gate apply unchanged, and conditions/Events always name the recorded uid, provenance, and snapshot — recorded metadata is treated as **untrusted repository data** (documented trust boundary: repo write credentials could forge a root tag; the gate + auditability are the mitigations). A snapshot that recorded no pinned identity reports `RecordedPinnedNoUid` instead of a hollow positive.

## Behavior changes / migration

- **Breaking (pre-1.0 minor bump)**: configurations where `moverDefaults`' container-level uid used to shadow an inherited or explicit pod-level identity now run as the *correct* (higher-layer) identity. If that identity is root, the run now blocks on the `kopiur.home-operations.com/privileged-movers` namespace opt-in with `MoverPermitted=False` instead of silently running as the wrong uid — annotate the namespace or pin `mover.securityContext.runAsUser` explicitly. Rendered mover Jobs may gain a container-level uid/gid where only pod-level was pinned (cosmetic; visible in GitOps diffs).
- `Snapshot.spec.tags` was documented but never sent; it is now real. New objects with colon/`kopiur`-prefixed/oversize keys are rejected at admission; stored objects degrade (invalid keys skipped with a warning), never fail.
- The new `snapshot: {}` enum variant is upgrade-safe but **not rollback-safe once used**: delete snapshot-inherit Restores before downgrading the operator (an older controller cannot deserialize the stored variant).

## Testing

- Regression-first throughout: the api merge tests reproduce the exact reported shape and fail on the old code; an associativity property test (46k layer-triples) guards the canonical merge form (and caught a real non-associativity in the first draft of the promotion rule).
- Real-kopia integration guard for every tag mechanic (pinned 0.23.1).
- E2e: `moverdefaults_uid_cannot_shadow_an_inherited_pod_level_root` (pod-level-root workload + moverDefaults uid 1000 → mover Job runs uid 0, `InheritApplied`); `recorded_meta_round_trips_through_deletion_and_adoption` (produced CR → delete with Retain → adopted row returns carrying `status.recorded` + description recovered purely from the kopia tag → stripped `recorded` is healed by the scan's backfill); restore-side snapshot-inherit scenario + webhook admission negatives.
- Full hermetic battery green: all test binaries, clippy, fmt, cognitive-complexity ratchet (29/29, held by refactoring), `gen-check` (no generated drift).
