### PR TITLE
ci: skip release-please PRs in checks and drop nightly e2e

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -34,6 +34,9 @@ env:
 
 jobs:
   coverage:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Coverage
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,19 +18,6 @@ on:
     paths-ignore:
       - "**.md"
       - ".release-please-manifest.json"
-  push:
-    branches:
-      - main
-    paths-ignore:
-      - "**.md"
-      - ".release-please-manifest.json"
-      # The release workflow's krew step pushes plugins/kopiur.yaml to main with
-      # the bot app token, which (unlike GITHUB_TOKEN) retriggers workflows —
-      # ignore it so a release doesn't re-run this workflow for a manifest bump.
-      - "plugins/**"
-  schedule:
-    # 07:00 UTC nightly.
-    - cron: "0 7 * * *"
   workflow_dispatch:
 
 concurrency:
@@ -51,6 +38,9 @@ jobs:
   # shards to load. Per-image Rust cache keys keep the legs from contending on one
   # shared cache.
   build:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Build ${{ matrix.image }} image
     runs-on: ubuntu-24.04
     timeout-minutes: 30
@@ -104,6 +94,9 @@ jobs:
   # binaries via KOPIUR_E2E_BINS. The discrete mise tasks are individual steps, so
   # the CI UI shows per-phase timing and a failure points straight at the shard.
   test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: E2E (${{ matrix.shard }})
     needs: build
     runs-on: ubuntu-24.04

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -33,6 +33,9 @@ env:
 
 jobs:
   rust-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Rust Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -64,6 +67,9 @@ jobs:
         run: mise run clippy
 
   helm-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Lint
     runs-on: ubuntu-24.04
     permissions:
@@ -87,6 +93,9 @@ jobs:
         run: mise run helm-docs-check
 
   cargo-audit:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Cargo Audit
     runs-on: ubuntu-24.04
     continue-on-error: true

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -42,6 +42,9 @@ env:
 
 jobs:
   rust-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Rust Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -75,6 +78,9 @@ jobs:
         run: mise run gen-check
 
   integration-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Integration Tests
     runs-on: ubuntu-24.04
     permissions:
@@ -114,6 +120,9 @@ jobs:
         run: cargo test --workspace --features integration --locked -- --include-ignored
 
   helm-test:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
     name: Helm Unit Tests
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Two changes, part of an org-wide CI conformity / minutes pass.

**1. Skip only genuine release-please PRs**, using a signal a contributor can't forge:

```yaml
if: >-
  ${{ !(startsWith(github.head_ref, 'release-please--')
  && github.event.pull_request.head.repo.full_name == github.repository) }}
```

`head_ref` alone (the PR's source branch name) is settable by anyone, including from a fork, so a `release-please--*` branch could skip every check. Requiring the PR head repo to be this repo means fork PRs - the realistic path for outside contributors - always run the full suite.

**2. Run e2e on pull requests and workflow_dispatch only.** Dropped both the nightly `schedule` and the redundant `push: main` run (a merged PR already ran e2e).
