### PR TITLE
ci: adopt the shared workflow-lint and docs-build actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ permissions:
   contents: read
 
 env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
   # Full debuginfo overflows the standard runner disk: the all-features
   # compile-check links every gated e2e/integration test binary against the
   # whole dep tree, and with debug=2 that plus the restored cache exceeds the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -544,6 +544,37 @@ jobs:
       - name: Check generated manifests
         run: mise run gen-check
 
+  workflow-lint:
+    if: >-
+      ${{ !(startsWith(github.head_ref, 'release-please--')
+      && github.event.pull_request.head.repo.full_name == github.repository) }}
+    name: Workflow Lint
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          install: false
+
+      - name: Resolve linter versions
+        id: tools
+        run: |
+          echo "actionlint=$(mise config get tools.actionlint)" >> "$GITHUB_OUTPUT"
+          echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
+
+      - name: Lint workflows
+        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        with:
+          actionlint-version: ${{ steps.tools.outputs.actionlint }}
+          zizmor-version: ${{ steps.tools.outputs.zizmor }}
+
   status:
     if: ${{ !cancelled() }}
     name: Build Success
@@ -558,6 +589,7 @@ jobs:
       - integration-test
       - rust-lint
       - rust-test
+      - workflow-lint
     runs-on: ubuntu-24.04
     permissions: {}
     steps:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,10 +15,6 @@ on:
 # id-token: write. publish inherits the caller's grant instead; build declares
 # its own reduction below, which is valid from either caller.
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-
 jobs:
   build:
     name: Build docs site

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,20 +42,10 @@ jobs:
         with:
           shared-key: docs
 
-      # Only needed for deployment (configures the base path); skip on PRs.
-      - name: Configure Pages
-        if: ${{ inputs.deploy }}
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
-
       - name: Build docs site
-        run: mise run docs
-
-      - name: Upload artifact
-        if: ${{ inputs.deploy }}
-        # MkDocs builds into site/ (with rustdoc nested under site/rustdoc/).
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        uses: home-operations/.github/actions/docs-build@d55d4551bf9ad29becda40b66792d94892a6307c # docs-build-1.0.0
         with:
-          path: ./site
+          deploy: ${{ inputs.deploy }}
 
   publish:
     name: Publish to GitHub Pages

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -23,7 +23,7 @@ lefthook = "2.1.10"
 # npm backend uses mise's own node+npm and never falls through to a system
 # `npm` on PATH (e.g. a stale/removed `/usr/bin/npm`), which silently breaks
 # `mise install` with `Cannot find module '/usr/bin/npm'`.
-node = "24"
+node = "24.18.0"
 oxfmt = "0.60.0"
 zizmor = "1.28.0"
 helm = "4.2.3"

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -54,6 +54,10 @@ yq = "4.53.3"
 # tier that pins alert BEHAVIOR (issue #280), not just the rendered text.
 promtool = "3.13.1"
 
+[env]
+CARGO_TERM_COLOR = "always"
+RUST_BACKTRACE = "1"
+
 [tasks.build]
 description = "Compile the whole workspace (debug, locked deps)"
 run = "cargo build --workspace --locked"

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -490,47 +490,36 @@ url_api = "https://api.github.com/repos/evilmartians/lefthook/releases/assets/47
 provenance = "github-attestations"
 
 [[tools.node]]
-version = "24.17.0"
+version = "24.18.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:faa0d59ba7fe7045c950ed09b190578fb8eee73e4358686d38fcc99ca58c1480"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-arm64.tar.gz"
+checksum = "sha256:6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-arm64-musl"]
-checksum = "sha256:cc54f73a1a4108d9e325eb201d90b25eeab60edc92b2a13240b2877a74c596da"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-arm64-musl.tar.gz"
+checksum = "sha256:b1c6c2dc31b46dd8fb2322f4fe75b07e775c5120bc37251deeea28f529d4567b"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-arm64-musl.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
+checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
 
 [tools.node."platforms.linux-x64-musl"]
-checksum = "sha256:f884c958c0652f7cd0ea43fdc39dddd1a98456ea9b1adeca85964847e2e39fb0"
-url = "https://unofficial-builds.nodejs.org/download/release/v24.17.0/node-v24.17.0-linux-x64-musl.tar.gz"
+checksum = "sha256:ea58409911e141ec6b19d9178efa2d9185a13295005b1cbf5521b3157eed1d95"
+url = "https://unofficial-builds.nodejs.org/download/release/v24.18.0/node-v24.18.0-linux-x64-musl.tar.gz"
 
 [tools.node."platforms.macos-arm64"]
-checksum = "sha256:4fc3266a3702eebc39cc37661cf4eeceeade307e242ab64e4d7ce7949197e11f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-arm64.tar.gz"
+checksum = "sha256:e1a97e14c99c803e96c7339403282ea05a499c32f8d83defe9ef5ec66f979ed1"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-arm64.tar.gz"
 
 [tools.node."platforms.macos-x64"]
-checksum = "sha256:80da552fe037290cb130e9dea590f5eeeb7aa450636f0c89ab41415511c1ec27"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-darwin-x64.tar.gz"
+checksum = "sha256:dfd0dbd3e721503434df7b7205e719f61b3a3a31b2bcf9729b8b91fea240f080"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-darwin-x64.tar.gz"
 
 [tools.node."platforms.windows-x64"]
-checksum = "sha256:f2aa33b35b75aca5f3f7b85675a6f6423201053e9381911e64961f3bda2528ab"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-win-x64.zip"
-
-[[tools.node]]
-version = "24.17.0"
-backend = "core:node"
-
-[tools.node.options]
-compile = "true"
-
-[tools.node."platforms.linux-x64"]
-checksum = "sha256:e0472427aa791ad80bdc426ff7cc73cdd28ed0f616d1ff9689a23a7f47f1265f"
-url = "https://nodejs.org/dist/v24.17.0/node-v24.17.0-linux-x64.tar.gz"
+checksum = "sha256:0ae68406b42d7725661da979b1403ec9926da205c6770827f33aac9d8f26e821"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-win-x64.zip"
 
 [[tools.oxfmt]]
 version = "0.60.0"


### PR DESCRIPTION
Two shared actions from home-operations/.github:

- `workflow-lint` (pinned to `workflow-lint-1.0.0`) as a new CI job, resolving the actionlint and zizmor versions from this repository's `.mise/config.toml` so CI and the pre-commit hooks run the same builds.
- `docs-build` (pinned to `docs-build-1.0.0`) replacing the build steps in `docs.yaml`.

`Setup Mise` and `Setup Rust cache` stay in the build job. The cache step must run before the docs build and needs the mise-pinned toolchain on PATH, so it cannot move inside the shared action — which is the point of keeping per-repository extras in the caller.

`publish` is unchanged: `actions/deploy-pages` needs a job `environment` and `pages`/`id-token` permissions, which a composite action cannot declare.