### PR TITLE
test(e2e): retry flaky tests with cargo-nextest

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,17 @@
+# Nextest is used only by the e2e harness (crates/e2e/mise.toml `run` task,
+# always with `--profile e2e`); the hermetic unit suite stays on plain
+# `cargo test`, which compile-checks feature-gated targets in a way nextest
+# does not replace.
+
+[profile.e2e]
+# Retry a failed test up to 2 more times before counting it as failed. The e2e
+# suite occasionally flakes on GitHub runners (kind/apiserver hiccups), and a
+# failed required check evicts the PR from the merge queue with no automatic
+# requeue — so absorb the transient failure inside the check run instead.
+# A retried-then-passed test is reported as FLAKY, keeping the flake visible
+# in the job log rather than silently swallowed.
+retries = 2
+# The suite is stateful against one shared kind cluster and was previously run
+# with libtest `--test-threads=1`; keep it serial. (`--no-capture` on the CLI
+# also forces this, but state it here so the profile stands on its own.)
+test-threads = 1

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -36,6 +36,9 @@ kind = "0.32.0"
 kopia = "v0.23.1"
 "aqua:EmbarkStudios/cargo-deny" = "0.20.2"
 "aqua:taiki-e/cargo-llvm-cov" = "0.8.7"
+# Runs the e2e suite (crates/e2e `run` task) so individual flaky tests retry
+# in-process-tree instead of failing the whole CI shard; see .config/nextest.toml.
+"aqua:nextest-rs/nextest/cargo-nextest" = "0.9.140"
 # Docs site toolchain. The docs are an MkDocs Material site (see `mise run docs`);
 # the MkDocs + Material + pymdown-extensions versions are pinned in pyproject.toml
 # / uv.lock and run via uv, so the only mise-managed tool here is uv itself (which

--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -170,6 +170,45 @@ checksum = "sha256:261f93081473ae8d465b29320f55282d979af9aa2c0585ad82dbc10db4d89
 url = "https://github.com/dadav/helm-schema/releases/download/0.23.4/helm-schema_0.23.4_Windows_x86_64.zip"
 url_api = "https://api.github.com/repos/dadav/helm-schema/releases/assets/437194958"
 
+[[tools."aqua:nextest-rs/nextest/cargo-nextest"]]
+version = "0.9.140"
+backend = "aqua:nextest-rs/nextest/cargo-nextest"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.linux-arm64"]
+checksum = "sha256:8b3f4d4560b6b0f83774fecc6be07e47716dbad0eb0bb6c3890f478f4affe4b6"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-aarch64-unknown-linux-gnu.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467464894"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.linux-arm64-musl"]
+checksum = "sha256:81fe08bda065ae74fa9092c444d797c31e12c245080bfb9f4dc207e21def4b98"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-aarch64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467465128"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.linux-x64"]
+checksum = "sha256:bc2a998567816eef7b087b920036f49fb89aa2a8a603f6a3d84098be160b62c5"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467467089"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.linux-x64-musl"]
+checksum = "sha256:bc2a998567816eef7b087b920036f49fb89aa2a8a603f6a3d84098be160b62c5"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-x86_64-unknown-linux-musl.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467467089"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.macos-arm64"]
+checksum = "sha256:58e0a722f9444078fab447783f322acf15a2a771ba785b3fbbe8bacda31c3df9"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467468113"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.macos-x64"]
+checksum = "sha256:58e0a722f9444078fab447783f322acf15a2a771ba785b3fbbe8bacda31c3df9"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-universal-apple-darwin.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467468113"
+
+[tools."aqua:nextest-rs/nextest/cargo-nextest"."platforms.windows-x64"]
+checksum = "sha256:b75c287b89df1fbfe033a98df058a94cd1f5119dab6ff56e4916e5a1597c7ac9"
+url = "https://github.com/nextest-rs/nextest/releases/download/cargo-nextest-0.9.140/cargo-nextest-0.9.140-x86_64-pc-windows-msvc.tar.gz"
+url_api = "https://api.github.com/repos/nextest-rs/nextest/releases/assets/467472280"
+
 [[tools."aqua:taiki-e/cargo-llvm-cov"]]
 version = "0.8.7"
 backend = "aqua:taiki-e/cargo-llvm-cov"

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -356,8 +356,8 @@ set -eu
 mkdir -p target/e2e; rm -f target/e2e/.diag-done
 trap 'rc=$?; if [ "$rc" -ne 0 ]; then echo "==> e2e tests FAILED (rc=$rc) — dumping cluster diagnostics" >&2; mise run //crates/e2e:diagnostics || true; touch target/e2e/.diag-done; fi; exit $rc' EXIT
 # KOPIUR_E2E_BINS — space-separated test-binary (file) names, expanded to repeated
-# `--test <name>` flags BEFORE `--`, so a CI shard runs only its files. Empty ⇒ all.
-# KOPIUR_E2E_TESTFILTER — libtest name-substring filter, kept AFTER `--`.
+# `--test <name>` target flags, so a CI shard runs only its files. Empty ⇒ all.
+# KOPIUR_E2E_TESTFILTER — name-substring filter (nextest positional filter).
 BINS=""
 for b in ${KOPIUR_E2E_BINS:-}; do BINS="$BINS --test $b"; done
 # The CLI e2e (tests/cli.rs) runs the compiled plugin binary (`kopiur`) as a
@@ -365,11 +365,16 @@ for b in ${KOPIUR_E2E_BINS:-}; do BINS="$BINS --test $b"; done
 echo "==> building kopiur CLI (e2e subject)"
 cargo build -p kopiur-cli --locked
 echo "==> running e2e tests${KOPIUR_E2E_BINS:+ (binaries:$KOPIUR_E2E_BINS)}"
-# `--no-fail-fast`: run EVERY test binary even when one fails, so a single flaky bin
+# nextest instead of `cargo test` for the `e2e` profile's per-test retries
+# (see .config/nextest.toml): a transient failure retries in place instead of
+# failing the CI shard and evicting the PR from the merge queue.
+# `--no-fail-fast`: run EVERY test even when one fails, so a single flaky bin
 # (e.g. the heavyweight NFS/server backend test) can't hide the pass/fail of the rest.
-# cargo still exits non-zero overall, so the trap + CI failure are unaffected.
-cargo test -p kopiur-e2e --features e2e $BINS --no-fail-fast -- \
-  --include-ignored --test-threads=1 --nocapture ${KOPIUR_E2E_TESTFILTER:-}
+# nextest still exits non-zero overall, so the trap + CI failure are unaffected.
+# `--run-ignored all` ≙ libtest `--include-ignored`; `--no-capture` streams
+# output live and keeps execution serial, like the old `--test-threads=1 --nocapture`.
+cargo nextest run --profile e2e -p kopiur-e2e --features e2e $BINS --no-fail-fast \
+  --run-ignored all --no-capture ${KOPIUR_E2E_TESTFILTER:-}
 echo "==> e2e tests passed"
 '''
 


### PR DESCRIPTION
## What

Runs the e2e harness (`crates/e2e` `run` task) through **cargo-nextest** with a dedicated `e2e` profile that sets `retries = 2`, so a transiently-failing test is retried in a fresh process inside the same check run instead of failing the whole CI shard.

- `.config/nextest.toml`: new `e2e` profile - `retries = 2`, `test-threads = 1` (the suite is stateful against one shared kind cluster; matches the old libtest `--test-threads=1`).
- `crates/e2e/mise.toml`: `cargo test` → `cargo nextest run --profile e2e`; flag mapping is 1:1 (`--include-ignored` → `--run-ignored all`, `--nocapture` → `--no-capture`, `--no-fail-fast` and `--test <bin>` sharding unchanged).
- `.mise/config.toml` + lockfile: pin `cargo-nextest` 0.9.140 via the aqua backend, locked for all 7 platforms.

The hermetic unit suite stays on plain `cargo test` - its second invocation compile-checks feature-gated targets, which nextest does not replace.

## Why

On #307 two consecutive merge-queue runs failed on *different* e2e shards (`apiserver-flap` + `cli-multicluster`, then `restore`) with the same PR head, and the third unchanged attempt passed. Each flake evicts the queue entry (~30 min) and disarms auto-merge, requiring a manual re-queue. Retrying at the test level absorbs the flake where it happens; a retried-then-passed test reports **FLAKY** in the job log, so flakes stay visible instead of silently swallowed.

## Verified

- `cargo nextest list -P e2e -p kopiur-e2e --features e2e --run-ignored all` compiles and enumerates every test binary with the new profile, no config warnings.
- The exact task invocation (incl. `--test` sharding and a name filter) parses and selects correctly.
- Behavior note: a name filter matching zero tests now fails (`error: no tests to run`) where libtest exited 0 - CI shards always match tests, so this only surfaces a typo'd `KOPIUR_E2E_TESTFILTER` locally, which failing loudly seems right for.