### PR TITLE
fix(ci): fail the merge gate on cancelled jobs, and cut e2e artifact time

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -259,6 +259,14 @@ jobs:
           experimental: true
           install_args: --locked
 
+      # Booting the node container and restoring the cache + image artifacts
+      # share no inputs, so they overlap: the cluster is not needed until the
+      # images are in the local daemon and ready to side-load.
+      - name: Create kind cluster
+        id: cluster
+        background: true
+        run: mise run //crates/e2e:cluster-create
+
       # Separate key from the build job: the shards compile the e2e *test* crate
       # (debug), not the release images, so they shouldn't thrash that cache.
       - name: Setup Rust cache
@@ -276,10 +284,9 @@ jobs:
       - name: Load images into docker
         run: |
           set -eu
-          for tar in image-*.tar; do docker load -i "$tar"; done
+          for tar in image-*.tar.gz; do docker load -i "$tar"; done
 
-      - name: Create kind cluster
-        run: mise run //crates/e2e:cluster-create
+      - wait: [cluster]
 
       - name: Load images into kind
         run: mise run //crates/e2e:images-load
@@ -377,14 +384,22 @@ jobs:
           KOPIUR_IMAGE_TAG: e2e
         run: mise run //:${{ matrix.task }}
 
+      # Every shard downloads all three images, so the tarballs cross the
+      # artifact store dozens of times per run and are worth compressing. gzip
+      # because the daemon may export layers uncompressed depending on its image
+      # store, and docker load reads either. shell: bash for the pipefail the
+      # implicit `bash -e` default lacks -- a failed save would otherwise leave
+      # gzip's exit status to pass the step and hand every shard a truncated
+      # tarball.
       - name: Save image
-        run: docker save kopiur/${{ matrix.image }}:e2e -o image-${{ matrix.image }}.tar
+        shell: bash
+        run: docker save kopiur/${{ matrix.image }}:e2e | gzip -1 > image-${{ matrix.image }}.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-image-${{ matrix.image }}
-          path: image-${{ matrix.image }}.tar
+          path: image-${{ matrix.image }}.tar.gz
           retention-days: 1
 
   helm-lint:
@@ -599,12 +614,17 @@ jobs:
     runs-on: ubuntu-24.04
     permissions: {}
     steps:
+      # cancelled counts as failed: !cancelled() above still runs this job when
+      # individual needs were cancelled but the run was not, and a required job
+      # that never reached a verdict must not clear the merge gate. The e2e
+      # matrix is fail-fast: false across seventeen shards, so a superseded push
+      # cancelling them is the common case, not a corner one.
       - name: Any jobs failed?
-        if: ${{ contains(needs.*.result, 'failure') }}
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
         run: |
           exit 1
 
       - name: All jobs passed or skipped?
-        if: ${{ !(contains(needs.*.result, 'failure')) }}
+        if: ${{ !(contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: |
           echo "All jobs passed or skipped" && echo "${{ toJSON(needs.*.result) }}"


### PR DESCRIPTION
Three things this repo's e2e workflow can take from the ones in home-operations/miroir and home-operations/tuppr. The traffic mostly runs the other way (the shard matrix, the per-image build fan-out and the diagnostics trap are all ahead of what those two do), but these transfer.

## `Build Success` treated `cancelled` as passing

`status` runs under `if: !cancelled()`, which still executes when individual `needs` were cancelled but the run as a whole was not. `needs.*.result` then contains `cancelled`, not `failure`, so `Any jobs failed?` was skipped and `All jobs passed or skipped?` exited 0. Branch protection saw the gate green with no e2e signal at all.

Not a corner case here. The e2e matrix is `fail-fast: false` across seventeen shards under `cancel-in-progress: true`, so a superseded push cancels all seventeen at once, which is exactly the state that used to read as success.

## The component images were shipped uncompressed

`docker save ... -o image-X.tar` produced three uncompressed tarballs, and every shard downloads all three (`pattern: e2e-image-*`), so they cross the artifact store dozens of times per run.

They now go through `gzip -1`, with `shell: bash` so `pipefail` catches a failed `docker save` rather than letting gzip's exit status pass the step and hand a shard a truncated tarball. `docker load` reads either form, so the shard side only changes its glob.

## Cluster creation now overlaps artifact restore

`Create kind cluster` ran between `Load images into docker` and `Load images into kind`, strictly serial with everything before it. It now starts in the background while the Rust cache and the image artifacts are restored, with the `wait` barrier just before `images-load`. The two share no inputs, and the cluster is not needed until the images are in the local daemon and ready to side-load.

This is the pattern `chaski`, `echo`, `gatus-sidecar`, `konflate`, `kromgo`, `miroir` and `tuppr` all use. The difference is that all seven background a `uses:` step (`helm/kind-action` or a build action), whereas this repo's cluster creation is a `run:` step, since `//crates/e2e:cluster-create` carries health-probe and reuse logic that `kind-action` has no equivalent for. **So this hunk is the one to check on the first run:** if `background:` turns out not to be honoured on `run:` steps, the step simply executes in place and the overlap silently does not happen. I will confirm from the step timings on this PR and drop the hunk if it did not take effect.

No lint plumbing needed for any of it: the pinned `workflow-lint` action and the shared `lefthook.common.toml` both already pass `-ignore 'unexpected key "(background|cancel|parallel|wait|wait-all)" for step'`.

Verified locally: `actionlint` with those flags, `zizmor`, and `oxfmt --check`.
