### PR TITLE
ci: update shared actions and use self-repository syntax

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,7 +113,7 @@ jobs:
   docs:
     if: ${{ github.event_name != 'push' }}
     name: Docs
-    uses: ./.github/workflows/docs.yaml
+    uses: $/.github/workflows/docs.yaml
     permissions:
       contents: read
     with:
@@ -591,7 +591,7 @@ jobs:
           echo "zizmor=$(mise config get tools.zizmor)" >> "$GITHUB_OUTPUT"
 
       - name: Lint workflows
-        uses: home-operations/.github/actions/workflow-lint@dfa0b198336d33dcbe73557a68315d3071ec7709 # workflow-lint-1.0.0
+        uses: home-operations/.github/actions/workflow-lint@5514ee499e8919d394b5376637025535dac84ff8 # workflow-lint-v1.0.2
         with:
           actionlint-version: ${{ steps.tools.outputs.actionlint }}
           zizmor-version: ${{ steps.tools.outputs.zizmor }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -39,7 +39,7 @@ jobs:
           shared-key: docs
 
       - name: Build docs site
-        uses: home-operations/.github/actions/docs-build@d55d4551bf9ad29becda40b66792d94892a6307c # docs-build-1.0.0
+        uses: home-operations/.github/actions/docs-build@4f44306d499ec70355fae5540103c2033955fc2c # docs-build-v1.0.1
         with:
           deploy: ${{ inputs.deploy }}
 

--- a/.github/workflows/goreleaser-check.yaml
+++ b/.github/workflows/goreleaser-check.yaml
@@ -26,7 +26,7 @@ jobs:
     name: Binaries
     permissions:
       contents: read
-    uses: ./.github/workflows/plugin-binaries.yaml
+    uses: $/.github/workflows/plugin-binaries.yaml
 
   snapshot:
     name: Snapshot

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   docs:
     name: Docs
-    uses: ./.github/workflows/docs.yaml
+    uses: $/.github/workflows/docs.yaml
     permissions:
       contents: read
       pages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -246,7 +246,7 @@ jobs:
     if: ${{ github.event_name == 'release' }}
     permissions:
       contents: read
-    uses: ./.github/workflows/plugin-binaries.yaml
+    uses: $/.github/workflows/plugin-binaries.yaml
     with:
       version: ${{ github.event.release.tag_name }}
 


### PR DESCRIPTION
Bump `home-operations/.github/actions/workflow-lint` from 1.0.0 to v1.0.2.

v1.0.1 pins tool versions and v1.0.2 makes actionlint ignore its false errors on GitHub's new `$/` self-repository `uses:` syntax, so workflows adopting `$/` lint clean.

Also bumps `docs-build` from 1.0.0 to v1.0.1.

Switch same-repository `uses:` references from `./` to the `$/` self-repository syntax ([changelog](https://github.blog/changelog/2026-07-30-reference-same-repository-actions-with-self-repository-syntax/)). `$/` resolves to this repository at the exact commit that is running, works everywhere `./` does, and is now the recommended form; the bumped workflow-lint v1.0.2 is what makes it lint clean.