### PR TITLE
feat(repository): object-lock blob retention (#332); fix blank volumeSnapshotClassName

### DIFF
--- a/crates/api/src/repository.rs
+++ b/crates/api/src/repository.rs
@@ -145,6 +145,103 @@ pub struct RepositoryParameters {
     /// blobs get compacted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch: Option<EpochParameters>,
+    /// Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+    /// "don't touch it"; use `disabled: true` to actively turn it off.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_retention: Option<BlobRetention>,
+}
+
+/// Object-lock blob retention (`kopia repository set-parameters --retention-mode/--retention-period`).
+///
+/// Externally tagged, so exactly one variant exists by construction. That is load-bearing
+/// rather than stylistic: kopia rejects a mode without a period and a period without a mode
+/// ("both retention mode and period must be provided when setting blob retention
+/// properties"), and pairing the period *with* the mode in the type makes that error
+/// unrepresentable instead of merely validated.
+///
+/// Requires a backend that supports object lock — S3, Azure, or GCS — **and** a bucket with
+/// object lock enabled at creation time (it cannot be turned on afterwards). kopia's flags do
+/// not create it. On an unsupported backend `set-parameters` hard-fails with
+/// `blob-retention: unsupported put-blob option`, so admission rejects those backends.
+///
+/// # What this does and does not protect
+///
+/// The lock is applied when a blob is **written**. Kopiur does not enable kopia's
+/// `maintenance set --extend-object-locks`, so locks on blobs that are still needed are never
+/// extended: a blob written today under `period: 720h` becomes deletable again in 30 days.
+/// Treat it as a rolling floor, not cumulative immutability, and size the period to exceed
+/// your longest recovery window. Blobs written *before* retention was enabled — including the
+/// repository format blob — are never retroactively locked.
+///
+/// ```
+/// use kopiur_api::repository::{BlobRetention, RetentionWindow};
+///
+/// // Externally tagged: the wire form is `{ "governance": { "period": "720h" } }`.
+/// let r: BlobRetention = serde_json::from_value(serde_json::json!({
+///     "governance": { "period": "720h" }
+/// }))
+/// .unwrap();
+/// assert_eq!(r, BlobRetention::Governance(RetentionWindow { period: "720h".into() }));
+/// assert_eq!(r.kind_str(), "Governance");
+///
+/// // Disabling carries no period — kopia ignores it, and the type says so.
+/// let off: BlobRetention = serde_json::from_value(serde_json::json!({ "disabled": true }))
+///     .unwrap();
+/// assert_eq!(off.kind_str(), "Disabled");
+/// ```
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum BlobRetention {
+    /// `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+    /// identity can still shorten or remove the lock. The safe default for most clusters.
+    Governance(RetentionWindow),
+    /// `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+    /// the account root. An oversized period is an unfixable storage-cost commitment; there
+    /// is no recovery path short of deleting the bucket after expiry.
+    Compliance(RetentionWindow),
+    /// Actively disable retention (`--retention-mode=none`). Must be `true`.
+    ///
+    /// A `bool` rather than a unit variant because an externally-tagged unit variant
+    /// serializes as the bare string `"Disabled"`, mixing string and object forms in one
+    /// `oneOf` and breaking the structural schema. Same shape, and same reason, as
+    /// [`crate::cluster_repository::AllowedNamespaces::All`].
+    ///
+    /// This is distinct from omitting `blobRetention` entirely: absent means "leave the
+    /// repository alone", so deleting the block from a manifest can never silently strip
+    /// ransomware protection someone configured deliberately.
+    Disabled(bool),
+}
+
+impl BlobRetention {
+    /// Stable discriminant string for status/metrics/printcolumns.
+    pub fn kind_str(&self) -> &'static str {
+        match self {
+            BlobRetention::Governance(_) => "Governance",
+            BlobRetention::Compliance(_) => "Compliance",
+            BlobRetention::Disabled(_) => "Disabled",
+        }
+    }
+
+    /// The declared retention window, or `None` when retention is being disabled.
+    pub fn window(&self) -> Option<&RetentionWindow> {
+        match self {
+            BlobRetention::Governance(w) | BlobRetention::Compliance(w) => Some(w),
+            BlobRetention::Disabled(_) => None,
+        }
+    }
+}
+
+/// How long a blob stays locked once written.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RetentionWindow {
+    /// Go-style duration; kopia's minimum is `24h` and there is no maximum.
+    ///
+    /// Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+    /// CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+    /// write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+    /// CRD field rather than matching kopia's per-flag variations.
+    pub period: String,
 }
 
 /// kopia epoch-manager parameters. Absent fields are left at whatever the repository
@@ -238,6 +335,33 @@ pub struct ObservedRepositoryParameters {
     /// The epoch parameters the repository reports.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch: Option<ObservedEpochParameters>,
+    /// The blob retention the repository reports.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_retention: Option<ObservedBlobRetention>,
+}
+
+/// The blob retention the repository ACTUALLY reports, mirrored into `status` from
+/// `kopia repository status` at the last bootstrap.
+///
+/// A separate type from [`BlobRetention`] for the same reasons [`ObservedEpochParameters`] is
+/// separate from [`EpochParameters`]: the spec type is a closed union that cannot express
+/// "kopia reported nothing", and non-`Option` fields encode "observed means complete".
+///
+/// `mode` is a plain `String`, not the spec enum, because kopia reports an empty mode when
+/// retention is off — a value the union deliberately cannot hold. Reporting kopia's own word
+/// verbatim also keeps the mirror honest if kopia ever adds a mode kopiur doesn't model.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ObservedBlobRetention {
+    /// Whether the repository currently has blob retention in force (kopia's
+    /// `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+    pub enabled: bool,
+    /// Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+    /// empty when off).
+    pub mode: String,
+    /// Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+    /// when retention is off.
+    pub period: String,
 }
 
 /// Repository health thresholds, shared by `Repository` and `ClusterRepository`.

--- a/crates/api/src/snapshot_policy.rs
+++ b/crates/api/src/snapshot_policy.rs
@@ -44,7 +44,9 @@ pub struct SnapshotPolicySpec {
     #[serde(default = "default_copy_method")]
     #[schemars(default = "default_copy_method")]
     pub copy_method: CopyMethod,
-    /// `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.
+    /// `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. Absent or
+    /// empty both mean auto-select the default class for the source PVC's CSI driver, so a
+    /// GitOps-templated value (Flux/Kustomize `${VAR}`) is safe when the variable is unset.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub volume_snapshot_class_name: Option<String>,
     /// Staging knobs for `copyMethod: Snapshot`/`Clone` (e.g. how long to wait for

--- a/crates/api/src/validate/repository.rs
+++ b/crates/api/src/validate/repository.rs
@@ -146,10 +146,23 @@ pub fn validate_backup_deletion_policy(
 pub fn validate_repository_parameters(
     parameters: Option<&crate::repository::RepositoryParameters>,
     mode: crate::common::RepositoryMode,
+    backend: &crate::backend::Backend,
     context: &str,
 ) -> Vec<ValidationError> {
     let mut errs = Vec::new();
-    let Some(epoch) = parameters.and_then(|p| p.epoch.as_ref()) else {
+    let Some(parameters) = parameters else {
+        return errs;
+    };
+    // `epoch` and `blobRetention` are validated as INDEPENDENT blocks. Returning early when
+    // one is absent would make the other's rules dead code — declaring only blobRetention
+    // must still be checked.
+    errs.extend(validate_blob_retention(
+        parameters.blob_retention.as_ref(),
+        mode,
+        backend,
+        context,
+    ));
+    let Some(epoch) = parameters.epoch.as_ref() else {
         return errs;
     };
     if !mode.allows_writes() {
@@ -215,6 +228,120 @@ pub fn validate_repository_parameters(
     positive("advanceOnSizeMiB", epoch.advance_on_size_mb);
     positive("checkpointFrequency", epoch.checkpoint_frequency);
     positive("deleteParallelism", epoch.delete_parallelism);
+    errs
+}
+
+/// kopia's minimum blob-retention period, straight from its own `Validate()`:
+/// "invalid retention-period, the minimum required is 1-day and there is no maximum limit".
+const MIN_RETENTION_PERIOD: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
+
+/// `spec.parameters.blobRetention` rules (#332).
+///
+/// Three classes of rule, all of which turn a guaranteed *runtime* failure into an admission
+/// error:
+///
+/// - **Backend applicability.** On a backend without object lock, `set-parameters` does not
+///   no-op — it hard-fails with `blob-retention: unsupported put-blob option`. Since the
+///   bootstrap re-runs it on every reconcile, declaring retention on such a backend would
+///   produce a recurring Warning event and permanently diverged status, forever.
+/// - **Grammar and range.** The period must parse and clear kopia's 1-day floor.
+/// - **Applicability to `mode: ReadOnly`**, exactly as for `epoch`.
+///
+/// Deliberately NOT checked: whether the period exceeds the full-maintenance interval. kopia
+/// only enforces that when `--extend-object-locks` is on (`CheckExtendRetention` returns
+/// early otherwise), and kopiur does not set that flag — so such a guard would reject
+/// configurations kopia accepts.
+fn validate_blob_retention(
+    retention: Option<&crate::repository::BlobRetention>,
+    mode: crate::common::RepositoryMode,
+    backend: &crate::backend::Backend,
+    context: &str,
+) -> Vec<ValidationError> {
+    use crate::backend::Backend;
+    let mut errs = Vec::new();
+    let Some(retention) = retention else {
+        return errs;
+    };
+    let field = format!("{context} spec.parameters.blobRetention");
+
+    if !mode.allows_writes() {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: field.clone(),
+            reason: "a ReadOnly repository cannot apply blob retention: \
+                     `kopia repository set-parameters` rewrites the repository-global format \
+                     blob and fails outright on a read-only connection. Declare \
+                     blobRetention on the cluster that owns this repository (mode: ReadWrite) \
+                     — object lock is a property of the repository, not of each consumer"
+                .to_string(),
+        });
+    }
+
+    // Exhaustive on purpose: a new Backend variant must be classified here before it
+    // compiles, rather than silently inheriting "supported" and hard-failing at runtime.
+    let supported = match backend {
+        Backend::S3(_) | Backend::Azure(_) | Backend::Gcs(_) => true,
+        Backend::B2(_)
+        | Backend::Filesystem(_)
+        | Backend::Sftp(_)
+        | Backend::WebDav(_)
+        | Backend::Rclone(_)
+        | Backend::Gdrive(_) => false,
+    };
+    if !supported {
+        errs.push(ValidationError::InvalidFieldValue {
+            field: field.clone(),
+            reason: format!(
+                "the {} backend does not support object lock, so kopia cannot apply blob \
+                 retention to it — `kopia repository set-parameters` fails with \
+                 `blob-retention: unsupported put-blob option`, and would keep failing on \
+                 every reconcile. Remove spec.parameters.blobRetention, or use an S3, Azure, \
+                 or GCS repository whose bucket had object lock enabled AT CREATION (it \
+                 cannot be turned on later)",
+                backend.kind_str()
+            ),
+        });
+    }
+
+    // Only the window variants carry a period; `Disabled` has nothing to check, and kopia
+    // short-circuits `--retention-mode=none` before its own validation.
+    let Some(window) = retention.window() else {
+        return errs;
+    };
+    let period_field = format!("{field}.{}.period", retention.kind_str().to_lowercase());
+    match crate::duration::parse_go_duration(&window.period) {
+        None => errs.push(ValidationError::InvalidFieldValue {
+            field: period_field,
+            reason: format!(
+                "{:?} is not a valid duration. Kopiur accepts a Go-style duration with a \
+                 single unit of h, m, or s — write 30 days as 720h, not 30d. (kopia's own CLI \
+                 does accept `30d`; kopiur keeps one duration grammar across every CRD field.)",
+                window.period
+            ),
+        }),
+        // Same 292-year ceiling as the epoch durations, and for the same reason: kopia stores
+        // this as an i64 nanosecond count, and the drift comparator compares in those units.
+        Some(d) if i64::try_from(d.as_nanos()).is_err() => {
+            errs.push(ValidationError::InvalidFieldValue {
+                field: period_field,
+                reason: format!(
+                    "{:?} is too large: kopia stores the retention period as a 64-bit \
+                     nanosecond count, so the maximum is roughly 292 years",
+                    window.period
+                ),
+            });
+        }
+        Some(d) if d < MIN_RETENTION_PERIOD => {
+            errs.push(ValidationError::InvalidFieldValue {
+                field: period_field,
+                reason: format!(
+                    "{:?} is below kopia's minimum: \"the minimum required is 1-day and there \
+                     is no maximum limit\". Use 24h or more",
+                    window.period
+                ),
+            });
+        }
+        Some(_) => {}
+    }
     errs
 }
 
@@ -503,6 +630,7 @@ pub fn validate_repository(spec: &RepositorySpec) -> Vec<ValidationError> {
     errs.extend(validate_repository_parameters(
         spec.parameters.as_ref(),
         spec.mode,
+        &spec.backend,
         "Repository",
     ));
     if let Err(e) = validate_repository_health(spec.health.as_ref(), "Repository") {
@@ -994,6 +1122,7 @@ pub fn validate_cluster_repository(spec: &ClusterRepositorySpec) -> Vec<Validati
     errs.extend(validate_repository_parameters(
         spec.parameters.as_ref(),
         spec.mode,
+        &spec.backend,
         "ClusterRepository",
     ));
     if let Err(e) = validate_repository_health(spec.health.as_ref(), "ClusterRepository") {

--- a/crates/api/src/validate/tests.rs
+++ b/crates/api/src/validate/tests.rs
@@ -5117,3 +5117,206 @@ fn cluster_repository_gets_the_identical_parameters_rules() {
     ));
     assert!(validate_cluster_repository(&spec).is_empty());
 }
+
+// --- #332: object-lock blob retention -------------------------------------------------
+
+/// An object-lock-capable base. `REPO_BASE` is `filesystem`, which blob retention rejects.
+const S3_REPO_BASE: &str = "backend: { s3: { bucket: b } }\n\
+                            encryption: { passwordSecretRef: { name: s, key: KOPIA_PASSWORD } }\n";
+
+#[test]
+fn blob_retention_accepts_both_modes_and_disable() {
+    // The inert case: no blobRetention at all changes nothing about the repository.
+    assert!(validate_repository(&repo_yaml(S3_REPO_BASE)).is_empty());
+
+    for mode in ["governance", "compliance"] {
+        let spec = repo_yaml(&format!(
+            "{S3_REPO_BASE}parameters:\n  blobRetention:\n    {mode}:\n      period: 720h\n"
+        ));
+        assert!(
+            validate_repository(&spec).is_empty(),
+            "{mode}/720h must be accepted"
+        );
+    }
+
+    // Disabling carries no period at all — the type has nowhere to put one.
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  blobRetention:\n    disabled: true\n"
+    ));
+    assert!(validate_repository(&spec).is_empty());
+
+    // blobRetention alongside epoch, and blobRetention with NO epoch — the second is the
+    // regression guard: validate_repository_parameters used to early-return when `epoch`
+    // was absent, which would have made every rule below dead code.
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  epoch:\n    minDuration: 6h\n  \
+         blobRetention:\n    governance:\n      period: 720h\n"
+    ));
+    assert!(validate_repository(&spec).is_empty());
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  blobRetention:\n    governance:\n      period: 1h\n"
+    ));
+    assert!(
+        !validate_repository(&spec).is_empty(),
+        "blobRetention must be validated even when spec.parameters.epoch is absent"
+    );
+}
+
+#[test]
+fn a_retention_period_below_kopias_one_day_floor_is_rejected() {
+    // kopia's own Validate(): "invalid retention-period, the minimum required is 1-day and
+    // there is no maximum limit". Catching it here turns a hard set-parameters failure on
+    // every reconcile into one admission error.
+    // Quoted, because YAML parses a bare `3600` as an integer and `period` is a string —
+    // that shape is rejected by the CRD's own `type: string` before it ever reaches here.
+    for period in ["1h", "23h", "60m", "\"3600\""] {
+        let spec = repo_yaml(&format!(
+            "{S3_REPO_BASE}parameters:\n  blobRetention:\n    governance:\n      period: {period}\n"
+        ));
+        let errs = validate_repository(&spec);
+        assert!(
+            !errs.is_empty(),
+            "{period} is under 24h and must be rejected"
+        );
+        assert!(
+            format!("{errs:?}").contains("1-day"),
+            "must quote kopia's own wording so the two are searchable together: {errs:?}"
+        );
+    }
+    // Exactly the floor is allowed.
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  blobRetention:\n    governance:\n      period: 24h\n"
+    ));
+    assert!(validate_repository(&spec).is_empty(), "24h is the boundary");
+}
+
+#[test]
+fn a_retention_period_in_days_is_rejected_with_the_hours_hint() {
+    // kopia's CLI DOES accept `30d` (it extends Go's parser), but kopiur's duration grammar
+    // is deliberately narrower — h/m/s only, one grammar across every CRD field. `30d` is
+    // therefore the single most likely thing a user copying from kopia's docs will write,
+    // so the message has to name the fix rather than just say "invalid".
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  blobRetention:\n    governance:\n      period: 30d\n"
+    ));
+    let errs = validate_repository(&spec);
+    let msg = format!("{errs:?}");
+    assert!(!errs.is_empty(), "30d must be rejected");
+    assert!(
+        msg.contains("720h"),
+        "must name the replacement value: {msg}"
+    );
+
+    // And the same i64-nanosecond ceiling the epoch durations carry.
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}parameters:\n  blobRetention:\n    governance:\n      \
+         period: \"999999999999999999\"\n"
+    ));
+    let errs = validate_repository(&spec);
+    assert!(
+        !errs.is_empty(),
+        "a period beyond i64 nanoseconds is rejected"
+    );
+    assert!(format!("{errs:?}").contains("292 years"), "{errs:?}");
+}
+
+#[test]
+fn blob_retention_is_rejected_on_backends_without_object_lock() {
+    // On an unsupported backend `set-parameters` does NOT no-op — it hard-fails with
+    // `blob-retention: unsupported put-blob option`, and the bootstrap re-runs it every
+    // reconcile. Rejecting at admission is what stops that becoming a permanent Warning loop.
+    let supported = [
+        ("s3", "backend: { s3: { bucket: b } }\n"),
+        (
+            "azure",
+            "backend: { azure: { container: c, storageAccount: a } }\n",
+        ),
+        ("gcs", "backend: { gcs: { bucket: b } }\n"),
+    ];
+    let unsupported = [
+        ("filesystem", "backend: { filesystem: { path: /repo } }\n"),
+        ("b2", "backend: { b2: { bucket: b } }\n"),
+        (
+            "sftp",
+            "backend: { sftp: { host: h, path: /p, username: u } }\n",
+        ),
+        ("webdav", "backend: { webDav: { url: 'https://w/dav' } }\n"),
+        ("rclone", "backend: { rclone: { remotePath: 'r:/p' } }\n"),
+        ("gdrive", "backend: { gdrive: { folderId: fid } }\n"),
+    ];
+    let enc = "encryption: { passwordSecretRef: { name: s, key: KOPIA_PASSWORD } }\n";
+    let params = "parameters:\n  blobRetention:\n    governance:\n      period: 720h\n";
+
+    for (name, backend) in supported {
+        let spec = repo_yaml(&format!("{backend}{enc}{params}"));
+        assert!(
+            validate_repository(&spec).is_empty(),
+            "{name} supports object lock and must be accepted"
+        );
+    }
+    for (name, backend) in unsupported {
+        let spec = repo_yaml(&format!("{backend}{enc}{params}"));
+        let errs = validate_repository(&spec);
+        assert!(
+            !errs.is_empty(),
+            "{name} cannot object-lock and must be rejected"
+        );
+        assert!(
+            format!("{errs:?}").contains("unsupported put-blob option"),
+            "the message must carry kopia's verbatim error so a user can grep for it: {errs:?}"
+        );
+        // ...but the same backend WITHOUT blobRetention stays perfectly valid.
+        let spec = repo_yaml(&format!("{backend}{enc}"));
+        assert!(
+            validate_repository(&spec).is_empty(),
+            "{name} without blobRetention must not be taxed"
+        );
+    }
+}
+
+#[test]
+fn a_read_only_repository_cannot_declare_blob_retention() {
+    let spec = repo_yaml(&format!(
+        "{S3_REPO_BASE}mode: ReadOnly\nparameters:\n  blobRetention:\n    \
+         governance:\n      period: 720h\n"
+    ));
+    let errs = validate_repository(&spec);
+    let msg = format!("{errs:?}");
+    assert!(
+        !errs.is_empty(),
+        "ReadOnly + blobRetention must be rejected"
+    );
+    assert!(msg.contains("set-parameters"), "must say WHY: {msg}");
+}
+
+#[test]
+fn cluster_repository_gets_the_identical_blob_retention_rules() {
+    // The two kinds have fully duplicated reconcilers; a rule landing on only one of them
+    // is how half an API surface ships as a silent no-op.
+    let base = "backend: { s3: { bucket: b } }\n\
+                encryption: { passwordSecretRef: { name: s, namespace: kopiur-system, key: KOPIA_PASSWORD } }\n\
+                allowedNamespaces: { all: true }\n";
+    let spec: ClusterRepositorySpec = crate::testutil::from_yaml(&format!(
+        "{base}parameters:\n  blobRetention:\n    governance:\n      period: 1h\n"
+    ));
+    assert!(
+        format!("{:?}", validate_cluster_repository(&spec)).contains("1-day"),
+        "ClusterRepository must enforce the retention floor too"
+    );
+
+    let fs_base = "backend: { filesystem: { path: /repo } }\n\
+                   encryption: { passwordSecretRef: { name: s, namespace: kopiur-system, key: KOPIA_PASSWORD } }\n\
+                   allowedNamespaces: { all: true }\n";
+    let spec: ClusterRepositorySpec = crate::testutil::from_yaml(&format!(
+        "{fs_base}parameters:\n  blobRetention:\n    governance:\n      period: 720h\n"
+    ));
+    assert!(
+        !validate_cluster_repository(&spec).is_empty(),
+        "the backend gate must apply to ClusterRepository as well"
+    );
+
+    let spec: ClusterRepositorySpec = crate::testutil::from_yaml(&format!(
+        "{base}parameters:\n  blobRetention:\n    governance:\n      period: 720h\n"
+    ));
+    assert!(validate_cluster_repository(&spec).is_empty());
+}

--- a/crates/controller/src/cluster_repository.rs
+++ b/crates/controller/src/cluster_repository.rs
@@ -1321,6 +1321,7 @@ fn cluster_bootstrap_work_spec(
             // Shares `epoch_parameters_for` with the Repository twin so the gate has one
             // definition rather than two that can drift apart.
             epoch_parameters: crate::repository::epoch_parameters_for(read_only, parameters),
+            blob_retention: crate::repository::blob_retention_for(read_only, parameters),
             // Stamped on CREATE unconditionally (elsewhere) AND re-stamped on
             // every connect-to-existing when stale (`maintenance_restamp_target`);
             // `None` means neither ever happens — see the doc above.
@@ -1557,11 +1558,25 @@ async fn finalize_cluster_bootstrap(
         "storageStats": storage_stats,
         "conditions": conditions,
     });
-    // Mirror the epoch parameters the repository actually reports (#258). The apply is
-    // best-effort in the mover, so this is what keeps it honest: a `spec.parameters.epoch`
-    // that failed to land stays visible here as drift from spec, rather than as silence.
-    if let Some(epoch) = &result.epoch {
-        status_patch["parameters"] = serde_json::json!({ "epoch": epoch });
+    // Mirror the parameters the repository actually reports (#258 epoch, #332 blob
+    // retention). The apply is best-effort in the mover, so this is what keeps it honest: a
+    // `spec.parameters` that failed to land stays visible here as drift from spec, rather
+    // than as silence.
+    //
+    // Built as ONE map and assigned once. `status_patch` is a local Value assembled
+    // key-by-key before a single patch, so two `status_patch["parameters"] = json!(..)`
+    // statements would not merge — the second would drop the first outright, silently.
+    {
+        let mut params = serde_json::Map::new();
+        if let Some(epoch) = &result.epoch {
+            params.insert("epoch".into(), serde_json::json!(epoch));
+        }
+        if let Some(retention) = &result.blob_retention {
+            params.insert("blobRetention".into(), serde_json::json!(retention));
+        }
+        if !params.is_empty() {
+            status_patch["parameters"] = serde_json::Value::Object(params);
+        }
     }
     // The apply is best-effort (see the mover), so a failure leaves the repository Ready
     // with `status.parameters.epoch` silently disagreeing with `spec`. Say so out loud —

--- a/crates/controller/src/io/staging.rs
+++ b/crates/controller/src/io/staging.rs
@@ -275,11 +275,21 @@ pub enum ClassDecision {
 /// classes (the cluster read is the caller's). Precedence: an explicit name wins (if it
 /// exists); otherwise the single class whose driver matches; otherwise — among several
 /// matches — the unique default-annotated one; otherwise `Ambiguous`/`NoneForDriver`.
+///
+/// An absent, empty, or whitespace-only `explicit` all mean the same thing: **unset** —
+/// fall through to auto-selection. `Option<&str>` alone is a leaky representation here,
+/// because `Some("")` is not a nameable Kubernetes object, and GitOps templating produces
+/// it routinely: a Flux/Kustomize `volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS}`
+/// post-build substitution renders empty whenever the variable is undefined. Normalizing
+/// here rather than at the call site makes the invalid state unreachable for every caller,
+/// and keeps the behavior provable in unit tests (the one production call site is async and
+/// `kube::Client`-bound, so only the e2e tier reaches it).
 pub fn decide_class(
     classes: &[ClassInfo],
     provisioner: &str,
     explicit: Option<&str>,
 ) -> ClassDecision {
+    let explicit = explicit.map(str::trim).filter(|s| !s.is_empty());
     if let Some(name) = explicit {
         return if classes.iter().any(|c| c.name == name) {
             ClassDecision::Use(name.to_string())
@@ -1325,6 +1335,46 @@ mod tests {
         );
         assert_eq!(
             decide_class(&classes, "ebs.csi.aws.com", Some("nope")),
+            ClassDecision::ExplicitNotFound("nope".into())
+        );
+    }
+
+    #[test]
+    fn decide_class_treats_a_blank_explicit_name_as_unset() {
+        let driver = "ebs.csi.aws.com";
+        let classes = [class("csi-a", driver, false)];
+
+        // A GitOps-templated `volumeSnapshotClassName: ${VAR}` renders empty when the
+        // variable is undefined. No VolumeSnapshotClass can be named "", so an empty or
+        // whitespace-only value is "unset", not "an explicit class that is missing" —
+        // otherwise the user gets the nonsense message "volumeSnapshotClassName `` does
+        // not exist" instead of the auto-selection they asked for.
+        for blank in ["", "   ", "\n\t "] {
+            assert_eq!(
+                decide_class(&classes, driver, Some(blank)),
+                ClassDecision::Use("csi-a".into()),
+                "blank name {blank:?} should auto-select, not report a missing class"
+            );
+        }
+
+        // Blank normalizes *before* the explicit branch, so the genuinely-useful
+        // "name one explicitly" diagnostic still wins over ExplicitNotFound("").
+        let ambiguous = [class("a", driver, false), class("b", driver, false)];
+        assert!(matches!(
+            decide_class(&ambiguous, driver, Some("")),
+            ClassDecision::Ambiguous { .. }
+        ));
+
+        // A padded name still resolves, and the padding never reaches the
+        // VolumeSnapshot's spec.volumeSnapshotClassName.
+        assert_eq!(
+            decide_class(&classes, driver, Some("  csi-a  ")),
+            ClassDecision::Use("csi-a".into())
+        );
+
+        // Regression guard: a real, genuinely-absent name is still reported as missing.
+        assert_eq!(
+            decide_class(&classes, driver, Some("nope")),
             ClassDecision::ExplicitNotFound("nope".into())
         );
     }

--- a/crates/controller/src/io/tests.rs
+++ b/crates/controller/src/io/tests.rs
@@ -2194,6 +2194,7 @@ mod bootstrap_outcomes {
             index_blob_count: None,
             epoch: None,
             epoch_error: None,
+            blob_retention: None,
             failure: None,
         }
     }

--- a/crates/controller/src/repository.rs
+++ b/crates/controller/src/repository.rs
@@ -1244,6 +1244,24 @@ pub(crate) fn epoch_parameters_for(
         .unwrap_or_default()
 }
 
+/// The blob retention to send to a bootstrap mover, or `None` when there is nothing to apply
+/// (#332). Pure; shared by both repository kinds, exactly like [`epoch_parameters_for`].
+///
+/// `None` here means "leave the repository's retention alone" — it is NOT "disable". A
+/// `ReadOnly` repository always sends `None`, for the same reason it sends no epoch
+/// parameters: `set-parameters` hard-errors on a read-only connection.
+pub(crate) fn blob_retention_for(
+    read_only: bool,
+    parameters: Option<&kopiur_api::repository::RepositoryParameters>,
+) -> Option<kopiur_mover::workspec::BlobRetentionSpec> {
+    if read_only {
+        return None;
+    }
+    parameters
+        .and_then(|p| p.blob_retention.as_ref())
+        .and_then(kopiur_mover::workspec::BlobRetentionSpec::from_api)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn bootstrap_work_spec(
     backend: &Backend,
@@ -1287,6 +1305,7 @@ fn bootstrap_work_spec(
             // this is the belt to its braces, and the same hazard shape as the
             // consumer-clobbers-the-primary's-maintenance-owner bug M6 fixed.)
             epoch_parameters: epoch_parameters_for(read_only, parameters),
+            blob_retention: blob_retention_for(read_only, parameters),
             // Stamped on CREATE unconditionally (elsewhere) AND re-stamped on
             // every connect-to-existing when stale (`maintenance_restamp_target`);
             // `None` means neither ever happens — see the doc above.
@@ -1482,12 +1501,25 @@ async fn finalize_bootstrap(
         // re-reporting the old repository's identity forever.
         "observedGeneration": repo.metadata.generation,
     });
-    // Mirror the epoch parameters the repository actually reports (#258). The apply is
-    // best-effort in the mover, so this is what keeps it honest: a `spec.parameters.epoch`
-    // that failed to land stays visible here as drift from spec, rather than as silence.
-    // Merge-patch, so this key does not disturb the rest of status.
-    if let Some(epoch) = &result.epoch {
-        status_patch["parameters"] = serde_json::json!({ "epoch": epoch });
+    // Mirror the parameters the repository actually reports (#258 epoch, #332 blob
+    // retention). The apply is best-effort in the mover, so this is what keeps it honest: a
+    // `spec.parameters` that failed to land stays visible here as drift from spec, rather
+    // than as silence.
+    //
+    // Built as ONE map and assigned once. `status_patch` is a local Value assembled
+    // key-by-key before a single patch, so two `status_patch["parameters"] = json!(..)`
+    // statements would not merge — the second would drop the first outright, silently.
+    {
+        let mut params = serde_json::Map::new();
+        if let Some(epoch) = &result.epoch {
+            params.insert("epoch".into(), serde_json::json!(epoch));
+        }
+        if let Some(retention) = &result.blob_retention {
+            params.insert("blobRetention".into(), serde_json::json!(retention));
+        }
+        if !params.is_empty() {
+            status_patch["parameters"] = serde_json::Value::Object(params);
+        }
     }
     // The apply is best-effort (see the mover), so a failure leaves the repository Ready
     // with `status.parameters.epoch` silently disagreeing with `spec`. Say so out loud —

--- a/crates/e2e/mise.toml
+++ b/crates/e2e/mise.toml
@@ -108,7 +108,7 @@ docker exec "$NODE" sh -c '
   # PVC ROOT is the kopia repo — a subdir under one shared PVC gives no isolation.
   # Each scenario binds its own PVC over one of these dirs. KEEP IN LOCKSTEP with
   # crates/e2e/src/consts.rs::REPO_SUBPATHS.
-  for s in moverdefaults scc-shadow recmeta nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune adopt-prune adopt-ignore polcasc-retain polcasc-delete polcasc-simul recrestore; do
+  for s in moverdefaults scc-shadow recmeta nsdel-orphan nsdel-delete pin pinrestore populator populator2 popempty popempty2 readonly kstatus verify vfydeep vfyinh vfygate repl-src repl-dst repl-s3-src projgate hooks gfs errh colocation colocation-off copymethod copymethod-csi copymethod-explicit idxhealth epochparams epochparams-default staging-recover staging-timeout staging-override staging-mismatch massdel-cascade massdel-breaker massdel-prune massdel-single massdel-nooverlap massdel-throttle massdel-outage massdel-heldprune adopt-prune adopt-ignore polcasc-retain polcasc-delete polcasc-simul recrestore; do
     mkdir -p "/kopiur-e2e/repos/$s"
   done
   # Source dir with one UNREADABLE file for the errorHandling.ignoreFileErrors

--- a/crates/e2e/src/consts.rs
+++ b/crates/e2e/src/consts.rs
@@ -86,6 +86,7 @@ pub const REPO_SUBPATHS: &[&str] = &[
     "colocation-off",
     "copymethod",
     "copymethod-csi",
+    "copymethod-explicit",
     "idxhealth",
     // #258: two scenarios, each needing its OWN kopia repository — the first MUTATES
     // epoch params, so sharing one repo would leak that into the defaults assertion.

--- a/crates/e2e/tests/copy_methods.rs
+++ b/crates/e2e/tests/copy_methods.rs
@@ -20,6 +20,7 @@ use common::*;
 
 use kube::Api;
 use kube::api::{DeleteParams, PostParams};
+use kube::core::{ApiResource, DynamicObject, GroupVersionKind};
 
 use k8s_openapi::api::batch::v1::Job;
 use k8s_openapi::api::core::v1::{PersistentVolumeClaim, Pod};
@@ -29,6 +30,17 @@ use kopiur_e2e::{E2E_NAMESPACE, Need, World, default_timeout, poll_interval, wai
 
 /// The storage class + snapshot class the `snapshot-stack` mise task installs.
 const CSI_STORAGE_CLASS: &str = "csi-hostpath-sc";
+/// The `VolumeSnapshotClass` from `manifests/csi-snapshot/30-hostpath-snapshotclass.yaml`
+/// (driver `hostpath.csi.k8s.io`, annotated as the cluster default).
+const CSI_SNAPSHOT_CLASS: &str = "csi-hostpath-snapclass";
+
+fn volume_snapshots(client: &kube::Client) -> Api<DynamicObject> {
+    let ar = ApiResource::from_gvk_with_plural(
+        &GroupVersionKind::gvk("snapshot.storage.k8s.io", "v1", "VolumeSnapshot"),
+        "volumesnapshots",
+    );
+    Api::namespaced_with(client.clone(), E2E_NAMESPACE, &ar)
+}
 
 /// FAIL-LOUD: a `Snapshot`-mode backup of a non-CSI (static hostPath) source PVC must
 /// fail with an actionable `SourceStaged=False` condition, not silently read the live
@@ -334,6 +346,246 @@ async fn snapshot_mode_stages_a_csi_volumesnapshot_and_cleans_up() {
         .await;
     let _ = pods
         .delete("e2e-cm-csi-seed", &DeleteParams::default())
+        .await;
+    let _ = pvcs.delete(src, &DeleteParams::default()).await;
+}
+
+/// EXPLICIT CLASS: `volumeSnapshotClassName` set by name lands verbatim on the
+/// `VolumeSnapshot`, and a BLANK value means "unset" (auto-select) rather than "a class
+/// named `` that does not exist".
+///
+/// The sibling test above only covers the field *unset*, so it cannot prove an explicitly
+/// named class is honored — it would pass identically if the name were dropped on the floor.
+///
+/// The blank case is the #332-adjacent regression: Flux/Kustomize post-build substitution
+/// renders `volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS}` as an empty value whenever the
+/// variable is undefined, which used to fail the Snapshot with
+/// ``volumeSnapshotClassName `` does not exist``.
+#[tokio::test]
+#[ignore = "requires the e2e harness + the CSI snapshot stack (mise run //crates/e2e:snapshot-stack)"]
+async fn explicit_volume_snapshot_class_is_honored_and_blank_means_unset() {
+    let Some(world) = World::connect().await else {
+        return;
+    };
+    world.ensure(&[Need::Filesystem]).await.expect("fixtures");
+    let client = world.client().clone();
+
+    // Hard requirement, same as the sibling test: a missing harness must fail loudly
+    // rather than masquerade as a pass.
+    let scs: Api<StorageClass> = Api::all(client.clone());
+    assert!(
+        scs.get_opt(CSI_STORAGE_CLASS)
+            .await
+            .expect("list storageclasses")
+            .is_some(),
+        "storageclass {CSI_STORAGE_CLASS} not found — run `mise run //crates/e2e:snapshot-stack` \
+         (or set KOPIUR_E2E_SKIP_SNAPSHOT_STACK=1 only for shards excluding copy_methods.rs)"
+    );
+
+    ensure_repo(&client, "copymethod-explicit").await;
+    let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let pods: Api<Pod> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let repos: Api<Repository> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let policies: Api<SnapshotPolicy> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let backups: Api<Snapshot> = Api::namespaced(client.clone(), E2E_NAMESPACE);
+    let vs_api = volume_snapshots(&client);
+
+    let src = "e2e-cm-explicit-src";
+    pvcs.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1", "kind": "PersistentVolumeClaim",
+            "metadata": { "name": src, "namespace": E2E_NAMESPACE },
+            "spec": {
+                "accessModes": ["ReadWriteOnce"],
+                "storageClassName": CSI_STORAGE_CLASS,
+                "resources": { "requests": { "storage": "64Mi" } },
+            },
+        })),
+    )
+    .await
+    .expect("create CSI source PVC");
+    pods.create(
+        &PostParams::default(),
+        &cr(serde_json::json!({
+            "apiVersion": "v1", "kind": "Pod",
+            "metadata": { "name": "e2e-cm-explicit-seed", "namespace": E2E_NAMESPACE },
+            "spec": {
+                "restartPolicy": "Never",
+                "containers": [{
+                    "name": "seed", "image": kopiur_e2e::consts::BUSYBOX_IMAGE,
+                    "imagePullPolicy": "IfNotPresent",
+                    "command": ["sh", "-c", "echo kopiur-explicit > /data/marker.txt"],
+                    "volumeMounts": [{ "name": "d", "mountPath": "/data" }],
+                }],
+                "volumes": [{ "name": "d", "persistentVolumeClaim": { "claimName": src } }],
+            },
+        })),
+    )
+    .await
+    .expect("create seed pod");
+    wait_until(
+        "CSI source PVC Bound",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let bound = pvcs
+                .get_opt(src)
+                .await?
+                .and_then(|p| p.status.and_then(|s| s.phase))
+                .as_deref()
+                == Some("Bound");
+            Ok(bound.then_some(()))
+        },
+    )
+    .await
+    .expect("source PVC should bind");
+
+    repos
+        .create(
+            &PostParams::default(),
+            &cr(repository_json(
+                "e2e-cm-explicit-repo",
+                "copymethod-explicit",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Repository");
+
+    // --- Case 1: an explicitly named class must reach the VolumeSnapshot verbatim. ---
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                "e2e-cm-explicit-policy",
+                "Repository",
+                "e2e-cm-explicit-repo",
+                serde_json::json!({
+                    "copyMethod": "Snapshot",
+                    "volumeSnapshotClassName": CSI_SNAPSHOT_CLASS,
+                    "sources": [ { "pvc": { "name": src } } ],
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy with an explicit class");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-cm-explicit-backup",
+                "e2e-cm-explicit-policy",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+
+    // Read the class off the live VolumeSnapshot. Staging happens before the mover Job, and
+    // the staged objects are reaped once the Snapshot succeeds — so capture it in the same
+    // poll that discovers the name, rather than racing the reaper with a second lookup.
+    let observed_class = wait_until(
+        "VolumeSnapshot created with the explicit class",
+        default_timeout(),
+        poll_interval(),
+        || async {
+            let Some(name) = status_json(&backups, "e2e-cm-explicit-backup")
+                .await
+                .get("staged")
+                .and_then(|s| s.get("volumeSnapshotName"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+            else {
+                return Ok(None);
+            };
+            Ok(vs_api.get_opt(&name).await?.and_then(|vs| {
+                vs.data
+                    .get("spec")
+                    .and_then(|s| s.get("volumeSnapshotClassName"))
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            }))
+        },
+    )
+    .await
+    .expect("the VolumeSnapshot should exist and carry a class");
+    assert_eq!(
+        observed_class, CSI_SNAPSHOT_CLASS,
+        "spec.volumeSnapshotClassName must land on the VolumeSnapshot verbatim"
+    );
+
+    wait_phase(&backups, "e2e-cm-explicit-backup", "Succeeded")
+        .await
+        .expect("Snapshot with an explicit VolumeSnapshotClass should Succeed");
+
+    // --- Case 2: a BLANK class means unset — auto-select, not ExplicitNotFound(""). ---
+    policies
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_policy_json(
+                E2E_NAMESPACE,
+                "e2e-cm-blank-policy",
+                "Repository",
+                "e2e-cm-explicit-repo",
+                serde_json::json!({
+                    "copyMethod": "Snapshot",
+                    "volumeSnapshotClassName": "",
+                    "sources": [ { "pvc": { "name": src } } ],
+                }),
+            )),
+        )
+        .await
+        .expect("create SnapshotPolicy with a blank class");
+    backups
+        .create(
+            &PostParams::default(),
+            &cr(snapshot_json(
+                E2E_NAMESPACE,
+                "e2e-cm-blank-backup",
+                "e2e-cm-blank-policy",
+                serde_json::json!({}),
+            )),
+        )
+        .await
+        .expect("create Snapshot");
+
+    wait_phase(&backups, "e2e-cm-blank-backup", "Succeeded")
+        .await
+        .expect(
+            "a blank volumeSnapshotClassName must auto-select the default class, not fail with \
+             NoVolumeSnapshotClass",
+        );
+    let blank_status = status_json(&backups, "e2e-cm-blank-backup").await;
+    let staged_reason = blank_status
+        .get("conditions")
+        .and_then(|c| c.as_array())
+        .into_iter()
+        .flatten()
+        .find(|c| c.get("type").and_then(|t| t.as_str()) == Some("SourceStaged"))
+        .and_then(|c| c.get("reason"))
+        .and_then(|r| r.as_str())
+        .unwrap_or_default()
+        .to_string();
+    assert_ne!(
+        staged_reason, "NoVolumeSnapshotClass",
+        "a blank class must never be reported as a missing explicit class: {blank_status}"
+    );
+
+    // Cleanup.
+    for name in ["e2e-cm-explicit-backup", "e2e-cm-blank-backup"] {
+        let _ = backups.delete(name, &DeleteParams::default()).await;
+    }
+    for name in ["e2e-cm-explicit-policy", "e2e-cm-blank-policy"] {
+        let _ = policies.delete(name, &DeleteParams::default()).await;
+    }
+    let _ = repos
+        .delete("e2e-cm-explicit-repo", &DeleteParams::default())
+        .await;
+    let _ = pods
+        .delete("e2e-cm-explicit-seed", &DeleteParams::default())
         .await;
     let _ = pvcs.delete(src, &DeleteParams::default()).await;
 }

--- a/crates/kopia/src/client/mod.rs
+++ b/crates/kopia/src/client/mod.rs
@@ -736,6 +736,16 @@ pub struct SetParametersArgs {
     pub epoch_checkpoint_frequency: Option<i64>,
     /// `--epoch-delete-parallelism`.
     pub epoch_delete_parallelism: Option<i64>,
+    /// `--retention-mode`. kopia declares this as an ENUM flag accepting exactly
+    /// `"none"`, `"GOVERNANCE"`, or `"COMPLIANCE"` — note the lowercase `none` against the
+    /// uppercase modes, which is kopia's own inconsistency, not a typo here. Anything else
+    /// is rejected by kopia's flag parser before the command runs.
+    pub retention_mode: Option<String>,
+    /// `--retention-period` (e.g. `"720h"`). Pre-rendered like the epoch durations. kopia's
+    /// own parser also accepts `d`, but kopiur never emits it — `render_go_duration` only
+    /// produces `h`/`m`/`s`. Omitted when `retention_mode` is `"none"`: kopia short-circuits
+    /// the disable path before validating, so a period there is meaningless.
+    pub retention_period: Option<String>,
 }
 
 impl SetParametersArgs {
@@ -766,6 +776,16 @@ impl SetParametersArgs {
         if let Some(v) = self.epoch_delete_parallelism {
             a.push("--epoch-delete-parallelism".into());
             a.push(v.to_string());
+        }
+        // Appended AFTER the epoch flags so the existing positional order assertions in
+        // `tests.rs` keep holding.
+        if let Some(v) = &self.retention_mode {
+            a.push("--retention-mode".into());
+            a.push(v.clone());
+        }
+        if let Some(v) = &self.retention_period {
+            a.push("--retention-period".into());
+            a.push(v.clone());
         }
         a
     }

--- a/crates/kopia/src/client/tests.rs
+++ b/crates/kopia/src/client/tests.rs
@@ -1235,6 +1235,10 @@ fn set_parameters_args_render_every_epoch_flag_in_a_stable_order() {
         epoch_advance_on_size_mb: Some(10),
         epoch_checkpoint_frequency: Some(7),
         epoch_delete_parallelism: Some(4),
+        // Exhaustive on purpose (no `..Default::default()`): this test is the change-detector
+        // that forces a new set-parameters flag to be positioned deliberately in `args()`.
+        retention_mode: None,
+        retention_period: None,
     };
     assert_eq!(
         opts.args(),
@@ -1280,6 +1284,8 @@ fn set_parameters_durations_always_carry_a_unit() {
     let opts = SetParametersArgs {
         epoch_min_duration: Some("6h".into()),
         epoch_refresh_frequency: Some("20m".into()),
+        retention_period: Some("720h".into()),
+        retention_mode: None,
         ..Default::default()
     };
     for v in opts.args().iter().filter(|a| !a.starts_with("--")) {
@@ -1288,6 +1294,66 @@ fn set_parameters_durations_always_carry_a_unit() {
             "a duration passed to kopia must carry a unit, got {v:?}"
         );
     }
+}
+
+#[test]
+fn set_parameters_renders_the_blob_retention_flags() {
+    let opts = SetParametersArgs {
+        retention_mode: Some("GOVERNANCE".into()),
+        retention_period: Some("720h".into()),
+        ..Default::default()
+    };
+    assert_eq!(
+        opts.args(),
+        vec![
+            "--retention-mode",
+            "GOVERNANCE",
+            "--retention-period",
+            "720h"
+        ]
+    );
+
+    // Retention rides the SAME invocation as the epoch flags — `set-parameters` rewrites
+    // the format blob and invalidates every other client's cached copy, so the two must
+    // never be applied as two separate commands.
+    let both = SetParametersArgs {
+        epoch_min_duration: Some("6h".into()),
+        retention_mode: Some("COMPLIANCE".into()),
+        retention_period: Some("8760h".into()),
+        ..Default::default()
+    };
+    assert_eq!(
+        both.args(),
+        vec![
+            "--epoch-min-duration",
+            "6h",
+            "--retention-mode",
+            "COMPLIANCE",
+            "--retention-period",
+            "8760h"
+        ],
+        "epoch flags stay first so the existing positional assertions keep holding"
+    );
+}
+
+#[test]
+fn set_parameters_disable_emits_the_mode_alone_and_is_not_empty() {
+    // Disabling is mode-only: kopia's `--retention-mode=none` path clears mode AND period
+    // and short-circuits before its own validation, so sending a period would be noise.
+    let off = SetParametersArgs {
+        retention_mode: Some("none".into()),
+        ..Default::default()
+    };
+    assert_eq!(off.args(), vec!["--retention-mode", "none"]);
+    // Load-bearing: `repository_set_parameters` early-returns on `is_empty()`. If disabling
+    // read as empty, turning retention OFF would silently no-op forever.
+    assert!(
+        !off.is_empty(),
+        "a disable must still invoke set-parameters"
+    );
+
+    // And the genuinely-inert case still skips the invocation entirely.
+    assert!(SetParametersArgs::default().is_empty());
 }
 
 // --- timed-out subprocess reaping (Greptile P1 on PR #287): the timeout branch

--- a/crates/kopia/src/lib.rs
+++ b/crates/kopia/src/lib.rs
@@ -15,10 +15,10 @@ pub use client::{
 };
 pub use error::{KopiaError, KopiaErrorClass, notfound_is_uninitialized};
 pub use model::{
-    ClientOptions, ContentFormat, DirEntry, DirManifest, DirSummary, DirSummaryLite, EntryError,
-    IndexBlobEntry, MaintenanceCadence, MaintenanceInfo, MaintenanceSchedule, RepositoryStatus,
-    RootEntry, SnapshotCreateResult, SnapshotListEntry, SnapshotSource, SnapshotStats, StorageInfo,
-    user_tags,
+    BlobRetention, ClientOptions, ContentFormat, DirEntry, DirManifest, DirSummary, DirSummaryLite,
+    EntryError, IndexBlobEntry, MaintenanceCadence, MaintenanceInfo, MaintenanceSchedule,
+    RepositoryStatus, RootEntry, SnapshotCreateResult, SnapshotListEntry, SnapshotSource,
+    SnapshotStats, StorageInfo, user_tags,
 };
 pub use selection::{filter_as_of, pick_offset};
 pub use session::SessionCmd;

--- a/crates/kopia/src/model.rs
+++ b/crates/kopia/src/model.rs
@@ -537,6 +537,40 @@ pub struct RepositoryStatus {
     pub storage: StorageInfo,
     /// Content format (hash/encryption/version).
     pub content_format: ContentFormat,
+    /// Object-lock blob retention, from kopia's `kopia.blobcfg` blob.
+    ///
+    /// **Top-level**, unlike the epoch parameters nested under `contentFormat` — do not
+    /// follow that pattern here. `omitempty` on both inner keys means kopia emits `{}` when
+    /// retention is off, so an all-default value is the "disabled" observation, not a
+    /// missing one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_retention: Option<BlobRetention>,
+}
+
+/// Blob retention as reported by `kopia repository status --json` → `blobRetention`.
+///
+/// Mirrors kopia's `format.BlobStorageConfiguration`. Unlike the sibling [`EpochParameters`],
+/// the keys here **are** camelCase (kopia gives that struct explicit JSON tags), and unlike
+/// it this type cannot be `Copy` — it carries a `String`.
+///
+/// `retentionPeriod` is a Go `time.Duration`, so the unit is **nanoseconds** (the same
+/// convention as [`MaintenanceCadence::interval`]), not seconds.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BlobRetention {
+    /// `GOVERNANCE`, `COMPLIANCE`, or empty when retention is off.
+    #[serde(rename = "retentionMode", default)]
+    pub mode: String,
+    /// Retention period in **nanoseconds**; `0` when retention is off.
+    #[serde(rename = "retentionPeriod", default)]
+    pub period_ns: i64,
+}
+
+impl BlobRetention {
+    /// Whether retention is actually in force. Mirrors kopia's own `IsRetentionEnabled()`:
+    /// a non-empty mode AND a non-zero period — kopia treats a half-set config as off.
+    pub fn is_enabled(&self) -> bool {
+        !self.mode.is_empty() && self.period_ns != 0
+    }
 }
 
 /// A maintenance cadence block (`quick` / `full`) from `maintenance info`.

--- a/crates/kopia/tests/fixtures_parse.rs
+++ b/crates/kopia/tests/fixtures_parse.rs
@@ -65,6 +65,53 @@ fn parse_repository_status() {
         s.storage.config.get("path").and_then(|v| v.as_str()),
         Some("/tmp/claude-0/tmp.xo1UiqvExG")
     );
+    // This fixture is REAL kopia output from a filesystem repo, which cannot object-lock —
+    // so kopia emits a bare `"blobRetention": {}` (both inner keys are omitempty). That is
+    // the "retention is off" observation, and it must decode as such rather than as absent.
+    // The enabled shape is covered by `blob_retention_enabled_shape` below with inline JSON,
+    // because no local backend can produce it and faking it in the fixture would falsify a
+    // file whose whole contract is "verbatim kopia output".
+    let retention = s
+        .blob_retention
+        .expect("kopia 0.23 always emits blobRetention");
+    assert!(!retention.is_enabled());
+    assert_eq!(retention.mode, "");
+    assert_eq!(retention.period_ns, 0);
+}
+
+#[test]
+fn blob_retention_enabled_shape() {
+    // 720h == 30 days == 2_592_000_000_000_000ns. kopia reports the period as a Go
+    // time.Duration, so the unit is NANOSECONDS — reading it as seconds would understate
+    // the window by a factor of a billion and make the drift comparator re-apply forever.
+    let s: RepositoryStatus = serde_json::from_str(
+        r#"{
+            "configFile": "/config/repository.config",
+            "uniqueIDHex": "deadbeef",
+            "clientOptions": {"hostname": "h", "username": "u"},
+            "storage": {"type": "s3", "config": {"bucket": "b"}},
+            "contentFormat": {"hash": "BLAKE2B-256-128", "encryption": "AES256-GCM-HMAC-SHA256", "version": 3},
+            "blobRetention": {"retentionMode": "GOVERNANCE", "retentionPeriod": 2592000000000000}
+        }"#,
+    )
+    .unwrap();
+    let r = s.blob_retention.expect("blobRetention present");
+    assert!(r.is_enabled());
+    assert_eq!(r.mode, "GOVERNANCE");
+    assert_eq!(r.period_ns, 2_592_000_000_000_000);
+
+    // kopia treats a half-set config as OFF (`IsRetentionEnabled` requires both) — mirror
+    // that exactly, or kopiur would report protection that does not exist.
+    let half = kopiur_kopia::BlobRetention {
+        mode: "GOVERNANCE".into(),
+        period_ns: 0,
+    };
+    assert!(!half.is_enabled());
+    let half = kopiur_kopia::BlobRetention {
+        mode: String::new(),
+        period_ns: 2_592_000_000_000_000,
+    };
+    assert!(!half.is_enabled());
 }
 
 #[test]

--- a/crates/mover/src/bootstrap.rs
+++ b/crates/mover/src/bootstrap.rs
@@ -287,6 +287,15 @@ pub struct BootstrapResult {
     /// with `spec`. The controller turns this into a Warning event on the repository.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub epoch_error: Option<String>,
+    /// The blob retention the repository reports (`repository status`), for the controller
+    /// to mirror into `status.parameters.blobRetention` (#332). Same best-effort contract as
+    /// `epoch`: `None` when the status could not be read.
+    ///
+    /// There is deliberately no `blob_retention_error` sibling — epoch tuning and blob
+    /// retention are applied by ONE `set-parameters` command, so they fail together and
+    /// `epoch_error` carries the single reason.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_retention: Option<kopiur_api::repository::ObservedBlobRetention>,
     /// Structured failure block on `success == false`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub failure: Option<FailureBlock>,
@@ -314,6 +323,7 @@ impl BootstrapResult {
             index_blob_count,
             epoch: None,
             epoch_error: None,
+            blob_retention: None,
             failure: None,
         }
     }
@@ -331,6 +341,17 @@ impl BootstrapResult {
         self
     }
 
+    /// Attach the blob retention observed at the end of the bootstrap (#332). A sibling of
+    /// [`BootstrapResult::with_epoch`] rather than two more positional arguments to it, for
+    /// the same reason that one exists.
+    pub fn with_blob_retention(
+        mut self,
+        blob_retention: Option<kopiur_api::repository::ObservedBlobRetention>,
+    ) -> Self {
+        self.blob_retention = blob_retention;
+        self
+    }
+
     /// A terminal-failure outcome carrying the kopia error class + stderr tail.
     pub fn failed(err: &KopiaError) -> Self {
         BootstrapResult {
@@ -344,6 +365,7 @@ impl BootstrapResult {
             index_blob_count: None,
             epoch: None,
             epoch_error: None,
+            blob_retention: None,
             failure: Some(failure_block_from_kopia(err)),
         }
     }
@@ -367,6 +389,7 @@ impl BootstrapResult {
             index_blob_count: None,
             epoch: None,
             epoch_error: None,
+            blob_retention: None,
             failure: Some(FailureBlock {
                 kopia_error_class: REPOSITORY_NOT_INITIALIZED_CLASS.to_string(),
                 message: REPOSITORY_NOT_INITIALIZED_MESSAGE.to_string(),

--- a/crates/mover/src/main.rs
+++ b/crates/mover/src/main.rs
@@ -1169,12 +1169,14 @@ async fn run_bootstrap(
         // Defense in depth: admission rejects `mode: ReadOnly` + `spec.parameters`, and the
         // controller does not send them — but `set-parameters` HARD-ERRORS on a read-only
         // connection (`storage is read-only`), so never risk it.
-        if !op.epoch_parameters.is_empty() {
+        if !op.epoch_parameters.is_empty() || op.blob_retention.is_some() {
             warn!("skipping repository set-parameters: this repository is connected read-only");
         }
-    } else if let Some(args) = kopiur_mover::workspec::epoch_drift(
+    } else if let Some(args) = kopiur_mover::workspec::parameters_drift(
         &op.epoch_parameters,
         status.content_format.epoch_parameters.as_ref(),
+        op.blob_retention.as_ref(),
+        status.blob_retention.as_ref(),
     ) {
         match client.repository_set_parameters(&args).await {
             Ok(()) => {
@@ -1203,13 +1205,19 @@ async fn run_bootstrap(
                 warn!(
                     class = %e.class(),
                     "could not apply repository set-parameters; continuing bootstrap — \
-                     status.parameters.epoch will show the drift"
+                     status.parameters will show the drift"
                 );
+                // ONE error channel, because it is one command: epoch tuning and blob
+                // retention ride the same `set-parameters` invocation, so they succeed or
+                // fail together and splitting the reason would invent a distinction kopia
+                // does not make. The message names both so the reader knows what to check.
                 epoch_error = Some(format!(
-                    "kopia repository set-parameters failed ({}): {}. spec.parameters.epoch \
-                     was NOT applied — status.parameters.epoch reports what the repository \
-                     actually has. The bootstrap re-runs on the next spec change; edit \
-                     spec.parameters.epoch to retry.",
+                    "kopia repository set-parameters failed ({}): {}. spec.parameters was NOT \
+                     applied — status.parameters reports what the repository actually has. \
+                     If you set spec.parameters.blobRetention, check that the backend and \
+                     bucket support object lock (kopia reports `blob-retention: unsupported \
+                     put-blob option` when they do not). The bootstrap re-runs on the next \
+                     spec change; edit spec.parameters to retry.",
                     e.class(),
                     e
                 ));
@@ -1221,6 +1229,12 @@ async fn run_bootstrap(
         .epoch_parameters
         .as_ref()
         .map(kopiur_mover::workspec::observed_epoch);
+    // Note the different nesting: epoch parameters live under `contentFormat`, blob
+    // retention is a TOP-LEVEL key of `repository status --json`.
+    let observed_blob_retention = status
+        .blob_retention
+        .as_ref()
+        .map(kopiur_mover::workspec::observed_blob_retention);
 
     // Always list to report an authoritative snapshot count (unaffected by either
     // the foreign-suffix prefilter or the cap below); return the entries for
@@ -1277,6 +1291,7 @@ async fn run_bootstrap(
         index_blob_count,
     )
     .with_epoch(observed_epoch, epoch_error)
+    .with_blob_retention(observed_blob_retention)
 }
 
 /// Apply the ConfigMap size backstop (issue #237) to a bootstrap result, warning

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -612,6 +612,15 @@ pub struct BootstrapRepositoryOp {
     /// `set-parameters` hard-errors on a read-only connection.
     #[serde(default, skip_serializing_if = "EpochParametersSpec::is_empty")]
     pub epoch_parameters: EpochParametersSpec,
+    /// Object-lock blob retention (#332), applied through the same `set-parameters` call as
+    /// `epoch_parameters`.
+    ///
+    /// An `Option`, NOT an `is_empty()` sentinel like its sibling above — see
+    /// [`BlobRetentionSpec`] for why. `None` means "leave the repository's retention alone";
+    /// disabling is the explicit `Some(mode: "none")`. Also `None` for a `mode: ReadOnly`
+    /// repository, for the same reason `epoch_parameters` is empty there.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub blob_retention: Option<BlobRetentionSpec>,
     /// This cluster's `identityDefaults.cluster` (multi-cluster shared repo),
     /// carried ONLY when the controller determined cluster identity is on AND the
     /// effective `catalog.foreignSnapshots` policy is `Ignore` — never under
@@ -818,6 +827,9 @@ pub fn epoch_drift(
             epoch_advance_on_size_mb: desired.advance_on_size_mb,
             epoch_checkpoint_frequency: desired.checkpoint_frequency,
             epoch_delete_parallelism: desired.delete_parallelism,
+            // Epoch drift never touches retention; `parameters_drift` merges the two.
+            retention_mode: None,
+            retention_period: None,
         });
     };
     // Compare a desired duration against an observed nanosecond count.
@@ -847,6 +859,9 @@ pub fn epoch_drift(
         ),
         epoch_checkpoint_frequency: num_drift(desired.checkpoint_frequency, o.checkpoint_frequency),
         epoch_delete_parallelism: num_drift(desired.delete_parallelism, o.delete_parallelism),
+        // Epoch drift never touches retention; `parameters_drift` merges the two.
+        retention_mode: None,
+        retention_period: None,
     };
     (!args.is_empty()).then_some(args)
 }
@@ -868,6 +883,141 @@ pub fn observed_epoch(
         advance_on_size_mb: o.advance_on_total_size_bytes / MIB,
         checkpoint_frequency: o.checkpoint_frequency,
         delete_parallelism: o.delete_parallelism,
+    }
+}
+
+/// Object-lock blob retention for the work spec (#332).
+///
+/// **Deliberately has no `Default` impl**, and rides `BootstrapRepositoryOp` as an
+/// `Option<_>` rather than as an `is_empty()` sentinel the way [`EpochParametersSpec`] does.
+/// That difference is load-bearing: `mode` is mandatory, so *some* value would have to be the
+/// default, and whichever one it was would make "the user never mentioned blobRetention"
+/// indistinguishable from "the user asked to disable it". A repository that never declares
+/// retention would then issue `--retention-mode none` and silently strip a lock configured by
+/// hand. `None` = unmanaged, `Some(mode: "none")` = disable, and the absent `Default` is what
+/// stops the sentinel pattern being reintroduced.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobRetentionSpec {
+    /// kopia's argv value: `"none"`, `"GOVERNANCE"`, or `"COMPLIANCE"`.
+    pub mode: String,
+    /// Go-style duration, already rendered with a unit for kopia's CLI. `None` when
+    /// disabling — kopia ignores a period on the `none` path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub period: Option<String>,
+}
+
+impl BlobRetentionSpec {
+    /// Build from the api crate's `BlobRetention`, rendering the period through
+    /// [`kopiur_api::render_go_duration`] for the same reason [`EpochParametersSpec::from_api`]
+    /// does — what reaches kopia's argv is never the user's raw text.
+    ///
+    /// Returns `None` for `disabled: false`. That is not "enable": there is nothing to enable
+    /// without a mode and a period, so it reads as "leave the repository alone", exactly like
+    /// omitting the block. Erring toward doing nothing is the only safe reading for a
+    /// ransomware control.
+    pub fn from_api(r: &kopiur_api::repository::BlobRetention) -> Option<Self> {
+        use kopiur_api::repository::BlobRetention as B;
+        let render = |w: &kopiur_api::repository::RetentionWindow| {
+            kopiur_api::parse_go_duration(&w.period).map(kopiur_api::render_go_duration)
+        };
+        match r {
+            B::Governance(w) => Some(Self {
+                mode: "GOVERNANCE".into(),
+                period: render(w),
+            }),
+            B::Compliance(w) => Some(Self {
+                mode: "COMPLIANCE".into(),
+                period: render(w),
+            }),
+            B::Disabled(true) => Some(Self {
+                mode: "none".into(),
+                period: None,
+            }),
+            B::Disabled(false) => None,
+        }
+    }
+}
+
+/// The `set-parameters` flags needed to bring observed blob retention in line with `desired`,
+/// or `None` when they already agree.
+///
+/// Same doctrine as [`epoch_drift`]: compare in kopia's OWN units (nanoseconds), never on the
+/// rendered strings, and mutate only on drift because `set-parameters` invalidates every other
+/// client's cached format blob.
+pub fn blob_retention_drift(
+    desired: Option<&BlobRetentionSpec>,
+    observed: Option<&kopiur_kopia::model::BlobRetention>,
+) -> Option<kopiur_kopia::client::SetParametersArgs> {
+    // Unmanaged: the repository is never touched. This is the inert case that makes adding
+    // the feature a no-op for every existing repository.
+    let desired = desired?;
+
+    if desired.mode == "none" {
+        // Only disable what is actually on. When nothing was observed we cannot tell whether
+        // there is anything to disable, and a blind `--retention-mode=none` against a backend
+        // that cannot object-lock hard-fails — so do nothing. This asymmetry with the enable
+        // path below (which DOES apply on no observation) is deliberate.
+        let currently_on = observed.is_some_and(|o| o.is_enabled());
+        return currently_on.then(|| kopiur_kopia::client::SetParametersArgs {
+            retention_mode: Some("none".into()),
+            ..Default::default()
+        });
+    }
+
+    // `try_from`, never `as` — see `epoch_drift`: a wrapping cast reports drift against every
+    // observation and re-applies on every bootstrap forever.
+    let want_period = desired.period.as_deref()?;
+    let want_ns = i64::try_from(kopiur_api::parse_go_duration(want_period)?.as_nanos()).ok()?;
+    let converged = observed.is_some_and(|o| o.mode == desired.mode && o.period_ns == want_ns);
+    // Emit BOTH flags whenever either drifts: kopia validates the merged blobcfg, and sending
+    // the pair unconditionally is one fewer invariant to keep true.
+    (!converged).then(|| kopiur_kopia::client::SetParametersArgs {
+        retention_mode: Some(desired.mode.clone()),
+        retention_period: Some(want_period.to_string()),
+        ..Default::default()
+    })
+}
+
+/// Every `set-parameters` flag needed this bootstrap, in ONE invocation.
+///
+/// Epoch tuning and blob retention are independent settings that share a single kopia
+/// command, and that command rewrites the repository-global format blob — forcing every other
+/// kopia client to reconnect. Applying them as two commands would pay that cost twice, so the
+/// two drift results are merged here rather than dispatched separately.
+pub fn parameters_drift(
+    epoch_desired: &EpochParametersSpec,
+    epoch_observed: Option<&kopiur_kopia::model::EpochParameters>,
+    retention_desired: Option<&BlobRetentionSpec>,
+    retention_observed: Option<&kopiur_kopia::model::BlobRetention>,
+) -> Option<kopiur_kopia::client::SetParametersArgs> {
+    let epoch = epoch_drift(epoch_desired, epoch_observed);
+    let retention = blob_retention_drift(retention_desired, retention_observed);
+    match (epoch, retention) {
+        (None, None) => None,
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        // Disjoint field sets, so the merge is total: retention's two fields over epoch's six.
+        (Some(a), Some(b)) => Some(kopiur_kopia::client::SetParametersArgs {
+            retention_mode: b.retention_mode,
+            retention_period: b.retention_period,
+            ..a
+        }),
+    }
+}
+
+/// Mirror kopia's reported blob retention into the api crate's status type, rendering the
+/// nanosecond period back to a Go-style string so `status.parameters.blobRetention` is
+/// directly comparable to `spec.parameters.blobRetention`.
+pub fn observed_blob_retention(
+    o: &kopiur_kopia::model::BlobRetention,
+) -> kopiur_api::repository::ObservedBlobRetention {
+    kopiur_api::repository::ObservedBlobRetention {
+        enabled: o.is_enabled(),
+        mode: o.mode.clone(),
+        period: kopiur_api::render_go_duration(std::time::Duration::from_nanos(
+            o.period_ns.max(0) as u64
+        )),
     }
 }
 

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -415,6 +415,7 @@ fn bootstrap_repository_roundtrip_and_wire_shape() {
             scan_catalog: true,
             create_options: Default::default(),
             epoch_parameters: Default::default(),
+            blob_retention: None,
             maintenance_owner: Some("kopiur@kopiur-ns-repo".into()),
             catalog_foreign_prefilter_cluster: Some("east".into()),
             restamp_policy: RestampPolicy::OwnFormatsOnly,
@@ -499,6 +500,7 @@ fn bootstrap_repository_new_wire_json_round_trips_to_old_shape_when_unset() {
         scan_catalog: true,
         create_options: Default::default(),
         epoch_parameters: Default::default(),
+        blob_retention: None,
         maintenance_owner: None,
         catalog_foreign_prefilter_cluster: None,
         restamp_policy: RestampPolicy::AnyStale,
@@ -1818,4 +1820,226 @@ fn observed_epoch_renders_nanoseconds_back_to_go_durations() {
     assert_eq!(o.advance_on_size_mb, 10, "bytes → MiB");
     assert_eq!(o.checkpoint_frequency, 7);
     assert_eq!(o.delete_parallelism, 4);
+}
+
+// --- #332: object-lock blob retention -------------------------------------------------
+
+fn retention_on(mode: &str, ns: i64) -> kopiur_kopia::model::BlobRetention {
+    kopiur_kopia::model::BlobRetention {
+        mode: mode.into(),
+        period_ns: ns,
+    }
+}
+/// What kopia reports for a repository with retention off: `{}` — both keys omitempty.
+fn retention_off() -> kopiur_kopia::model::BlobRetention {
+    kopiur_kopia::model::BlobRetention::default()
+}
+/// 720h == 30 days, in the nanoseconds kopia reports.
+const NS_720H: i64 = 2_592_000_000_000_000;
+
+fn want(mode: &str, period: Option<&str>) -> BlobRetentionSpec {
+    BlobRetentionSpec {
+        mode: mode.into(),
+        period: period.map(str::to_string),
+    }
+}
+
+#[test]
+fn blob_retention_drift_is_none_when_nothing_is_declared() {
+    // THE inert case. A repository that never mentions blobRetention must never have
+    // `set-parameters` run against it — adding this feature has to be a no-op for every
+    // existing repository, and `set-parameters` invalidates every client's cached format
+    // blob. Checked against all three observation shapes.
+    assert!(blob_retention_drift(None, None).is_none());
+    assert!(blob_retention_drift(None, Some(&retention_off())).is_none());
+    assert!(blob_retention_drift(None, Some(&retention_on("GOVERNANCE", NS_720H))).is_none());
+}
+
+#[test]
+fn blob_retention_drift_is_none_when_already_converged() {
+    let desired = want("GOVERNANCE", Some("720h"));
+    assert!(
+        blob_retention_drift(Some(&desired), Some(&retention_on("GOVERNANCE", NS_720H))).is_none()
+    );
+}
+
+#[test]
+fn blob_retention_drift_compares_periods_by_value_not_by_string() {
+    // "720h", "43200m" and "2592000s" are the same period. A string compare would report
+    // drift forever and rewrite the format blob on every single bootstrap.
+    for equivalent in ["720h", "43200m", "2592000s", "2592000"] {
+        let desired = want("GOVERNANCE", Some(equivalent));
+        assert!(
+            blob_retention_drift(Some(&desired), Some(&retention_on("GOVERNANCE", NS_720H)))
+                .is_none(),
+            "{equivalent} is 720h and must not read as drift"
+        );
+    }
+}
+
+#[test]
+fn blob_retention_drift_emits_both_flags_when_either_changes() {
+    // Period changed.
+    let args = blob_retention_drift(
+        Some(&want("GOVERNANCE", Some("1440h"))),
+        Some(&retention_on("GOVERNANCE", NS_720H)),
+    )
+    .expect("a longer period is drift");
+    assert_eq!(
+        args.args(),
+        vec![
+            "--retention-mode",
+            "GOVERNANCE",
+            "--retention-period",
+            "1440h"
+        ]
+    );
+
+    // Mode changed — the period is re-sent even though it did not.
+    let args = blob_retention_drift(
+        Some(&want("COMPLIANCE", Some("720h"))),
+        Some(&retention_on("GOVERNANCE", NS_720H)),
+    )
+    .expect("a mode change is drift");
+    assert_eq!(
+        args.args(),
+        vec![
+            "--retention-mode",
+            "COMPLIANCE",
+            "--retention-period",
+            "720h"
+        ]
+    );
+
+    // Turning it ON from off.
+    assert!(
+        blob_retention_drift(
+            Some(&want("GOVERNANCE", Some("720h"))),
+            Some(&retention_off())
+        )
+        .is_some()
+    );
+    // No observation at all → apply what is declared (set-parameters is idempotent),
+    // matching epoch_drift's behavior.
+    assert!(blob_retention_drift(Some(&want("GOVERNANCE", Some("720h"))), None).is_some());
+}
+
+#[test]
+fn blob_retention_drift_disables_only_what_is_actually_on() {
+    // Disabling is mode-only.
+    let args = blob_retention_drift(
+        Some(&want("none", None)),
+        Some(&retention_on("GOVERNANCE", NS_720H)),
+    )
+    .expect("retention is on, so disabling is drift");
+    assert_eq!(args.args(), vec!["--retention-mode", "none"]);
+
+    // Already off → nothing to do. Re-applying would churn the format blob every bootstrap.
+    assert!(blob_retention_drift(Some(&want("none", None)), Some(&retention_off())).is_none());
+
+    // Deliberately asymmetric with the enable path: with NO observation we cannot tell
+    // whether there is anything to disable, and a blind `--retention-mode=none` against a
+    // backend that cannot object-lock hard-fails. Do nothing.
+    assert!(blob_retention_drift(Some(&want("none", None)), None).is_none());
+}
+
+#[test]
+fn blob_retention_spec_renders_durations_for_kopias_cli_and_drops_garbage() {
+    use kopiur_api::repository::{BlobRetention as B, RetentionWindow};
+    let s = BlobRetentionSpec::from_api(&B::Governance(RetentionWindow {
+        period: "2592000".into(), // bare seconds — kopia REJECTS this form
+    }))
+    .unwrap();
+    assert_eq!(s.mode, "GOVERNANCE");
+    assert_eq!(
+        s.period.as_deref(),
+        Some("720h"),
+        "must reach kopia with a unit"
+    );
+
+    // `30d` is valid for kopia's own CLI but not for kopiur's grammar; admission rejects it,
+    // and if one ever slipped through it is dropped rather than forwarded as garbage.
+    let s = BlobRetentionSpec::from_api(&B::Compliance(RetentionWindow {
+        period: "30d".into(),
+    }))
+    .unwrap();
+    assert_eq!(s.period, None);
+
+    // `disabled: true` is a real instruction; `disabled: false` is not "enable" — there is
+    // nothing to enable without a mode and period — so it reads as "leave it alone".
+    assert_eq!(
+        BlobRetentionSpec::from_api(&B::Disabled(true)),
+        Some(want("none", None))
+    );
+    assert_eq!(BlobRetentionSpec::from_api(&B::Disabled(false)), None);
+}
+
+#[test]
+fn parameters_drift_merges_epoch_and_retention_into_one_invocation() {
+    // `set-parameters` rewrites the repository-global format blob and forces every other
+    // kopia client to reconnect. Epoch tuning and retention must therefore ride ONE command.
+    let epoch = EpochParametersSpec {
+        min_duration: Some("6h".into()),
+        ..Default::default()
+    };
+    let args = parameters_drift(
+        &epoch,
+        None,
+        Some(&want("GOVERNANCE", Some("720h"))),
+        Some(&retention_off()),
+    )
+    .expect("both drifted");
+    assert_eq!(
+        args.args(),
+        vec![
+            "--epoch-min-duration",
+            "6h",
+            "--retention-mode",
+            "GOVERNANCE",
+            "--retention-period",
+            "720h"
+        ],
+        "one invocation carrying both settings"
+    );
+
+    // Either alone still works...
+    assert!(parameters_drift(&epoch, None, None, None).is_some());
+    assert!(
+        parameters_drift(
+            &EpochParametersSpec::default(),
+            None,
+            Some(&want("GOVERNANCE", Some("720h"))),
+            None
+        )
+        .is_some()
+    );
+    // ...and declaring neither runs no command at all.
+    assert!(parameters_drift(&EpochParametersSpec::default(), None, None, None).is_none());
+}
+
+#[test]
+fn observed_blob_retention_renders_nanoseconds_back_to_go_durations() {
+    let o = observed_blob_retention(&retention_on("GOVERNANCE", NS_720H));
+    assert!(o.enabled);
+    assert_eq!(o.mode, "GOVERNANCE");
+    assert_eq!(o.period, "720h", "status must be comparable to spec");
+
+    let off = observed_blob_retention(&retention_off());
+    assert!(!off.enabled);
+    assert_eq!(off.mode, "");
+}
+
+#[test]
+fn a_work_spec_without_blob_retention_decodes_as_unmanaged() {
+    // Old work-spec JSON (and every repository that never declares retention) must decode
+    // to None — "leave it alone" — and NOT to a default that would read as "disable".
+    let op: BootstrapRepositoryOp = serde_json::from_value(serde_json::json!({})).unwrap();
+    assert!(op.blob_retention.is_none());
+    assert!(
+        blob_retention_drift(
+            op.blob_retention.as_ref(),
+            Some(&retention_on("GOVERNANCE", NS_720H))
+        )
+        .is_none()
+    );
 }

--- a/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
+++ b/crates/xtask/tests/snapshots/snapshots_test__repository_crd.snap
@@ -2182,6 +2182,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2755,6 +2817,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true

--- a/deploy/crds/all-crds.yaml
+++ b/deploy/crds/all-crds.yaml
@@ -2178,6 +2178,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2751,6 +2813,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true
@@ -5132,6 +5218,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -5716,6 +5864,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true
@@ -7130,7 +7302,10 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
+                description: |-
+                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. Absent or
+                  empty both mean auto-select the default class for the source PVC's CSI driver, so a
+                  GitOps-templated value (Flux/Kustomize `${VAR}`) is safe when the variable is unset.
                 nullable: true
                 type: string
             required:

--- a/deploy/crds/clusterrepositories.yaml
+++ b/deploy/crds/clusterrepositories.yaml
@@ -2231,6 +2231,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2815,6 +2877,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true

--- a/deploy/crds/repositories.yaml
+++ b/deploy/crds/repositories.yaml
@@ -2178,6 +2178,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2751,6 +2813,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true

--- a/deploy/crds/snapshotpolicies.yaml
+++ b/deploy/crds/snapshotpolicies.yaml
@@ -1264,7 +1264,10 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
+                description: |-
+                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. Absent or
+                  empty both mean auto-select the default class for the source PVC's CSI driver, so a
+                  GitOps-templated value (Flux/Kustomize `${VAR}`) is safe when the variable is unset.
                 nullable: true
                 type: string
             required:

--- a/deploy/examples/38-repository-blob-retention.yaml
+++ b/deploy/examples/38-repository-blob-retention.yaml
@@ -1,0 +1,96 @@
+# Example 38 — object-lock blob retention / ransomware protection
+# (spec.parameters.blobRetention)
+#
+# THE SYMPTOM: nothing, until the day it matters. If the Kopiur container, the Helm
+# release, or the cluster itself is compromised, an attacker holding the repository
+# credentials can delete every backup you have. Backups that a single stolen
+# credential can erase are not a recovery plan.
+#
+# THE FIX: have the object store refuse the delete. S3 (and Azure/GCS) can lock a
+# blob for a fixed period at the moment it is written; until that period expires the
+# storage layer rejects deletion, no matter who asks. kopia drives this through
+# `repository set-parameters --retention-mode/--retention-period`, and this field
+# declares it so kopiur re-applies it whenever it drifts.
+#
+# PREREQUISITE THAT KOPIUR CANNOT DO FOR YOU: the bucket must have Object Lock
+# ENABLED AT CREATION TIME. It cannot be turned on afterwards, and these flags do not
+# create it. On AWS that is `aws s3api create-bucket --object-lock-enabled-for-bucket`;
+# on MinIO/RustFS, `mc mb --with-lock`. Without it, kopia fails with
+# `blob-retention: unsupported put-blob option`.
+#
+# SUPPORTED BACKENDS: s3, azure, gcs. Anything else (filesystem, sftp, webdav,
+# rclone, b2, gdrive) is rejected at admission — those protocols have no object lock,
+# and kopia would hard-fail on every single reconcile rather than quietly ignoring it.
+#
+# ABSENT MEANS "DON'T TOUCH", exactly like spec.parameters.epoch. Deleting this block
+# from your manifest does NOT turn retention off — it leaves the repository at
+# whatever you last applied, so a stray `kubectl apply` can never silently strip
+# ransomware protection. To actually turn it off, say so:
+#
+#   parameters:
+#     blobRetention:
+#       disabled: true
+#
+# READ THE RESULT at status.parameters.blobRetention, which mirrors what the
+# repository actually reports — so a failed apply shows up as drift from spec rather
+# than as silence.
+#
+# ┌──────────────────────────────────────────────────────────────────────────────┐
+# │ LIMITATION — protection is a ROLLING WINDOW, not cumulative immutability.     │
+# │                                                                              │
+# │ The lock is applied when a blob is WRITTEN. Kopiur does not enable kopia's    │
+# │ `maintenance set --extend-object-locks`, so locks on blobs that are still     │
+# │ needed are never extended: a blob written today under `period: 720h` becomes  │
+# │ deletable again in 30 days. Size the period to comfortably exceed your        │
+# │ longest recovery window, and run `kopia maintenance set                       │
+# │ --extend-object-locks=true` by hand if you need durable protection.           │
+# │                                                                              │
+# │ Blobs written BEFORE you enabled retention — including the repository format  │
+# │ blob — are never retroactively locked.                                        │
+# └──────────────────────────────────────────────────────────────────────────────┘
+#
+# GOVERNANCE vs COMPLIANCE — choose deliberately:
+#
+#   governance: locked against ordinary deletes, but a sufficiently privileged
+#               identity can still shorten or remove the lock. Start here.
+#
+#   compliance: NOBODY can shorten or remove the lock before it expires — not you,
+#               not the account root, not support. A mistyped period is an unfixable
+#               storage-cost commitment for its full duration. Only choose this if
+#               you specifically need protection against an attacker who has your
+#               cloud admin credentials, and only after testing the period on a
+#               throwaway bucket.
+#
+# PERIOD GRAMMAR: kopiur accepts h/m/s (or a bare number of seconds) — write 30 days
+# as `720h`. Note that kopia's own CLI *does* accept `30d`; kopiur deliberately keeps
+# one duration grammar across every CRD field, so a period copied from kopia's
+# documentation is rejected at admission with a message naming the fix. kopia's
+# minimum is 1 day; there is no maximum.
+#
+# EXPECT THE REPOSITORY TO GROW. Maintenance still issues deletes, but the storage
+# layer refuses them until the lock expires, so reclaim lags your retention period.
+# That is the cost of the guarantee, not a bug.
+---
+apiVersion: kopiur.home-operations.com/v1alpha1
+kind: Repository
+metadata:
+  name: s3-locked
+  namespace: kopiur-system
+spec:
+  backend:
+    s3:
+      bucket: my-kopiur-backups # MUST have been created with object lock enabled
+      region: us-east-1
+      auth:
+        secretRef:
+          name: s3-credentials
+  encryption:
+    passwordSecretRef:
+      name: kopiur-repo-password
+      key: KOPIA_PASSWORD
+  parameters:
+    blobRetention:
+      # Exactly one of governance / compliance / disabled — the CRD's own schema
+      # enforces it, so "a mode without a period" is not expressible.
+      governance:
+        period: 720h # 30 days. NOT `30d` — see PERIOD GRAMMAR above.

--- a/deploy/helm/kopiur/crds/clusterrepositories.yaml
+++ b/deploy/helm/kopiur/crds/clusterrepositories.yaml
@@ -2231,6 +2231,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2815,6 +2877,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true

--- a/deploy/helm/kopiur/crds/repositories.yaml
+++ b/deploy/helm/kopiur/crds/repositories.yaml
@@ -2178,6 +2178,68 @@ spec:
                 description: Mutable kopia repository parameters, re-applied on bootstrap whenever they drift.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: |-
+                      Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means
+                      "don't touch it"; use `disabled: true` to actively turn it off.
+                    nullable: true
+                    oneOf:
+                    - required:
+                      - governance
+                    - required:
+                      - compliance
+                    - required:
+                      - disabled
+                    properties:
+                      compliance:
+                        description: |-
+                          `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including
+                          the account root. An oversized period is an unfixable storage-cost commitment; there
+                          is no recovery path short of deleting the bucket after expiry.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                      disabled:
+                        description: |-
+                          Actively disable retention (`--retention-mode=none`). Must be `true`.
+
+                          A `bool` rather than a unit variant because an externally-tagged unit variant
+                          serializes as the bare string `"Disabled"`, mixing string and object forms in one
+                          `oneOf` and breaking the structural schema. Same shape, and same reason, as
+                          [`crate::cluster_repository::AllowedNamespaces::All`].
+
+                          This is distinct from omitting `blobRetention` entirely: absent means "leave the
+                          repository alone", so deleting the block from a manifest can never silently strip
+                          ransomware protection someone configured deliberately.
+                        type: boolean
+                      governance:
+                        description: |-
+                          `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged
+                          identity can still shorten or remove the lock. The safe default for most clusters.
+                        properties:
+                          period:
+                            description: |-
+                              Go-style duration; kopia's minimum is `24h` and there is no maximum.
+
+                              Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own
+                              CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here;
+                              write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every
+                              CRD field rather than matching kopia's per-flag variations.
+                            type: string
+                        required:
+                        - period
+                        type: object
+                    type: object
                   epoch:
                     description: |-
                       Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index
@@ -2751,6 +2813,30 @@ spec:
                   against `spec.parameters` to see whether a declared value landed.
                 nullable: true
                 properties:
+                  blobRetention:
+                    description: The blob retention the repository reports.
+                    nullable: true
+                    properties:
+                      enabled:
+                        description: |-
+                          Whether the repository currently has blob retention in force (kopia's
+                          `IsRetentionEnabled()`: a non-empty mode AND a non-zero period).
+                        type: boolean
+                      mode:
+                        description: |-
+                          Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or
+                          empty when off).
+                        type: string
+                      period:
+                        description: |-
+                          Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`)
+                          when retention is off.
+                        type: string
+                    required:
+                    - enabled
+                    - mode
+                    - period
+                    type: object
                   epoch:
                     description: The epoch parameters the repository reports.
                     nullable: true

--- a/deploy/helm/kopiur/crds/snapshotpolicies.yaml
+++ b/deploy/helm/kopiur/crds/snapshotpolicies.yaml
@@ -1264,7 +1264,10 @@ spec:
                     type: integer
                 type: object
               volumeSnapshotClassName:
-                description: '`VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source.'
+                description: |-
+                  `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. Absent or
+                  empty both mean auto-select the default class for the source PVC's CSI driver, so a
+                  GitOps-templated value (Flux/Kustomize `${VAR}`) is safe when the variable is unset.
                 nullable: true
                 type: string
             required:

--- a/docs/backends/azure.md
+++ b/docs/backends/azure.md
@@ -264,6 +264,7 @@ you touching the `Repository` object.
 
 ## See also
 
+- [Object lock (ransomware protection)](s3.md#object-lock-ransomware-protection) — `spec.parameters.blobRetention` works on Azure Blob too; the S3 page documents it in full.
 - [Repositories & backends](../repositories.md) — concepts: scope, encryption, creation.
 - [Movers, RBAC & credentials](../movers.md) — where the credential Secret must live.
 - Sibling backends: [S3](s3.md) · [GCS](gcs.md) · [B2](b2.md).

--- a/docs/backends/gcs.md
+++ b/docs/backends/gcs.md
@@ -241,6 +241,7 @@ block). The mover writes that body to the credentials file for you.
 
 ## See also
 
+- [Object lock (ransomware protection)](s3.md#object-lock-ransomware-protection) — `spec.parameters.blobRetention` works on GCS too; the S3 page documents it in full.
 - [Repositories & backends](../repositories.md) — concepts: scope, encryption, creation.
 - [Movers, RBAC & credentials](../movers.md) — where the credential Secret must live.
 - Sibling backends: [S3](s3.md) · [Azure](azure.md) · [rclone](rclone.md) (for Google Drive).

--- a/docs/backends/s3.md
+++ b/docs/backends/s3.md
@@ -151,6 +151,38 @@ endpoint, prefer pointing `tls.caBundleRef` at a `ConfigMap` holding the CA over
 --8<-- "deploy/examples/backends/s3-minio-http.yaml"
 ```
 
+## Object lock (ransomware protection)
+
+If the operator, the chart, or the cluster is compromised, whoever holds the repository credentials can delete every backup. Object lock makes the **object store** refuse the delete: a blob is locked for a fixed period when it is written, and until that expires the storage layer rejects deletion regardless of who asks.
+
+Declare it under `spec.parameters.blobRetention`:
+
+```yaml
+--8<-- "deploy/examples/38-repository-blob-retention.yaml"
+```
+
+/// warning | Locks are not extended — protection is a rolling window
+
+Kopiur applies the lock at write time only. kopia's `maintenance set --extend-object-locks`, which re-locks blobs that are still needed as full maintenance runs, is **not** configurable through Kopiur today. A blob written under `period: 720h` becomes deletable again 30 days later even if your retention policy still needs it.
+
+Treat the period as a rolling floor, not cumulative immutability: size it to comfortably exceed your longest recovery window, and run `kopia maintenance set --extend-object-locks=true` by hand if you need durable protection. Blobs written *before* you enabled retention — including the repository format blob — are never retroactively locked.
+
+///
+
+/// warning | `compliance` cannot be undone
+
+Under `governance`, a sufficiently privileged identity can still shorten or remove a lock. Under `compliance`, **nobody** can — not you, not the account root. A mistyped period is an unfixable storage-cost commitment for its full duration. Start with `governance`, and test any `compliance` period on a throwaway bucket first.
+
+///
+
+Three things that bite:
+
+- **The bucket must have object lock enabled at creation.** It cannot be turned on later, and these fields do not create it (`aws s3api create-bucket --object-lock-enabled-for-bucket`, or `mc mb --with-lock`). Without it kopia fails with `blob-retention: unsupported put-blob option`, and Kopiur surfaces that as a Warning event on every reconcile.
+- **Write the period as `720h`, not `30d`.** Kopiur accepts `h`/`m`/`s` only, one grammar across every CRD field. kopia's own CLI *does* take `30d`, so a value copied from kopia's documentation is rejected at admission — the error names the fix. The minimum is 1 day.
+- **Expect the repository to grow.** [Maintenance](../maintenance.md) still issues deletes, but the storage layer refuses them until locks expire, so reclaim lags your retention period. That is the cost of the guarantee. It is also why `s3:DeleteObject` stays in the [bucket policy](#provider-prerequisites): kopia keeps *issuing* the deletes, and the lock — not a missing permission — is what declines them.
+
+Absent means "don't touch": removing the block leaves the repository at whatever you last applied, so a stray apply cannot silently strip protection. Turn it off explicitly with `blobRetention: { disabled: true }`. Read back what actually landed at `status.parameters.blobRetention`.
+
 ## Workload identity (IRSA / EKS Pod Identity)
 
 On EKS (or any cluster with AWS IAM federation), you can drop the static

--- a/docs/backups.md
+++ b/docs/backups.md
@@ -148,7 +148,7 @@ When a selector matches several PVCs, `groupBy` defaults to `VolumeGroupSnapshot
 | `Clone`                | CSI clone of the source PVC → kopia reads the clone.          | A CSI driver that supports volume **cloning**.                       |
 | `Direct`               | Read the **live** PVC directly (co-located on its node).     | Nothing — works on any storage.                                      |
 
-`volumeSnapshotClassName` selects the snapshot class when `Snapshot`/`Clone` is used; leave it unset to auto-pick your driver's **default** class.
+`volumeSnapshotClassName` selects the snapshot class when `Snapshot`/`Clone` is used; leave it unset — or empty, which means the same thing — to auto-pick your driver's **default** class.
 
 /// note | `Direct` is opt-in; non-CSI sources must set it explicitly
 

--- a/docs/copy-methods.md
+++ b/docs/copy-methods.md
@@ -152,6 +152,18 @@ spec:
 - **Leave it unset** and Kopiur picks the **default `VolumeSnapshotClass` for your source's driver** (the one annotated `snapshot.storage.kubernetes.io/is-default-class: "true"`). If exactly one class exists for the driver it's used even without the annotation.
 - If **no** class matches your driver, or **several** match with no single default, the backup fails asking you to create/annotate a class or name one explicitly.
 
+/// tip | Templating this field with Flux or Kustomize?
+
+An **empty** value counts as unset, exactly like omitting the field. That makes the field safe to template unconditionally — a Kustomize component can always emit the line and let a Flux post-build substitution fill it in:
+
+```yaml
+volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS:=}
+```
+
+With the variable undefined this renders empty and Kopiur auto-selects the driver's default class; with it set, the named class is used. You do not need conditional templating to keep the field optional.
+
+///
+
 ### How long staging may wait (`spec.staging.timeout`)
 
 Staging has a **deadline budget** that bounds each of its phases:
@@ -327,7 +339,7 @@ If a `SnapshotPolicy` never sets `copyMethod` and the cluster has no CSI snapsho
 | Condition / symptom | Cause | Fix |
 | --- | --- | --- |
 | `SourceStaged=False`, reason **`SnapshotStackMissing`** | No `VolumeSnapshotClass` API — the external-snapshotter isn't installed. | Install the snapshot-controller and a `VolumeSnapshotClass` ([What it requires](#what-it-requires) has the `snapshot-controller` chart command), or set `copyMethod: Direct`. |
-| `SourceStaged=False`, reason **`NoVolumeSnapshotClass`** | No class matches your source PVC's driver (or several do with no single default). | Create/annotate a `VolumeSnapshotClass` for the driver, set `volumeSnapshotClassName` explicitly, or use `Direct`. |
+| `SourceStaged=False`, reason **`NoVolumeSnapshotClass`** | No class matches your source PVC's driver, or several do with no single default. (An **empty** `volumeSnapshotClassName` is not a cause — it counts as unset.) | Create/annotate a `VolumeSnapshotClass` for the driver, set `volumeSnapshotClassName` explicitly, or use `Direct`. |
 | `SourceStaged=False`, reason **`VolumeSnapshotFailed`** | The VolumeSnapshot was **still reporting an error when the staging deadline passed** (`spec.staging.timeout`, default `10m`) — transient errors during the wait are retried, never fatal on their own. | Read the message (it includes the driver's last error); fix the class/driver, or raise `spec.staging.timeout` if the backend is just slow. The next scheduled run (or a new `Snapshot`) retries. |
 | `SourceStaged=False`, reason **`StagingTimedOut`** | The VolumeSnapshot never became `readyToUse` within the staging deadline and reported **no error** — the CSI driver / snapshot-controller is stuck or very slow. | Check the driver and the snapshot-controller; raise `spec.staging.timeout` (or set it to `"0"` to wait indefinitely) if the backend is just slow. |
 | `SourceStaged=False`, reason **`SourceNotCSIProvisioned`** | The source PVC has no `StorageClass` (a static/hostPath volume) — nothing to snapshot. | Use a CSI-provisioned PVC, or `copyMethod: Direct`. |

--- a/docs/field-reference.md
+++ b/docs/field-reference.md
@@ -524,7 +524,30 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `wo
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `blobRetention` | [union](#repository-spec-parameters-blobretention) | — | Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means "don't touch it"; use `disabled: true` to actively turn it off. |
 | `epoch` | [object](#repository-spec-parameters-epoch) | — | Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index blobs get compacted. |
+
+##### `spec.parameters.blobRetention` { #repository-spec-parameters-blobretention }
+
+Externally tagged — set **exactly one** of: `compliance` · `disabled` · `governance`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `compliance` | [object](#repository-spec-parameters-blobretention-compliance) | — | `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including the account root. An oversized period is an unfixable storage-cost commitment; there is no recovery path short of deleting the bucket after expiry. |
+| `disabled` | boolean | — | Actively disable retention (`--retention-mode=none`). Must be `true`.<br>A `bool` rather than a unit variant because an externally-tagged unit variant serializes as the bare string `"Disabled"`, mixing string and object forms in one `oneOf` and breaking the structural schema. Same shape, and same reason, as `crate::cluster_repository::AllowedNamespaces::All`.<br>This is distinct from omitting `blobRetention` entirely: absent means "leave the repository alone", so deleting the block from a manifest can never silently strip ransomware protection someone configured deliberately. |
+| `governance` | [object](#repository-spec-parameters-blobretention-governance) | — | `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged identity can still shorten or remove the lock. The safe default for most clusters. |
+
+###### `spec.parameters.blobRetention.compliance` { #repository-spec-parameters-blobretention-compliance }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `period` | string | **required** | Go-style duration; kopia's minimum is `24h` and there is no maximum.<br>Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here; write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every CRD field rather than matching kopia's per-flag variations. |
+
+###### `spec.parameters.blobRetention.governance` { #repository-spec-parameters-blobretention-governance }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `period` | string | **required** | Go-style duration; kopia's minimum is `24h` and there is no maximum.<br>Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here; write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every CRD field rather than matching kopia's per-flag variations. |
 
 ##### `spec.parameters.epoch` { #repository-spec-parameters-epoch }
 
@@ -644,7 +667,16 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `blobRetention` | [object](#repository-status-parameters-blobretention) | — | The blob retention the repository reports. |
 | `epoch` | [object](#repository-status-parameters-epoch) | — | The epoch parameters the repository reports. |
+
+##### `status.parameters.blobRetention` { #repository-status-parameters-blobretention }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | boolean | **required** | Whether the repository currently has blob retention in force (kopia's `IsRetentionEnabled()`: a non-empty mode AND a non-zero period). |
+| `mode` | string | **required** | Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or empty when off). |
+| `period` | string | **required** | Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`) when retention is off. |
 
 ##### `status.parameters.epoch` { #repository-status-parameters-epoch }
 
@@ -1211,7 +1243,30 @@ Externally tagged — set **exactly one** of: `pvcConsumer` · `snapshot` · `wo
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `blobRetention` | [union](#clusterrepository-spec-parameters-blobretention) | — | Object-lock blob retention (S3/Azure/GCS) — ransomware protection. Absent means "don't touch it"; use `disabled: true` to actively turn it off. |
 | `epoch` | [object](#clusterrepository-spec-parameters-epoch) | — | Epoch-manager tuning — how fast kopia closes epochs and therefore how fast index blobs get compacted. |
+
+##### `spec.parameters.blobRetention` { #clusterrepository-spec-parameters-blobretention }
+
+Externally tagged — set **exactly one** of: `compliance` · `disabled` · `governance`.
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `compliance` | [object](#clusterrepository-spec-parameters-blobretention-compliance) | — | `COMPLIANCE` — **nobody can shorten or remove the lock before it expires**, including the account root. An oversized period is an unfixable storage-cost commitment; there is no recovery path short of deleting the bucket after expiry. |
+| `disabled` | boolean | — | Actively disable retention (`--retention-mode=none`). Must be `true`.<br>A `bool` rather than a unit variant because an externally-tagged unit variant serializes as the bare string `"Disabled"`, mixing string and object forms in one `oneOf` and breaking the structural schema. Same shape, and same reason, as `crate::cluster_repository::AllowedNamespaces::All`.<br>This is distinct from omitting `blobRetention` entirely: absent means "leave the repository alone", so deleting the block from a manifest can never silently strip ransomware protection someone configured deliberately. |
+| `governance` | [object](#clusterrepository-spec-parameters-blobretention-governance) | — | `GOVERNANCE` — locked against ordinary deletes, but a sufficiently privileged identity can still shorten or remove the lock. The safe default for most clusters. |
+
+###### `spec.parameters.blobRetention.compliance` { #clusterrepository-spec-parameters-blobretention-compliance }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `period` | string | **required** | Go-style duration; kopia's minimum is `24h` and there is no maximum.<br>Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here; write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every CRD field rather than matching kopia's per-flag variations. |
+
+###### `spec.parameters.blobRetention.governance` { #clusterrepository-spec-parameters-blobretention-governance }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `period` | string | **required** | Go-style duration; kopia's minimum is `24h` and there is no maximum.<br>Accepts `h`/`m`/`s` (or a bare number of seconds) — **not `d`**. Note that kopia's own CLI *does* take `30d`, so a period copied from kopia's documentation is rejected here; write 30 days as `720h`. Kopiur deliberately keeps one duration grammar across every CRD field rather than matching kopia's per-flag variations. |
 
 ##### `spec.parameters.epoch` { #clusterrepository-spec-parameters-epoch }
 
@@ -1333,7 +1388,16 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 
 | Field | Type | Default | Description |
 | --- | --- | --- | --- |
+| `blobRetention` | [object](#clusterrepository-status-parameters-blobretention) | — | The blob retention the repository reports. |
 | `epoch` | [object](#clusterrepository-status-parameters-epoch) | — | The epoch parameters the repository reports. |
+
+##### `status.parameters.blobRetention` { #clusterrepository-status-parameters-blobretention }
+
+| Field | Type | Default | Description |
+| --- | --- | --- | --- |
+| `enabled` | boolean | **required** | Whether the repository currently has blob retention in force (kopia's `IsRetentionEnabled()`: a non-empty mode AND a non-zero period). |
+| `mode` | string | **required** | Observed retention mode exactly as kopia reports it (`GOVERNANCE`, `COMPLIANCE`, or empty when off). |
+| `period` | string | **required** | Observed retention period, as a Go-style duration (`720h`). Empty-equivalent (`0s`) when retention is off. |
 
 ##### `status.parameters.epoch` { #clusterrepository-status-parameters-epoch }
 
@@ -1406,7 +1470,7 @@ Externally tagged — set **exactly one** of: `generate` · `insecure` · `secre
 | `suspend` | boolean | — | Pause this recipe declaratively (schedules and reconcile skip a suspended policy). |
 | `upload` | [object](#snapshotpolicy-spec-upload) | — | Upload parallelism (kopia's `--max-parallel-snapshots` / `--max-parallel-file-reads`). |
 | `verification` | [object](#snapshotpolicy-spec-verification) | — | First-class backup verification; opt-in (absent ⇒ no verification runs). |
-| `volumeSnapshotClassName` | string | — | `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. |
+| `volumeSnapshotClassName` | string | — | `VolumeSnapshotClass` used when `copyMethod` snapshots/clones the source. Absent or empty both mean auto-select the default class for the source PVC's CSI driver, so a GitOps-templated value (Flux/Kustomize `${VAR}`) is safe when the variable is unset. |
 
 #### `spec.repository` { #snapshotpolicy-spec-repository }
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -269,6 +269,8 @@ Three things worth knowing:
 - **`mode: ReadOnly` repositories cannot declare parameters.** `set-parameters` is a repository-wide write and kopia refuses it on a read-only connection, so the combination is rejected at admission. In a multi-cluster layout, declare them on the cluster that owns the repository — they describe the repository, not each consumer. Two clusters declaring *different* values for one repository will fight over it.
 - **`cleanupSafetyMargin` is reported but not settable.** It is the grace window that stops kopia deleting index blobs a concurrent writer still needs, and there is no safe generic advice for lowering it.
 
+`spec.parameters` has a second key, `blobRetention`, which turns on S3/Azure/GCS **object lock** so a compromised credential cannot delete your backups. It rides the same `set-parameters` call as `epoch` — one invocation, applied only on drift — and it changes what maintenance can reclaim: deletes are still issued, but the storage layer refuses them until locks expire, so the repository grows for at least the retention period. See [Object lock](backends/s3.md#object-lock-ransomware-protection).
+
 /// warning | A high index-blob count means maintenance isn't running
 
 The warning is a symptom; the fix is to get maintenance compacting again. Check that a `Maintenance` exists and is `Ready`, that it isn't yielding (`LeaseOwned=False`, reason `LeaseHeldByOther`), and that its owner is the stable lease owner — not an ephemeral `…-bootstrap-…` identity. The operator self-heals a stale owner on the next bootstrap; to recover **now**, set `spec.maintenance.takeoverPolicy: Force` once. Raising or zeroing `indexBlobWarnThreshold` only silences the warning — it does not compact the index.

--- a/docs/reference/crds/snapshot-policy.md
+++ b/docs/reference/crds/snapshot-policy.md
@@ -75,6 +75,12 @@ snapshot stack. See [Copy methods](../../copy-methods.md).
 
 The `VolumeSnapshotClass` used when `copyMethod` is `Snapshot` or `Clone`.
 
+Absent **and empty** both mean the same thing: auto-select the default class for the
+source PVC's CSI driver. That matters when the field is templated — a Flux/Kustomize
+post-build substitution like `volumeSnapshotClassName: ${KOPIUR_SNAPSHOTCLASS}` renders
+empty whenever the variable is undefined, and is treated as unset rather than as a class
+whose name happens to be blank.
+
 ### `staging`
 
 Knobs for the CSI capture (`copyMethod: Snapshot`/`Clone`) that runs before the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -49,6 +49,19 @@ primary   Failed    S3        2m
 $ kubectl describe repository primary -n <ns>   # the condition message names the exact cause
 ```
 
+### `Ready`, but a recurring Warning event about `set-parameters`
+
+The repository is healthy — connect, backups and restores all work — but every reconcile emits a `Warning` event saying `kopia repository set-parameters failed`. `spec.parameters` is not landing, and `status.parameters` shows what the repository actually has, which disagrees with your manifest.
+
+The apply is deliberately best-effort: a bad parameter must not take an otherwise-healthy repository to `Failed`. But it repeats until you fix the cause.
+
+| Message contains | Cause | Fix |
+| --- | --- | --- |
+| `blob-retention: unsupported put-blob option` | `spec.parameters.blobRetention` on a bucket **without object lock enabled at creation**. Object lock cannot be added to an existing bucket. | Recreate the bucket with object lock (`aws s3api create-bucket --object-lock-enabled-for-bucket`, or `mc mb --with-lock`) and migrate, or remove `blobRetention`. See [Object lock](backends/s3.md#object-lock-ransomware-protection). |
+| `storage is read-only` | The repository is connected `mode: ReadOnly`. | Declare `spec.parameters` on the cluster that owns the repository. Admission normally rejects this pairing, so seeing it means the mode changed after the fact. |
+
+A backend that has no object lock at all (filesystem, sftp, webdav, rclone, b2, gdrive) is rejected at admission instead, so it never reaches this state.
+
 ## Backup (or Restore) stuck in `Pending` with no Job
 
 The mover is blocked on a precondition. The common ones, all surfaced as conditions and `Warning` Events:
@@ -287,7 +300,7 @@ $ kubectl get snapshot <name> -n <ns> -o jsonpath='{.status.conditions[?(@.type=
 | Reason | Cause | Fix |
 | --- | --- | --- |
 | `SnapshotStackMissing` | The cluster has no `VolumeSnapshotClass` API — the external-snapshotter (snapshot-controller + CRDs) isn't installed. | Install the CSI snapshot stack + a `VolumeSnapshotClass` ([Copy methods → What it requires](copy-methods.md#what-it-requires) has the `snapshot-controller` chart command), or set `copyMethod: Direct`. |
-| `NoVolumeSnapshotClass` | No `VolumeSnapshotClass` matches the source PVC's driver, several match with no single default, or an explicit `volumeSnapshotClassName` doesn't exist. | Create/annotate a class for the driver, set `volumeSnapshotClassName` explicitly, or use `Direct`. |
+| `NoVolumeSnapshotClass` | No `VolumeSnapshotClass` matches the source PVC's driver, several match with no single default, or an explicit `volumeSnapshotClassName` doesn't exist. An **empty** `volumeSnapshotClassName` never causes this — it is treated as unset. | Create/annotate a class for the driver, set `volumeSnapshotClassName` explicitly, or use `Direct`. |
 | `VolumeSnapshotFailed` | The VolumeSnapshot was still reporting an error when the staging deadline passed (`spec.staging.timeout`, default `10m`); transient snapshot-controller errors (e.g. a benign 409 conflict) during the wait are retried, never fatal on their own. | Fix the class/driver issue named in the message, or raise `spec.staging.timeout` if the backend is just slow. The next scheduled run (or a new `Snapshot`) retries. |
 | `StagingTimedOut` | The VolumeSnapshot never became `readyToUse` within the staging deadline and reported no error — the driver/snapshot-controller is stuck or very slow. | Check the CSI driver and snapshot-controller; raise `spec.staging.timeout` (`"0"` waits indefinitely) for slow backends. |
 | `SourceNotCSIProvisioned` | The source PVC has no `StorageClass` (static/hostPath) — nothing to snapshot. | Use a CSI-provisioned PVC, or `copyMethod: Direct`. |


### PR DESCRIPTION
Two independent changes, kept in one PR at the maintainer's request.

---

## 1. Object-lock blob retention — closes #332

`#332` was closed `not planned`; reopening the capability here because the gap is real: if the operator, chart, or cluster is compromised, whoever holds the repository credentials can delete every backup. `spec.parameters.blobRetention` turns on S3/Azure/GCS object lock so the **storage layer** refuses the delete.

```yaml
spec:
  parameters:
    blobRetention:
      governance:        # or `compliance:` / `disabled: true`
        period: 720h
```

### Design

Modeled as an **externally-tagged union**, so kopia's *"both retention mode and period must be provided"* error is unrepresentable rather than merely validated. The generated schema is a `oneOf` over `required: [governance|compliance|disabled]` with `period` required inside each window variant — so a half-set config is rejected by the apiserver before any kopiur code runs.

`disabled` carries a `bool` rather than being a unit variant, following the existing `AllowedNamespaces::All(bool)` precedent: an externally-tagged unit variant serializes as the bare string `"Disabled"`, mixing string and object forms in one `oneOf` and breaking the structural schema.

**One `set-parameters` call.** Retention rides the same invocation as `spec.parameters.epoch` via a merged `parameters_drift`. That command rewrites the format blob and forces every other kopia client to reconnect, so it must never be issued twice — and only on drift.

**Absent means "leave the repository alone."** Deleting the block from a manifest cannot silently strip ransomware protection; disabling is the explicit `disabled: true`. `BlobRetentionSpec` deliberately has **no `Default` impl** so that distinction can't be collapsed back into a sentinel.

**Backend gate is load-bearing, not cosmetic.** Verified against the real binary: on a backend without object lock, `set-parameters` *hard-fails* (`blob-retention: unsupported put-blob option`, exit 1) rather than no-op'ing. Since the bootstrap re-runs every reconcile, that would be a permanent Warning-event loop. Admission rejects it via an exhaustive `match` on all nine `Backend` variants — a tenth variant won't compile until it's classified.

### Verified against kopia 0.23.1

| Fact | Consequence |
| --- | --- |
| `--retention-mode` is an enum: `none｜GOVERNANCE｜COMPLIANCE` | modeled exactly; note the lowercase `none` |
| Minimum period 24h, no maximum | validated at admission with kopia's own wording |
| `mode=none` needs no period and skips validation | the `Disabled` variant carries none — falls out of the type |
| `repository status --json` → `blobRetention` is **top-level**, period in **nanoseconds** | *not* nested under `contentFormat` like epoch params — don't copy that pattern |
| kopia's CLI **does** accept `30d`; kopiur's grammar is h/m/s only | the validator message names the fix (`720h`), since copying from kopia's docs is the likely first attempt |

### Deliberately out of scope

kopiur does not set `maintenance set --extend-object-locks`, so locks on still-needed blobs are never extended. **Protection is a rolling window, not cumulative immutability** — a blob written under `period: 720h` is deletable again 30 days later. This is documented loudly in the example, the S3 backend page, and the CRD doc comment rather than engineered around. The field is additive, so adding extend-object-locks later is not a breaking change.

Also skipped, deliberately: kopia only enforces `period − fullMaintenanceInterval ≥ 24h` when extend-object-locks is on (`CheckExtendRetention` returns early otherwise), so a guard for it would reject configurations kopia accepts.

### Drive-by fix

`status_patch["parameters"]` was a whole-object assignment in both repository reconcilers. A second sibling key would have silently dropped the first — `status_patch` is a local `Value` assembled key-by-key before a single patch, so the two assignments never merge. Now built as one map.

---

## 2. Blank `volumeSnapshotClassName` is treated as unset

`decide_class` passed `Some("")` through as an explicit class name. No `VolumeSnapshotClass` can be named `""`, so it always landed in `ExplicitNotFound("")` and rendered:

```
volumeSnapshotClassName `` does not exist; create it (driver `...`)
```

Empty backticks — reads as an operator bug, not as user-actionable output.

That is exactly what a GitOps template produces: a Flux/Kustomize post-build substitution of `volumeSnapshotClassName: ${VAR}` renders empty whenever the variable is undefined. Normalizing inside the pure function means every present and future call site inherits it, and the behavior is provable in a unit test — the one production call site is `async` and `kube::Client`-bound, so a call-site fix would only be testable in the e2e tier.

**Closes an e2e coverage gap.** The existing test only exercised the field *unset*, so it would have passed identically if an explicit class name were dropped on the floor. The new case asserts the name lands **verbatim** on the `VolumeSnapshot`, plus a blank-class regression guard.

`spec.staging.storageClassName` is **not** changed: for a PVC, `""` is a meaningful Kubernetes value ("no dynamic provisioning") and is propagated into the staged PVC spec, so the semantics genuinely differ.

---

## Verification

```
cargo test --workspace       exit=0   2065 passed, 0 failed
cargo clippy -D warnings     exit=0   (--all-targets --all-features)
cargo fmt --all --check      clean
cargo xtask gen-all --check  OK (no drift, 23 files)
complexity ratchet           29 / 29  — unchanged
mkdocs build --strict        clean (no broken links)
examples_match_crd_shapes    2 passed — the new example validates against real CRD types
```

The complexity budget had **zero headroom** (29/29), so the retention logic is extracted into small pure helpers (`blob_retention_drift`, `parameters_drift`) rather than inlined into `run_bootstrap`, which is already an offender.

**Not executed:** the new e2e test compiles and is registered (3 tests in `copy_methods.rs`, was 2) but needs a kind cluster with the CSI snapshot stack. Object lock has no e2e — kind has no lock-capable backend; a negative test (unsupported backend → admission rejection) is possible as a follow-up.

## Reviewer notes

- The `oneOf` shape is worth a look in `deploy/crds/repositories.yaml` — it's the load-bearing part.
- `blob_retention_drift`'s disable path is deliberately asymmetric with its enable path: with **no** observation it does nothing, because a blind `--retention-mode=none` against a backend that can't object-lock hard-fails, whereas enabling on no observation is safe and idempotent.
