### PR TITLE
chore(renovate): keep 0.x minors out of automerge

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -7,5 +7,11 @@
       matchUpdateTypes: ["minor", "patch", "digest", "lockFileMaintenance"],
       automerge: true,
     },
+    {
+      description: "zer0ver: 0.x minors can break at any time, don't automerge them",
+      matchUpdateTypes: ["minor"],
+      matchCurrentVersion: "/^v?0\\./",
+      automerge: false,
+    },
   ],
 }


### PR DESCRIPTION
The shared zer0ver policy ([renovate-config#64](https://github.com/home-operations/renovate-config/pull/64)) labels 0.x minors as majors, gives them the breaking commit prefix, and routes them onto the `major-` branches. Automerge is evaluated per update though, not per branch, so this repo's automerge-all-minors rule would still merge a breaking 0.x bump unreviewed - repo `packageRules` concatenate after preset rules, so the guard has to live here.

This adds a later rule that unsets automerge for minors where the current version matches `/^v?0\\./`, so they wait for review like majors while patches, digests, and lock file maintenance keep automerging.