### PR TITLE
fix(mover): mount the S3 CA bundle into mover Jobs

### DIFF
--- a/crates/controller/src/server/tests.rs
+++ b/crates/controller/src/server/tests.rs
@@ -49,6 +49,7 @@ fn inputs<'a>(ns: &'a str, auth: ResolvedAuth) -> ServerBuildInputs<'a> {
             disable_tls: false,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         read_only: false,
         port: 51515,

--- a/crates/mover/src/jobs.rs
+++ b/crates/mover/src/jobs.rs
@@ -39,6 +39,15 @@ pub const DEFAULT_MOVER_IMAGE: &str = "ghcr.io/home-operations/kopiur-mover:v0.1
 /// `VolumeMount`, and the mover's writability preflight + restore target all
 /// reference this single constant so they can never drift (centralize-config).
 pub const DEEP_SCRATCH_PATH: &str = "/scratch";
+
+/// Volume name for the mounted CA bundle.
+pub const CA_BUNDLE_VOLUME: &str = "ca-bundle";
+/// Directory the CA bundle is mounted at.
+pub const CA_BUNDLE_DIR: &str = "/etc/kopia/ca";
+/// Filename the bundle is projected to, regardless of the ConfigMap key.
+pub const CA_BUNDLE_FILE: &str = "ca.crt";
+/// The image's public root set, kept alongside the custom bundle via SSL_CERT_DIR.
+pub const SYSTEM_CERT_DIR: &str = "/etc/ssl/certs";
 /// Data key the LEGACY per-run work-spec ConfigMaps carried (operator versions
 /// that mounted the spec instead of embedding it in the Job env). Still
 /// referenced by the controller's orphan sweep, which reaps those leftovers.
@@ -514,6 +523,38 @@ pub fn build_job(inputs: &MoverJobInputs<'_>) -> Result<Job, BuildJobError> {
         volume_mounts.push(repo.to_volume_mount("repo"));
     }
 
+    // A self-signed object-store endpoint needs its CA *inside* the mover pod:
+    // kopia exposes no CA flag, so the bundle is mounted and Go's verifier is
+    // pointed at it via SSL_CERT_FILE below. Without this the repository can
+    // connect (the controller resolves the ConfigMap itself) while every mover
+    // fails `x509: certificate signed by unknown authority`.
+    let ca_bundle = match &inputs.work_spec.repository {
+        crate::workspec::RepositoryConnect::S3 { ca_bundle, .. } => ca_bundle.as_ref(),
+        _ => None,
+    };
+    if let Some(ca) = ca_bundle {
+        volumes.push(Volume {
+            name: CA_BUNDLE_VOLUME.to_string(),
+            config_map: Some(k8s_openapi::api::core::v1::ConfigMapVolumeSource {
+                name: ca.config_map_name.clone(),
+                items: Some(vec![k8s_openapi::api::core::v1::KeyToPath {
+                    key: ca.key.clone(),
+                    path: CA_BUNDLE_FILE.to_string(),
+                    ..Default::default()
+                }]),
+                optional: Some(false),
+                ..Default::default()
+            }),
+            ..Default::default()
+        });
+        volume_mounts.push(VolumeMount {
+            name: CA_BUNDLE_VOLUME.to_string(),
+            mount_path: CA_BUNDLE_DIR.to_string(),
+            read_only: Some(true),
+            ..Default::default()
+        });
+    }
+
     // Credentials (KOPIA_PASSWORD + backend creds) come from Secret(s) as env,
     // never from the ConfigMap. One `envFrom` per distinct secret so an
     // object-store repo whose password and backend keys live in separate Secrets
@@ -565,6 +606,21 @@ pub fn build_job(inputs: &MoverJobInputs<'_>) -> Result<Job, BuildJobError> {
             value_from: None,
         },
     ];
+    if ca_bundle.is_some() {
+        // SSL_CERT_FILE alone would REPLACE the image's root set; pairing it with
+        // SSL_CERT_DIR keeps the public roots so a mover can still reach an
+        // OTLP collector or a publicly-signed endpoint.
+        env.push(k8s_openapi::api::core::v1::EnvVar {
+            name: "SSL_CERT_FILE".to_string(),
+            value: Some(format!("{CA_BUNDLE_DIR}/{CA_BUNDLE_FILE}")),
+            value_from: None,
+        });
+        env.push(k8s_openapi::api::core::v1::EnvVar {
+            name: "SSL_CERT_DIR".to_string(),
+            value: Some(SYSTEM_CERT_DIR.to_string()),
+            value_from: None,
+        });
+    }
     if let Some(cm) = inputs.result_configmap {
         env.push(k8s_openapi::api::core::v1::EnvVar {
             name: RESULT_CONFIGMAP_ENV.to_string(),
@@ -1329,6 +1385,96 @@ mod tests {
             .find(|e| e.secret_ref.as_ref().map(|s| s.name.as_str()) == Some("dest-creds"))
             .expect("dest envFrom");
         assert_eq!(dest.prefix.as_deref(), Some("KOPIUR_DEST_"));
+    }
+
+    #[test]
+    fn s3_ca_bundle_is_mounted_and_trusted_by_the_mover() {
+        use crate::workspec::{CaBundle, RepositoryConnect};
+        // The repository connects via the controller, which resolves the CA itself;
+        // the mover only ever sees what build_job mounts. Without this the mover
+        // fails `x509: certificate signed by unknown authority` while the
+        // repository reports Ready.
+        let mut ws = sample_work_spec();
+        ws.repository = RepositoryConnect::S3 {
+            bucket: "kopiur".into(),
+            endpoint: Some("minio.storage.svc:9001".into()),
+            prefix: None,
+            region: Some("us-east-1".into()),
+            disable_tls: false,
+            disable_tls_verification: false,
+            ambient_credentials: false,
+            ca_bundle: Some(CaBundle {
+                config_map_name: "minio-ca".into(),
+                key: "ca.crt".into(),
+            }),
+        };
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+
+        let vol = pod
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.name == CA_BUNDLE_VOLUME)
+            .expect("ca-bundle volume missing");
+        let cm = vol.config_map.as_ref().expect("configMap source");
+        assert_eq!(cm.name, "minio-ca");
+        // The key is projected to a fixed filename so the env below is constant.
+        let item = &cm.items.as_ref().unwrap()[0];
+        assert_eq!(item.key, "ca.crt");
+        assert_eq!(item.path, CA_BUNDLE_FILE);
+
+        let container = &pod.containers[0];
+        let mount = container
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.name == CA_BUNDLE_VOLUME)
+            .expect("ca-bundle mount missing");
+        assert_eq!(mount.mount_path, CA_BUNDLE_DIR);
+        assert_eq!(mount.read_only, Some(true));
+
+        let env = container.env.as_ref().unwrap();
+        let file = env
+            .iter()
+            .find(|e| e.name == "SSL_CERT_FILE")
+            .expect("SSL_CERT_FILE set");
+        assert_eq!(
+            file.value.as_deref(),
+            Some(format!("{CA_BUNDLE_DIR}/{CA_BUNDLE_FILE}").as_str())
+        );
+        // Paired with SSL_CERT_DIR so the image's public roots survive.
+        let dir = env
+            .iter()
+            .find(|e| e.name == "SSL_CERT_DIR")
+            .expect("SSL_CERT_DIR set");
+        assert_eq!(dir.value.as_deref(), Some(SYSTEM_CERT_DIR));
+    }
+
+    #[test]
+    fn s3_without_a_ca_bundle_mounts_nothing_extra() {
+        let ws = sample_work_spec();
+        let job = build_job(&inputs(&ws, JobLimits::default())).unwrap();
+        let pod = job.spec.unwrap().template.spec.unwrap();
+        assert!(
+            !pod.volumes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|v| v.name == CA_BUNDLE_VOLUME),
+            "no CA volume without caBundleRef"
+        );
+        assert!(
+            !pod.containers[0]
+                .env
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|e| e.name == "SSL_CERT_FILE"),
+            "SSL_CERT_FILE must not be set without a bundle"
+        );
     }
 
     #[test]

--- a/crates/mover/src/repo_meta.rs
+++ b/crates/mover/src/repo_meta.rs
@@ -11,6 +11,7 @@
 //! Every mapping is exhaustive over [`Backend`] (ADR §5.5): a new backend
 //! variant cannot compile until each projection decides what it yields.
 
+use crate::workspec::CaBundle;
 use kopiur_api::backend::{Backend, RepoVolume};
 
 use crate::jobs::MountSource;
@@ -87,6 +88,19 @@ pub fn backend_to_repository_connect(backend: &Backend) -> RepositoryConnect {
                 .as_ref()
                 .map(|t| t.insecure_skip_verify)
                 .unwrap_or(false),
+            // A CA bundle only reaches kopia as a mounted file, so carry the
+            // ConfigMap reference through to `build_job`. `key` defaults to the
+            // conventional `ca.crt` when the CRD leaves it unset.
+            ca_bundle: s
+                .tls
+                .as_ref()
+                .and_then(|t| t.ca_bundle_ref.as_ref())
+                .and_then(|r| {
+                    r.config_map_name.as_ref().map(|name| CaBundle {
+                        config_map_name: name.clone(),
+                        key: r.key.clone().unwrap_or_else(|| "ca.crt".to_string()),
+                    })
+                }),
             // Workload identity: no static keys in the env — kopia is invoked
             // with explicitly-empty key flags so its credential chain resolves
             // ambiently (IRSA / EKS Pod Identity / IMDS).

--- a/crates/mover/src/serve.rs
+++ b/crates/mover/src/serve.rs
@@ -115,6 +115,7 @@ mod tests {
                 disable_tls: false,
                 disable_tls_verification: false,
                 ambient_credentials: false,
+                ca_bundle: None,
             },
             listen_port: 51515,
             auth: ServerAuthSpec::Password {

--- a/crates/mover/src/workspec/mod.rs
+++ b/crates/mover/src/workspec/mod.rs
@@ -1391,6 +1391,19 @@ impl ResolvedIdentity {
         format!("{}@{}:{}", self.username, self.hostname, self.source_path)
     }
 }
+/// A PEM CA bundle in a `ConfigMap`, mounted into the mover so it can verify a
+/// self-signed object-store endpoint.
+///
+/// Resolved in the mover's OWN namespace: `ConfigMap` volumes are namespace-local,
+/// so the bundle must exist wherever movers run, not only beside the repository.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaBundle {
+    /// Name of the `ConfigMap`.
+    pub config_map_name: String,
+    /// Key inside the `ConfigMap` holding the PEM bundle.
+    pub key: String,
+}
 
 /// How to reach the repository. Externally tagged: exactly one backend.
 ///
@@ -1429,6 +1442,12 @@ pub enum RepositoryConnect {
         /// Skip TLS certificate verification (`--disable-tls-verification`).
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         disable_tls_verification: bool,
+        /// `ConfigMap` holding a PEM CA bundle the mover must trust to verify this
+        /// endpoint. kopia exposes no CA flag, so the bundle is mounted into the
+        /// pod and Go's verifier is pointed at it; see `build_job`. Omitted from
+        /// the wire when absent, so work specs written before this field parse.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ca_bundle: Option<CaBundle>,
         /// Authenticate via the ambient AWS credential chain (workload identity:
         /// IRSA / EKS Pod Identity) instead of static keys from the env. Defaults
         /// to `false` and is omitted from the wire when false, so work-spec
@@ -1543,6 +1562,9 @@ impl RepositoryConnect {
                 disable_tls,
                 disable_tls_verification,
                 ambient_credentials,
+                // Not a kopia flag: the bundle reaches kopia as a mounted file
+                // plus SSL_CERT_FILE on the mover pod (see jobs::build_job).
+                ca_bundle: _,
             } => ConnectSpec::S3 {
                 bucket: bucket.clone(),
                 endpoint: endpoint.clone(),

--- a/crates/mover/src/workspec/tests.rs
+++ b/crates/mover/src/workspec/tests.rs
@@ -147,6 +147,7 @@ fn restore_roundtrip() {
             disable_tls: false,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         target_ref: TargetRef {
             kind: "Restore".into(),
@@ -244,6 +245,7 @@ fn restore_resolve_source_roundtrips_and_wire_shape() {
             disable_tls: false,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         target_ref: TargetRef {
             kind: "Restore".into(),
@@ -431,6 +433,7 @@ fn bootstrap_repository_roundtrip_and_wire_shape() {
             disable_tls: true,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         target_ref: TargetRef {
             kind: "Repository".into(),
@@ -544,6 +547,7 @@ fn maintenance_roundtrip_and_wire_shape() {
             disable_tls: true,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         target_ref: TargetRef {
             kind: "Maintenance".into(),
@@ -676,6 +680,7 @@ fn connect_spec_conversion() {
         disable_tls: false,
         disable_tls_verification: false,
         ambient_credentials: false,
+        ca_bundle: None,
     };
     assert_eq!(
         s3.to_connect_spec(),
@@ -889,6 +894,7 @@ fn s3_ambient_credentials_roundtrips_and_defaults_false() {
         disable_tls: false,
         disable_tls_verification: false,
         ambient_credentials: true,
+        ca_bundle: None,
     };
     let v: serde_json::Value = serde_json::to_value(&wire).unwrap();
     assert_eq!(v["s3"]["ambientCredentials"], true);
@@ -1317,6 +1323,7 @@ fn verify_quick_roundtrip_and_wire_shape() {
             disable_tls: false,
             disable_tls_verification: false,
             ambient_credentials: false,
+            ca_bundle: None,
         },
         target_ref: TargetRef {
             kind: "SnapshotPolicy".into(),
@@ -1467,6 +1474,7 @@ fn replicate_roundtrip_and_wire_shape() {
                 disable_tls: false,
                 disable_tls_verification: false,
                 ambient_credentials: false,
+                ca_bundle: None,
             },
             delete_extra: true,
             parallel: Some(8),


### PR DESCRIPTION
## The problem

`backend.s3.tls.caBundleRef` is accepted by the CRD and watched for changes, but it never reaches a mover. `build_job` mounts no ConfigMap, and `RepositoryConnect::S3` carries only `disable_tls` / `disable_tls_verification` — there is no field for the bundle in the work spec at all.

The controller resolves the bundle itself, so the failure is asymmetric and easy to misread:

```
ClusterRepository:  Ready=True  Bootstrapped
mover:              kopia repository connect s3 --bucket kopiur --endpoint <host>:9001 --region us-east-1
                    tls: failed to verify certificate: x509: certificate signed by unknown authority
```

The repository looks healthy while 100% of backups fail, which reads as a credential or bucket problem rather than a missing CA. `insecureSkipVerify: true` is the only working option today, and the docs point at `caBundleRef` as the thing to prefer over it.

### Reproduction

1. MinIO (or any S3 store) behind a private CA, TLS port.
2. `ClusterRepository` with `backend.s3.tls.caBundleRef` pointing at a ConfigMap holding the PEM bundle, present in the mover's namespace.
3. Repository reaches `Ready=True Bootstrapped`; every `Snapshot` fails with the `x509` error above.

Confirmed on chart `0.9.3`, controller `sha256:c6239f6d…`, mover `sha256:4547a851…`. The mover Job's pod spec shows the gap directly:

```
volumes: [kopia-cache, source]
env:     KOPIUR_WORK_SPEC, KOPIA_CACHE_DIRECTORY, KOPIA_LOG_DIR, KOPIA_CONFIG_PATH, RUST_LOG, KOPIUR_LOG_FORMAT
```

## The fix

- `RepositoryConnect::S3` gains an optional `ca_bundle` (ConfigMap name + key). It is populated by the existing `backend_to_repository_connect`, so **no call site changes** — all ten `MoverJobInputs` construction sites are untouched.
- `build_job` mounts that ConfigMap read-only at `/etc/kopia/ca`, projecting the key to a fixed `ca.crt` so the env value is constant.
- kopia exposes no CA flag, so Go's verifier is the lever: `SSL_CERT_FILE` points at the bundle. `SSL_CERT_DIR` is set alongside it deliberately — `SSL_CERT_FILE` alone *replaces* the image's root set, which would break a mover talking to an OTLP collector or a publicly-signed endpoint.
- The ConfigMap resolves in the mover's own namespace, consistent with how `envFrom` credentials already work. Worth a docs note, since `caBundleRef` has no `namespace` field unlike `auth.secretRef`.
- `serde(skip_serializing_if)` keeps the field off the wire when absent, so work specs written before this change still parse.

New field is `Option`, omitted when unset — no behaviour change for anyone not using `caBundleRef`.

## Tests

- `s3_ca_bundle_is_mounted_and_trusted_by_the_mover` — asserts the volume, the read-only mount path, the projected filename, and both env vars.
- `s3_without_a_ca_bundle_mounts_nothing_extra` — asserts no CA volume and no `SSL_CERT_FILE` when unset.

`cargo test --workspace --lib` → **2057 passed, 0 failed**. `cargo fmt --all` clean.

## What I have not verified

The unit tests prove the pod spec, not the handshake. I reproduced the bug against a live private-CA MinIO endpoint, but I have not run a **patched** mover image end-to-end against it — so the `SSL_CERT_FILE` + `SSL_CERT_DIR` pairing is verified by Go's documented behaviour rather than by an observed successful backup. Happy to do that if you'd like it confirmed before merge, and equally happy to adjust the approach if you'd rather pass the CA some other way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)