### PR TITLE
fix(mover): read status.resolved via the /status subresource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1827,6 +1827,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "http",
+ "http-body-util",
  "k8s-openapi",
  "kopiur-api",
  "kopiur-kopia",
@@ -1840,6 +1842,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.20",
  "tokio",
+ "tower",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,7 +961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1192,9 +1192,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2902,7 +2902,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2959,7 +2959,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3422,7 +3422,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4079,7 +4079,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/e2e/tests/cli.rs
+++ b/crates/e2e/tests/cli.rs
@@ -892,6 +892,35 @@ async fn cli_restore_from_policy_into_created_pvc() {
         .await
         .expect("S3 fromPolicy-restored PVC must contain the seeded bytes");
 
+    // #401 regression guard: the in-Job resolver's `status.resolved` read must
+    // be authorized under the chart's REAL mover RBAC. Before the fix the mover
+    // GETted the base `restores` resource (granted nowhere), so every in-Job
+    // resolution warned `status.resolved read failed ... Forbidden` and a Job
+    // retry could never reuse the pinned snapshot. The mover pods persist —
+    // restore Jobs set no TTL and are owner-GC'd only with the Restore CR,
+    // which this test leaves in place — so their logs are the observable
+    // contract. `backoffLimit` is 2, so assert across EVERY pod of the Job, and
+    // require at least one so the check can never pass vacuously.
+    let mover_pods = pods
+        .list(&ListParams::default().labels("batch.kubernetes.io/job-name=e2e-cli-restore-s3pol"))
+        .await
+        .expect("list S3 fromPolicy mover pods");
+    assert!(
+        !mover_pods.items.is_empty(),
+        "no mover pod found for Job e2e-cli-restore-s3pol; the #401 log guard would be vacuous"
+    );
+    for pod in &mover_pods.items {
+        let pod_name = pod.metadata.name.as_deref().expect("pod has a name");
+        let logs = kopiur_e2e::wait::pod_logs(&client, E2E_NAMESPACE, pod_name)
+            .await
+            .unwrap_or_else(|e| panic!("fetch mover pod {pod_name} logs: {e}"));
+        assert!(
+            !logs.contains("status.resolved read failed"),
+            "#401 regression: mover pod {pod_name} could not read status.resolved under the \
+             chart's mover RBAC; logs:\n{logs}"
+        );
+    }
+
     // Restore error path: a snapshotRef that doesn't exist fails closed
     // (onMissingSnapshot defaults to Fail for explicit sources) → exit 1.
     let out = run_cli(&[

--- a/crates/mover/Cargo.toml
+++ b/crates/mover/Cargo.toml
@@ -27,6 +27,13 @@ clap = { workspace = true }
 [dev-dependencies]
 serial_test = { workspace = true }
 tempfile = "3"
+# Mock kube client for the KubeStatusReporter tests (`tower::service_fn` needs
+# the `util` feature — the workspace `tower` is default-features, and relying on
+# feature unification with kube-client would make `cargo test -p kopiur-mover`
+# fragile on its own).
+tower = { workspace = true, features = ["util"] }
+http = "1"
+http-body-util = "0.1"
 
 [features]
 integration = []

--- a/crates/mover/src/error.rs
+++ b/crates/mover/src/error.rs
@@ -393,6 +393,30 @@ pub enum MoverError {
         source: Box<kube::Error>,
     },
 
+    /// A CR status READ (a GET on the `/status` subresource) failed. Distinct
+    /// from [`MoverError::StatusPatch`] so the log line names the call that was
+    /// actually rejected — #401's 403 was reported as "failed to PATCH" when
+    /// the rejected call was a GET, which sent the reporter debugging the wrong
+    /// request.
+    #[error(
+        "failed to read the status of {kind} {namespace}/{name} (GET on the status \
+         subresource): {source}. The mover reads status.resolved so a Job retry reuses the \
+         snapshot a prior attempt pinned; without it this run re-resolves from the \
+         repository. Requires `get` on the CRD's /status subresource in the kopiur-mover \
+         role (shipped by default)"
+    )]
+    StatusRead {
+        /// The target CR kind.
+        kind: String,
+        /// The target CR namespace.
+        namespace: String,
+        /// The target CR name.
+        name: String,
+        /// The underlying kube error (boxed, see [`MoverError::KubeClient`]).
+        #[source]
+        source: Box<kube::Error>,
+    },
+
     /// The bootstrap result could not be serialized.
     #[error("failed to serialize the bootstrap result: {source}")]
     ResultSerialize {
@@ -576,6 +600,7 @@ impl MoverError {
             | MoverError::SuccessExprEval { .. }
             | MoverError::KubeClient { .. }
             | MoverError::StatusPatch { .. }
+            | MoverError::StatusRead { .. }
             | MoverError::ResultSerialize { .. }
             | MoverError::ResultConfigMapPatch { .. }
             | MoverError::Telemetry(_)

--- a/crates/mover/src/status.rs
+++ b/crates/mover/src/status.rs
@@ -168,6 +168,7 @@ impl From<&crate::error::MoverError> for FailureBlock {
             | MoverError::SuccessExprEval { .. }
             | MoverError::KubeClient { .. }
             | MoverError::StatusPatch { .. }
+            | MoverError::StatusRead { .. }
             | MoverError::ResultSerialize { .. }
             | MoverError::ResultConfigMapPatch { .. }
             | MoverError::Telemetry(_)
@@ -867,7 +868,10 @@ impl StatusReporter {
     /// Read the target's currently-pinned `status.resolved`, if any. Used by the
     /// in-Job restore resolver to reuse a snapshot a PRIOR pod attempt already
     /// pinned (deterministic across Job retries) instead of re-resolving "latest".
-    /// Best-effort: returns `None` when there's no client or the read fails.
+    /// The read goes through the `/status` subresource, the one resource the
+    /// least-privilege mover role grants `get` on (#401 — a base-object GET is
+    /// Forbidden under that role). Best-effort: returns `None` when there's no
+    /// client or the read fails.
     pub async fn resolved(&self) -> Option<ResolvedRestore> {
         let r = self.inner.as_ref()?;
         let guard = r.lock().await;
@@ -915,25 +919,42 @@ impl KubeStatusReporter {
     /// Build the dynamic-API reporter for `target`, erroring when no kube
     /// client can be constructed.
     pub async fn try_new(target: &workspec::TargetRef) -> Result<Self> {
-        use kube::core::{ApiResource, GroupVersionKind};
-
         let client =
             kube::Client::try_default()
                 .await
                 .map_err(|source| MoverError::KubeClient {
                     source: Box::new(source),
                 })?;
+        Ok(Self::from_client(client, target))
+    }
+
+    /// Build the reporter around an existing client. The seam the unit tests
+    /// inject a mock service through ([`kube::Client::new`]); production goes
+    /// via [`Self::try_new`].
+    fn from_client(client: kube::Client, target: &workspec::TargetRef) -> Self {
+        use kube::core::{ApiResource, GroupVersionKind};
+
         let (group, version) = split_api_version(&target.api_version);
         let gvk = GroupVersionKind::gvk(&group, &version, &target.kind);
         let ar = ApiResource::from_gvk(&gvk);
-        let api =
-            kube::Api::<kube::api::DynamicObject>::namespaced_with(client, &target.namespace, &ar);
-        Ok(KubeStatusReporter {
+        // ClusterRepository is the one cluster-scoped mover target kind: a
+        // namespaced API would build `/namespaces/<ns>/clusterrepositories/...`,
+        // a path that does not exist, so every status call would 404 into the
+        // best-effort warn. No operation reaches this today (the only
+        // ClusterRepository targetRef is the bootstrap work-spec, and the
+        // bootstrap flow reports via its result ConfigMap, never a
+        // StatusReporter) — this keeps the trap from going live with a future op.
+        let api = if target.kind == "ClusterRepository" {
+            kube::Api::<kube::api::DynamicObject>::all_with(client, &ar)
+        } else {
+            kube::Api::<kube::api::DynamicObject>::namespaced_with(client, &target.namespace, &ar)
+        };
+        KubeStatusReporter {
             api,
             kind: target.kind.clone(),
             namespace: target.namespace.clone(),
             name: target.name.clone(),
-        })
+        }
     }
 
     /// PATCH the update's `.status` merge body onto the target object.
@@ -952,18 +973,32 @@ impl KubeStatusReporter {
         Ok(())
     }
 
-    /// GET the target and deserialize its `status.resolved`, if present.
+    /// GET the target THROUGH THE `/status` SUBRESOURCE (which returns the full
+    /// object) and deserialize its `status.resolved`, if present.
+    ///
+    /// The subresource route is load-bearing, not a style choice (#401): the
+    /// least-privilege mover role grants `get` only on `{crd}/status`, never on
+    /// the base resource, so a base-object GET is Forbidden in every real
+    /// install and the retry-determinism this read exists for silently never
+    /// works. A NotFound (CR deleted mid-run) is "no pin", matching the old
+    /// `get_opt` semantics; any other failure is a [`MoverError::StatusRead`]
+    /// so the log names the rejected GET rather than a PATCH.
     async fn read_resolved(&self) -> Result<Option<ResolvedRestore>> {
-        let obj = self
-            .api
-            .get_opt(&self.name)
-            .await
-            .map_err(|source| MoverError::StatusPatch {
-                kind: self.kind.clone(),
-                namespace: self.namespace.clone(),
-                name: self.name.clone(),
-                source: Box::new(source),
-            })?;
+        let obj = match self.api.get_status(&self.name).await {
+            Ok(obj) => Some(obj),
+            // `is_not_found()` (reason == "NotFound"), not a bare 404 check:
+            // a non-NotFound 404 (e.g. the CRD or API path absent) is a real
+            // misconfiguration and must surface, not read as "no pin yet".
+            Err(kube::Error::Api(status)) if status.is_not_found() => None,
+            Err(source) => {
+                return Err(MoverError::StatusRead {
+                    kind: self.kind.clone(),
+                    namespace: self.namespace.clone(),
+                    name: self.name.clone(),
+                    source: Box::new(source),
+                });
+            }
+        };
         Ok(obj
             .and_then(|o| {
                 o.data
@@ -1706,6 +1741,164 @@ mod tests {
                 stamps["Repository/backups/nas"].is_string()
                     && stamps["ClusterRepository/offsite"].is_string(),
                 "both concurrent stamps must survive in either order: {status}"
+            );
+        }
+    }
+
+    /// Wire-level `KubeStatusReporter` tests through a mock client
+    /// (`tower::service_fn`, no cluster): the request PATH is the contract the
+    /// mover RBAC authorizes, so it is asserted literally.
+    mod reporter {
+        use std::sync::{Arc, Mutex};
+
+        use http::{Request, Response, StatusCode};
+        use kube::client::Body;
+
+        use super::super::KubeStatusReporter;
+        use crate::workspec::TargetRef;
+
+        fn target(kind: &str) -> TargetRef {
+            TargetRef {
+                api_version: kopiur_api::consts::API_VERSION.to_string(),
+                kind: kind.to_string(),
+                name: "plex".to_string(),
+                namespace: "test-ns".to_string(),
+            }
+        }
+
+        /// A mock client that logs every request path and answers with
+        /// `status` + `body` (mirrors `controller::io::cached`'s harness).
+        fn logging_client(
+            log: Arc<Mutex<Vec<String>>>,
+            status: StatusCode,
+            body: serde_json::Value,
+        ) -> kube::Client {
+            let body = Arc::new(body);
+            let svc = tower::service_fn(move |req: Request<Body>| {
+                let log = log.clone();
+                let body = body.clone();
+                async move {
+                    log.lock().unwrap().push(req.uri().path().to_string());
+                    Ok::<_, std::convert::Infallible>(
+                        Response::builder()
+                            .status(status)
+                            .header("content-type", "application/json")
+                            .body(Body::from(serde_json::to_vec(&*body).unwrap()))
+                            .unwrap(),
+                    )
+                }
+            });
+            kube::Client::new(svc, "test-ns")
+        }
+
+        fn not_found_body() -> serde_json::Value {
+            serde_json::json!({
+                "kind": "Status", "apiVersion": "v1", "status": "Failure",
+                "reason": "NotFound", "code": 404,
+            })
+        }
+
+        fn restore_with_resolved() -> serde_json::Value {
+            serde_json::json!({
+                "apiVersion": kopiur_api::consts::API_VERSION,
+                "kind": "Restore",
+                "metadata": { "name": "plex", "namespace": "test-ns", "uid": "uid-r" },
+                "spec": {},
+                "status": { "resolved": {
+                    "resolution": "Snapshot",
+                    "kopiaSnapshotID": "abc123",
+                } },
+            })
+        }
+
+        /// #401 regression guard: the read MUST go through the `/status`
+        /// subresource — that is the resource the least-privilege mover role
+        /// grants `get` on. The buggy code GETted the BASE resource
+        /// (`.../restores/plex`), which the role does not grant, and 403'd on
+        /// every in-Job restore resolution.
+        #[tokio::test]
+        async fn read_resolved_gets_the_status_subresource() {
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let client = logging_client(log.clone(), StatusCode::OK, restore_with_resolved());
+            let reporter = KubeStatusReporter::from_client(client, &target("Restore"));
+            let resolved = reporter
+                .read_resolved()
+                .await
+                .expect("read succeeds against the mock");
+            assert_eq!(
+                log.lock().unwrap().as_slice(),
+                [
+                    "/apis/kopiur.home-operations.com/v1alpha1/namespaces/test-ns/restores/plex/status"
+                ],
+                "the read must target the status subresource, not the base resource (#401)"
+            );
+            assert_eq!(
+                resolved
+                    .expect("status.resolved present")
+                    .kopia_snapshot_id
+                    .as_deref(),
+                Some("abc123"),
+                "the pinned snapshot id round-trips"
+            );
+        }
+
+        /// A deleted CR (404 NotFound) is "no pin", not an error — the same
+        /// semantics `get_opt` gave the base-resource read.
+        #[tokio::test]
+        async fn read_resolved_maps_not_found_to_none() {
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let client = logging_client(log, StatusCode::NOT_FOUND, not_found_body());
+            let reporter = KubeStatusReporter::from_client(client, &target("Restore"));
+            let resolved = reporter
+                .read_resolved()
+                .await
+                .expect("NotFound is not an error");
+            assert!(resolved.is_none(), "a deleted CR has no pinned resolution");
+        }
+
+        /// A non-NotFound failure surfaces as `StatusRead` — naming the GET,
+        /// not a PATCH (#401's log line said "failed to PATCH" for a rejected
+        /// GET, which sent the reporter debugging the wrong call).
+        #[tokio::test]
+        async fn read_resolved_failure_names_the_read_not_a_patch() {
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let forbidden = serde_json::json!({
+                "kind": "Status", "apiVersion": "v1", "status": "Failure",
+                "reason": "Forbidden", "code": 403,
+            });
+            let client = logging_client(log, StatusCode::FORBIDDEN, forbidden);
+            let reporter = KubeStatusReporter::from_client(client, &target("Restore"));
+            let err = reporter
+                .read_resolved()
+                .await
+                .expect_err("403 is a real error");
+            let msg = err.to_string();
+            assert!(
+                msg.starts_with("failed to read the status of Restore test-ns/plex"),
+                "the message must name the read: {msg}"
+            );
+            assert!(
+                !msg.contains("PATCH"),
+                "a rejected GET must not be reported as a PATCH: {msg}"
+            );
+            // Environmental, not a kopia failure: Unknown and not retryable.
+            assert_eq!(err.kopia_class(), kopiur_kopia::KopiaErrorClass::Unknown);
+            assert!(!err.retry_recommended());
+        }
+
+        /// ClusterRepository is cluster-scoped: its status path must not carry
+        /// a `/namespaces/` segment (a namespaced path 404s — the latent trap
+        /// found while fixing #401; dead code today, guarded anyway).
+        #[tokio::test]
+        async fn cluster_scoped_target_builds_a_cluster_path() {
+            let log = Arc::new(Mutex::new(Vec::new()));
+            let client = logging_client(log.clone(), StatusCode::NOT_FOUND, not_found_body());
+            let reporter = KubeStatusReporter::from_client(client, &target("ClusterRepository"));
+            let _ = reporter.read_resolved().await;
+            assert_eq!(
+                log.lock().unwrap().as_slice(),
+                ["/apis/kopiur.home-operations.com/v1alpha1/clusterrepositories/plex/status"],
+                "cluster-scoped kinds must not use a namespaced path"
             );
         }
     }

--- a/crates/xtask/src/rbac.rs
+++ b/crates/xtask/src/rbac.rs
@@ -341,6 +341,13 @@ fn webhook_cert_secret_rules() -> Vec<PolicyRule> {
 /// spec rides the Job's own pod env (no `configmaps` get for it). This is deliberately a
 /// tiny subset of [`workload_rules`]; the mover runs as its own least-privilege SA.
 ///
+/// The `get` verb on `{crd}/status` is LOAD-BEARING (#401): the restore mover
+/// reads the CR's pinned `status.resolved` (retry determinism) via a GET on the
+/// status subresource — the one route this role authorizes. The mover must
+/// never GET/LIST the base resources, and this role must never grant them; the
+/// mover-side counterpart is `KubeStatusReporter::read_resolved` using
+/// `get_status`, guarded by tests on both sides.
+///
 /// `cluster` decides whether `clusterrepositories/status` is included. The
 /// namespaced mover Role must EXCLUDE it: RBAC escalation prevention rejects a
 /// RoleBinding whose referenced role grants permissions the binder does not

--- a/crates/xtask/tests/rbac.rs
+++ b/crates/xtask/tests/rbac.rs
@@ -234,6 +234,27 @@ fn mover_role_is_least_privilege() {
             rule_grants(&role_rules, "", "configmaps"),
             "{rel} must grant configmaps (bootstrap result write)"
         );
+        // #401: `get` on `{crd}/status` is LOAD-BEARING, not an unused verb —
+        // it authorizes the mover's `read_resolved` GET on the status
+        // subresource (restore-retry determinism). A "trim unused verbs" pass
+        // dropping it would silently kill that read again.
+        for verb in ["get", "patch"] {
+            assert!(
+                rule_grants_verb(
+                    &role_rules,
+                    "kopiur.home-operations.com",
+                    "restores/status",
+                    verb
+                ),
+                "{rel} must grant `{verb}` on restores/status (#401: get backs read_resolved)"
+            );
+        }
+        // ...and the base resource stays UNgranted: the mover reads through the
+        // subresource precisely so it never needs (and must never get) this.
+        assert!(
+            !rule_grants(&role_rules, "kopiur.home-operations.com", "restores"),
+            "{rel}: the mover must NOT be granted the base restores resource (#401)"
+        );
         // Least privilege: NONE of the operator's broad grants leak into the mover.
         for (g, r) in [
             ("batch", "jobs"),

--- a/docs/movers.md
+++ b/docs/movers.md
@@ -23,7 +23,7 @@ The mover patches its owning `Snapshot`/`Restore` `.status`, so it needs a Servi
 
 /// info | Least privilege
 
-The `kopiur-mover` role grants only what a mover actually uses: `patch` on the owning CRDs' `/status` subresource and on the bootstrap-result ConfigMap. It does **not** grant Secrets, Jobs, Pods, or PVCs — a far smaller surface than the operator's own role. A namespace tenant who can read that SA's token can do almost nothing with it (see [Privileged movers](#privileged-movers) for the one exception that needs your sign-off).
+The `kopiur-mover` role grants only what a mover actually uses: `get` + `patch` on the owning CRDs' `/status` subresource (`patch` to report progress and the terminal result; `get` so a retried restore Job can re-read the snapshot a prior attempt pinned in `status.resolved` instead of re-resolving "latest"), and `get` + `patch` on the bootstrap-result ConfigMap. It does **not** grant the base CRD resources, Secrets, Jobs, Pods, or PVCs — a far smaller surface than the operator's own role. A namespace tenant who can read that SA's token can do almost nothing with it (see [Privileged movers](#privileged-movers) for the one exception that needs your sign-off).
 
 ///
 

--- a/docs/rbac.md
+++ b/docs/rbac.md
@@ -47,11 +47,12 @@ confined to admin-chosen namespaces.
 
 ## The mover (`kopiur-mover`)
 
-The mover is deliberately tiny — it can **only** report its result:
+The mover is deliberately tiny — it can only report its result and read back
+what a prior attempt reported:
 
 | API group → resources | Verbs | Why |
 | --- | --- | --- |
-| `kopiur.home-operations.com` → every CRD's `/status` | get, patch | Patch progress and the terminal result (snapshot id, stats, timing, `logTail`, `failure`) onto the CR that owns the Job. |
+| `kopiur.home-operations.com` → every CRD's `/status` | get, patch | `patch`: progress and the terminal result (snapshot id, stats, timing, `logTail`, `failure`) onto the CR that owns the Job. `get`: a restore mover re-reads the CR's pinned `status.resolved` through the status subresource, so a retried Job pod restores the same snapshot a prior attempt chose instead of re-resolving "latest". |
 | core → `configmaps` | get, patch | Write bootstrap results back to the result ConfigMap (the work spec itself rides the Job env). |
 
 It cannot read Secrets (credentials arrive via `envFrom` on the Job), cannot


### PR DESCRIPTION
Fixes #401.

## What was broken

Every restore mover Job warned:

```
status.resolved read failed error=failed to PATCH the status of Restore default/plex: ...
User "system:serviceaccount:default:kopiur-mover" cannot get resource "restores" ... Forbidden
```

Two defects, exactly as the issue diagnosed:

1. `KubeStatusReporter::read_resolved()` GETted the **base** `Restore` object, but the least-privilege mover role deliberately grants `get`/`patch` only on the `{crd}/status` subresources — so the read 403'd in every real install, and the retry-determinism it exists for (a retried Job pod reusing the snapshot a prior attempt pinned in `status.resolved`, instead of re-resolving "latest") was silently dead code.
2. The failure was wrapped in `MoverError::StatusPatch`, so the WARN said "failed to PATCH" for a rejected GET.

## The fix — no RBAC widening

A GET on `.../restores/<name>/status` returns the **full object** and is authorized against resource `restores`, subresource `status`, verb `get` — which the mover role has always granted. `read_resolved` now uses `Api::get_status`:

- NotFound maps to `None` — byte-for-byte the old `get_opt` semantics (`Status::is_not_found()`, i.e. `reason == "NotFound"`; a bare `code == 404` check would additionally swallow a CRD-absent misconfiguration as "no pin yet").
- Any other failure surfaces as a new `MoverError::StatusRead` that names the GET (classified in both exhaustive matches; the compiler enforced it).

Zero changes to `deploy/rbac/`, the chart's mover role templates, or any generated artifact (`gen-check` green) — existing installs are fixed by the mover image alone, and the status-subresource-only privilege boundary answers the issue's open question: it stays.

## Also hardened while here

- `KubeStatusReporter` is now scope-aware: a `ClusterRepository` target builds a cluster-scoped path. The unconditional namespaced path would 404 — dead code today (only the bootstrap work-spec targets ClusterRepository, and bootstrap reports via its result ConfigMap, never a `StatusReporter`), but the constructor is generic and the trap would have gone live with any future op.
- The issue's workaround ClusterRole (extra `get` on base `restores`) becomes unnecessary; it's harmless to leave in place.

## Tests

- **Unit (fails on the buggy code):** mock-client tests pin the request path to `.../restores/plex/status` (the buggy code produced the base path), the NotFound→`None` mapping, the `StatusRead` message ("failed to read the status…", never "PATCH"), and the ClusterRepository cluster-scoped path.
- **RBAC layer:** `mover_role_is_least_privilege` now asserts `get` stays granted on `restores/status` **and** the base resource stays ungranted — a future verb-trim can't silently re-break this.
- **e2e (against the chart's real RBAC):** the S3 `fromPolicy` scenario — the exact reported path — now asserts no mover pod logged `status.resolved read failed`, across every pod of the Job, with a non-empty-pod-list guard so it can never pass vacuously. Fails on the buggy code (the WARN fired on every in-Job resolution).

## Docs

`docs/rbac.md` + `docs/movers.md` now explain why the mover holds `get` on `{crd}/status` (it was documented as patch-only).

## Verification

`mise run build` / `test` (all 81 suites ok) / `clippy` / `fmt-check` / `complexity-check` (29/29 budget) / `gen-check` (no drift) / `docs` — all green.
Scoped e2e: `KOPIUR_E2E_BINS=cli KOPIUR_E2E_TESTFILTER=cli_restore_from_policy_into_created_pvc mise run //crates/e2e:test` → `PASS [51.3s]`.